### PR TITLE
fix: replace awk TOML parsing with Python tomllib

### DIFF
--- a/scripts/ci/actions/publish-pypi.sh
+++ b/scripts/ci/actions/publish-pypi.sh
@@ -36,14 +36,8 @@ validate)
 		die "Invalid version format: $version"
 	fi
 
-	# Extract name (scoped to [project] or [tool.poetry] tables)
-	name=$(awk '/^\[project\]$/,/^\[/ { if (/^name\s*=/) print }' "pyproject.toml" |
-		head -1 | sed 's/.*=\s*["\x27]\([^"\x27]*\)["\x27].*/\1/')
-	if [[ -z "$name" ]]; then
-		# Try [tool.poetry] table
-		name=$(awk '/^\[tool\.poetry\]$/,/^\[/ { if (/^name\s*=/) print }' "pyproject.toml" |
-			head -1 | sed 's/.*=\s*["\x27]\([^"\x27]*\)["\x27].*/\1/')
-	fi
+	# Extract name
+	name=$(extract_pypi_name ".") || true
 	if [[ -z "$name" ]]; then
 		die "Could not extract package name from pyproject.toml"
 	fi
@@ -57,14 +51,9 @@ build)
 	# Clean previous builds
 	rm -rf dist/ build/ ./*.egg-info/
 
-	# Extract version and name first (scoped to [project] or [tool.poetry] tables)
+	# Extract version and name
 	version=$(extract_pypi_version ".") || die "Could not extract version"
-	name=$(awk '/^\[project\]$/,/^\[/ { if (/^name\s*=/) print }' "pyproject.toml" |
-		head -1 | sed 's/.*=\s*["\x27]\([^"\x27]*\)["\x27].*/\1/')
-	if [[ -z "$name" ]]; then
-		name=$(awk '/^\[tool\.poetry\]$/,/^\[/ { if (/^name\s*=/) print }' "pyproject.toml" |
-			head -1 | sed 's/.*=\s*["\x27]\([^"\x27]*\)["\x27].*/\1/')
-	fi
+	name=$(extract_pypi_name ".") || true
 
 	# Build using uv or python -m build
 	if command -v uv >/dev/null 2>&1; then

--- a/scripts/ci/actions/validate-package.sh
+++ b/scripts/ci/actions/validate-package.sh
@@ -65,12 +65,7 @@ validate)
 		# Extract version and name
 		if [[ -f "$PACKAGE_PATH/pyproject.toml" ]]; then
 			version=$(extract_pypi_version "$PACKAGE_PATH") || true
-			name=$(awk '/^\[project\]$/,/^\[/ { if (/^name\s*=/) print }' "$PACKAGE_PATH/pyproject.toml" |
-				head -1 | sed 's/.*=\s*["\x27]\([^"\x27]*\)["\x27].*/\1/' || true)
-			if [[ -z "$name" ]]; then
-				name=$(awk '/^\[tool\.poetry\]$/,/^\[/ { if (/^name\s*=/) print }' "$PACKAGE_PATH/pyproject.toml" |
-					head -1 | sed 's/.*=\s*["\x27]\([^"\x27]*\)["\x27].*/\1/' || true)
-			fi
+			name=$(extract_pypi_name "$PACKAGE_PATH") || true
 		fi
 
 		# Validate dist files if they exist

--- a/scripts/ci/lib/publish/version.sh
+++ b/scripts/ci/lib/publish/version.sh
@@ -9,7 +9,7 @@
 [[ -n "${_PUBLISH_VERSION_LOADED:-}" ]] && return 0
 readonly _PUBLISH_VERSION_LOADED=1
 
