### PR TITLE
fix(lint): add markdownlint config for MD013/MD024

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,8 @@
+{
+  "MD013": {
+    "line_length": 100
+  },
+  "MD024": {
+    "siblings_only": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -106,11 +106,11 @@ Located in `scripts/ci/lib/`:
 lgtm-ci uses [semantic versioning](https://semver.org/) with
 [conventional commits](https://www.conventionalcommits.org/) for automated releases.
 
-| Ref       | Example                                                  | Description                             |
-| --------- | -------------------------------------------------------- | --------------------------------------- |
-| `@v1`     | `uses: lgtm-hq/lgtm-ci/.github/actions/setup-env@v1`     | Recommended — gets all v1.x.x updates   |
-| `@v1.2.3` | `uses: lgtm-hq/lgtm-ci/.github/actions/setup-env@v1.2.3` | Pinned to exact version                 |
-| `@main`   | `uses: lgtm-hq/lgtm-ci/.github/actions/setup-env@main`   | Latest development (not for production) |
+| Ref       | Example                                                  | Description          |
+| --------- | -------------------------------------------------------- | -------------------- |
+| `@v1`     | `uses: lgtm-hq/lgtm-ci/.github/actions/setup-env@v1`     | All v1.x.x updates   |
+| `@v1.2.3` | `uses: lgtm-hq/lgtm-ci/.github/actions/setup-env@v1.2.3` | Pinned exact version |
+| `@main`   | `uses: lgtm-hq/lgtm-ci/.github/actions/setup-env@main`   | Latest, not for prod |
 
 Releases are automated — every push to `main` with releasable commits
 (`feat:`, `fix:`, etc.) creates a new tagged release and updates the


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Add `.markdownlint.jsonc` to fix MD024 and MD013 violations that broke the release-version-pr workflow.

- Configure MD024 `siblings_only: true` for changelogs that repeat section headings (`### Features`, `### Bug Fixes`) across version sections
- Align MD013 `line_length` with prettier's `printWidth: 100` to prevent tool conflicts
- Shorten README versioning table descriptions to fit within the 100-char line limit

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Related Issues

Fixes https://github.com/lgtm-hq/lgtm-ci/actions/runs/21855013612/job/63069874647

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified and updated versioning descriptions and information in README.

* **Chores**
  * Added markdown linting configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->