### PR TITLE
fix(ci): fix changelog blank lines and Docker write permissions

### DIFF
--- a/scripts/ci/release/create-version-pr.sh
+++ b/scripts/ci/release/create-version-pr.sh
@@ -10,8 +10,7 @@
 #   MAX_BUMP          - Maximum bump type: major, minor, patch (default: major)
 #   TAG_PREFIX        - Prefix for version tags (default: v)
 #   PR_LABELS         - Comma-separated PR labels (default: release)
-#   LINTRO_DOCKER_USER - UID[:GID] for Docker container; a bare UID
-#                        defaults to the user's primary group (default: 0)
+#   LINTRO_DOCKER_USER - UID[:GID] for Docker container (default: $(id -u):$(id -g))
 #
 # Required: GH_TOKEN must be set for gh CLI authentication
 #
@@ -115,10 +114,9 @@ export PUSH="false"
 "$RELEASE_SCRIPT_DIR/update-changelog.sh"
 
 # Format and verify CHANGELOG passes lint checks (mirrors py-lintro pattern)
-# Default to root (0) for CI where the runner owns the workspace.
-# Locally, export LINTRO_DOCKER_USER="$(id -u):$(id -g)" to avoid root-owned files.
-: "${LINTRO_DOCKER_USER:=0}"
+: "${LINTRO_DOCKER_USER:=$(id -u):$(id -g)}"
 if [[ -n "${LINTRO_IMAGE:-}" ]]; then
+	mkdir -p .lintro
 	log_info "Formatting CHANGELOG.md with lintro (Docker)..."
 	docker run --rm --user "$LINTRO_DOCKER_USER" -v "$PWD:/workspace" -w /workspace \
 		"$LINTRO_IMAGE" lintro fmt

--- a/scripts/ci/release/update-changelog.sh
+++ b/scripts/ci/release/update-changelog.sh
@@ -143,6 +143,7 @@ in_unreleased && /^## \[/ {
 		in_dup_version=1
 		next
 	}
+	print ""
 	print
 	next
 }
@@ -159,7 +160,7 @@ in_dup_version && /^\[Unreleased\]:/ { in_dup_version=0 }
 in_dup_version { next }
 # Replace [Unreleased]: link even inside the unreleased section
 /^\[Unreleased\]:/ {
-	print ""
+	if (in_unreleased) print ""
 	print ENVIRON["UNRELEASED_LINK"]
 	print ENVIRON["VERSION_LINK"]
 	next


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Fix changelog formatting issues and Docker write permissions in the release version PR workflow:

- Fix missing blank line before the next version heading in `update-changelog.sh` awk output
- Fix extra blank line before link definitions when previous version sections exist (conditional `print ""` only when `in_unreleased`)
- Default `LINTRO_DOCKER_USER` to `$(id -u):$(id -g)` instead of root (`0`) so Docker bind-mount files are writable
- Pre-create `.lintro` directory before Docker runs to ensure lintro output is writable

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->