### PR TITLE
feat(docker): support configurable per-platform runners to eliminate QEMU emulation

### DIFF
--- a/.github/actions/docker-login/action.yml
+++ b/.github/actions/docker-login/action.yml
@@ -21,20 +21,11 @@ runs:
     - name: Validate inputs
       shell: bash
       env:
+        STEP: validate
         REGISTRY: ${{ inputs.registry }}
         DOCKERHUB_USERNAME: ${{ inputs.dockerhub-username }}
         DOCKERHUB_TOKEN: ${{ inputs.dockerhub-token }}
-      run: |
-        if [[ "${REGISTRY}" != "ghcr.io" && "${REGISTRY}" != "docker.io" ]]; then
-          echo "::error::Unsupported registry '${REGISTRY}'. Supported values: ghcr.io, docker.io"
-          exit 1
-        fi
-        if [[ "${REGISTRY}" == "docker.io" ]]; then
-          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
-            echo "::error::dockerhub-username and dockerhub-token are required when registry is docker.io"
-            exit 1
-          fi
-        fi
+      run: ./scripts/ci/actions/docker-login.sh
 
     - name: Login to GHCR
       if: inputs.registry == 'ghcr.io'

--- a/.github/actions/docker-login/action.yml
+++ b/.github/actions/docker-login/action.yml
@@ -18,6 +18,24 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        REGISTRY: ${{ inputs.registry }}
+        DOCKERHUB_USERNAME: ${{ inputs.dockerhub-username }}
+        DOCKERHUB_TOKEN: ${{ inputs.dockerhub-token }}
+      run: |
+        if [[ "${REGISTRY}" != "ghcr.io" && "${REGISTRY}" != "docker.io" ]]; then
+          echo "::error::Unsupported registry '${REGISTRY}'. Supported values: ghcr.io, docker.io"
+          exit 1
+        fi
+        if [[ "${REGISTRY}" == "docker.io" ]]; then
+          if [[ -z "${DOCKERHUB_USERNAME}" || -z "${DOCKERHUB_TOKEN}" ]]; then
+            echo "::error::dockerhub-username and dockerhub-token are required when registry is docker.io"
+            exit 1
+          fi
+        fi
+
     - name: Login to GHCR
       if: inputs.registry == 'ghcr.io'
       # Pinned to SHA for supply chain security

--- a/.github/actions/docker-login/action.yml
+++ b/.github/actions/docker-login/action.yml
@@ -1,0 +1,36 @@
+---
+name: Docker Registry Login
+description: Login to GHCR or Docker Hub based on registry input
+
+inputs:
+  registry:
+    description: "Container registry URL"
+    required: true
+  dockerhub-username:
+    description: "Docker Hub username (required when registry is docker.io)"
+    required: false
+    default: ""
+  dockerhub-token:
+    description: "Docker Hub token (required when registry is docker.io)"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Login to GHCR
+      if: inputs.registry == 'ghcr.io'
+      # Pinned to SHA for supply chain security
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Login to Docker Hub
+      if: inputs.registry == 'docker.io'
+      # Pinned to SHA for supply chain security
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-token }}

--- a/.github/actions/docker-metadata/action.yml
+++ b/.github/actions/docker-metadata/action.yml
@@ -1,0 +1,47 @@
+---
+name: Docker Metadata
+description: Generate Docker image tags and labels via docker/metadata-action
+
+inputs:
+  registry:
+    description: "Container registry URL"
+    required: true
+  image-name:
+    description: "Image name (registry-relative, e.g. org/repo)"
+    required: true
+  version:
+    description: "Version string for semver tags"
+    required: false
+    default: ""
+  extra-tags:
+    description: "Additional tags in metadata-action format (newline-separated type=raw,... entries)"
+    required: false
+    default: ""
+
+outputs:
+  tags:
+    description: "Generated image tags (newline-separated)"
+    value: ${{ steps.meta.outputs.tags }}
+  labels:
+    description: "Generated OCI image labels"
+    value: ${{ steps.meta.outputs.labels }}
+
+runs:
+  using: composite
+  steps:
+    - name: Extract metadata
+      id: meta
+      # Pinned to SHA for supply chain security
+      uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+      with:
+        images: |
+          ${{ inputs.registry }}/${{ inputs.image-name }}
+        tags: |
+          type=sha,prefix=sha-
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}},value=${{ inputs.version }}
+          type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
+          type=semver,pattern={{major}},value=${{ inputs.version }}
+          type=raw,value=latest,enable=${{ inputs.version != '' }}
+          ${{ inputs.extra-tags }}

--- a/.github/actions/docker-metadata/action.yml
+++ b/.github/actions/docker-metadata/action.yml
@@ -40,8 +40,8 @@ runs:
           type=sha,prefix=sha-
           type=ref,event=branch
           type=ref,event=pr
-          type=semver,pattern={{version}},value=${{ inputs.version }}
-          type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
-          type=semver,pattern={{major}},value=${{ inputs.version }}
+          type=semver,pattern={{version}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
+          type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
+          type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
           type=raw,value=latest,enable=${{ inputs.version != '' }}
           ${{ inputs.extra-tags }}

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -232,6 +232,14 @@ jobs:
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Extract metadata
+        id: meta
+        uses: ./.github/actions/docker-metadata
+        with:
+          registry: ${{ inputs.registry }}
+          image-name: ${{ inputs.image-name || github.repository }}
+          version: ${{ inputs.version }}
+
       - name: Build and push (linux/amd64)
         id: build
         # Pinned to SHA for supply chain security
@@ -244,6 +252,7 @@ jobs:
           tags: >-
             ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:build-${{
             github.run_id }}-linux-amd64
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ inputs.build-args }}
           cache-from: type=gha,scope=linux-amd64
           cache-to: type=gha,mode=max,scope=linux-amd64
@@ -291,6 +300,14 @@ jobs:
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Extract metadata
+        id: meta
+        uses: ./.github/actions/docker-metadata
+        with:
+          registry: ${{ inputs.registry }}
+          image-name: ${{ inputs.image-name || github.repository }}
+          version: ${{ inputs.version }}
+
       - name: Build and push (linux/arm64)
         id: build
         # Pinned to SHA for supply chain security
@@ -303,6 +320,7 @@ jobs:
           tags: >-
             ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:build-${{
             github.run_id }}-linux-arm64
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ inputs.build-args }}
           cache-from: type=gha,scope=linux-arm64
           cache-to: type=gha,mode=max,scope=linux-arm64

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -103,7 +103,7 @@ jobs:
     steps:
       - name: Harden runner
         # Pinned to SHA for supply chain security
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
         with:
           egress-policy: audit
 
