### PR TITLE
fix(release): deduplicate changelog when same version is re-created

### DIFF
--- a/scripts/ci/release/update-changelog.sh
+++ b/scripts/ci/release/update-changelog.sh
@@ -124,10 +124,10 @@ ${CHANGELOG_BODY}"
 TMPFILE=$(mktemp "${CHANGELOG_FILE}.XXXXXX")
 trap 'rm -f "$TMPFILE"' EXIT
 
-export NEW_SECTION UNRELEASED_SECTION UNRELEASED_LINK VERSION_LINK
+export NEW_SECTION UNRELEASED_SECTION UNRELEASED_LINK VERSION_LINK CLEAN_VERSION
 
 awk '
-BEGIN { in_unreleased=0 }
+BEGIN { in_unreleased=0; in_dup_version=0 }
 /^## \[Unreleased\]/ {
 	print ENVIRON["UNRELEASED_SECTION"]
 	print ""
@@ -137,15 +137,37 @@ BEGIN { in_unreleased=0 }
 }
 in_unreleased && /^## \[/ {
 	in_unreleased=0
+	# Skip duplicate version section when re-creating the same release
+	v = ENVIRON["CLEAN_VERSION"]
+	if (index($0, "## [" v "]") == 1) {
+		in_dup_version=1
+		next
+	}
 	print
 	next
 }
+# Skip content of duplicate version section until the next version heading
+in_dup_version && /^## \[/ {
+	in_dup_version=0
+	print ""
+	print
+	next
+}
+# Clear in_dup_version when reaching the link-definition block so the
+# [Unreleased]: handler below still fires (no next — fall through).
+in_dup_version && /^\[Unreleased\]:/ { in_dup_version=0 }
+in_dup_version { next }
 # Replace [Unreleased]: link even inside the unreleased section
 /^\[Unreleased\]:/ {
 	print ""
 	print ENVIRON["UNRELEASED_LINK"]
 	print ENVIRON["VERSION_LINK"]
 	next
+}
+# Skip existing version link definition to prevent duplicates (MD053)
+{
+	v = ENVIRON["CLEAN_VERSION"]
+	if (index($0, "[" v "]: ") == 1) next
 }
 # Preserve reference-style link definitions (e.g., [#1]: https://...)
 # even inside the unreleased section

--- a/tests/bats/integration/test_update_changelog.bats
+++ b/tests/bats/integration/test_update_changelog.bats
@@ -518,6 +518,158 @@ run_update_changelog() {
 	assert_success
 }
 
