### PR TITLE
fix(workflows): use github.sha as default tooling-ref in auto-tag workflow

### DIFF
--- a/.github/workflows/reusable-release-auto-tag.yml
+++ b/.github/workflows/reusable-release-auto-tag.yml
@@ -15,10 +15,11 @@ name: "Reusable: Release Auto Tag"
         type: string
         default: "v"
       tooling-ref:
-        description: "Git ref for lgtm-ci tooling checkout (should match the workflow ref)"
+        # yamllint disable-line rule:line-length
+        description: "Git ref for lgtm-ci tooling checkout. Same-repo callers default to github.sha; cross-repo callers default to main."
         required: false
         type: string
-        default: "v0.5.0"
+        default: ""
     secrets:
       RELEASE_APP_ID:
         description: "GitHub App ID for creating release tokens"
@@ -55,12 +56,31 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
+      - name: Resolve tooling ref
+        id: tooling
+        shell: bash
+        env:
+          TOOLING_REF: ${{ inputs.tooling-ref }}
+          GH_REPO: ${{ github.repository }}
+          GH_SHA: ${{ github.sha }}
+        run: |
+          if [[ -n "$TOOLING_REF" ]]; then
+            # Explicit override from caller
+            echo "ref=$TOOLING_REF" >> "$GITHUB_OUTPUT"
+          elif [[ "$GH_REPO" == "lgtm-hq/lgtm-ci" ]]; then
+            # Same repo: use the current commit
+            echo "ref=$GH_SHA" >> "$GITHUB_OUTPUT"
+          else
+            # Cross-repo caller: use main (github.sha is the caller's SHA)
+            echo "ref=main" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: ${{ inputs.tooling-ref }}
+          ref: ${{ steps.tooling.outputs.ref }}
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Fix the `reusable-release-auto-tag` workflow failing with `exit code 127` (`configure-git-remote.sh: No such file or directory`) when triggered by the v0.6.0 release commit (#61).

The `tooling-ref` input defaulted to `v0.5.0`, but the scripts it references (`configure-git-remote.sh`, `write-skip-summary.sh`) were added in the same PR (#60) and don't exist at that tag. This changes the default to `github.sha` so the workflow always checks out scripts from the same commit, eliminating the chicken-and-egg version mismatch. External callers can still override `tooling-ref` to pin a specific tag.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [ ] Python code passes `ruff` and `black` (N/A — no Python changes)

## Breaking Changes

None. External callers that explicitly pass `tooling-ref` are unaffected. Callers relying on the default now get `github.sha` instead of the stale `v0.5.0`, which is the correct behavior.

## Related Issues

Fixes the failed [Release: Auto Tag run](https://github.com/lgtm-hq/lgtm-ci/actions/runs/21880709847) caused by #60.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released workflow updated to support dynamic tooling references with improved fallback logic.
  * Default tooling reference behavior changed to use the current run commit for same-repo calls and main for cross-repo calls; explicit input still honored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->