@@ -240,7 +240,7 @@ jobs:
     steps:
       - name: Harden runner
         # Pinned to SHA for supply chain security
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
         with:
           egress-policy: audit
 
@@ -312,7 +312,7 @@ jobs:
     steps:
       - name: Harden runner
         # Pinned to SHA for supply chain security
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -182,8 +182,10 @@ jobs:
         id: metadata
         if: inputs.push
         shell: bash
-        run: |
-          echo "digest=${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+        env:
+          STEP: set-output-digest
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: ./scripts/ci/actions/build-docker.sh
 
       - name: Generate artifact attestation
         if: inputs.push && inputs.provenance
@@ -400,49 +402,16 @@ jobs:
           push-to-registry: true
 
       - name: Delete staging manifests
-        # Clean up per-platform staging tags that are no longer needed after the manifest merge.
-        # Only GHCR supports tag deletion via the GitHub Packages API.
+        # Clean up per-platform staging tags via the GitHub Packages API.
+        # Only runs for GHCR; other registries are skipped.
         if: always() && inputs.registry == 'ghcr.io'
         shell: bash
         env:
+          STEP: cleanup-staging
           GH_TOKEN: ${{ github.token }}
           IMAGE_NAME: ${{ inputs.image-name || github.repository }}
           RUN_ID: ${{ github.run_id }}
-        run: |
-          # Parse owner and package name from image ref (owner/package or owner/nested/package)
-          pkg_owner="${IMAGE_NAME%%/*}"
-          pkg_name="${IMAGE_NAME#*/}"
-          pkg_name_encoded="${pkg_name//\//%2F}"
-
-          for arch in linux-amd64 linux-arm64; do
-            tag="build-${RUN_ID}-${arch}"
-
-            # Prefer org endpoint; fall back to user endpoint for personal repos
-            version_id=$(
-              gh api "orgs/${pkg_owner}/packages/container/${pkg_name_encoded}/versions" \
-                --paginate \
-                --jq ".[] | select(.metadata.container.tags[]? == \"${tag}\") | .id" \
-                2>/dev/null ||
-              gh api "user/packages/container/${pkg_name_encoded}/versions" \
-                --paginate \
-                --jq ".[] | select(.metadata.container.tags[]? == \"${tag}\") | .id" \
-                2>/dev/null ||
-              true
-            )
-
-            if [[ -n "${version_id}" ]]; then
-              gh api --method DELETE \
-                "orgs/${pkg_owner}/packages/container/${pkg_name_encoded}/versions/${version_id}" \
-                2>/dev/null ||
-              gh api --method DELETE \
-                "user/packages/container/${pkg_name_encoded}/versions/${version_id}" \
-                2>/dev/null ||
-              true
-              echo "Deleted staging manifest: ${tag}"
-            else
-              echo "::warning::Could not locate staging manifest version for tag ${tag} — skipping deletion"
-            fi
-          done
+        run: ./scripts/ci/actions/build-docker.sh
 
   scan:
     name: Vulnerability Scan

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -74,6 +74,13 @@ on:
         required: false
         type: string
         default: "ubuntu-24.04"
+      enable-qemu:
+        description: >-
+          Enable QEMU for arm64 cross-compilation in the linux/arm64 build leg.
+          Set false when runner-arm64 is a native arm64 host (e.g. ubuntu-24.04-arm).
+        required: false
+        type: boolean
+        default: true
 
     outputs:
       tags:
@@ -104,7 +111,7 @@ jobs:
       attestations: write
 
     outputs:
-      tags: ${{ steps.build.outputs.tags }}
+      tags: ${{ steps.meta.outputs.tags }}
       digest: ${{ steps.metadata.outputs.digest }}
 
     steps:
@@ -128,22 +135,13 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Login to GHCR
-        if: inputs.push && inputs.registry == 'ghcr.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - name: Login to registry
+        if: inputs.push
+        uses: ./.github/actions/docker-login
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Docker Hub
-        if: inputs.push && inputs.registry == 'docker.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ inputs.registry }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Parse additional tags
         id: extra-tags
@@ -156,20 +154,12 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        # Pinned to SHA for supply chain security
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        uses: ./.github/actions/docker-metadata
         with:
-          images: |
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
-          tags: |
-            type=sha,prefix=sha-
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}},value=${{ inputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
-            type=semver,pattern={{major}},value=${{ inputs.version }}
-            type=raw,value=latest,enable=${{ inputs.version != '' }}
-            ${{ steps.extra-tags.outputs.tags }}
+          registry: ${{ inputs.registry }}
+          image-name: ${{ inputs.image-name || github.repository }}
+          version: ${{ inputs.version }}
+          extra-tags: ${{ steps.extra-tags.outputs.tags }}
 
       - name: Build and push
         id: build
@@ -233,22 +223,12 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Login to GHCR
-        if: inputs.registry == 'ghcr.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - name: Login to registry
+        uses: ./.github/actions/docker-login
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Docker Hub
-        if: inputs.registry == 'docker.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ inputs.registry }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push (linux/amd64)
         id: build
@@ -266,7 +246,7 @@ jobs:
           cache-from: type=gha,scope=linux-amd64
           cache-to: type=gha,mode=max,scope=linux-amd64
           provenance: false
-          sbom: false
+          sbom: ${{ inputs.sbom }}
 
   # Native linux/arm64 build leg (multi-arch split path)
   build-arm64:
@@ -294,8 +274,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup QEMU
-        # Only needed when runner is not a native arm64 host
-        if: inputs.runner-arm64 == 'ubuntu-24.04'
+        if: inputs.enable-qemu
         # Pinned to SHA for supply chain security
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
@@ -303,22 +282,12 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Login to GHCR
-        if: inputs.registry == 'ghcr.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - name: Login to registry
+        uses: ./.github/actions/docker-login
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Docker Hub
-        if: inputs.registry == 'docker.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ inputs.registry }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push (linux/arm64)
         id: build
@@ -336,7 +305,7 @@ jobs:
           cache-from: type=gha,scope=linux-arm64
           cache-to: type=gha,mode=max,scope=linux-arm64
           provenance: false
-          sbom: false
+          sbom: ${{ inputs.sbom }}
 
   # Assemble multi-arch manifest from per-platform images
   merge:
@@ -366,27 +335,20 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          sparse-checkout: |
+            scripts/ci
+            .github/actions
 
       - name: Setup Docker Buildx
         # Pinned to SHA for supply chain security
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Login to GHCR
-        if: inputs.registry == 'ghcr.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - name: Login to registry
+        uses: ./.github/actions/docker-login
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to Docker Hub
-        if: inputs.registry == 'docker.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ inputs.registry }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Parse additional tags
         id: extra-tags
@@ -399,31 +361,24 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        # Pinned to SHA for supply chain security
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        uses: ./.github/actions/docker-metadata
         with:
-          images: |
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
-          tags: |
-            type=sha,prefix=sha-
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}},value=${{ inputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
-            type=semver,pattern={{major}},value=${{ inputs.version }}
-            type=raw,value=latest,enable=${{ inputs.version != '' }}
-            ${{ steps.extra-tags.outputs.tags }}
+          registry: ${{ inputs.registry }}
+          image-name: ${{ inputs.image-name || github.repository }}
+          version: ${{ inputs.version }}
+          extra-tags: ${{ steps.extra-tags.outputs.tags }}
 
       - name: Create multi-arch manifest
         shell: bash
         env:
           STEP: merge-manifests
+          # Reference by digest for immutability — tags can be overwritten, digests cannot
           SOURCE_AMD64: >-
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:build-${{
-            github.run_id }}-linux-amd64
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}@${{
+            needs.build-amd64.outputs.digest }}
           SOURCE_ARM64: >-
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:build-${{
-            github.run_id }}-linux-arm64
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}@${{
+            needs.build-arm64.outputs.digest }}
           TARGET_TAGS: ${{ steps.meta.outputs.tags }}
         run: ./scripts/ci/actions/build-docker.sh
 
