### PR TITLE
fix(actions): normalize Windows paths in all composite actions

### DIFF
--- a/.github/actions/attest-build/action.yml
+++ b/.github/actions/attest-build/action.yml
@@ -34,6 +34,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Prepare attestation
       id: prepare
       shell: bash
@@ -42,7 +48,7 @@ runs:
         SUBJECT_PATH: ${{ inputs.subject-path }}
         SUBJECT_NAME: ${{ inputs.subject-name }}
         SUBJECT_DIGEST: ${{ inputs.subject-digest }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/attest-build.sh
+      run: $SCRIPTS_DIR/ci/actions/attest-build.sh
 
     - name: Create attestation
       id: attest
@@ -62,7 +68,7 @@ runs:
         ATTESTATION_URL: ${{ steps.attest.outputs.attestation-url }}
         BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
         SUBJECT_NAME: ${{ steps.prepare.outputs.subject-name }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/attest-build.sh
+      run: $SCRIPTS_DIR/ci/actions/attest-build.sh
 
 branding:
   icon: "check-circle"

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -72,11 +72,17 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Setup Docker environment
       shell: bash
       env:
         STEP: setup
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/build-docker.sh
+      run: $SCRIPTS_DIR/ci/actions/build-docker.sh
 
     - name: Setup QEMU for multi-platform
       # Run for multi-platform builds OR single non-native platform
@@ -121,7 +127,7 @@ runs:
         LABELS: ${{ inputs.labels }}
         CACHE_FROM: ${{ inputs.cache-from }}
         CACHE_TO: ${{ inputs.cache-to }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/build-docker.sh
+      run: $SCRIPTS_DIR/ci/actions/build-docker.sh
 
     - name: Extract metadata
       id: metadata
@@ -132,7 +138,7 @@ runs:
         REGISTRY: ${{ inputs.registry }}
         IMAGE_NAME: ${{ inputs.image-name }}
         BUILT_TAGS: ${{ steps.build.outputs.tags }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/build-docker.sh
+      run: $SCRIPTS_DIR/ci/actions/build-docker.sh
 
     - name: Generate summary
       shell: bash
@@ -142,7 +148,7 @@ runs:
         TAGS: ${{ steps.build.outputs.tags }}
         PLATFORMS: ${{ inputs.platforms }}
         PUSH: ${{ inputs.push }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/build-docker.sh
+      run: $SCRIPTS_DIR/ci/actions/build-docker.sh
 
 branding:
   icon: "box"

--- a/.github/actions/calculate-version/action.yml
+++ b/.github/actions/calculate-version/action.yml
@@ -34,6 +34,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Calculate next version
       id: calculate
       shell: bash
@@ -41,7 +47,7 @@ runs:
         MAX_BUMP: ${{ inputs.max-bump }}
         FROM_REF: ${{ inputs.from-ref }}
         TO_REF: ${{ inputs.to-ref }}
-      run: ${{ github.action_path }}/../../../scripts/ci/release/calculate-version.sh
+      run: $SCRIPTS_DIR/ci/release/calculate-version.sh
 
 branding:
   icon: "tag"

--- a/.github/actions/check-coverage-threshold/action.yml
+++ b/.github/actions/check-coverage-threshold/action.yml
@@ -26,6 +26,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Check coverage threshold
       id: check
       shell: bash
@@ -33,8 +39,7 @@ runs:
         COVERAGE: ${{ inputs.coverage-percent }}
         THRESHOLD: ${{ inputs.threshold }}
         FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
-      run: ${{ github.action_path
-        }}/../../../scripts/ci/actions/check-coverage-threshold.sh
+      run: $SCRIPTS_DIR/ci/actions/check-coverage-threshold.sh
 
 branding:
   icon: "check-circle"

--- a/.github/actions/collect-coverage/action.yml
+++ b/.github/actions/collect-coverage/action.yml
@@ -49,6 +49,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Detect coverage files
       id: detect
       if: inputs.coverage-files == ''
@@ -56,7 +62,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       env:
         STEP: detect
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/collect-coverage.sh
+      run: $SCRIPTS_DIR/ci/actions/collect-coverage.sh
 
     - name: Merge coverage
       id: merge
@@ -70,7 +76,7 @@ runs:
         OUTPUT_FORMAT: ${{ inputs.output-format }}
         MERGE_STRATEGY: ${{ inputs.merge-strategy }}
         OUTPUT_FILE: ${{ inputs.output-file }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/collect-coverage.sh
+      run: $SCRIPTS_DIR/ci/actions/collect-coverage.sh
 
     - name: Generate summary
       id: summary
@@ -80,7 +86,7 @@ runs:
         STEP: summary
         COVERAGE_FILE: ${{ steps.merge.outputs.merged-coverage-file }}
         COVERAGE_PERCENT: ${{ steps.merge.outputs.coverage-percent }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/collect-coverage.sh
+      run: $SCRIPTS_DIR/ci/actions/collect-coverage.sh
 
 branding:
   icon: "pie-chart"

--- a/.github/actions/create-github-release/action.yml
+++ b/.github/actions/create-github-release/action.yml
@@ -47,6 +47,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Create GitHub release
       id: release
       shell: bash
@@ -60,7 +66,7 @@ runs:
         FILES: ${{ inputs.files }}
         REPO: ${{ inputs.repo }}
         GH_TOKEN: ${{ github.token }}
-      run: ${{ github.action_path }}/../../../scripts/ci/release/create-github-release.sh
+      run: $SCRIPTS_DIR/ci/release/create-github-release.sh
 
 branding:
   icon: "package"

--- a/.github/actions/create-release-tag/action.yml
+++ b/.github/actions/create-release-tag/action.yml
@@ -41,6 +41,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Create release tag
       id: tag
       shell: bash
@@ -50,7 +56,7 @@ runs:
         MESSAGE: ${{ inputs.message }}
         PUSH: ${{ inputs.push }}
         FROM_REF: ${{ inputs.from-ref }}
-      run: ${{ github.action_path }}/../../../scripts/ci/release/create-tag.sh
+      run: $SCRIPTS_DIR/ci/release/create-tag.sh
 
 branding:
   icon: "tag"

--- a/.github/actions/deploy-pages/action.yml
+++ b/.github/actions/deploy-pages/action.yml
@@ -28,6 +28,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Prepare content
       id: prepare
       shell: bash
@@ -35,14 +41,14 @@ runs:
         STEP: prepare
         SOURCE_PATH: ${{ inputs.source-path }}
         BUILD_COMMAND: ${{ inputs.build-command }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/deploy-pages.sh
+      run: $SCRIPTS_DIR/ci/actions/deploy-pages.sh
 
     - name: Validate content
       shell: bash
       env:
         STEP: validate
         SOURCE_PATH: ${{ inputs.source-path }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/deploy-pages.sh
+      run: $SCRIPTS_DIR/ci/actions/deploy-pages.sh
 
     - name: Upload Pages artifact
       id: upload

--- a/.github/actions/egress-audit/action.yml
+++ b/.github/actions/egress-audit/action.yml
@@ -46,6 +46,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Setup egress monitoring
       id: setup
       shell: bash
@@ -53,7 +59,7 @@ runs:
         STEP: setup
         MODE: ${{ inputs.mode }}
         ALLOWED_DOMAINS: ${{ inputs['allowed-domains'] }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/egress-audit.sh
+      run: $SCRIPTS_DIR/ci/actions/egress-audit.sh
 
     - name: Configure egress policy
       id: audit
@@ -62,7 +68,7 @@ runs:
         STEP: audit
         MODE: ${{ inputs.mode }}
         FAIL_ON_VIOLATION: ${{ inputs['fail-on-violation'] }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/egress-audit.sh
+      run: $SCRIPTS_DIR/ci/actions/egress-audit.sh
 
     - name: Generate egress report
       if: inputs['report-format'] != 'none'
@@ -71,7 +77,7 @@ runs:
         STEP: report
         MODE: ${{ inputs.mode }}
         REPORT_FORMAT: ${{ inputs['report-format'] }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/egress-audit.sh
+      run: $SCRIPTS_DIR/ci/actions/egress-audit.sh
 
 branding:
   icon: "wifi"

--- a/.github/actions/generate-changelog/action.yml
+++ b/.github/actions/generate-changelog/action.yml
@@ -33,6 +33,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Generate changelog
       id: generate
       shell: bash
@@ -42,7 +48,7 @@ runs:
         VERSION: ${{ inputs.version }}
         FORMAT: ${{ inputs.format }}
         OUTPUT_FILE: ${{ inputs.output-file }}
-      run: ${{ github.action_path }}/../../../scripts/ci/release/generate-changelog.sh
+      run: $SCRIPTS_DIR/ci/release/generate-changelog.sh
 
 branding:
   icon: "file-text"

--- a/.github/actions/generate-coverage-badge/action.yml
+++ b/.github/actions/generate-coverage-badge/action.yml
@@ -50,6 +50,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Calculate coverage
       id: calculate
       shell: bash
@@ -60,7 +66,7 @@ runs:
         COVERAGE_PERCENT: ${{ inputs.coverage-percent }}
         RED_THRESHOLD: ${{ fromJSON(format('[{0}]', inputs.thresholds))[0] || 50 }}
         YELLOW_THRESHOLD: ${{ fromJSON(format('[{0}]', inputs.thresholds))[1] || 80 }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/generate-coverage-badge.sh
+      run: $SCRIPTS_DIR/ci/actions/generate-coverage-badge.sh
 
     - name: Generate badge
       id: generate
@@ -74,7 +80,7 @@ runs:
         LABEL: ${{ inputs.label }}
         RED_THRESHOLD: ${{ fromJSON(format('[{0}]', inputs.thresholds))[0] || 50 }}
         YELLOW_THRESHOLD: ${{ fromJSON(format('[{0}]', inputs.thresholds))[1] || 80 }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/generate-coverage-badge.sh
+      run: $SCRIPTS_DIR/ci/actions/generate-coverage-badge.sh
 
     - name: Generate summary
       shell: bash
@@ -83,7 +89,7 @@ runs:
         COVERAGE_PERCENT: ${{ steps.calculate.outputs.coverage-percent }}
         BADGE_FILE: ${{ steps.generate.outputs.badge-file }}
         BADGE_URL: ${{ steps.generate.outputs.badge-url }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/generate-coverage-badge.sh
+      run: $SCRIPTS_DIR/ci/actions/generate-coverage-badge.sh
 
 branding:
   icon: "award"

--- a/.github/actions/generate-coverage-comment/action.yml
+++ b/.github/actions/generate-coverage-comment/action.yml
@@ -60,6 +60,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Generate comment
       id: generate
       shell: bash
@@ -72,8 +78,7 @@ runs:
         THRESHOLD_FUNCTIONS: ${{ inputs['threshold-functions'] }}
         SHOW_FILE_COVERAGE: ${{ inputs['show-file-coverage'] }}
         MAX_FILES: ${{ inputs['max-files'] }}
-      run: ${{ github.action_path
-        }}/../../../scripts/ci/actions/generate-coverage-comment.sh
+      run: $SCRIPTS_DIR/ci/actions/generate-coverage-comment.sh
 
 branding:
   icon: "percent"

--- a/.github/actions/generate-lighthouse-comment/action.yml
+++ b/.github/actions/generate-lighthouse-comment/action.yml
@@ -51,6 +51,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Generate comment
       id: generate
       shell: bash
@@ -61,8 +67,7 @@ runs:
         THRESHOLD_ACCESSIBILITY: ${{ inputs['threshold-accessibility'] }}
         THRESHOLD_BEST_PRACTICES: ${{ inputs['threshold-best-practices'] }}
         THRESHOLD_SEO: ${{ inputs['threshold-seo'] }}
-      run: ${{ github.action_path
-        }}/../../../scripts/ci/actions/generate-lighthouse-comment.sh
+      run: $SCRIPTS_DIR/ci/actions/generate-lighthouse-comment.sh
 
 branding:
   icon: "zap"

--- a/.github/actions/generate-playwright-comment/action.yml
+++ b/.github/actions/generate-playwright-comment/action.yml
@@ -44,6 +44,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Generate comment
       id: generate
       shell: bash
@@ -52,7 +58,7 @@ runs:
         REPORT_URL: ${{ inputs['report-url'] }}
         SHOW_FAILED: ${{ inputs['show-failed-tests'] }}
         MAX_FAILED: ${{ inputs['max-failed-tests'] }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/generate-playwright-comment.sh
+      run: $SCRIPTS_DIR/ci/actions/generate-playwright-comment.sh
 
 branding:
   icon: "play-circle"

--- a/.github/actions/generate-sbom/action.yml
+++ b/.github/actions/generate-sbom/action.yml
@@ -43,6 +43,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Generate SBOM
       id: generate
       # Pinned to SHA for supply chain security
@@ -63,7 +69,7 @@ runs:
         STEP: summary
         SBOM_FILE: ${{ inputs.output-file }}
         FORMAT: ${{ inputs.format }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/generate-sbom.sh
+      run: $SCRIPTS_DIR/ci/actions/generate-sbom.sh
 
 branding:
   icon: "package"

--- a/.github/actions/merge-playwright-reports/action.yml
+++ b/.github/actions/merge-playwright-reports/action.yml
@@ -37,6 +37,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Collect reports
       id: collect
       shell: bash
@@ -44,8 +50,7 @@ runs:
         STEP: collect
         INPUT_DIR: ${{ inputs.input-dir }}
         OUTPUT_DIR: ${{ inputs.output-dir }}
-      run: ${{ github.action_path
-        }}/../../../scripts/ci/actions/merge-playwright-reports.sh
+      run: $SCRIPTS_DIR/ci/actions/merge-playwright-reports.sh
 
     - name: Merge reports
       id: merge
@@ -56,8 +61,7 @@ runs:
         INPUT_DIR: ${{ inputs.input-dir }}
         OUTPUT_DIR: ${{ inputs.output-dir }}
         REPORT_FORMAT: ${{ inputs.report-format }}
-      run: ${{ github.action_path
-        }}/../../../scripts/ci/actions/merge-playwright-reports.sh
+      run: $SCRIPTS_DIR/ci/actions/merge-playwright-reports.sh
 
     - name: Parse merged results
       id: parse
@@ -67,7 +71,7 @@ runs:
         STEP: parse-merged
         MERGED_PATH: ${{ steps.merge.outputs.merged-path }}
       run: |
-        ${{ github.action_path }}/../../../scripts/ci/actions/merge-playwright-reports.sh
+        $SCRIPTS_DIR/ci/actions/merge-playwright-reports.sh
 
     - name: Generate summary
       if: steps.collect.outputs.report-count != '0'
@@ -78,8 +82,7 @@ runs:
         TOTAL_FAILED: ${{ steps.parse.outputs.total-failed }}
         TOTAL_SKIPPED: ${{ steps.parse.outputs.total-skipped }}
         REPORT_COUNT: ${{ steps.collect.outputs.report-count }}
-      run: ${{ github.action_path
-        }}/../../../scripts/ci/actions/merge-playwright-reports.sh
+      run: $SCRIPTS_DIR/ci/actions/merge-playwright-reports.sh
 
 branding:
   icon: "layers"

--- a/.github/actions/post-pr-comment/action.yml
+++ b/.github/actions/post-pr-comment/action.yml
@@ -46,6 +46,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Detect PR number
       id: pr
       shell: bash
@@ -57,7 +63,7 @@ runs:
         EVENT_NAME: ${{ github.event_name }}
         EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
         EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/post-pr-comment.sh
+      run: $SCRIPTS_DIR/ci/actions/post-pr-comment.sh
 
     - name: Read comment from file
       id: read
@@ -66,7 +72,7 @@ runs:
       env:
         STEP: read-file
         COMMENT_FILE: ${{ inputs.file }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/post-pr-comment.sh
+      run: $SCRIPTS_DIR/ci/actions/post-pr-comment.sh
 
     - name: Post comment
       id: post
@@ -83,7 +89,7 @@ runs:
         FILE_PROVIDED: ${{ steps.read.outputs.file_provided }}
         BODY_FROM_FILE: ${{ steps.read.outputs.body }}
         BODY_FROM_INPUT: ${{ inputs.body }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/post-pr-comment.sh
+      run: $SCRIPTS_DIR/ci/actions/post-pr-comment.sh
 
 branding:
   icon: "message-square"

--- a/.github/actions/publish-gem/action.yml
+++ b/.github/actions/publish-gem/action.yml
@@ -34,6 +34,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Validate gemspec
       id: validate
       shell: bash
@@ -41,7 +47,7 @@ runs:
         STEP: validate
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
         GEMSPEC: ${{ inputs.gemspec }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/publish-gem.sh
+      run: $SCRIPTS_DIR/ci/actions/publish-gem.sh
 
     - name: Build gem
       id: build
@@ -50,7 +56,7 @@ runs:
         STEP: build
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
         GEMSPEC: ${{ inputs.gemspec }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/publish-gem.sh
+      run: $SCRIPTS_DIR/ci/actions/publish-gem.sh
 
     - name: Publish to RubyGems
       id: publish
@@ -60,7 +66,7 @@ runs:
         STEP: publish
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
         GEM_FILE: ${{ steps.build.outputs.gem-file }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/publish-gem.sh
+      run: $SCRIPTS_DIR/ci/actions/publish-gem.sh
 
     - name: Generate summary
       shell: bash
@@ -71,7 +77,7 @@ runs:
         GEM_FILE: ${{ steps.build.outputs.gem-file }}
         DRY_RUN: ${{ inputs.dry-run }}
         PUBLISHED: ${{ steps.publish.outputs.published || 'false' }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/publish-gem.sh
+      run: $SCRIPTS_DIR/ci/actions/publish-gem.sh
 
 branding:
   icon: "box"

--- a/.github/actions/publish-npm/action.yml
+++ b/.github/actions/publish-npm/action.yml
@@ -46,13 +46,19 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Validate package
       id: validate
       shell: bash
       env:
         STEP: validate
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/publish-npm.sh
+      run: $SCRIPTS_DIR/ci/actions/publish-npm.sh
 
     - name: Build and pack
       id: build
@@ -60,7 +66,7 @@ runs:
       env:
         STEP: build
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/publish-npm.sh
+      run: $SCRIPTS_DIR/ci/actions/publish-npm.sh
 
     - name: Publish to npm
       id: publish
@@ -72,7 +78,7 @@ runs:
         DIST_TAG: ${{ inputs.dist-tag }}
         PROVENANCE: ${{ inputs.provenance }}
         ACCESS: ${{ inputs.access }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/publish-npm.sh
+      run: $SCRIPTS_DIR/ci/actions/publish-npm.sh
 
     - name: Generate summary
       shell: bash
@@ -84,7 +90,7 @@ runs:
         DIST_TAG: ${{ inputs.dist-tag }}
         DRY_RUN: ${{ inputs.dry-run }}
         PUBLISHED: ${{ steps.publish.outputs.published || 'false' }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/publish-npm.sh
+      run: $SCRIPTS_DIR/ci/actions/publish-npm.sh
 
 branding:
   icon: "package"

--- a/.github/actions/publish-pypi/action.yml
+++ b/.github/actions/publish-pypi/action.yml
@@ -35,6 +35,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Validate package metadata
       id: validate
       if: inputs.validate == 'true'
@@ -42,7 +48,7 @@ runs:
       env:
         STEP: validate
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/publish-pypi.sh
+      run: $SCRIPTS_DIR/ci/actions/publish-pypi.sh
 
     - name: Build package
       id: build
@@ -50,7 +56,7 @@ runs:
       env:
         STEP: build
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/publish-pypi.sh
+      run: $SCRIPTS_DIR/ci/actions/publish-pypi.sh
 
     - name: Validate distribution
       if: inputs.validate == 'true'
@@ -58,7 +64,7 @@ runs:
       env:
         STEP: validate-dist
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/publish-pypi.sh
+      run: $SCRIPTS_DIR/ci/actions/publish-pypi.sh
 
     - name: Publish to PyPI
       id: publish
@@ -86,7 +92,7 @@ runs:
         DRY_RUN: ${{ inputs.dry-run }}
         TEST_PYPI: ${{ inputs.test-pypi }}
         PUBLISHED: ${{ steps.set-published.outputs.published || 'false' }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/publish-pypi.sh
+      run: $SCRIPTS_DIR/ci/actions/publish-pypi.sh
 
 branding:
   icon: "upload-cloud"

--- a/.github/actions/publish-test-results/action.yml
+++ b/.github/actions/publish-test-results/action.yml
@@ -45,6 +45,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Prepare files
       id: prepare
       shell: bash
@@ -57,7 +63,7 @@ runs:
         TARGET_DIR: ${{ inputs.target-dir }}
         KEEP_HISTORY: ${{ inputs.keep-history }}
         RETENTION_DAYS: ${{ inputs.retention-days }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/publish-test-results.sh
+      run: $SCRIPTS_DIR/ci/actions/publish-test-results.sh
 
     - name: Deploy to GitHub Pages
       id: deploy
@@ -77,7 +83,7 @@ runs:
       env:
         STEP: pages-url
         TARGET_DIR: ${{ inputs.target-dir }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/publish-test-results.sh
+      run: $SCRIPTS_DIR/ci/actions/publish-test-results.sh
 
     - name: Generate summary
       shell: bash
@@ -85,7 +91,7 @@ runs:
         STEP: summary
         PAGES_URL: ${{ steps.pages-url.outputs.pages-url }}
         TARGET_BRANCH: ${{ inputs.target-branch }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/publish-test-results.sh
+      run: $SCRIPTS_DIR/ci/actions/publish-test-results.sh
 
 branding:
   icon: "upload-cloud"

--- a/.github/actions/run-lighthouse/action.yml
+++ b/.github/actions/run-lighthouse/action.yml
@@ -69,6 +69,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Setup Node.js
       uses: ./.github/actions/setup-node
       with:
@@ -78,7 +84,7 @@ runs:
       shell: bash
       env:
         STEP: setup
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-lighthouse.sh
+      run: $SCRIPTS_DIR/ci/actions/run-lighthouse.sh
 
     - name: Run Lighthouse
       id: run
@@ -89,7 +95,7 @@ runs:
         CONFIG_PATH: ${{ inputs.config-path }}
         OUTPUT_DIR: ${{ inputs.output-dir }}
         EXTRA_ARGS: ${{ inputs.extra-args }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-lighthouse.sh
+      run: $SCRIPTS_DIR/ci/actions/run-lighthouse.sh
       continue-on-error: true
 
     - name: Parse results
@@ -103,7 +109,7 @@ runs:
         THRESHOLD_ACCESSIBILITY: ${{ inputs.threshold-accessibility }}
         THRESHOLD_BEST_PRACTICES: ${{ inputs.threshold-best-practices }}
         THRESHOLD_SEO: ${{ inputs.threshold-seo }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-lighthouse.sh
+      run: $SCRIPTS_DIR/ci/actions/run-lighthouse.sh
 
     - name: Generate summary
       shell: bash
@@ -118,7 +124,7 @@ runs:
         THRESHOLD_ACCESSIBILITY: ${{ inputs.threshold-accessibility }}
         THRESHOLD_BEST_PRACTICES: ${{ inputs.threshold-best-practices }}
         THRESHOLD_SEO: ${{ inputs.threshold-seo }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-lighthouse.sh
+      run: $SCRIPTS_DIR/ci/actions/run-lighthouse.sh
 
     - name: Upload results
       if: always()

--- a/.github/actions/run-playwright/action.yml
+++ b/.github/actions/run-playwright/action.yml
@@ -56,6 +56,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Setup Node.js
       uses: ./.github/actions/setup-node
       with:
@@ -68,7 +74,7 @@ runs:
       env:
         STEP: setup
         BROWSER: ${{ inputs.browser }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-playwright.sh
+      run: $SCRIPTS_DIR/ci/actions/run-playwright.sh
 
     - name: Run Playwright
       id: run
@@ -81,7 +87,7 @@ runs:
         REPORTER: ${{ inputs.reporter }}
         SHARD: ${{ inputs.shard }}
         EXTRA_ARGS: ${{ inputs.extra-args }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-playwright.sh
+      run: $SCRIPTS_DIR/ci/actions/run-playwright.sh
       continue-on-error: true
 
     - name: Parse results
@@ -92,7 +98,7 @@ runs:
         STEP: parse
         REPORT_PATH: ${{ steps.run.outputs.report-path }}
         REPORTER: ${{ inputs.reporter }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-playwright.sh
+      run: $SCRIPTS_DIR/ci/actions/run-playwright.sh
 
     - name: Generate summary
       shell: bash
@@ -105,7 +111,7 @@ runs:
         BROWSER: ${{ inputs.browser }}
         SHARD: ${{ inputs.shard }}
         EXIT_CODE: ${{ steps.run.outputs.exit-code }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-playwright.sh
+      run: $SCRIPTS_DIR/ci/actions/run-playwright.sh
 
     - name: Upload report
       if: inputs.reporter == 'html' && always()

--- a/.github/actions/run-pytest/action.yml
+++ b/.github/actions/run-pytest/action.yml
@@ -59,6 +59,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Setup Python
       uses: ./.github/actions/setup-python
       with:
@@ -71,7 +77,7 @@ runs:
       env:
         STEP: setup
         COVERAGE: ${{ inputs.coverage }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-pytest.sh
+      run: $SCRIPTS_DIR/ci/actions/run-pytest.sh
 
     - name: Run pytest
       id: run
@@ -84,7 +90,7 @@ runs:
         COVERAGE_FORMAT: ${{ inputs.coverage-format }}
         MARKERS: ${{ inputs.markers }}
         EXTRA_ARGS: ${{ inputs.extra-args }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-pytest.sh
+      run: $SCRIPTS_DIR/ci/actions/run-pytest.sh
       continue-on-error: true
 
     - name: Parse results
@@ -95,7 +101,7 @@ runs:
         STEP: parse
         RESULTS_FILE: pytest-results.json
         COVERAGE_FILE: ${{ steps.run.outputs.coverage-file }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-pytest.sh
+      run: $SCRIPTS_DIR/ci/actions/run-pytest.sh
 
     - name: Generate summary
       shell: bash
@@ -107,7 +113,7 @@ runs:
         TESTS_TOTAL: ${{ steps.parse.outputs.tests-total }}
         COVERAGE_PERCENT: ${{ steps.parse.outputs.coverage-percent }}
         EXIT_CODE: ${{ steps.run.outputs.exit-code }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-pytest.sh
+      run: $SCRIPTS_DIR/ci/actions/run-pytest.sh
 
     - name: Check test result
       if: steps.run.outputs.exit-code != '' && steps.run.outputs.exit-code != '0'

--- a/.github/actions/run-quality/action.yml
+++ b/.github/actions/run-quality/action.yml
@@ -36,6 +36,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Run lintro quality checks
       id: lint
       shell: bash
@@ -44,7 +50,7 @@ runs:
         STEP: ${{ inputs.mode }}
         TOOLS: ${{ inputs.tools }}
         FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
-      run: ${{ github.action_path }}/../../../scripts/ci/quality/lint-check.sh
+      run: $SCRIPTS_DIR/ci/quality/lint-check.sh
 
     - name: Run actionlint
       if: inputs.run-actionlint == 'true'
@@ -55,7 +61,7 @@ runs:
         FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
       run: |
         if command -v actionlint &>/dev/null; then
-          ${{ github.action_path }}/../../../scripts/ci/quality/actionlint-check.sh
+          $SCRIPTS_DIR/ci/quality/actionlint-check.sh
           EXIT_CODE=$?
           if [[ "$FAIL_ON_ERROR" != "true" ]]; then
             exit 0

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -55,13 +55,19 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Detect test runner
       id: detect
       shell: bash
       env:
         STEP: detect
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-tests.sh
+      run: $SCRIPTS_DIR/ci/actions/run-tests.sh
 
     - name: Run tests
       id: run
@@ -73,7 +79,7 @@ runs:
         COVERAGE_FORMAT: ${{ inputs.coverage-format }}
         EXTRA_ARGS: ${{ inputs.extra-args }}
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-tests.sh
+      run: $SCRIPTS_DIR/ci/actions/run-tests.sh
       continue-on-error: true
 
     - name: Parse results
@@ -85,7 +91,7 @@ runs:
           ${{ inputs.runner != 'auto' && inputs.runner != '' && inputs.runner ||
           steps.detect.outputs.runner }}
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-tests.sh
+      run: $SCRIPTS_DIR/ci/actions/run-tests.sh
 
     - name: Generate summary
       shell: bash
@@ -99,7 +105,7 @@ runs:
         TESTS_SKIPPED: ${{ steps.parse.outputs.tests-skipped }}
         TESTS_TOTAL: ${{ steps.parse.outputs.tests-total }}
         EXIT_CODE: ${{ steps.run.outputs.exit-code }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-tests.sh
+      run: $SCRIPTS_DIR/ci/actions/run-tests.sh
 
     - name: Check test result
       if: steps.run.outputs.exit-code != '' && steps.run.outputs.exit-code != '0'

--- a/.github/actions/run-vitest/action.yml
+++ b/.github/actions/run-vitest/action.yml
@@ -55,6 +55,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Setup Node.js
       uses: ./.github/actions/setup-node
       with:
@@ -67,7 +73,7 @@ runs:
       env:
         STEP: setup
         COVERAGE: ${{ inputs.coverage }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-vitest.sh
+      run: $SCRIPTS_DIR/ci/actions/run-vitest.sh
 
     - name: Run vitest
       id: run
@@ -79,7 +85,7 @@ runs:
         COVERAGE: ${{ inputs.coverage }}
         COVERAGE_FORMAT: ${{ inputs.coverage-format }}
         EXTRA_ARGS: ${{ inputs.extra-args }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-vitest.sh
+      run: $SCRIPTS_DIR/ci/actions/run-vitest.sh
       continue-on-error: true
 
     - name: Parse results
@@ -90,7 +96,7 @@ runs:
         STEP: parse
         RESULTS_FILE: vitest-results.json
         COVERAGE_FILE: ${{ steps.run.outputs.coverage-file }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-vitest.sh
+      run: $SCRIPTS_DIR/ci/actions/run-vitest.sh
 
     - name: Generate summary
       shell: bash
@@ -102,7 +108,7 @@ runs:
         TESTS_TOTAL: ${{ steps.parse.outputs.tests-total }}
         COVERAGE_PERCENT: ${{ steps.parse.outputs.coverage-percent }}
         EXIT_CODE: ${{ steps.run.outputs.exit-code }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/run-vitest.sh
+      run: $SCRIPTS_DIR/ci/actions/run-vitest.sh
 
     - name: Check test result
       if: steps.run.outputs.exit-code != '' && steps.run.outputs.exit-code != '0'

--- a/.github/actions/scan-vulnerabilities/action.yml
+++ b/.github/actions/scan-vulnerabilities/action.yml
@@ -51,6 +51,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Determine scan target
       id: target
       shell: bash
@@ -120,7 +126,7 @@ runs:
         STEP: sarif
         TARGET: ${{ steps.target.outputs.path }}
         TARGET_TYPE: ${{ inputs.target-type }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/scan-vulnerabilities.sh
+      run: $SCRIPTS_DIR/ci/actions/scan-vulnerabilities.sh
 
     - name: Upload SARIF to GitHub Security
       if: inputs.upload-sarif == 'true' && steps.sarif.outputs.sarif-file != ''
@@ -140,7 +146,7 @@ runs:
         HIGH_COUNT: ${{ steps.counts.outputs.high-count }}
         MEDIUM_COUNT: ${{ steps.counts.outputs.medium-count }}
         LOW_COUNT: ${{ steps.counts.outputs.low-count }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/scan-vulnerabilities.sh
+      run: $SCRIPTS_DIR/ci/actions/scan-vulnerabilities.sh
 
 branding:
   icon: "shield"

--- a/.github/actions/secure-checkout/action.yml
+++ b/.github/actions/secure-checkout/action.yml
@@ -88,6 +88,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Checkout repository
       id: checkout
       # Pinned to SHA for supply chain security
@@ -119,9 +125,7 @@ runs:
         STEP: repo-dir
         WORKSPACE: ${{ github.workspace }}
         CHECKOUT_PATH: ${{ inputs.path }}
-      run: |
-        SCRIPT="${GITHUB_ACTION_PATH//\\//}/../../../scripts/ci/actions/secure-checkout.sh"
-        "$SCRIPT"
+      run: $SCRIPTS_DIR/ci/actions/secure-checkout.sh
 
     - name: Verify checkout integrity
       shell: bash
@@ -130,9 +134,7 @@ runs:
         STEP: verify
         REPOSITORY: ${{ inputs.repository }}
         PERSIST_CREDENTIALS: ${{ inputs['persist-credentials'] }}
-      run: |
-        SCRIPT="${GITHUB_ACTION_PATH//\\//}/../../../scripts/ci/actions/secure-checkout.sh"
-        "$SCRIPT"
+      run: $SCRIPTS_DIR/ci/actions/secure-checkout.sh
 
 branding:
   icon: "download"

--- a/.github/actions/semantic-pr-title/action.yml
+++ b/.github/actions/semantic-pr-title/action.yml
@@ -50,6 +50,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Validate PR title
       id: validate
       shell: bash
@@ -60,7 +66,7 @@ runs:
         REQUIRE_SCOPE: ${{ inputs['require-scope'] }}
         MAX_LENGTH: ${{ inputs['max-length'] }}
         FAIL_ON_INVALID: ${{ inputs['fail-on-invalid'] }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/semantic-pr-title.sh
+      run: $SCRIPTS_DIR/ci/actions/semantic-pr-title.sh
 
 branding:
   icon: "check-circle"

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -30,13 +30,19 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Setup environment
       id: setup
       shell: bash
       env:
         BIN_DIR: ${{ inputs['bin-dir'] }}
         ADD_TO_PATH: ${{ inputs['add-to-path'] }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/setup-env.sh
+      run: $SCRIPTS_DIR/ci/actions/setup-env.sh
 
 branding:
   icon: "settings"

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -47,6 +47,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Setup Node.js
       # Pinned to SHA for supply chain security - line exceeds 80 but under 120 limit
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -58,7 +64,7 @@ runs:
       shell: bash
       env:
         STEP: node-version
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/setup-node.sh
+      run: $SCRIPTS_DIR/ci/actions/setup-node.sh
 
     - name: Setup Bun
       # Pinned to SHA for supply chain security - line exceeds 80 but under 120 limit
@@ -71,7 +77,7 @@ runs:
       shell: bash
       env:
         STEP: bun-version
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/setup-node.sh
+      run: $SCRIPTS_DIR/ci/actions/setup-node.sh
 
     - name: Get bun cache directory
       id: bun-cache
@@ -79,7 +85,7 @@ runs:
       shell: bash
       env:
         STEP: bun-cache
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/setup-node.sh
+      run: $SCRIPTS_DIR/ci/actions/setup-node.sh
 
     - name: Cache bun dependencies
       if: inputs.cache == 'true'
@@ -108,7 +114,7 @@ runs:
       env:
         STEP: deps
         FROZEN_LOCKFILE: ${{ inputs['frozen-lockfile'] }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/setup-node.sh
+      run: $SCRIPTS_DIR/ci/actions/setup-node.sh
 
 branding:
   icon: "package"

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -50,6 +50,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Install uv
       # Pinned to SHA for supply chain security
       uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.1.0
@@ -62,7 +68,7 @@ runs:
       shell: bash
       env:
         STEP: uv-version
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/setup-python.sh
+      run: $SCRIPTS_DIR/ci/actions/setup-python.sh
 
     - name: Setup Python
       shell: bash
@@ -70,7 +76,7 @@ runs:
       env:
         STEP: python-install
         PYTHON_VERSION: ${{ inputs.python-version }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/setup-python.sh
+      run: $SCRIPTS_DIR/ci/actions/setup-python.sh
 
     - name: Get Python version
       id: python-version
@@ -78,7 +84,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       env:
         STEP: python-version
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/setup-python.sh
+      run: $SCRIPTS_DIR/ci/actions/setup-python.sh
 
     - name: Cache uv dependencies
       if: inputs.cache == 'true'
@@ -104,7 +110,7 @@ runs:
       env:
         STEP: deps
         EXTRAS: ${{ inputs.install-extras }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/setup-python.sh
+      run: $SCRIPTS_DIR/ci/actions/setup-python.sh
 
 branding:
   icon: "code"

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -45,6 +45,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Setup Ruby
       # Pinned to SHA for supply chain security
       uses: ruby/setup-ruby@a4effe49ee8ee5b8224f9b18fb5c7d6ac6239857 # v1.221.0
@@ -58,21 +64,21 @@ runs:
       shell: bash
       env:
         STEP: ruby-version
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/setup-ruby.sh
+      run: $SCRIPTS_DIR/ci/actions/setup-ruby.sh
 
     - name: Get Bundler version
       id: bundler-version
       shell: bash
       env:
         STEP: bundler-version
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/setup-ruby.sh
+      run: $SCRIPTS_DIR/ci/actions/setup-ruby.sh
 
     - name: Configure bundler
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
         STEP: bundle-config
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/setup-ruby.sh
+      run: $SCRIPTS_DIR/ci/actions/setup-ruby.sh
 
     - name: Cache gem dependencies
       if: inputs.cache == 'true'
@@ -97,7 +103,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       env:
         STEP: deps
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/setup-ruby.sh
+      run: $SCRIPTS_DIR/ci/actions/setup-ruby.sh
 
 branding:
   icon: "package"

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -43,6 +43,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Install Rust toolchain
       # Pinned to SHA for supply chain security
       uses: dtolnay/rust-toolchain@a54c7afa936fefeb4456b2dd8068152669aa8203 # master
@@ -56,13 +62,13 @@ runs:
       shell: bash
       env:
         STEP: version
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/setup-rust.sh
+      run: $SCRIPTS_DIR/ci/actions/setup-rust.sh
 
     - name: Configure cargo for CI
       shell: bash
       env:
         STEP: cargo-env
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/setup-rust.sh
+      run: $SCRIPTS_DIR/ci/actions/setup-rust.sh
 
     - name: Cache cargo registry and build
       if: inputs.cache == 'true'
@@ -88,7 +94,7 @@ runs:
       shell: bash
       env:
         STEP: binstall
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/setup-rust.sh
+      run: $SCRIPTS_DIR/ci/actions/setup-rust.sh
 
 branding:
   icon: "cpu"

--- a/.github/actions/sign-artifact/action.yml
+++ b/.github/actions/sign-artifact/action.yml
@@ -41,6 +41,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Install Cosign
       # Pinned to SHA for supply chain security
       uses: sigstore/cosign-installer@c56c2d3e59e4281cc41dea2217323ba5694b171e # v3.8.0
@@ -51,7 +57,7 @@ runs:
       env:
         STEP: sign
         FILES: ${{ inputs.files }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/sign-artifact.sh
+      run: $SCRIPTS_DIR/ci/actions/sign-artifact.sh
 
     - name: Upload signatures artifact
       if: steps.sign.outputs.signed-count != '0' && inputs.upload-signatures == 'true'
@@ -75,7 +81,7 @@ runs:
         STEP: upload-release
         RELEASE_TAG: ${{ inputs.release-tag }}
         SIGNATURES_DIR: ${{ steps.sign.outputs.signatures-dir }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/sign-artifact.sh
+      run: $SCRIPTS_DIR/ci/actions/sign-artifact.sh
 
     - name: Generate summary
       if: always()
@@ -86,7 +92,7 @@ runs:
         FILES: ${{ inputs.files }}
         CERTIFICATE: ${{ steps.sign.outputs.certificate }}
         SIGNATURES: ${{ steps.sign.outputs.signatures }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/sign-artifact.sh
+      run: $SCRIPTS_DIR/ci/actions/sign-artifact.sh
 
 branding:
   icon: "edit-3"

--- a/.github/actions/update-homebrew/action.yml
+++ b/.github/actions/update-homebrew/action.yml
@@ -51,6 +51,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Wait for package availability
       if: inputs.wait-for-availability == 'true'
       shell: bash
@@ -60,7 +66,7 @@ runs:
         VERSION: ${{ inputs.version }}
         MAX_WAIT: ${{ inputs.max-wait-minutes }}
         TEST_PYPI: ${{ inputs.test-pypi }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/update-homebrew.sh
+      run: $SCRIPTS_DIR/ci/actions/update-homebrew.sh
 
     - name: Generate formula
       id: generate
@@ -72,7 +78,7 @@ runs:
         PACKAGE: ${{ inputs.package-name }}
         VERSION: ${{ inputs.version }}
         TEST_PYPI: ${{ inputs.test-pypi }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/update-homebrew.sh
+      run: $SCRIPTS_DIR/ci/actions/update-homebrew.sh
 
     - name: Commit changes
       id: commit
@@ -86,7 +92,7 @@ runs:
         PUSH: ${{ inputs.push }}
         CREATE_PR: ${{ inputs.create-pr }}
         GH_TOKEN: ${{ github.token }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/update-homebrew.sh
+      run: $SCRIPTS_DIR/ci/actions/update-homebrew.sh
 
     - name: Create pull request
       id: pr
@@ -98,7 +104,7 @@ runs:
         FORMULA: ${{ inputs.formula }}
         VERSION: ${{ inputs.version }}
         GH_TOKEN: ${{ github.token }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/update-homebrew.sh
+      run: $SCRIPTS_DIR/ci/actions/update-homebrew.sh
 
     - name: Generate summary
       shell: bash
@@ -111,7 +117,7 @@ runs:
         UPDATED: ${{ steps.commit.outputs.updated || 'false' }}
         COMMIT_SHA: ${{ steps.commit.outputs.commit-sha }}
         PR_URL: ${{ steps.pr.outputs.pr-url }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/update-homebrew.sh
+      run: $SCRIPTS_DIR/ci/actions/update-homebrew.sh
 
 branding:
   icon: "download"

--- a/.github/actions/validate-package/action.yml
+++ b/.github/actions/validate-package/action.yml
@@ -26,13 +26,19 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Detect package type
       shell: bash
       env:
         STEP: detect
         PACKAGE_TYPE: ${{ inputs.type }}
         PACKAGE_PATH: ${{ inputs.path }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/validate-package.sh
+      run: $SCRIPTS_DIR/ci/actions/validate-package.sh
 
     - name: Validate package
       id: validate
@@ -41,7 +47,7 @@ runs:
         STEP: validate
         PACKAGE_TYPE: ${{ inputs.type }}
         PACKAGE_PATH: ${{ inputs.path }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/validate-package.sh
+      run: $SCRIPTS_DIR/ci/actions/validate-package.sh
 
     - name: Generate summary
       shell: bash
@@ -51,7 +57,7 @@ runs:
         PACKAGE_NAME: ${{ steps.validate.outputs.name }}
         PACKAGE_VERSION: ${{ steps.validate.outputs.version }}
         VALID: ${{ steps.validate.outputs.valid }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/validate-package.sh
+      run: $SCRIPTS_DIR/ci/actions/validate-package.sh
 
 branding:
   icon: "check-circle"

--- a/.github/actions/verify-attestation/action.yml
+++ b/.github/actions/verify-attestation/action.yml
@@ -31,6 +31,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Verify attestation
       id: verify
       shell: bash
@@ -40,7 +46,7 @@ runs:
         TARGET_TYPE: ${{ inputs.target-type }}
         OWNER: ${{ inputs.owner || github.repository_owner }}
         REPO: ${{ inputs.repo }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/verify-attestation.sh
+      run: $SCRIPTS_DIR/ci/actions/verify-attestation.sh
 
     - name: Parse verification output
       if: steps.verify.outputs.verified == 'true'
@@ -48,7 +54,7 @@ runs:
       env:
         STEP: parse
         VERIFICATION_OUTPUT: ${{ steps.verify.outputs.verification-output }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/verify-attestation.sh
+      run: $SCRIPTS_DIR/ci/actions/verify-attestation.sh
 
     - name: Generate summary
       if: always()
@@ -59,7 +65,7 @@ runs:
         SIGNER_IDENTITY: ${{ steps.verify.outputs.signer-identity }}
         TARGET: ${{ inputs.target }}
         TARGET_TYPE: ${{ inputs.target-type }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/verify-attestation.sh
+      run: $SCRIPTS_DIR/ci/actions/verify-attestation.sh
 
 branding:
   icon: "check-square"

--- a/.github/actions/verify-signature/action.yml
+++ b/.github/actions/verify-signature/action.yml
@@ -29,6 +29,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Install Cosign
       # Pinned to SHA for supply chain security
       uses: sigstore/cosign-installer@c56c2d3e59e4281cc41dea2217323ba5694b171e # v3.8.0
@@ -43,7 +49,7 @@ runs:
         CERTIFICATE: ${{ inputs.certificate }}
         CERTIFICATE_IDENTITY: ${{ inputs.certificate-identity }}
         CERTIFICATE_OIDC_ISSUER: ${{ inputs.certificate-oidc-issuer }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/verify-signature.sh
+      run: $SCRIPTS_DIR/ci/actions/verify-signature.sh
 
     - name: Generate summary
       if: always()
@@ -54,7 +60,7 @@ runs:
         FILE: ${{ inputs.file }}
         SIGNATURE: ${{ inputs.signature }}
         CERTIFICATE_IDENTITY: ${{ inputs.certificate-identity }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/verify-signature.sh
+      run: $SCRIPTS_DIR/ci/actions/verify-signature.sh
 
 branding:
   icon: "check-square"

--- a/.github/actions/wait-for-package/action.yml
+++ b/.github/actions/wait-for-package/action.yml
@@ -35,6 +35,12 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
     - name: Check initial availability
       id: check
       shell: bash
@@ -44,7 +50,7 @@ runs:
         PACKAGE: ${{ inputs.package }}
         VERSION: ${{ inputs.version }}
         TEST_PYPI: ${{ inputs.test-pypi }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/wait-for-package.sh
+      run: $SCRIPTS_DIR/ci/actions/wait-for-package.sh
 
     - name: Wait for availability
       id: wait
@@ -57,7 +63,7 @@ runs:
         VERSION: ${{ inputs.version }}
         MAX_WAIT: ${{ inputs.max-wait }}
         TEST_PYPI: ${{ inputs.test-pypi }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/wait-for-package.sh
+      run: $SCRIPTS_DIR/ci/actions/wait-for-package.sh
 
     - name: Generate summary
       shell: bash
@@ -70,7 +76,7 @@ runs:
           ${{ steps.check.outputs.available == 'true' && 'true' ||
           steps.wait.outputs.available || 'false' }}
         ELAPSED: ${{ steps.wait.outputs.elapsed || '0' }}
-      run: ${{ github.action_path }}/../../../scripts/ci/actions/wait-for-package.sh
+      run: $SCRIPTS_DIR/ci/actions/wait-for-package.sh
 
 branding:
   icon: "clock"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Add a `Resolve scripts directory` setup step to all 41 composite actions that reference bash scripts, replacing direct `${{ github.action_path }}` expansions with a normalized `$SCRIPTS_DIR` env var. On Windows runners, GitHub Actions expands `${{ github.action_path }}` with backslashes, which breaks Git Bash script execution. This centralizes the fix from PR #74 (which only addressed secure-checkout) across the entire action suite.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Related Issues

Fixes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored GitHub Actions workflows to centralize script path resolution across all action configurations, improving maintainability without affecting user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->