### PR TITLE
fix(lint): align enforce.line_length with tool configs

### DIFF
--- a/.lintro-config.yaml
+++ b/.lintro-config.yaml
@@ -16,7 +16,7 @@ execution:
 
 # Cross-cutting enforcement settings
 enforce:
-  line_length: 88
+  line_length: 100
 
 # Default configurations for tools without native config files
 defaults:
@@ -24,8 +24,7 @@ defaults:
     semi: false
     singleQuote: true
     tabWidth: 2
-    printWidth: 100
-    proseWrap: "preserve"
+    proseWrap: "always"
 
   yamllint:
     extends: "default"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Fix recurring CHANGELOG lint failures caused by a line-length mismatch between
lintro's cross-cutting `enforce.line_length` (88) and the actual tool configs
(prettier `printWidth: 100`, markdownlint `MD013: 100`).

Prettier was formatting at 100 chars, but `enforce.line_length: 88` could cause
markdownlint to reject lines between 88–100 characters — making `lintro fmt`
produce output that `lintro chk` would then reject.

The fix aligns `enforce.line_length` to 100 (the actual project standard),
removes the now-redundant `printWidth` from prettier defaults (enforce propagates
it), and restores `proseWrap: "always"` since the `"preserve"` workaround is no
longer needed with consistent widths.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Relates to #89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code formatting and linting configuration settings (line length enforcement and prose wrapping behavior).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->