### PR TITLE
fix(workflows): fall back to full CODEOWNERS list when author is sole candidate

### DIFF
--- a/scripts/ci/actions/assign-codeowner.sh
+++ b/scripts/ci/actions/assign-codeowner.sh
@@ -55,12 +55,13 @@ owner_array=("${filtered_array[@]}")
 count=${#owner_array[@]}
 
 if [[ $count -eq 0 ]]; then
-	echo "No eligible assignees after filtering out PR author ($PR_AUTHOR), skipping"
-	exit 0
+	echo "No other assignees available, falling back to full CODEOWNERS list"
+	mapfile -t owner_array <<<"$owners"
+	count=${#owner_array[@]}
 fi
 
 random_index=$((RANDOM % count))
 selected="${owner_array[$random_index]}"
 
-echo "Selected assignee: $selected (from $count eligible CODEOWNERS, excluding PR author $PR_AUTHOR)"
+echo "Selected assignee: $selected (from $count eligible CODEOWNERS)"
 gh pr edit "$PR_NUMBER" --add-assignee "$selected"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

When the PR author is the only individual CODEOWNER, filtering them out leaves zero candidates and the script skips assignment entirely. This changes the fallback behavior to use the unfiltered list, so the sole CODEOWNER still gets assigned to their own PRs.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [ ] Python code passes `ruff` and `black`

## Breaking Changes

None

## Related Issues

Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced code owner assignment logic to include a fallback mechanism, ensuring assignees can be reliably selected even when initial eligibility filters result in no candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->