### PR TITLE
docs: revamp README to match org standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,26 @@
 # lgtm-ci
 
-Reusable CI/CD components for GitHub Actions - composite actions, reusable workflows,
+<!-- markdownlint-disable MD033 MD013 -->
+<p align="center">
+Reusable CI/CD components for GitHub Actions — composite actions, reusable workflows,
 and shell utilities.
+</p>
 
-## Overview
+<!-- Badges: Build & Quality -->
+<p align="center">
+<a href="https://github.com/lgtm-hq/lgtm-ci/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/lgtm-hq/lgtm-ci/ci.yml?label=ci&branch=main&logo=githubactions&logoColor=white" alt="CI"></a>
+<a href="https://github.com/lgtm-hq/lgtm-ci/releases/latest"><img src="https://img.shields.io/github/v/release/lgtm-hq/lgtm-ci?label=release" alt="Release"></a>
+<a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License"></a>
+</p>
 
-**lgtm-ci** provides a collection of production-ready CI/CD building blocks:
+<!-- Badges: Tech Stack -->
+<p align="center">
+<a href="https://github.com/features/actions"><img src="https://img.shields.io/badge/GitHub_Actions-2088FF?logo=githubactions&logoColor=white" alt="GitHub Actions"></a>
+<a href="https://www.gnu.org/software/bash/"><img src="https://img.shields.io/badge/Bash-4EAA25?logo=gnubash&logoColor=white" alt="Bash"></a>
+</p>
+<!-- markdownlint-enable MD033 MD013 -->
 
-- **Composite Actions** - Reusable actions for environment setup, security hardening, PR
-  comments, and more
-- **Reusable Workflows** - Complete workflow templates for quality gates, releases, and
-  publishing
-- **Shell Libraries** - Modular bash utilities for logging, platform detection, GitHub
-  integration, and downloads
-
-## Quick Start
+## 🚀 Quick Start
 
 ### Using a Composite Action
 