@@ -443,6 +398,19 @@ jobs:
           subject-name: ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
           subject-digest: ${{ steps.metadata.outputs.digest }}
           push-to-registry: true
+
+      - name: Delete staging manifests
+        if: always()
+        shell: bash
+        env:
+          STAGING_AMD64: >-
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:build-${{
+            github.run_id }}-linux-amd64
+          STAGING_ARM64: >-
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:build-${{
+            github.run_id }}-linux-arm64
+        run: |
+          docker buildx imagetools rm "${STAGING_AMD64}" "${STAGING_ARM64}" || true
 
   scan:
     name: Vulnerability Scan

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -64,14 +64,24 @@ on:
         required: false
         type: string
         default: ""
+      runner-amd64:
+        description: "Runner for linux/amd64 build leg"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+      runner-arm64:
+        description: "Runner for linux/arm64 build leg (set ubuntu-24.04-arm to use native)"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
 
     outputs:
       tags:
         description: "Generated image tags"
-        value: ${{ jobs.build.outputs.tags }}
+        value: ${{ jobs.build.outputs.tags || jobs.merge.outputs.tags }}
       digest:
         description: "Image digest"
-        value: ${{ jobs.build.outputs.digest }}
+        value: ${{ jobs.build.outputs.digest || jobs.merge.outputs.digest }}
 
     secrets:
       DOCKERHUB_USERNAME:
@@ -82,9 +92,11 @@ on:
         description: "Docker Hub token (for docker.io registry)"
 
 jobs:
+  # Single-platform builds, or multi-platform when push is disabled (QEMU fallback)
   build:
     name: Build and Push
-    runs-on: ubuntu-latest
+    if: ${{ !contains(inputs.platforms, ',') || !inputs.push }}
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
@@ -192,11 +204,255 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
+  # Native linux/amd64 build leg (multi-arch split path)
+  build-amd64:
+    name: Build linux/amd64
+    if: ${{ contains(inputs.platforms, ',') && inputs.push }}
+    runs-on: ${{ inputs.runner-amd64 }}
+    permissions:
+      contents: read
+      packages: write
+
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+
+    steps:
+      - name: Harden runner
+        # Pinned to SHA for supply chain security
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        # Pinned to SHA for supply chain security
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Docker Buildx
+        # Pinned to SHA for supply chain security
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to GHCR
+        if: inputs.registry == 'ghcr.io'
+        # Pinned to SHA for supply chain security
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        if: inputs.registry == 'docker.io'
+        # Pinned to SHA for supply chain security
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push (linux/amd64)
+        id: build
+        # Pinned to SHA for supply chain security
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.file }}
+          platforms: linux/amd64
+          push: true
+          tags: >-
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:build-${{
+            github.run_id }}-linux-amd64
+          build-args: ${{ inputs.build-args }}
+          cache-from: type=gha,scope=linux-amd64
+          cache-to: type=gha,mode=max,scope=linux-amd64
+          provenance: false
+          sbom: false
+
+  # Native linux/arm64 build leg (multi-arch split path)
+  build-arm64:
+    name: Build linux/arm64
+    if: ${{ contains(inputs.platforms, ',') && inputs.push }}
+    runs-on: ${{ inputs.runner-arm64 }}
+    permissions:
+      contents: read
+      packages: write
+
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+
+    steps:
+      - name: Harden runner
+        # Pinned to SHA for supply chain security
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        # Pinned to SHA for supply chain security
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup QEMU
+        # Only needed when runner is not a native arm64 host
+        if: inputs.runner-arm64 == 'ubuntu-24.04'
+        # Pinned to SHA for supply chain security
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Setup Docker Buildx
+        # Pinned to SHA for supply chain security
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to GHCR
+        if: inputs.registry == 'ghcr.io'
+        # Pinned to SHA for supply chain security
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        if: inputs.registry == 'docker.io'
+        # Pinned to SHA for supply chain security
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push (linux/arm64)
+        id: build
+        # Pinned to SHA for supply chain security
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.file }}
+          platforms: linux/arm64
+          push: true
+          tags: >-
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:build-${{
+            github.run_id }}-linux-arm64
+          build-args: ${{ inputs.build-args }}
+          cache-from: type=gha,scope=linux-arm64
+          cache-to: type=gha,mode=max,scope=linux-arm64
+          provenance: false
+          sbom: false
+
+  # Assemble multi-arch manifest from per-platform images
+  merge:
+    name: Merge Manifests
+    needs: [build-amd64, build-arm64]
+    if: ${{ contains(inputs.platforms, ',') && inputs.push }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+      digest: ${{ steps.metadata.outputs.digest }}
+
+    steps:
+      - name: Harden runner
+        # Pinned to SHA for supply chain security
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        # Pinned to SHA for supply chain security
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Docker Buildx
+        # Pinned to SHA for supply chain security
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Login to GHCR
+        if: inputs.registry == 'ghcr.io'
+        # Pinned to SHA for supply chain security
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        if: inputs.registry == 'docker.io'
+        # Pinned to SHA for supply chain security
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Parse additional tags
+        id: extra-tags
+        if: inputs.tags != ''
+        shell: bash
+        env:
+          STEP: parse-tags
+          INPUT_TAGS: ${{ inputs.tags }}
+        run: ./scripts/ci/actions/build-docker.sh
+
+      - name: Extract metadata
+        id: meta
+        # Pinned to SHA for supply chain security
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: |
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
+          tags: |
+            type=sha,prefix=sha-
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}},value=${{ inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
+            type=semver,pattern={{major}},value=${{ inputs.version }}
+            type=raw,value=latest,enable=${{ inputs.version != '' }}
+            ${{ steps.extra-tags.outputs.tags }}
+
+      - name: Create multi-arch manifest
+        shell: bash
+        env:
+          STEP: merge-manifests
+          SOURCE_AMD64: >-
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:build-${{
+            github.run_id }}-linux-amd64
+          SOURCE_ARM64: >-
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:build-${{
+            github.run_id }}-linux-arm64
+          TARGET_TAGS: ${{ steps.meta.outputs.tags }}
+        run: ./scripts/ci/actions/build-docker.sh
+
+      - name: Extract digest
+        id: metadata
+        shell: bash
+        env:
+          STEP: metadata
+          BUILT_TAGS: ${{ steps.meta.outputs.tags }}
+        run: ./scripts/ci/actions/build-docker.sh
+
+      - name: Generate artifact attestation
+        if: inputs.provenance
+        # Pinned to SHA for supply chain security
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-name: ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
+          subject-digest: ${{ steps.metadata.outputs.digest }}
+          push-to-registry: true
+
   scan:
     name: Vulnerability Scan
-    needs: build
-    if: inputs.scan && inputs.push
-    runs-on: ubuntu-latest
+    needs: [build, merge]
+    if: >-
+      always() &&
+      (needs.build.result == 'success' || needs.merge.result == 'success') &&
+      inputs.scan &&
+      inputs.push
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       security-events: write
@@ -206,9 +462,9 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
-          image-ref:
+          image-ref: >-
             ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}@${{
-            needs.build.outputs.digest }}
+            needs.build.outputs.digest || needs.merge.outputs.digest }}
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH"

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -400,17 +400,49 @@ jobs:
           push-to-registry: true
 
       - name: Delete staging manifests
