### PR TITLE
feat(docker): add per-platform smoke tests before manifest merge

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1426,6 +1426,10 @@ jobs:
       provenance: true
       sbom: true
       scan: true
+      # Trivial smoke check (mutually exclusive with smoke-test-script)
+      smoke-test: "--version"
+      # Or escape hatch for flag/env/network needs:
+      # smoke-test-script: "scripts/ci/smoke.sh"
 ```
 
 **Inputs:**
@@ -1440,6 +1444,18 @@ jobs:
 - `provenance` - Generate provenance attestation (default: true)
 - `sbom` - Generate SBOM attestation (default: true)
 - `scan` - Run vulnerability scan (default: false)
+- `runner-map` - JSON object mapping platform → runner label. Platforms not
+  in the map default to `ubuntu-24.04` with QEMU. Example:
+  `{"linux/arm64":"ubuntu-24.04-arm"}` (default: `{}`)
+- `smoke-test` - Shorthand command + args run inside each per-platform
+  staging image as `docker run --rm --platform <p> <image> <smoke-test>`.
+  Word-split; values with spaces or shell metacharacters need
+  `smoke-test-script`. Mutually exclusive with `smoke-test-script`. Only
+  applies to the split per-platform push path (default: '')
+- `smoke-test-script` - Path (relative to checkout root) to a caller-owned
+  script run on the runner with env `IMAGE`, `PLATFORM`, `REGISTRY`. Script
+  owns the `docker run` invocation — full control over flags, env, network,
+  tmpfs, etc. Mutually exclusive with `smoke-test` (default: '')
 
 **Outputs:**
 
@@ -1448,11 +1464,24 @@ jobs:
 
 **Features:**
 
-- Multi-platform builds with QEMU
+- Multi-platform builds with QEMU or split native-runner per-platform builds
 - docker/metadata-action for intelligent tag generation
 - GitHub Actions cache for layer caching
 - Provenance and SBOM attestations
 - Optional Trivy vulnerability scanning with SARIF upload
+- Optional per-platform smoke-test gate — any failing platform blocks the
+  manifest merge, so partial multi-arch manifests are never published
+
+**Per-platform smoke tests:**
+
+When `push` is true and two or more platforms are requested, the workflow
+splits into per-platform native (or QEMU) build legs, then merges a
+multi-arch manifest. Set `smoke-test` or `smoke-test-script` to gate the
+merge on a per-platform health check against the freshly pushed staging
+image. `smoke-test` is a convenience for trivial checks like `--version`;
+reach for `smoke-test-script` when you need `-e`, `--network`, `--read-only`,
+or any other `docker run` flag. Validation is performed in the `classify`
+job, so setting both fails fast before any build runs.
 
 **Permissions Required:**
 

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -346,11 +346,13 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        if: inputs.smoke-test-script != ''
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          sparse-checkout: |
+            scripts/ci
+            ${{ inputs.smoke-test-script }}
 
       - name: Setup QEMU
         if: ${{ matrix.qemu }}
@@ -367,6 +369,7 @@ jobs:
       - name: Smoke test (${{ matrix.platform }})
         shell: bash
         env:
+          STEP: smoke-test
           REGISTRY: ${{ inputs.registry }}
           IMAGE_NAME: ${{ inputs.image-name || github.repository }}
           RUN_ID: ${{ github.run_id }}
@@ -374,30 +377,7 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
           SMOKE_TEST: ${{ inputs.smoke-test }}
           SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
-        run: |
-          set -euo pipefail
-          IMAGE="${REGISTRY}/${IMAGE_NAME}:build-${RUN_ID}-${SLUG}"
-          export IMAGE
-          echo "::group::Pulling ${IMAGE} (${PLATFORM})"
-          docker pull --platform "${PLATFORM}" "${IMAGE}"
-          echo "::endgroup::"
-
-          if [[ -n "${SMOKE_TEST_SCRIPT}" ]]; then
-            if [[ ! -f "${SMOKE_TEST_SCRIPT}" ]]; then
-              echo "::error::smoke-test-script not found: ${SMOKE_TEST_SCRIPT}"
-              exit 1
-            fi
-            echo "::group::${SMOKE_TEST_SCRIPT} (IMAGE=${IMAGE} PLATFORM=${PLATFORM})"
-            chmod +x "${SMOKE_TEST_SCRIPT}"
-            "./${SMOKE_TEST_SCRIPT#./}"
-            echo "::endgroup::"
-          else
-            echo "::group::docker run --rm --platform ${PLATFORM} ${IMAGE} ${SMOKE_TEST}"
-            # Intentionally word-split SMOKE_TEST so callers can pass flags+args
-            # shellcheck disable=SC2086
-            docker run --rm --platform "${PLATFORM}" "${IMAGE}" ${SMOKE_TEST}
-            echo "::endgroup::"
-          fi
+        run: ./scripts/ci/actions/build-docker.sh
 
   # Assemble multi-arch manifest from per-platform staging images
   merge:

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -352,6 +352,7 @@ jobs:
           persist-credentials: false
           sparse-checkout: |
             scripts/ci
+            .github/actions
             ${{ inputs.smoke-test-script }}
 
       - name: Setup QEMU

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -317,6 +317,27 @@ jobs:
           provenance: false
           sbom: ${{ inputs.sbom }}
 
+      # Publish the per-platform push digest as an artifact so the verify job
+      # can pull the exact immutable image (IMAGE@sha256:...) instead of
+      # resolving the mutable staging tag — closes the TOCTOU window between
+      # build and verify.
+      - name: Record staging digest
+        shell: bash
+        env:
+          STEP: record-digest
+          DIGEST: ${{ steps.build.outputs.digest }}
+          DIGEST_FILE: ${{ runner.temp }}/staging-digest/digest.txt
+        run: ./scripts/ci/actions/build-docker.sh
+
+      - name: Upload staging digest
+        # Pinned to SHA for supply chain security
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: staging-digest-${{ matrix.slug }}
+          path: ${{ runner.temp }}/staging-digest/digest.txt
+          if-no-files-found: error
+          retention-days: 1
+
   # Optional per-platform smoke test gate.
   # Runs against each staging image on its native runner before manifest
   # merge. Any failure blocks the merge so partial multi-arch manifests are
@@ -374,14 +395,22 @@ jobs:
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # Pull the immutable digest recorded by the matching build-per-platform
+      # entry so smoke-test runs against the exact pushed image.
+      - name: Download staging digest
+        # Pinned to SHA for supply chain security
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: staging-digest-${{ matrix.slug }}
+          path: ${{ runner.temp }}/staging-digest
+
       - name: Smoke test (${{ matrix.platform }})
         shell: bash
         env:
           STEP: smoke-test
           REGISTRY: ${{ inputs.registry }}
           IMAGE_NAME: ${{ inputs.image-name || github.repository }}
-          RUN_ID: ${{ github.run_id }}
-          SLUG: ${{ matrix.slug }}
+          DIGEST_FILE: ${{ runner.temp }}/staging-digest/digest.txt
           PLATFORM: ${{ matrix.platform }}
           SMOKE_TEST: ${{ inputs.smoke-test }}
           SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -72,6 +72,28 @@ on:
         required: false
         type: string
         default: "{}"
+      smoke-test:
+        description: >-
+          Shorthand command + args to run inside each per-platform staging
+          image. Executed as `docker run --rm --platform <p> <image> <smoke-test>`.
+          Good for trivial checks like `--version`. Word-split; values with
+          spaces or shell metacharacters need `smoke-test-script` instead.
+          Mutually exclusive with `smoke-test-script`. Skipped when both empty.
+          Only applies to the split per-platform path (multi-arch push).
+        required: false
+        type: string
+        default: ""
+      smoke-test-script:
+        description: >-
+          Path (relative to checkout root) to a caller-owned script. Executed
+          on the runner with env `IMAGE`, `PLATFORM`, `REGISTRY`. The script
+          owns the `docker run` invocation — full control over flags, env,
+          network, tmpfs, etc. Preferred over `smoke-test` for anything
+          beyond a bare command. Mutually exclusive with `smoke-test`.
+          Any failing platform blocks the entire manifest merge.
+        required: false
+        type: string
+        default: ""
 
     outputs:
       tags:
@@ -122,6 +144,8 @@ jobs:
           PLATFORMS: ${{ inputs.platforms }}
           PUSH: ${{ inputs.push }}
           RUNNER_MAP: ${{ inputs.runner-map }}
+          SMOKE_TEST: ${{ inputs.smoke-test }}
+          SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
         run: ./scripts/ci/actions/build-docker.sh
 
   # Single-platform builds, or multi-platform when push is disabled (QEMU fallback)
@@ -293,11 +317,98 @@ jobs:
           provenance: false
           sbom: ${{ inputs.sbom }}
 
+  # Optional per-platform smoke test gate.
+  # Runs against each staging image on its native runner before manifest
+  # merge. Any failure blocks the merge so partial multi-arch manifests are
+  # never published. Two modes:
+  #   - smoke-test (shorthand): `docker run --rm --platform <p> <image> <cmd>`
+  #   - smoke-test-script: caller-owned script with env IMAGE/PLATFORM/REGISTRY
+  verify-per-platform:
+    name: Verify ${{ matrix.platform }}
+    needs: [classify, build-per-platform]
+    if: >-
+      needs.classify.outputs.use-split == 'true' &&
+      (inputs.smoke-test != '' || inputs.smoke-test-script != '')
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.classify.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Harden runner
+        # Pinned to SHA for supply chain security
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        if: inputs.smoke-test-script != ''
+        # Pinned to SHA for supply chain security
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup QEMU
+        if: ${{ matrix.qemu }}
+        # Pinned to SHA for supply chain security
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Login to registry
+        uses: ./.github/actions/docker-login
+        with:
+          registry: ${{ inputs.registry }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Smoke test (${{ matrix.platform }})
+        shell: bash
+        env:
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SLUG: ${{ matrix.slug }}
+          PLATFORM: ${{ matrix.platform }}
+          SMOKE_TEST: ${{ inputs.smoke-test }}
+          SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
+        run: |
+          set -euo pipefail
+          IMAGE="${REGISTRY}/${IMAGE_NAME}:build-${RUN_ID}-${SLUG}"
+          export IMAGE
+          echo "::group::Pulling ${IMAGE} (${PLATFORM})"
+          docker pull --platform "${PLATFORM}" "${IMAGE}"
+          echo "::endgroup::"
+
+          if [[ -n "${SMOKE_TEST_SCRIPT}" ]]; then
+            if [[ ! -f "${SMOKE_TEST_SCRIPT}" ]]; then
+              echo "::error::smoke-test-script not found: ${SMOKE_TEST_SCRIPT}"
+              exit 1
+            fi
+            echo "::group::${SMOKE_TEST_SCRIPT} (IMAGE=${IMAGE} PLATFORM=${PLATFORM})"
+            chmod +x "${SMOKE_TEST_SCRIPT}"
+            "./${SMOKE_TEST_SCRIPT#./}"
+            echo "::endgroup::"
+          else
+            echo "::group::docker run --rm --platform ${PLATFORM} ${IMAGE} ${SMOKE_TEST}"
+            # Intentionally word-split SMOKE_TEST so callers can pass flags+args
+            # shellcheck disable=SC2086
+            docker run --rm --platform "${PLATFORM}" "${IMAGE}" ${SMOKE_TEST}
+            echo "::endgroup::"
+          fi
+
   # Assemble multi-arch manifest from per-platform staging images
   merge:
     name: Merge Manifests
-    needs: [classify, build-per-platform]
-    if: ${{ needs.classify.outputs.use-split == 'true' }}
+    needs: [classify, build-per-platform, verify-per-platform]
+    if: >-
+      always() &&
+      needs.classify.outputs.use-split == 'true' &&
+      needs.build-per-platform.result == 'success' &&
+      (needs.verify-per-platform.result == 'success' ||
+       needs.verify-per-platform.result == 'skipped')
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -345,7 +345,15 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Checkout repository
+      - name: Checkout repository (full, for smoke-test-script)
+        if: inputs.smoke-test-script != ''
+        # Pinned to SHA for supply chain security
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout repository (sparse, smoke-test shorthand)
+        if: inputs.smoke-test-script == ''
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -353,7 +361,6 @@ jobs:
           sparse-checkout: |
             scripts/ci
             .github/actions
-            ${{ inputs.smoke-test-script }}
 
       - name: Setup QEMU
         if: ${{ matrix.qemu }}

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -4,7 +4,8 @@
 #
 # Required environment variables:
 #   STEP - Which step to run: setup, build, push, metadata, parse-tags, summary,
-#          set-output-digest, classify, smoke-test, merge-manifests, cleanup-staging
+#          set-output-digest, classify, record-digest, smoke-test,
+#          merge-manifests, cleanup-staging
 #
 # Optional environment variables:
 #   CONTEXT - Build context path (default: .)
@@ -421,15 +422,35 @@ classify)
 	done
 	;;
 
-smoke-test)
-	# Run a smoke test against a per-platform staging image.
+record-digest)
+	# Persist a build-push-action digest to an artifact-friendly path.
 	#
 	# Required environment variables:
-	#   REGISTRY   - Container registry URL
-	#   IMAGE_NAME - Registry-relative image name
-	#   RUN_ID     - GitHub Actions run ID used to locate the staging tag
-	#   SLUG       - Platform slug component of the staging tag
-	#   PLATFORM   - Target platform (e.g. linux/arm64)
+	#   DIGEST      - Image digest emitted by build-push-action (sha256:...)
+	#   DIGEST_FILE - Absolute path to write the digest to
+	: "${DIGEST:?DIGEST is required}"
+	: "${DIGEST_FILE:?DIGEST_FILE is required}"
+
+	if ! [[ "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+		die "DIGEST is not a valid sha256 digest: ${DIGEST}"
+	fi
+
+	mkdir -p "$(dirname "$DIGEST_FILE")"
+	printf '%s' "$DIGEST" >"$DIGEST_FILE"
+	log_info "Recorded digest to ${DIGEST_FILE}"
+	;;
+
+smoke-test)
+	# Run a smoke test against a per-platform staging image.
+	# Pulls by immutable digest (IMAGE@sha256:...) to avoid TOCTOU between
+	# the build and verify jobs.
+	#
+	# Required environment variables:
+	#   REGISTRY    - Container registry URL
+	#   IMAGE_NAME  - Registry-relative image name
+	#   PLATFORM    - Target platform (e.g. linux/arm64)
+	#   DIGEST_FILE - Path to a file containing the sha256:... digest of the
+	#                 staging image (produced by the `record-digest` step)
 	#
 	# Optional environment variables (mutually exclusive; at least one required):
 	#   SMOKE_TEST        - Shorthand command + args; word-split into `docker run`
@@ -437,9 +458,8 @@ smoke-test)
 	#                       REGISTRY in the environment and owns the docker run
 	: "${REGISTRY:?REGISTRY is required}"
 	: "${IMAGE_NAME:?IMAGE_NAME is required}"
-	: "${RUN_ID:?RUN_ID is required}"
-	: "${SLUG:?SLUG is required}"
 	: "${PLATFORM:?PLATFORM is required}"
+	: "${DIGEST_FILE:?DIGEST_FILE is required}"
 	: "${SMOKE_TEST:=}"
 	: "${SMOKE_TEST_SCRIPT:=}"
 
@@ -449,8 +469,16 @@ smoke-test)
 	if [[ -z "$SMOKE_TEST" && -z "$SMOKE_TEST_SCRIPT" ]]; then
 		die "One of SMOKE_TEST or SMOKE_TEST_SCRIPT is required"
 	fi
+	if [[ ! -s "$DIGEST_FILE" ]]; then
+		die "DIGEST_FILE missing or empty: ${DIGEST_FILE}"
+	fi
 
-	IMAGE="${REGISTRY}/${IMAGE_NAME}:build-${RUN_ID}-${SLUG}"
+	digest=$(<"$DIGEST_FILE")
+	if ! [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+		die "Invalid digest in ${DIGEST_FILE}: ${digest}"
+	fi
+
+	IMAGE="${REGISTRY}/${IMAGE_NAME}@${digest}"
 	export IMAGE
 
 	echo "::group::Pulling ${IMAGE} (${PLATFORM})"

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -304,9 +304,12 @@ classify)
 	#   PUSH       - Whether images will be pushed ("true"/"false")
 	#
 	# Optional environment variables:
-	#   RUNNER_MAP - JSON object mapping platform → runner label (default: "{}")
-	#               Platforms not in the map default to ubuntu-24.04 with QEMU.
-	#               Example: {"linux/arm64":"ubuntu-24.04-arm"}
+	#   RUNNER_MAP        - JSON object mapping platform → runner label (default: "{}")
+	#                       Platforms not in the map default to ubuntu-24.04 with QEMU.
+	#                       Example: {"linux/arm64":"ubuntu-24.04-arm"}
+	#   SMOKE_TEST        - Smoke-test shorthand command (validated only; not used here).
+	#   SMOKE_TEST_SCRIPT - Smoke-test script path (validated only; not used here).
+	#                       SMOKE_TEST and SMOKE_TEST_SCRIPT are mutually exclusive.
 	#
 	# Outputs:
 	#   use-split - "true" when split per-platform build should be used
@@ -314,6 +317,13 @@ classify)
 	: "${PLATFORMS:?PLATFORMS is required}"
 	: "${PUSH:?PUSH is required}"
 	: "${RUNNER_MAP:={}}"
+	: "${SMOKE_TEST:=}"
+	: "${SMOKE_TEST_SCRIPT:=}"
+
+	# Mutex: smoke-test and smoke-test-script cannot both be set
+	if [[ -n "$SMOKE_TEST" && -n "$SMOKE_TEST_SCRIPT" ]]; then
+		die "smoke-test and smoke-test-script are mutually exclusive (set at most one)"
+	fi
 
 	# Validate RUNNER_MAP is parseable JSON
 	if ! echo "$RUNNER_MAP" | jq empty 2>/dev/null; then

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -4,7 +4,7 @@
 #
 # Required environment variables:
 #   STEP - Which step to run: setup, build, push, metadata, parse-tags, summary,
-#          set-output-digest, classify, merge-manifests, cleanup-staging
+#          set-output-digest, classify, smoke-test, merge-manifests, cleanup-staging
 #
 # Optional environment variables:
 #   CONTEXT - Build context path (default: .)
@@ -419,6 +419,60 @@ classify)
 	for platform in "${platforms[@]}"; do
 		log_info "  ${platform}"
 	done
+	;;
+
+smoke-test)
+	# Run a smoke test against a per-platform staging image.
+	#
+	# Required environment variables:
+	#   REGISTRY   - Container registry URL
+	#   IMAGE_NAME - Registry-relative image name
+	#   RUN_ID     - GitHub Actions run ID used to locate the staging tag
+	#   SLUG       - Platform slug component of the staging tag
+	#   PLATFORM   - Target platform (e.g. linux/arm64)
+	#
+	# Optional environment variables (mutually exclusive; at least one required):
+	#   SMOKE_TEST        - Shorthand command + args; word-split into `docker run`
+	#   SMOKE_TEST_SCRIPT - Path to caller-owned script; receives IMAGE, PLATFORM,
+	#                       REGISTRY in the environment and owns the docker run
+	: "${REGISTRY:?REGISTRY is required}"
+	: "${IMAGE_NAME:?IMAGE_NAME is required}"
+	: "${RUN_ID:?RUN_ID is required}"
+	: "${SLUG:?SLUG is required}"
+	: "${PLATFORM:?PLATFORM is required}"
+	: "${SMOKE_TEST:=}"
+	: "${SMOKE_TEST_SCRIPT:=}"
+
+	if [[ -n "$SMOKE_TEST" && -n "$SMOKE_TEST_SCRIPT" ]]; then
+		die "SMOKE_TEST and SMOKE_TEST_SCRIPT are mutually exclusive"
+	fi
+	if [[ -z "$SMOKE_TEST" && -z "$SMOKE_TEST_SCRIPT" ]]; then
+		die "One of SMOKE_TEST or SMOKE_TEST_SCRIPT is required"
+	fi
+
+	IMAGE="${REGISTRY}/${IMAGE_NAME}:build-${RUN_ID}-${SLUG}"
+	export IMAGE
+
+	echo "::group::Pulling ${IMAGE} (${PLATFORM})"
+	docker pull --platform "${PLATFORM}" "${IMAGE}"
+	echo "::endgroup::"
+
+	if [[ -n "$SMOKE_TEST_SCRIPT" ]]; then
+		if [[ ! -f "$SMOKE_TEST_SCRIPT" ]]; then
+			echo "::error::smoke-test-script not found: ${SMOKE_TEST_SCRIPT}"
+			exit 1
+		fi
+		echo "::group::${SMOKE_TEST_SCRIPT} (IMAGE=${IMAGE} PLATFORM=${PLATFORM})"
+		chmod +x "$SMOKE_TEST_SCRIPT"
+		"./${SMOKE_TEST_SCRIPT#./}"
+		echo "::endgroup::"
+	else
+		echo "::group::docker run --rm --platform ${PLATFORM} ${IMAGE} ${SMOKE_TEST}"
+		# Intentionally word-split SMOKE_TEST so callers can pass flags+args
+		# shellcheck disable=SC2086
+		docker run --rm --platform "${PLATFORM}" "${IMAGE}" ${SMOKE_TEST}
+		echo "::endgroup::"
+	fi
 	;;
 
 merge-manifests)

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -479,7 +479,7 @@ smoke-test)
 	fi
 
 	IMAGE="${REGISTRY}/${IMAGE_NAME}@${digest}"
-	export IMAGE
+	export IMAGE PLATFORM REGISTRY
 
 	echo "::group::Pulling ${IMAGE} (${PLATFORM})"
 	docker pull --platform "${PLATFORM}" "${IMAGE}"

--- a/tests/bats/integration/test_build_docker.bats
+++ b/tests/bats/integration/test_build_docker.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Integration tests for build-docker.sh action script (classify step)
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+load "../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/build-docker.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+	setup_github_env
+	export LIB_DIR
+	export BATS_TEST_TMPDIR
+	export PROJECT_ROOT
+	export SCRIPT
+
+	# Defaults for classify step; individual tests override as needed
+	export STEP="classify"
+	export PLATFORMS="linux/amd64,linux/arm64"
+	export PUSH="true"
+	export RUNNER_MAP='{"linux/arm64":"ubuntu-24.04-arm"}'
+	unset SMOKE_TEST SMOKE_TEST_SCRIPT || true
+}
+
+teardown() {
+	restore_path
+	teardown_github_env
+	teardown_temp_dir
+}
+
+# Require jq (classify shells out) and bash 4+ (classify uses `declare -A`).
+# GitHub Actions ubuntu runners satisfy both; macOS system bash is 3.x.
+setup_file() {
+	if ! command -v jq >/dev/null 2>&1; then
+		skip "jq not available — required by build-docker.sh classify step"
+	fi
+}
+
+# Run the script with modern bash (bash 4+); skip on bash 3 hosts.
+_run_script() {
+	if ! bash4_available; then
+		skip "requires bash 4+ (classify uses associative arrays)"
+	fi
+	run "$MODERN_BASH" "$SCRIPT"
+}
+
+# =============================================================================
+# Smoke-test mutex validation (fail fast before any build job runs)
+# =============================================================================
+
+@test "build-docker classify: fails when smoke-test and smoke-test-script both set" {
+	export SMOKE_TEST="--version"
+	export SMOKE_TEST_SCRIPT="scripts/smoke.sh"
+
+	_run_script
+	assert_failure
+	assert_output --partial "mutually exclusive"
+}
+
+@test "build-docker classify: succeeds with only smoke-test set" {
+	export SMOKE_TEST="--version"
+
+	_run_script
+	assert_success
+	assert_github_output "use-split" "true"
+}
+
+@test "build-docker classify: succeeds with only smoke-test-script set" {
+	export SMOKE_TEST_SCRIPT="scripts/smoke.sh"
+
+	_run_script
+	assert_success
+	assert_github_output "use-split" "true"
+}
+
+@test "build-docker classify: succeeds with neither smoke input set" {
+	_run_script
+	assert_success
+	assert_github_output "use-split" "true"
+}
+
+# =============================================================================
+# Sanity: required-input validation is unchanged by the smoke additions
+# =============================================================================
+
+@test "build-docker classify: fails when PLATFORMS is unset" {
+	if ! bash4_available; then
+		skip "requires bash 4+"
+	fi
+	unset PLATFORMS
+	run "$MODERN_BASH" "$SCRIPT"
+	assert_failure
+	assert_output --partial "PLATFORMS"
+}
+
+@test "build-docker classify: fails when PUSH is unset" {
+	if ! bash4_available; then
+		skip "requires bash 4+"
+	fi
+	unset PUSH
+	run "$MODERN_BASH" "$SCRIPT"
+	assert_failure
+	assert_output --partial "PUSH"
+}

--- a/tests/bats/integration/test_build_docker.bats
+++ b/tests/bats/integration/test_build_docker.bats
@@ -87,21 +87,15 @@ _run_script() {
 # =============================================================================
 
 @test "build-docker classify: fails when PLATFORMS is unset" {
-	if ! bash4_available; then
-		skip "requires bash 4+"
-	fi
 	unset PLATFORMS
-	run "$MODERN_BASH" "$SCRIPT"
+	_run_script
 	assert_failure
 	assert_output --partial "PLATFORMS"
 }
 
 @test "build-docker classify: fails when PUSH is unset" {
-	if ! bash4_available; then
-		skip "requires bash 4+"
-	fi
 	unset PUSH
-	run "$MODERN_BASH" "$SCRIPT"
+	_run_script
 	assert_failure
 	assert_output --partial "PUSH"
 }

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 
 [[package]]
 name = "lgtm-ci"
-version = "0.10.2"
+version = "0.11.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Add optional per-platform smoke tests to the reusable Docker workflow.
Each staging image is verified via `docker run <image> <smoke-test>` on
its native runner before the multi-arch manifest is merged, catching
broken binaries (wrong arch, missing deps, bad entrypoint) before they
reach consumers.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Changes Made

- `reusable-docker.yml`: new `smoke-test` and `smoke-test-script` inputs;
  `verify-per-platform` matrix job gated between build and merge.
- `build-docker.sh`: `classify` validates mutually-exclusive smoke inputs
  and emits per-platform matrix data.
- `.github/actions/README.md`: document smoke-test inputs and topology.
- `tests/bats/integration/test_build_docker.bats`: coverage for classify
  input validation.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. New inputs are optional; smoke tests skipped when unset.

## Closes

- Closes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional per-platform smoke-test via a simple command or caller-owned script (mutually exclusive) to verify each platform image before publishing; applies only to split per-platform flow
  * Platform-to-runner mapping to target specific runners per platform, with QEMU fallback
  * Per-platform digests recorded; any smoke-test failure blocks manifest merge to prevent partial publishes

* **Tests**
  * Integration tests validating smoke-test input handling, mutual-exclusion, and classify-step behavior

* **Documentation**
  * Updated docs describing smoke-test options, runner-map behavior, gating, and validation rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->