@@ -57,51 +63,125 @@ steps:
       log_info "Starting build..."
 ```
 
-## Components
+## 📦 Components
 
 ### Composite Actions
 
-| Action                        | Description                                 |
-| ----------------------------- | ------------------------------------------- |
-| `setup-env`                   | Unified Python/Node/Ruby environment setup  |
-| `setup-python`                | Python + uv setup with caching              |
-| `setup-node`                  | Node.js + Bun setup with Playwright caching |
-| `setup-rust`                  | Rust toolchain setup                        |
-| `harden-runner`               | Security hardening with egress presets      |
-| `secure-checkout`             | Hardened git checkout                       |
-| `post-pr-comment`             | Marker-based PR commenting                  |
-| `semantic-pr-title`           | Conventional commits validation             |
-| `extract-version`             | Version extraction from multiple sources    |
-| `generate-coverage-comment`   | Coverage report PR comments                 |
-| `generate-playwright-comment` | E2E test result comments                    |
-| `generate-lighthouse-comment` | Performance metric comments                 |
-| `run-quality`                 | Lintro quality checks with actionlint       |
-| `egress-audit`                | Network egress monitoring and reporting     |
+#### Environment Setup
+
+| Action         | Description                                     |
+| -------------- | ----------------------------------------------- |
+| `setup-env`    | Unified Python/Node/Ruby/Rust environment setup |
+| `setup-python` | Python + uv setup with caching                  |
+| `setup-node`   | Node.js + Bun setup with Playwright caching     |
+| `setup-ruby`   | Ruby + Bundler setup                            |
+| `setup-rust`   | Rust toolchain setup                            |
+
+#### Security & Hardening
+
+| Action                 | Description                             |
+| ---------------------- | --------------------------------------- |
+| `harden-runner`        | Security hardening with egress presets  |
+| `secure-checkout`      | Hardened git checkout                   |
+| `scan-vulnerabilities` | Vulnerability scanning                  |
+| `egress-audit`         | Network egress monitoring and reporting |
+
+#### Quality & Testing
+
+| Action              | Description                              |
+| ------------------- | ---------------------------------------- |
+| `run-quality`       | Lintro quality checks with actionlint    |
+| `run-tests`         | Generic test runner                      |
+| `run-vitest`        | Vitest test execution                    |
+| `run-pytest`        | Pytest test execution                    |
+| `run-playwright`    | Playwright E2E test execution            |
+| `run-lighthouse`    | Lighthouse performance audits            |
+| `semantic-pr-title` | Conventional commits PR title validation |
+
+#### Reporting & Comments
+
+| Action                        | Description                   |
+| ----------------------------- | ----------------------------- |
+| `post-pr-comment`             | Marker-based PR commenting    |
+| `generate-coverage-badge`     | Coverage badge generation     |
+| `generate-coverage-comment`   | Coverage report PR comments   |
+| `generate-playwright-comment` | E2E test result comments      |
+| `generate-lighthouse-comment` | Performance metric comments   |
+| `publish-test-results`        | Test result publishing        |
+| `check-coverage-threshold`    | Coverage threshold validation |
+| `collect-coverage`            | Coverage data collection      |
+| `merge-playwright-reports`    | Playwright report merging     |
+
+#### Build & Release
+
+| Action                  | Description                     |
+| ----------------------- | ------------------------------- |
+| `build-docker`          | Docker image building           |
+| `attest-build`          | Build attestation with Sigstore |
+| `sign-artifact`         | Artifact signing                |
+| `verify-attestation`    | Attestation verification        |
+| `verify-signature`      | Signature verification          |
+| `calculate-version`     | Semantic version calculation    |
+| `create-release-tag`    | Release tag creation            |
+| `create-github-release` | GitHub release creation         |
+| `generate-changelog`    | Changelog generation            |
+| `generate-sbom`         | SBOM generation with CycloneDX  |
+
+#### Publishing & Deployment
+
+| Action             | Description                  |
+| ------------------ | ---------------------------- |
+| `publish-npm`      | npm package publishing       |
+| `publish-pypi`     | PyPI publishing with OIDC    |
+| `publish-gem`      | RubyGems publishing          |
+| `update-homebrew`  | Homebrew formula updates     |
+| `validate-package` | Package validation           |
+| `wait-for-package` | Package availability polling |
+| `deploy-pages`     | GitHub Pages deployment      |
 
 ### Reusable Workflows
 
-| Workflow                    | Description                          |
-| --------------------------- | ------------------------------------ |
-| `reusable-quality.yml`      | Lintro + shellcheck + action pinning |
-| `reusable-sbom.yml`         | SBOM generation with Cosign signing  |
-| `reusable-release.yml`      | Semantic release automation          |
-| `reusable-publish-pypi.yml` | PyPI publishing with OIDC            |
+| Workflow                        | Description                          |
+| ------------------------------- | ------------------------------------ |
+| `reusable-quality.yml`          | Lintro + shellcheck + action pinning |
+| `reusable-sbom.yml`             | SBOM generation with Cosign signing  |
+| `reusable-release-auto-tag.yml` | Automated release tagging            |
+| `reusable-publish-pypi.yml`     | PyPI publishing with OIDC            |
+| `reusable-publish-npm.yml`      | npm publishing                       |
+| `reusable-publish-gem.yml`      | RubyGems publishing                  |
+| `reusable-publish-homebrew.yml` | Homebrew formula publishing          |
+| `reusable-deploy-pages.yml`     | GitHub Pages deployment              |
+| `reusable-docker.yml`           | Docker build and publish             |
+| `reusable-coverage.yml`         | Test coverage collection             |
+| `reusable-test-python.yml`      | Python test execution                |
+| `reusable-test-node.yml`        | Node.js test execution               |
+| `reusable-test-shell.yml`       | Shell script testing with BATS       |
+| `reusable-test-e2e.yml`         | E2E testing with Playwright          |
+| `reusable-test-e2e-matrix.yml`  | Matrix E2E testing                   |
+| `reusable-pr-auto-assign.yml`   | PR auto-assignment                   |
+| `reusable-pr-labeler.yml`       | PR auto-labeling                     |
 
 ### Shell Libraries
 
 Located in `scripts/ci/lib/`:
 
-| Library        | Description                     |
-| -------------- | ------------------------------- |
-| `log.sh`       | Colored logging functions       |
-| `platform.sh`  | OS and architecture detection   |
-| `fs.sh`        | File system utilities           |
-| `git.sh`       | Git helper functions            |
-| `github.sh`    | GitHub Actions integration      |
-| `network.sh`   | Download and checksum utilities |
-| `installer.sh` | Tool installation framework     |
+| Library        | Description                                        |
+| -------------- | -------------------------------------------------- |
+| `log.sh`       | Colored logging with levels and GitHub annotations |
+| `platform.sh`  | OS and architecture detection                      |
+| `fs.sh`        | File system utilities                              |
+| `git.sh`       | Git helper functions                               |
+| `github.sh`    | GitHub API and Actions integration                 |
+| `network.sh`   | Download, checksum, and retry utilities            |
+| `installer.sh` | Tool installation framework                        |
+| `docker.sh`    | Docker build and push utilities                    |
+| `publish.sh`   | Package publishing utilities                       |
+| `release.sh`   | Release management                                 |
+| `sbom.sh`      | SBOM generation utilities                          |
+| `testing.sh`   | Test execution utilities                           |
+| `actions.sh`   | GitHub Actions helper functions                    |
 
-## Versioning
+## 📌 Versioning
 
 lgtm-ci uses [semantic versioning](https://semver.org/) with
 [conventional commits](https://www.conventionalcommits.org/) for automated releases.
@@ -116,14 +196,24 @@ Releases are automated — every push to `main` with releasable commits
 (`feat:`, `fix:`, etc.) creates a new tagged release and updates the
 floating major version tag.
 
-## Contributing
+## 🔨 Development
 
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Run `uv run lintro chk` to validate
-5. Submit a PR
+```bash
+git clone https://github.com/lgtm-hq/lgtm-ci.git
+cd lgtm-ci
 
-## License
+# Lint
+uv run lintro chk
+
+# Auto-fix formatting
+uv run lintro fmt
+```
+
+## 🤝 Community
+
+- 🐛 [Bug Reports](https://github.com/lgtm-hq/lgtm-ci/issues/new)
+- 💡 [Feature Requests](https://github.com/lgtm-hq/lgtm-ci/issues/new)
+
+## 📄 License
 
 MIT License - see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Revamp README.md to match the organizational standard set by py-lintro and turbo-themes.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck` — N/A (docs-only change)
- [x] YAML files pass `yamllint` — N/A (docs-only change)
- [x] Python code passes `ruff` and `black` — N/A (docs-only change)

## Breaking Changes

None

## Related Issues

None