-        if: always()
+        # Clean up per-platform staging tags that are no longer needed after the manifest merge.
+        # Only GHCR supports tag deletion via the GitHub Packages API.
+        if: always() && inputs.registry == 'ghcr.io'
         shell: bash
         env:
-          STAGING_AMD64: >-
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:build-${{
-            github.run_id }}-linux-amd64
-          STAGING_ARM64: >-
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:build-${{
-            github.run_id }}-linux-arm64
+          GH_TOKEN: ${{ github.token }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          docker buildx imagetools rm "${STAGING_AMD64}" "${STAGING_ARM64}" || true
+          # Parse owner and package name from image ref (owner/package or owner/nested/package)
+          pkg_owner="${IMAGE_NAME%%/*}"
+          pkg_name="${IMAGE_NAME#*/}"
+          pkg_name_encoded="${pkg_name//\//%2F}"
+
+          for arch in linux-amd64 linux-arm64; do
+            tag="build-${RUN_ID}-${arch}"
+
+            # Prefer org endpoint; fall back to user endpoint for personal repos
+            version_id=$(
+              gh api "orgs/${pkg_owner}/packages/container/${pkg_name_encoded}/versions" \
+                --paginate \
+                --jq ".[] | select(.metadata.container.tags[]? == \"${tag}\") | .id" \
+                2>/dev/null ||
+              gh api "user/packages/container/${pkg_name_encoded}/versions" \
+                --paginate \
+                --jq ".[] | select(.metadata.container.tags[]? == \"${tag}\") | .id" \
+                2>/dev/null ||
+              true
+            )
+
+            if [[ -n "${version_id}" ]]; then
+              gh api --method DELETE \
+                "orgs/${pkg_owner}/packages/container/${pkg_name_encoded}/versions/${version_id}" \
+                2>/dev/null ||
+              gh api --method DELETE \
+                "user/packages/container/${pkg_name_encoded}/versions/${version_id}" \
+                2>/dev/null ||
+              true
+              echo "Deleted staging manifest: ${tag}"
+            else
+              echo "::warning::Could not locate staging manifest version for tag ${tag} — skipping deletion"
+            fi
+          done
 
   scan:
     name: Vulnerability Scan

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -277,7 +277,7 @@ jobs:
       - name: Build and push (${{ matrix.platform }})
         id: build
         # Pinned to SHA for supply chain security
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.file }}

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -64,23 +64,14 @@ on:
         required: false
         type: string
         default: ""
-      runner-amd64:
-        description: "Runner for linux/amd64 build leg"
-        required: false
-        type: string
-        default: "ubuntu-24.04"
-      runner-arm64:
-        description: "Runner for linux/arm64 build leg (set ubuntu-24.04-arm to use native)"
-        required: false
-        type: string
-        default: "ubuntu-24.04"
-      enable-qemu:
+      runner-map:
         description: >-
-          Enable QEMU for arm64 cross-compilation in the linux/arm64 build leg.
-          Set false when runner-arm64 is a native arm64 host (e.g. ubuntu-24.04-arm).
+          JSON object mapping platform to runner label.
+          Platforms not in the map default to ubuntu-24.04 with QEMU.
+          Example: {"linux/arm64":"ubuntu-24.04-arm"}
         required: false
-        type: boolean
-        default: true
+        type: string
+        default: "{}"
 
     outputs:
       tags:
@@ -99,10 +90,45 @@ on:
         description: "Docker Hub token (for docker.io registry)"
 
 jobs:
+  # Classify platforms and determine build strategy.
+  # Outputs use-split=true and a per-platform matrix when push is enabled
+  # and two or more platforms are requested; otherwise use-split=false.
+  classify:
+    name: Classify Platforms
+    runs-on: ubuntu-24.04
+    outputs:
+      use-split: ${{ steps.classify.outputs.use-split }}
+      matrix: ${{ steps.classify.outputs.matrix }}
+
+    steps:
+      - name: Harden runner
+        # Pinned to SHA for supply chain security
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        # Pinned to SHA for supply chain security
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          sparse-checkout: scripts/ci
+
+      - name: Classify platforms
+        id: classify
+        shell: bash
+        env:
+          STEP: classify
+          PLATFORMS: ${{ inputs.platforms }}
+          PUSH: ${{ inputs.push }}
+          RUNNER_MAP: ${{ inputs.runner-map }}
+        run: ./scripts/ci/actions/build-docker.sh
+
   # Single-platform builds, or multi-platform when push is disabled (QEMU fallback)
   build:
     name: Build and Push
