### PR TITLE
fix(ci): use proseWrap preserve to fix version PR prettier failure

### DIFF
--- a/.lintro-config.yaml
+++ b/.lintro-config.yaml
@@ -25,7 +25,7 @@ defaults:
     singleQuote: true
     tabWidth: 2
     printWidth: 100
-    proseWrap: "always"
+    proseWrap: "preserve"
 
   yamllint:
     extends: "default"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Change `proseWrap` from `"always"` to `"preserve"` in `.lintro-config.yaml`.

The **Release: Create Version PR** workflow fails on every push to `main` since the lintro container image was updated to `sha256:0cee6a15` (Feb 24). The newer prettier version produces non-idempotent output with `proseWrap: "always"` on CHANGELOG.md — `lintro fmt` writes the file, but `lintro chk` still reports a formatting mismatch, exiting non-zero before PR creation.

`"preserve"` is the correct setting for programmatically generated markdown where line breaks are intentional.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Related Issues

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code formatting configuration to adjust text wrapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->