### PR TITLE
fix: add Renovate rule for container image digest pinning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,13 @@
       "automergeType": "branch"
     },
     {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/lgtm-hq/py-lintro"],
+      "pinDigests": true,
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
       "matchManagers": ["pip_requirements", "pep621"],
       "matchUpdateTypes": ["patch"],
       "automerge": true,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Adds a Renovate package rule to automatically manage digest pinning for the `ghcr.io/lgtm-hq/py-lintro` container image. The image is already SHA-pinned in CI workflows; this ensures Renovate keeps the digest up to date automatically.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Related Issues

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency updates with digest pinning and branch-based merging to enhance package management stability and streamline maintenance workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->