-    if: ${{ !contains(inputs.platforms, ',') || !inputs.push }}
+    needs: classify
+    if: ${{ needs.classify.outputs.use-split == 'false' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -196,74 +222,17 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
-  # Native linux/amd64 build leg (multi-arch split path)
-  build-amd64:
-    name: Build linux/amd64
-    if: ${{ contains(inputs.platforms, ',') && inputs.push }}
-    runs-on: ${{ inputs.runner-amd64 }}
-    permissions:
-      contents: read
-      packages: write
-
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
-
-    steps:
-      - name: Harden runner
-        # Pinned to SHA for supply chain security
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
-        with:
-          egress-policy: audit
-
-      - name: Checkout repository
-        # Pinned to SHA for supply chain security
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Setup Docker Buildx
-        # Pinned to SHA for supply chain security
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Login to registry
-        uses: ./.github/actions/docker-login
-        with:
-          registry: ${{ inputs.registry }}
-          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: ./.github/actions/docker-metadata
-        with:
-          registry: ${{ inputs.registry }}
-          image-name: ${{ inputs.image-name || github.repository }}
-          version: ${{ inputs.version }}
-
-      - name: Build and push (linux/amd64)
-        id: build
-        # Pinned to SHA for supply chain security
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-        with:
-          context: ${{ inputs.context }}
-          file: ${{ inputs.file }}
-          platforms: linux/amd64
-          push: true
-          tags: >-
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:build-${{
-            github.run_id }}-linux-amd64
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: ${{ inputs.build-args }}
-          cache-from: type=gha,scope=linux-amd64
-          cache-to: type=gha,mode=max,scope=linux-amd64
-          provenance: false
-          sbom: ${{ inputs.sbom }}
-
-  # Native linux/arm64 build leg (multi-arch split path)
-  build-arm64:
-    name: Build linux/arm64
-    if: ${{ contains(inputs.platforms, ',') && inputs.push }}
-    runs-on: ${{ inputs.runner-arm64 }}
+  # Per-platform native build leg (multi-arch split path).
+  # One matrix entry per platform; runner and QEMU config resolved by classify.
+  build-per-platform:
+    name: Build ${{ matrix.platform }}
+    needs: classify
+    if: ${{ needs.classify.outputs.use-split == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.classify.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write
@@ -285,7 +254,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup QEMU
-        if: inputs.enable-qemu
+        if: ${{ matrix.qemu }}
         # Pinned to SHA for supply chain security
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
@@ -308,30 +277,30 @@ jobs:
           image-name: ${{ inputs.image-name || github.repository }}
           version: ${{ inputs.version }}
 
-      - name: Build and push (linux/arm64)
+      - name: Build and push (${{ matrix.platform }})
         id: build
         # Pinned to SHA for supply chain security
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.file }}
-          platforms: linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
           tags: >-
             ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:build-${{
-            github.run_id }}-linux-arm64
+            github.run_id }}-${{ matrix.slug }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ inputs.build-args }}
-          cache-from: type=gha,scope=linux-arm64
-          cache-to: type=gha,mode=max,scope=linux-arm64
+          cache-from: type=gha,scope=${{ matrix.slug }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.slug }}
           provenance: false
           sbom: ${{ inputs.sbom }}
 
-  # Assemble multi-arch manifest from per-platform images
+  # Assemble multi-arch manifest from per-platform staging images
   merge:
     name: Merge Manifests
-    needs: [build-amd64, build-arm64]
-    if: ${{ contains(inputs.platforms, ',') && inputs.push }}
+    needs: [classify, build-per-platform]
+    if: ${{ needs.classify.outputs.use-split == 'true' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -392,13 +361,10 @@ jobs:
         shell: bash
         env:
           STEP: merge-manifests
-          # Reference by digest for immutability — tags can be overwritten, digests cannot
-          SOURCE_AMD64: >-
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}@${{
-            needs.build-amd64.outputs.digest }}
-          SOURCE_ARM64: >-
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}@${{
-            needs.build-arm64.outputs.digest }}
+          MATRIX: ${{ needs.classify.outputs.matrix }}
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+          RUN_ID: ${{ github.run_id }}
           TARGET_TAGS: ${{ steps.meta.outputs.tags }}
         run: ./scripts/ci/actions/build-docker.sh
 
@@ -429,6 +395,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           IMAGE_NAME: ${{ inputs.image-name || github.repository }}
           RUN_ID: ${{ github.run_id }}
+          MATRIX: ${{ needs.classify.outputs.matrix }}
         run: ./scripts/ci/actions/build-docker.sh
 
   scan:

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -237,9 +237,6 @@ jobs:
       contents: read
       packages: write
 
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
-
     steps:
       - name: Harden runner
         # Pinned to SHA for supply chain security

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -4,7 +4,7 @@
 #
 # Required environment variables:
 #   STEP - Which step to run: setup, build, push, metadata, parse-tags, summary,
-#          set-output-digest, merge-manifests, cleanup-staging
+#          set-output-digest, classify, merge-manifests, cleanup-staging
 #
 # Optional environment variables:
 #   CONTEXT - Build context path (default: .)
@@ -296,15 +296,103 @@ set-output-digest)
 	log_info "Digest: ${DIGEST}"
 	;;
 