+@test "update-changelog: deduplicates when same version already exists" {
+	setup_changelog_repo
+
+	# Simulate the scenario where a version PR was merged but the tag was
+	# never created, so the next run calculates the same version again.
+	write_changelog '# Changelog
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.6.0] - 2026-02-10
+
+### Features
+
+- old feature from first run (aaa1111)
+
+## [0.5.0] - 2026-02-09
+
+### Features
+
+- even older feature (bbb2222)
+
+[Unreleased]: https://github.com/test-org/test-repo/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/test-org/test-repo/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/test-org/test-repo/releases/tag/v0.5.0'
+
+	(cd "$MOCK_GIT_REPO" && git tag v0.5.0)
+
+	run_update_changelog "0.6.0" "### Features
+
+- old feature from first run (aaa1111)
+
+### Bug Fixes
+
+- new fix added since first run (ccc3333)"
+	assert_success
+
+	local changelog
+	changelog=$(cat "${MOCK_GIT_REPO}/CHANGELOG.md")
+
+	# Exactly one version header for 0.6.0
+	local count
+	count=$(echo "$changelog" | grep -c '## \[0\.6\.0\]')
+	[[ "$count" -eq 1 ]] || {
+		echo "Expected exactly 1 version header for 0.6.0, found $count" >&2
+		echo "$changelog" >&2
+		return 1
+	}
+
+	# Exactly one link definition for 0.6.0 (no MD053 duplicate)
+	local link_count
+	link_count=$(echo "$changelog" | grep -c '^\[0\.6\.0\]:')
+	[[ "$link_count" -eq 1 ]] || {
+		echo "Expected exactly 1 link definition for [0.6.0], found $link_count" >&2
+		echo "$changelog" >&2
+		return 1
+	}
+
+	# The 0.5.0 section should still be preserved
+	echo "$changelog" | grep -q '## \[0\.5\.0\]' || fail "'## [0.5.0]' not found in changelog"
+	echo "$changelog" | grep -q 'even older feature' || fail "'even older feature' not found in changelog"
+
+	# The 0.5.0 link should still be preserved
+	echo "$changelog" | grep -q '\[0\.5\.0\]:' || fail "'[0.5.0]' link not found in changelog"
+
+	# The new fix should be present in the updated 0.6.0 section
+	echo "$changelog" | grep -q 'new fix added since first run' || fail "'new fix added since first run' not found in changelog"
+}
+
+@test "update-changelog: deduplicates when duplicate is the only version section" {
+	setup_changelog_repo
+
+	# Edge case: the duplicate version is the last (and only) section before
+	# the link definitions. in_dup_version must be cleared so the
+	# [Unreleased]: handler still fires.
+	write_changelog '# Changelog
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [1.0.0] - 2026-02-10
+
+### Features
+
+- initial release feature (aaa1111)
+
+[Unreleased]: https://github.com/test-org/test-repo/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/test-org/test-repo/releases/tag/v1.0.0'
+
+	run_update_changelog "1.0.0" "### Features
+
+- initial release feature (aaa1111)
+
+### Bug Fixes
+
+- hotfix after version PR merged (bbb2222)"
+	assert_success
+
+	local changelog
+	changelog=$(cat "${MOCK_GIT_REPO}/CHANGELOG.md")
+
+	# Exactly one version header
+	local count
+	count=$(echo "$changelog" | grep -c '## \[1\.0\.0\]')
+	[[ "$count" -eq 1 ]] || {
+		echo "Expected exactly 1 version header for 1.0.0, found $count" >&2
+		echo "$changelog" >&2
+		return 1
+	}
+
+	# Exactly one link definition (no MD053 duplicate)
+	local link_count
+	link_count=$(echo "$changelog" | grep -c '^\[1\.0\.0\]:')
+	[[ "$link_count" -eq 1 ]] || {
+		echo "Expected exactly 1 link definition for [1.0.0], found $link_count" >&2
+		echo "$changelog" >&2
+		return 1
+	}
+
+	# Unreleased link must still be emitted
+	echo "$changelog" | grep -q '^\[Unreleased\]: https://github.com/test-org/test-repo/compare/v1.0.0...HEAD' || {
+		echo "Missing or incorrect [Unreleased] link" >&2
+		echo "$changelog" >&2
+		return 1
+	}
+
+	# The hotfix should be present
+	echo "$changelog" | grep -q 'hotfix after version PR merged' || fail "'hotfix after version PR merged' not found in changelog"
+}
+
 @test "update-changelog: no triple-blank-line runs" {
 	setup_changelog_repo
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Fix duplicate `## [version]` sections and `[version]:` link reference definitions (MD053) when `update-changelog.sh` re-creates the same version — e.g., when a version PR merges but the tag is never created due to an auto-tag workflow bug.

The AWK script now detects and skips existing version sections and link definitions matching the target version, making changelog generation idempotent for the same version.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Related Issues

Fixes the linting failure in [CI run #21897489050](https://github.com/lgtm-hq/lgtm-ci/actions/runs/21897489050/job/63216895069) triggered after PR #62 was merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved changelog generation to skip duplicate release entries, preserve existing version sections and reference links, and ensure the Unreleased block is reconstructed correctly without duplicating content.

* **Tests**
  * Added integration tests covering deduplication scenarios to verify single version headers/links, preservation of prior content, and proper Unreleased handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->