### PR TITLE
ci: add Renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+---
+name: Maintenance - Renovate Dependencies
+# Automated dependency updates using Renovate bot. Runs daily to check for
+# outdated dependencies and creates PRs with updates.
+
+"on":
+  schedule:
+    # Run daily at 22:00 UTC
+    - cron: "0 22 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    concurrency:
+      group: renovate-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Harden Runner
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            objects.githubusercontent.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
+
+      - name: Checkout
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
+          persist-credentials: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Self-hosted Renovate
+        # yamllint disable-line rule:line-length
+        uses: renovatebot/github-action@eaf12548c13069dcc28bb75c4ee4610cdbe400c5 # v44.2.6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          configurationFile: renovate.json
+        env:
+          LOG_LEVEL: ${{ github.event_name == 'workflow_dispatch' && 'debug' || 'info' }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Add self-hosted Renovate workflow (`.github/workflows/renovate.yml`) so automated dependency updates actually run. The `renovate.json` config exists but there was no workflow to drive it — Renovate was completely dormant. This is especially important for lgtm-ci since it hosts reusable workflows consumed by all other org repos.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed — N/A
- [x] Shell scripts pass `shellcheck` — N/A (YAML only)
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black` — N/A

## Breaking Changes

None

## Related Issues

Closes #70

References:
- [Rustume PR #53](https://github.com/lgtm-hq/Rustume/pull/53) — reference implementation
- [holy-grail #31](https://github.com/lgtm-hq/holy-grail/issues/31) — same change
- [py-lintro #605](https://github.com/lgtm-hq/py-lintro/issues/605) — related rename
- [turbo-themes #361](https://github.com/lgtm-hq/turbo-themes/issues/361) — related rename