+classify)
+	# Classify platforms and determine build strategy.
+	#
+	# Required environment variables:
+	#   PLATFORMS  - Comma-separated list of target platforms
+	#   PUSH       - Whether images will be pushed ("true"/"false")
+	#
+	# Optional environment variables:
+	#   RUNNER_MAP - JSON object mapping platform → runner label (default: "{}")
+	#               Platforms not in the map default to ubuntu-24.04 with QEMU.
+	#               Example: {"linux/arm64":"ubuntu-24.04-arm"}
+	#
+	# Outputs:
+	#   use-split - "true" when split per-platform build should be used
+	#   matrix    - JSON array of {platform, runner, slug, qemu} entries
+	: "${PLATFORMS:?PLATFORMS is required}"
+	: "${PUSH:?PUSH is required}"
+	: "${RUNNER_MAP:={}}"
+
+	# Validate RUNNER_MAP is parseable JSON
+	if ! echo "$RUNNER_MAP" | jq empty 2>/dev/null; then
+		die "RUNNER_MAP is not valid JSON: ${RUNNER_MAP}"
+	fi
+
+	# Parse comma-separated platforms into array, trimming whitespace
+	platforms=()
+	while IFS= read -r p; do
+		p=$(echo "$p" | xargs)
+		[[ -n "$p" ]] && platforms+=("$p")
+	done < <(echo "$PLATFORMS" | tr ',' '\n')
+
+	# Single-platform or push=false → use the QEMU build job, not split
+	if [[ "${#platforms[@]}" -lt 2 || "$PUSH" != "true" ]]; then
+		set_github_output "use-split" "false"
+		set_github_output "matrix" "[]"
+		log_info "Split disabled: ${#platforms[@]} platform(s), push=${PUSH}"
+		exit 0
+	fi
+
+	# Build matrix JSON array
+	matrix_json="[]"
+	for platform in "${platforms[@]}"; do
+		# Resolve runner from map; default to ubuntu-24.04
+		runner=$(echo "$RUNNER_MAP" | jq -r --arg p "$platform" '.[$p] // "ubuntu-24.04"')
+
+		# Generate slug: replace all / with - (e.g. linux/arm/v7 → linux-arm-v7)
+		slug=$(echo "$platform" | tr '/' '-')
+
+		# Determine runner architecture from label
+		runner_arch="amd64"
+		if [[ "$runner" == *"-arm"* ]]; then
+			runner_arch="arm64"
+		fi
+
+		# Extract platform architecture (second path component, strip variant)
+		platform_arch="${platform#*/}"       # linux/arm/v7 → arm/v7
+		platform_arch="${platform_arch%%/*}" # arm/v7 → arm
+
+		# QEMU not needed when runner and platform architectures match
+		qemu=true
+		if [[ "$runner_arch" == "amd64" && "$platform_arch" == "amd64" ]]; then
+			qemu=false
+		elif [[ "$runner_arch" == "arm64" && "$platform_arch" == "arm64" ]]; then
+			qemu=false
+		fi
+
+		# Build JSON entry and append to matrix array
+		entry=$(jq -n \
+			--arg platform "$platform" \
+			--arg runner "$runner" \
+			--arg slug "$slug" \
+			--argjson qemu "$qemu" \
+			'{platform: $platform, runner: $runner, slug: $slug, qemu: $qemu}')
+		matrix_json=$(echo "$matrix_json" | jq --argjson e "$entry" '. + [$e]')
+	done
+
+	set_github_output "use-split" "true"
+	set_github_output "matrix" "$matrix_json"
+	log_info "Split enabled: ${#platforms[@]} platform(s)"
+	for platform in "${platforms[@]}"; do
+		log_info "  ${platform}"
+	done
+	;;
+
 merge-manifests)
 	# Assemble a multi-arch manifest list from per-platform staging images.
 	#
 	# Required environment variables:
-	#   SOURCE_AMD64 - Fully-qualified staging tag for the linux/amd64 image
-	#   SOURCE_ARM64 - Fully-qualified staging tag for the linux/arm64 image
-	#   TARGET_TAGS  - Newline-separated list of final tags to create
-	: "${SOURCE_AMD64:?SOURCE_AMD64 is required}"
-	: "${SOURCE_ARM64:?SOURCE_ARM64 is required}"
+	#   MATRIX     - JSON matrix from classify step (array of {platform, runner, slug, qemu})
+	#   REGISTRY   - Container registry URL
+	#   IMAGE_NAME - Registry-relative image name
+	#   RUN_ID     - GitHub Actions run ID used to locate staging tags
+	#   TARGET_TAGS - Newline-separated list of final tags to create
+	: "${MATRIX:?MATRIX is required}"
+	: "${REGISTRY:?REGISTRY is required}"
+	: "${IMAGE_NAME:?IMAGE_NAME is required}"
+	: "${RUN_ID:?RUN_ID is required}"
 	: "${TARGET_TAGS:?TARGET_TAGS is required}"
 
 	MERGE_CMD=("docker" "buildx" "imagetools" "create")
@@ -320,9 +408,13 @@ merge-manifests)
 		exit 1
 	fi
 
-	MERGE_CMD+=("$SOURCE_AMD64" "$SOURCE_ARM64")
+	# Add per-platform staging images as sources (referenced by staging tag)
+	while IFS= read -r slug; do
+		[[ -n "$slug" ]] && MERGE_CMD+=("${REGISTRY}/${IMAGE_NAME}:build-${RUN_ID}-${slug}")
+	done < <(echo "$MATRIX" | jq -r '.[].slug')
 
-	log_info "Merging manifests: ${SOURCE_AMD64} + ${SOURCE_ARM64}"
+	platform_count=$(echo "$MATRIX" | jq 'length')
+	log_info "Merging ${platform_count} platform(s) into manifest..."
 	"${MERGE_CMD[@]}"
 	log_success "Multi-arch manifest created"
 	;;
@@ -335,17 +427,20 @@ cleanup-staging)
 	#   IMAGE_NAME - Registry-relative image name (e.g. org/repo or org/group/repo)
 	#   RUN_ID     - GitHub Actions run ID used to construct staging tag names
 	#   GH_TOKEN   - GitHub token with packages:delete permission
+	#   MATRIX     - JSON matrix from classify step (array of {platform, runner, slug, qemu})
 	: "${IMAGE_NAME:?IMAGE_NAME is required}"
 	: "${RUN_ID:?RUN_ID is required}"
 	: "${GH_TOKEN:?GH_TOKEN is required}"
+	: "${MATRIX:?MATRIX is required}"
 
 	# Parse owner and package name; URL-encode nested slashes
 	pkg_owner="${IMAGE_NAME%%/*}"
 	pkg_name="${IMAGE_NAME#*/}"
 	pkg_name_encoded="${pkg_name//\//%2F}"
 
-	for arch in linux-amd64 linux-arm64; do
-		tag="build-${RUN_ID}-${arch}"
+	while IFS= read -r slug; do
+		[[ -z "$slug" ]] && continue
+		tag="build-${RUN_ID}-${slug}"
 		log_info "Looking up staging manifest: ${tag}"
 
 		# Prefer org endpoint; fall back to user endpoint for personal repos
@@ -380,7 +475,7 @@ cleanup-staging)
 		else
 			log_warn "Could not locate staging manifest version for tag ${tag} — skipping deletion"
 		fi
-	done
+	done < <(echo "$MATRIX" | jq -r '.[].slug')
 	;;
 
 summary)

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -314,6 +314,12 @@ merge-manifests)
 		[[ -n "$tag" ]] && MERGE_CMD+=("--tag" "$tag")
 	done <<<"$TARGET_TAGS"
 
+	# Validate at least one --tag was appended (TARGET_TAGS was not all whitespace)
+	if [[ "${#MERGE_CMD[@]}" -le 4 ]]; then
+		log_error "No valid tags found in TARGET_TAGS — cannot create manifest"
+		exit 1
+	fi
+
 	MERGE_CMD+=("$SOURCE_AMD64" "$SOURCE_ARM64")
 
 	log_info "Merging manifests: ${SOURCE_AMD64} + ${SOURCE_ARM64}"
@@ -356,14 +362,21 @@ cleanup-staging)
 		)
 
 		if [[ -n "${version_id}" ]]; then
-			gh api --method DELETE \
+			deleted=false
+			if gh api --method DELETE \
 				"orgs/${pkg_owner}/packages/container/${pkg_name_encoded}/versions/${version_id}" \