-# Extract version from pyproject.toml
+# Extract version from pyproject.toml using Python's tomllib (stdlib in 3.11+)
 # Usage: extract_pypi_version [path]
 # Returns version string or empty if not found
 extract_pypi_version() {
@@ -20,19 +20,53 @@ extract_pypi_version() {
 		return 1
 	fi
 
-	# Try [project] table first (PEP 621) - only match version within [project] section
 	local version
-	version=$(awk '/^\[project\]$/,/^\[/ { if (/^version[[:space:]]*=/) print }' "$pyproject" |
-		head -1 | sed 's/.*=[[:space:]]*["\x27]\([^"\x27]*\)["\x27].*/\1/')
-
-	if [[ -z "$version" ]]; then
-		# Try [tool.poetry] for Poetry projects
-		version=$(awk '/^\[tool\.poetry\]$/,/^\[/ { if (/^version[[:space:]]*=/) print }' "$pyproject" |
-			head -1 | sed 's/.*=[[:space:]]*["\x27]\([^"\x27]*\)["\x27].*/\1/')
-	fi
+	version=$(python3 -c "
+import tomllib, sys
+with open(sys.argv[1], 'rb') as f:
+    data = tomllib.load(f)
+project = data.get('project') or data.get('tool', {}).get('poetry', {})
+v = project.get('version', '')
+if v:
+    print(v)
+else:
+    sys.exit(1)
+" "$pyproject" 2>/dev/null)
 
 	if [[ -n "$version" ]]; then
 		echo "$version"
+		return 0
+	fi
+
+	return 1
+}
+
+# Extract package name from pyproject.toml using Python's tomllib (stdlib in 3.11+)
+# Usage: extract_pypi_name [path]
+# Returns name string or empty if not found
+extract_pypi_name() {
+	local path="${1:-.}"
+	local pyproject="$path/pyproject.toml"
+
+	if [[ ! -f "$pyproject" ]]; then
+		return 1
+	fi
+
+	local name
+	name=$(python3 -c "
+import tomllib, sys
+with open(sys.argv[1], 'rb') as f:
+    data = tomllib.load(f)
+project = data.get('project') or data.get('tool', {}).get('poetry', {})
+n = project.get('name', '')
+if n:
+    print(n)
+else:
+    sys.exit(1)
+" "$pyproject" 2>/dev/null)
+
+	if [[ -n "$name" ]]; then
+		echo "$name"
 		return 0
 	fi
 
@@ -169,5 +203,5 @@ get_dist_tag_for_version() {
 # =============================================================================
 # Export functions
 # =============================================================================
-export -f extract_pypi_version extract_npm_version extract_gem_version
+export -f extract_pypi_version extract_pypi_name extract_npm_version extract_gem_version
 export -f is_prerelease_version get_dist_tag_for_version

--- a/tests/bats/unit/lib/publish/test_version.bats
+++ b/tests/bats/unit/lib/publish/test_version.bats
@@ -21,11 +21,37 @@ teardown() {
 # extract_pypi_version tests
 # =============================================================================
 
-@test "extract_pypi_version: exercises PEP 621 and Poetry code paths" {
-	# The awk range pattern /^\[project\]$/,/^\[/ has a known limitation where
-	# [project] matches both start and end patterns (both match /^\[/),
-	# causing the range to collapse. This test ensures all code paths are
-	# exercised for coverage even though extraction may not succeed.
+@test "extract_pypi_version: extracts version from PEP 621 project table" {
+	cat >"$PKG_DIR/pyproject.toml" <<'EOF'
+[project]
+name = "my-package"
+version = "1.2.3"
+
+[build-system]
+requires = ["setuptools"]
+EOF
+
+	run bash -c "source \"\$LIB_DIR/publish/version.sh\" && extract_pypi_version \"$PKG_DIR\""
+	assert_success
+	assert_output "1.2.3"
+}
+
+@test "extract_pypi_version: falls back to tool.poetry table" {
+	cat >"$PKG_DIR/pyproject.toml" <<'EOF'
+[tool.poetry]
+name = "my-package"
+version = "2.0.0"
+
+[build-system]
+requires = ["poetry-core"]
+EOF
+
+	run bash -c "source \"\$LIB_DIR/publish/version.sh\" && extract_pypi_version \"$PKG_DIR\""
+	assert_success
+	assert_output "2.0.0"
+}
+
+@test "extract_pypi_version: prefers project table over tool.poetry" {
 	cat >"$PKG_DIR/pyproject.toml" <<'EOF'
 [project]
 name = "my-package"
@@ -38,8 +64,31 @@ version = "2.0.0"
 requires = ["setuptools"]
 EOF
 
-	run bash -c "source \"\$LIB_DIR/publish/version.sh\" && extract_pypi_version \"$PKG_DIR\" || true"
+	run bash -c "source \"\$LIB_DIR/publish/version.sh\" && extract_pypi_version \"$PKG_DIR\""
 	assert_success
+	assert_output "1.2.3"
+}
+
+@test "extract_pypi_version: handles inline tables and complex TOML" {
+	cat >"$PKG_DIR/pyproject.toml" <<'EOF'
+[project]
+name = "my-package"
+version = "3.0.0"
+dependencies = [
+    {name = "foo", version = "1.0"},
+]
+description = """
+A package with
+multi-line description
+"""
+
+[build-system]
+requires = ["setuptools"]
+EOF
+
+	run bash -c "source \"\$LIB_DIR/publish/version.sh\" && extract_pypi_version \"$PKG_DIR\""
+	assert_success
+	assert_output "3.0.0"
 }
 
 @test "extract_pypi_version: returns 1 for missing file" {
@@ -65,6 +114,49 @@ EOF
 
 	# With no version found, should return 1
 	run bash -c "cd \"$PKG_DIR\" && source \"\$LIB_DIR/publish/version.sh\" && extract_pypi_version"
+	assert_failure
+}
+
+# =============================================================================
+# extract_pypi_name tests
+# =============================================================================
+
+@test "extract_pypi_name: extracts name from PEP 621 project table" {
+	cat >"$PKG_DIR/pyproject.toml" <<'EOF'
+[project]
+name = "my-package"
+version = "1.2.3"
+EOF
+
+	run bash -c "source \"\$LIB_DIR/publish/version.sh\" && extract_pypi_name \"$PKG_DIR\""
+	assert_success
+	assert_output "my-package"
+}
+
+@test "extract_pypi_name: falls back to tool.poetry table" {
+	cat >"$PKG_DIR/pyproject.toml" <<'EOF'
+[tool.poetry]
+name = "poetry-pkg"
+version = "1.0.0"
+EOF
+
+	run bash -c "source \"\$LIB_DIR/publish/version.sh\" && extract_pypi_name \"$PKG_DIR\""
+	assert_success
+	assert_output "poetry-pkg"
+}
+
+@test "extract_pypi_name: returns 1 for missing file" {
+	run bash -c "source \"\$LIB_DIR/publish/version.sh\" && extract_pypi_name \"/nonexistent\""
+	assert_failure
+}
+
+@test "extract_pypi_name: returns 1 when no name found" {
+	cat >"$PKG_DIR/pyproject.toml" <<'EOF'
+[build-system]
+requires = ["setuptools"]
+EOF
+
+	run bash -c "source \"\$LIB_DIR/publish/version.sh\" && extract_pypi_name \"$PKG_DIR\""
 	assert_failure
 }
 
@@ -287,6 +379,12 @@ EOF
 
 @test "version.sh: exports extract_pypi_version function" {
 	run bash -c 'source "$LIB_DIR/publish/version.sh" && declare -f extract_pypi_version >/dev/null && echo "ok"'
+	assert_success
+	assert_output "ok"
+}
+
+@test "version.sh: exports extract_pypi_name function" {
+	run bash -c 'source "$LIB_DIR/publish/version.sh" && declare -f extract_pypi_name >/dev/null && echo "ok"'
 	assert_success
 	assert_output "ok"
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Replaces fragile awk/sed-based TOML parsing with Python's stdlib `tomllib` (3.11+). The awk range pattern `[project]` was matching both start and end brackets, causing incorrect extraction. This adds a robust `extract_pypi_name()` function and updates `extract_pypi_version()` to use tomllib, with proper fallback for Poetry-style `[tool.poetry]` layouts. Eliminates duplicate inline awk blocks in `publish-pypi.sh` and `validate-package.sh`.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None — requires Python 3.11+ (tomllib is stdlib). This was already an implicit requirement.

## Related Issues

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined package configuration extraction in the CI/CD pipeline using centralized helpers for greater reliability
  * Consolidated package name and version extraction logic for improved consistency and clearer failure handling

* **Tests**
  * Expanded test coverage with dedicated scenarios for package name and version extraction
  * Added validation tests to ensure the extraction helpers are available and behave deterministically
<!-- end of auto-generated comment: release notes by coderabbit.ai -->