-				2>/dev/null ||
-				gh api --method DELETE \
-					"user/packages/container/${pkg_name_encoded}/versions/${version_id}" \
-					2>/dev/null ||
-				true
-			log_success "Deleted staging manifest: ${tag}"
+				2>/dev/null; then
+				deleted=true
+			elif gh api --method DELETE \
+				"user/packages/container/${pkg_name_encoded}/versions/${version_id}" \
+				2>/dev/null; then
+				deleted=true
+			fi
+			if [[ "$deleted" == true ]]; then
+				log_success "Deleted staging manifest: ${tag}"
+			else
+				log_warn "Failed to delete staging manifest: ${tag} (version ${version_id})"
+			fi
 		else
 			log_warn "Could not locate staging manifest version for tag ${tag} — skipping deletion"
 		fi

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -339,6 +339,11 @@ classify)
 	platforms=("${deduped_platforms[@]}")
 	unset _seen_platforms deduped_platforms
 
+	# Fail fast on empty/whitespace-only PLATFORMS input
+	if [[ "${#platforms[@]}" -eq 0 ]]; then
+		die "PLATFORMS is empty or contains only whitespace"
+	fi
+
 	# push=false → always use the QEMU build job (imagetools requires a registry)
 	if [[ "$PUSH" != "true" ]]; then
 		set_github_output "use-split" "false"

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -327,12 +327,38 @@ classify)
 		[[ -n "$p" ]] && platforms+=("$p")
 	done < <(echo "$PLATFORMS" | tr ',' '\n')
 
-	# Single-platform or push=false → use the QEMU build job, not split
-	if [[ "${#platforms[@]}" -lt 2 || "$PUSH" != "true" ]]; then
+	# Deduplicate platform entries (preserve order, drop repeats)
+	declare -A _seen_platforms=()
+	deduped_platforms=()
+	for p in "${platforms[@]}"; do
+		if [[ -z "${_seen_platforms[$p]+x}" ]]; then
+			_seen_platforms[$p]=1
+			deduped_platforms+=("$p")
+		fi
+	done
+	platforms=("${deduped_platforms[@]}")
+	unset _seen_platforms deduped_platforms
+
+	# push=false → always use the QEMU build job (imagetools requires a registry)
+	if [[ "$PUSH" != "true" ]]; then
 		set_github_output "use-split" "false"
 		set_github_output "matrix" "[]"
-		log_info "Split disabled: ${#platforms[@]} platform(s), push=${PUSH}"
+		log_info "Split disabled: push=${PUSH}"
 		exit 0
+	fi
+
+	# Single platform: use split only if a native runner is mapped for it
+	if [[ "${#platforms[@]}" -lt 2 ]]; then
+		_single="${platforms[0]}"
+		_mapped=$(echo "$RUNNER_MAP" | jq -r --arg p "$_single" '.[$p] // empty')
+		if [[ -z "$_mapped" ]]; then
+			set_github_output "use-split" "false"
+			set_github_output "matrix" "[]"
+			log_info "Split disabled: single platform '${_single}' has no runner mapping"
+			exit 0
+		fi
+		log_info "Split enabled: single platform '${_single}' mapped to runner '${_mapped}'"
+		unset _single _mapped
 	fi
 
 	# Build matrix JSON array
@@ -373,7 +399,7 @@ classify)
 	done
 
 	set_github_output "use-split" "true"
-	set_github_output "matrix" "$matrix_json"
+	set_github_output "matrix" "$(echo "$matrix_json" | jq -c .)"
 	log_info "Split enabled: ${#platforms[@]} platform(s)"
 	for platform in "${platforms[@]}"; do
 		log_info "  ${platform}"

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -285,6 +285,31 @@ parse-tags)
 	log_info "Parsed tags for metadata-action"
 	;;
 
+merge-manifests)
+	# Assemble a multi-arch manifest list from per-platform staging images.
+	#
+	# Required environment variables:
+	#   SOURCE_AMD64 - Fully-qualified staging tag for the linux/amd64 image
+	#   SOURCE_ARM64 - Fully-qualified staging tag for the linux/arm64 image
+	#   TARGET_TAGS  - Newline-separated list of final tags to create
+	: "${SOURCE_AMD64:?SOURCE_AMD64 is required}"
+	: "${SOURCE_ARM64:?SOURCE_ARM64 is required}"
+	: "${TARGET_TAGS:?TARGET_TAGS is required}"
+
+	MERGE_CMD=("docker" "buildx" "imagetools" "create")
+
+	while IFS= read -r tag; do
+		tag=$(echo "$tag" | xargs)
+		[[ -n "$tag" ]] && MERGE_CMD+=("--tag" "$tag")
+	done <<<"$TARGET_TAGS"
+
+	MERGE_CMD+=("$SOURCE_AMD64" "$SOURCE_ARM64")
+
+	log_info "Merging manifests: ${SOURCE_AMD64} + ${SOURCE_ARM64}"
+	"${MERGE_CMD[@]}"
+	log_success "Multi-arch manifest created"
+	;;
+
 summary)
 	: "${IMAGE_NAME:=}"
 	: "${TAGS:=}"

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -3,7 +3,8 @@
 # Purpose: Build and push Docker images with multi-platform support
 #
 # Required environment variables:
-#   STEP - Which step to run: setup, build, push, metadata, parse-tags, summary
+#   STEP - Which step to run: setup, build, push, metadata, parse-tags, summary,
+#          set-output-digest, merge-manifests, cleanup-staging
 #
 # Optional environment variables:
 #   CONTEXT - Build context path (default: .)
@@ -285,6 +286,16 @@ parse-tags)
 	log_info "Parsed tags for metadata-action"
 	;;
 
+set-output-digest)
+	# Write a pre-computed digest to GITHUB_OUTPUT.
+	#
+	# Required environment variables:
+	#   DIGEST - Image digest (e.g. sha256:abc123...)
+	: "${DIGEST:?DIGEST is required}"
+	set_github_output "digest" "${DIGEST}"
+	log_info "Digest: ${DIGEST}"
+	;;
+
 merge-manifests)
 	# Assemble a multi-arch manifest list from per-platform staging images.
 	#
@@ -308,6 +319,55 @@ merge-manifests)
 	log_info "Merging manifests: ${SOURCE_AMD64} + ${SOURCE_ARM64}"
 	"${MERGE_CMD[@]}"
 	log_success "Multi-arch manifest created"
+	;;
+
+cleanup-staging)
+	# Delete per-platform staging manifests from GHCR after a multi-arch merge.
+	# Uses the GitHub Packages API; skips non-GHCR registries.
+	#
+	# Required environment variables:
+	#   IMAGE_NAME - Registry-relative image name (e.g. org/repo or org/group/repo)
+	#   RUN_ID     - GitHub Actions run ID used to construct staging tag names
+	#   GH_TOKEN   - GitHub token with packages:delete permission
+	: "${IMAGE_NAME:?IMAGE_NAME is required}"
+	: "${RUN_ID:?RUN_ID is required}"
+	: "${GH_TOKEN:?GH_TOKEN is required}"
+
+	# Parse owner and package name; URL-encode nested slashes
+	pkg_owner="${IMAGE_NAME%%/*}"
+	pkg_name="${IMAGE_NAME#*/}"
+	pkg_name_encoded="${pkg_name//\//%2F}"
+
+	for arch in linux-amd64 linux-arm64; do
+		tag="build-${RUN_ID}-${arch}"
+		log_info "Looking up staging manifest: ${tag}"
+
+		# Prefer org endpoint; fall back to user endpoint for personal repos
+		version_id=$(
+			gh api "orgs/${pkg_owner}/packages/container/${pkg_name_encoded}/versions" \
+				--paginate \
+				--jq ".[] | select(.metadata.container.tags[]? == \"${tag}\") | .id" \
+				2>/dev/null ||
+				gh api "user/packages/container/${pkg_name_encoded}/versions" \
+					--paginate \
+					--jq ".[] | select(.metadata.container.tags[]? == \"${tag}\") | .id" \
+					2>/dev/null ||
+				true
+		)
+
+		if [[ -n "${version_id}" ]]; then
+			gh api --method DELETE \
+				"orgs/${pkg_owner}/packages/container/${pkg_name_encoded}/versions/${version_id}" \
+				2>/dev/null ||
+				gh api --method DELETE \
+					"user/packages/container/${pkg_name_encoded}/versions/${version_id}" \
+					2>/dev/null ||
+				true
+			log_success "Deleted staging manifest: ${tag}"
+		else
+			log_warn "Could not locate staging manifest version for tag ${tag} — skipping deletion"
+		fi
+	done
 	;;
 
 summary)

--- a/scripts/ci/actions/docker-login.sh
+++ b/scripts/ci/actions/docker-login.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Docker registry login helpers
+#
+# Required environment variables:
+#   STEP - Which step to run: validate
+#
+# validate step environment variables:
+#   REGISTRY        - Container registry URL (required)
+#   DOCKERHUB_USERNAME - Docker Hub username (required when REGISTRY=docker.io)
+#   DOCKERHUB_TOKEN    - Docker Hub token (required when REGISTRY=docker.io)
+
+set -euo pipefail
+
+: "${STEP:?STEP is required}"
+
+# Source common action libraries
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/actions.sh
+source "$SCRIPT_DIR/../lib/actions.sh"
+
+case "$STEP" in
+validate)
+	: "${REGISTRY:?REGISTRY is required}"
+
+	if [[ "${REGISTRY}" != "ghcr.io" && "${REGISTRY}" != "docker.io" ]]; then
+		die "Unsupported registry '${REGISTRY}'. Supported values: ghcr.io, docker.io"
+	fi
+
+	if [[ "${REGISTRY}" == "docker.io" ]]; then
+		if [[ -z "${DOCKERHUB_USERNAME:-}" || -z "${DOCKERHUB_TOKEN:-}" ]]; then
+			die "DOCKERHUB_USERNAME and DOCKERHUB_TOKEN are required when REGISTRY is docker.io"
+		fi
+	fi
+
+	log_success "Registry validation passed: ${REGISTRY}"
+	;;
+
+*)
+	die_unknown_step "$STEP"
+	;;
+esac


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Eliminates QEMU emulation overhead for multi-platform Docker builds by routing each platform to its own native runner, then assembling the final multi-arch manifest with `docker buildx imagetools create`.

The core change is a `classify` job that parses the `platforms` input into a typed matrix JSON (`{platform, runner, slug, qemu}` per entry), replacing the previous hardcoded `build-amd64`/`build-arm64` job pair with a single `build-per-platform` matrix job. This generalises the split path to any number of platforms — not just amd64+arm64.

Callers supply a `runner-map` JSON input to opt into native runners. Platforms not in the map default to `ubuntu-24.04` with QEMU, so existing callers are fully backwards-compatible.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [x] Refactoring (no functional changes)
- [x] CI/CD improvement

## Changes Made

- **`reusable-docker.yml`**: replace `runner-amd64`/`runner-arm64`/`enable-qemu` inputs with `runner-map` (JSON object); add `classify` job; replace `build-amd64`+`build-arm64` with `build-per-platform` matrix job; update `merge`, `scan`, and workflow outputs
- **`scripts/ci/actions/build-docker.sh`**: add `STEP=classify` (parses platforms, deduplicates, resolves runners from map, auto-derives QEMU flag by comparing runner arch vs platform arch, outputs compact matrix JSON); update `merge-manifests` to derive sources from matrix slugs; update `cleanup-staging` to iterate matrix slugs
- **`.github/actions/docker-login/`**: new composite action eliminating 4× duplicated login blocks across jobs
- **`.github/actions/docker-metadata/`**: new composite action eliminating duplicated `docker/metadata-action` config
- **`scripts/ci/actions/docker-login.sh`**: new script for `STEP=validate` (registry + credential validation)

## Caller Example

```yaml
uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@main
with:
  platforms: linux/amd64,linux/arm64
  push: true
  runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
```

Platforms not in `runner-map` fall back to `ubuntu-24.04` + QEMU automatically.

## Job Topology

```
classify
  ├── build            (use-split=false: single platform with no mapping, or push=false — QEMU path)
  ├── build-per-platform  (use-split=true: matrix, one job per platform, native runners)
  │     └── merge      (imagetools create → final multi-arch manifest)
  └── scan             (always, needs build + merge, only if inputs.scan && inputs.push)
```

## Breaking Changes

`runner-amd64`, `runner-arm64`, and `enable-qemu` inputs are replaced by `runner-map`. Callers using the defaults (no runner customisation) are unaffected — `runner-map` defaults to `"{}"` which maps all platforms to `ubuntu-24.04` + QEMU, preserving prior behaviour.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Closes

- Closes #122

## Relates To

- Relates to #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-platform build mode with configurable runner selection, optional QEMU support, and split‑and‑merge multi‑architecture workflow.
  * Automated classification that decides split builds, emits a per‑platform build matrix, sets digest outputs, merges manifests, and can clean up staging images.
  * New reusable registry login and metadata actions to standardize authentication and image tag generation.

* **Chores**
  * Prefer build outputs for exported tags/digest and update scan gating to use whichever digest is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->