### PR TITLE
ci: run lintro via full py-lintro docker image

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -892,33 +892,47 @@ Build and push Docker images with multi-platform support.
 
 ### run-quality
 
-Run lintro quality checks with optional actionlint validation.
+Runs **lintro inside the full [`py-lintro`](https://github.com/lgtm-hq/py-lintro)
+Docker image** (`docker pull` + `docker run` with the repo mounted at `/code`),
+so every bundled CLI matches upstream docs — not `uv run lintro` on the runner.
+
+Callers need **`permissions: packages: read`** (and GitHub logs into GHCR via
+`GITHUB_TOKEN`) when pulling from GHCR.
 
 ```yaml
-- uses: lgtm-hq/lgtm-ci/.github/actions/run-quality@main
-  with:
-    tools: "" # optional, comma-separated list (empty = all)
-    mode: "check" # 'check' or 'format'
-    fail-on-error: "true" # optional
-    run-actionlint: "true" # optional, run actionlint on GitHub Actions
-    working-directory: "." # optional, working directory for linting
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@…
+      - uses: lgtm-hq/lgtm-ci/.github/actions/run-quality@main
+        with:
+          # Pin digest in production (default matches this repo’s CI pin)
+          lintro-image: ghcr.io/lgtm-hq/py-lintro@sha256:…
+          tools: "" # optional, comma-separated list (empty = all)
+          mode: "check" # 'check' or 'format'
+          fail-on-error: "true" # optional
+          working-directory: "." # optional
 ```
 
 **Inputs:**
 
+- `lintro-image` - Full `ghcr.io/lgtm-hq/py-lintro` reference (**digest recommended**)
 - `tools` - Comma-separated list of lintro tools to run (empty = all)
 - `mode` - Mode: 'check' (lint only) or 'format' (auto-fix)
 - `fail-on-error` - Fail workflow if linting errors found (default: true)
-- `run-actionlint` - Run actionlint validation on GitHub Actions (default: true)
+- `run-actionlint` - Deprecated (ignored); actionlint runs inside the py-lintro image
 - `working-directory` - Working directory for linting (default: '.')
 
 **Features:**
 
-- Runs all configured lintro tools (shellcheck, shfmt, prettier, yamllint, etc.)
-- Optional actionlint validation for GitHub Actions workflows
-- Support for check mode (lint only) or format mode (auto-fix)
-- Configurable tool selection
-- Respects fail-on-error for both lintro and actionlint
+- Same toolchain as the official py-lintro container (shellcheck, prettier, semgrep, etc.)
+- Check or format mode with optional `--tools` filtering
+- Writes `chk-output.txt` in `working-directory` when `mode` is `check` (for artifacts)
 
 **Outputs:**
 

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -925,7 +925,6 @@ jobs:
 - `tools` - Comma-separated list of lintro tools to run (empty = all)
 - `mode` - Mode: 'check' (lint only) or 'format' (auto-fix)
 - `fail-on-error` - Fail workflow if linting errors found (default: true)
-- `run-actionlint` - Deprecated (ignored); actionlint runs inside the py-lintro image
 - `working-directory` - Working directory for linting (default: '.')
 
 **Features:**

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -912,7 +912,7 @@ jobs:
       - uses: lgtm-hq/lgtm-ci/.github/actions/run-quality@main
         with:
           # Pin digest in production (default matches this repo’s CI pin)
-          lintro-image: ghcr.io/lgtm-hq/py-lintro@sha256:…
+          lintro-image: ghcr.io/lgtm-hq/py-lintro@sha256:6b6ee149e4daa0f17447b4c1c481e949277eb7a28453c5cb819dd95119ba42dc
           tools: "" # optional, comma-separated list (empty = all)
           mode: "check" # 'check' or 'format'
           fail-on-error: "true" # optional

--- a/.github/actions/run-quality/action.yml
+++ b/.github/actions/run-quality/action.yml
@@ -36,12 +36,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Resolve scripts directory
-      shell: bash
-      run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
-
     - name: Log in to GitHub Container Registry
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
@@ -58,7 +52,7 @@ runs:
         TOOLS: ${{ inputs.tools }}
         FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
         LINTRO_IMAGE: ${{ inputs.lintro-image }}
-      run: "$SCRIPTS_DIR/ci/quality/run-lintro-docker.sh"
+      run: bash "$GITHUB_ACTION_PATH/../../../scripts/ci/quality/run-lintro-docker.sh"
 
 branding:
   icon: "check-circle"

--- a/.github/actions/run-quality/action.yml
+++ b/.github/actions/run-quality/action.yml
@@ -1,9 +1,13 @@
 ---
 name: "Run Quality Checks"
-description: "Run lintro quality checks with configurable tools"
+description: "Run lintro via full ghcr.io/lgtm-hq/py-lintro image (all bundled tools)"
 author: "lgtm-hq"
 
 inputs:
+  lintro-image:
+    description: "Pinned ghcr.io/lgtm-hq/py-lintro image (digest strongly recommended)"
+    required: true
+    default: "ghcr.io/lgtm-hq/py-lintro@sha256:6b6ee149e4daa0f17447b4c1c481e949277eb7a28453c5cb819dd95119ba42dc"
   tools:
     description: "Comma-separated list of lintro tools to run (empty = all)"
     required: false
@@ -17,7 +21,7 @@ inputs:
     required: false
     default: "true"
   run-actionlint:
-    description: "Also run actionlint on GitHub Actions"
+    description: "Deprecated — ignored; actionlint runs inside full py-lintro image."
     required: false
     default: "true"
   working-directory:
@@ -42,6 +46,13 @@ runs:
         echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
           >> "$GITHUB_ENV"
 
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
     - name: Run lintro quality checks
       id: lint
       shell: bash
@@ -50,26 +61,8 @@ runs:
         STEP: ${{ inputs.mode }}
         TOOLS: ${{ inputs.tools }}
         FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
-      run: $SCRIPTS_DIR/ci/quality/lint-check.sh
-
-    - name: Run actionlint
-      if: inputs.run-actionlint == 'true'
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-      env:
-        STEP: check
-        FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
-      run: |
-        if command -v actionlint &>/dev/null; then
-          $SCRIPTS_DIR/ci/quality/actionlint-check.sh
-          EXIT_CODE=$?
-          if [[ "$FAIL_ON_ERROR" != "true" ]]; then
-            exit 0
-          fi
-          exit $EXIT_CODE
-        else
-          echo "::debug::actionlint not found, skipping GitHub Actions linting"
-        fi
+        LINTRO_IMAGE: ${{ inputs.lintro-image }}
+      run: "$SCRIPTS_DIR/ci/quality/run-lintro-docker.sh"
 
 branding:
   icon: "check-circle"

--- a/.github/actions/run-quality/action.yml
+++ b/.github/actions/run-quality/action.yml
@@ -20,10 +20,6 @@ inputs:
     description: "Fail if linting errors found"
     required: false
     default: "true"
-  run-actionlint:
-    description: "Deprecated — ignored; actionlint runs inside full py-lintro image."
-    required: false
-    default: "true"
   working-directory:
     description: "Working directory for linting"
     required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,19 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   quality:
     name: Lintro Quality Checks
     runs-on: ubuntu-latest
-    container:
-      # Pinned to digest for supply chain security (sha-<commit> tag keeps it from GC)
+    permissions:
+      contents: read
+      packages: read
+    env:
+      # Pinned digest — keep in sync with pyproject.toml lintro pin / reusable-quality.yml
       # yamllint disable-line rule:line-length
-      image: ghcr.io/lgtm-hq/py-lintro@sha256:f93473dea60ac4d28540e9e15c1d47267c2cfc3cc291beef6d4563d14a60e2f0
-      # Run as root to avoid permission issues with GitHub Actions file commands
-      options: --user 0
+      LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro@sha256:f93473dea60ac4d28540e9e15c1d47267c2cfc3cc291beef6d4563d14a60e2f0
     outputs:
       exit-code: ${{ steps.lintro.outputs.exit-code }}
 
@@ -30,22 +32,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Add lintro to PATH
-        shell: bash
-        run: echo "/app/.venv/bin" >> "$GITHUB_PATH"
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Run lintro quality checks
         id: lintro
         shell: bash
-        run: |
-          # Use pipefail to capture lintro exit code through the pipe
-          # tee failures are intentionally ignored (PIPESTATUS[0] captures lintro)
-          set -o pipefail
-          set +e
-          lintro chk 2>&1 | tee chk-output.txt
-          EXIT_CODE=${PIPESTATUS[0]}
-          echo "exit-code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
-          exit "$EXIT_CODE"
+        env:
+          STEP: check
+          FAIL_ON_ERROR: "true"
+        run: bash scripts/ci/quality/run-lintro-docker.sh
 
       - name: Upload linting report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,20 +32,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
       - name: Run lintro quality checks
         id: lintro
-        shell: bash
-        env:
-          STEP: check
-          FAIL_ON_ERROR: "true"
-        run: bash scripts/ci/quality/run-lintro-docker.sh
+        uses: ./.github/actions/run-quality
+        with:
+          lintro-image: ${{ env.LINTRO_IMAGE }}
+          mode: check
+          fail-on-error: "true"
 
       - name: Upload linting report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       # Pinned digest — keep in sync with pyproject.toml lintro pin / reusable-quality.yml
       # yamllint disable-line rule:line-length
-      LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro@sha256:f93473dea60ac4d28540e9e15c1d47267c2cfc3cc291beef6d4563d14a60e2f0
+      LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro@sha256:6b6ee149e4daa0f17447b4c1c481e949277eb7a28453c5cb819dd95119ba42dc
     outputs:
       exit-code: ${{ steps.lintro.outputs.exit-code }}
 

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -4,28 +4,13 @@ name: Reusable Quality Workflow
 on:
   workflow_call:
     inputs:
-      python-version:
-        description: "Deprecated — unused; lintro runs in full py-lintro Docker image."
-        required: false
-        type: string
-        default: "3.11"
-      node-version:
-        description: "Deprecated — unused; lintro runs in full py-lintro Docker image."
-        required: false
-        type: string
-        default: "20"
-      lintro-tools:
-        description: "Comma-separated list of lintro tools to run (empty = all)"
+      tools:
+        description: "Comma-separated lintro --tools list (empty = all tools)"
         required: false
         type: string
         default: ""
       fail-on-error:
         description: "Fail workflow if linting errors found"
-        required: false
-        type: boolean
-        default: true
-      run-actionlint:
-        description: "Deprecated — ignored; actionlint runs inside full py-lintro image."
         required: false
         type: boolean
         default: true
@@ -69,7 +54,7 @@ jobs:
         uses: ./.github/actions/run-quality
         with:
           lintro-image: ${{ env.LINTRO_IMAGE }}
-          tools: ${{ inputs.lintro-tools }}
+          tools: ${{ inputs.tools }}
           fail-on-error: ${{ inputs.fail-on-error }}
           working-directory: ${{ inputs.working-directory }}
 

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -5,12 +5,12 @@ on:
   workflow_call:
     inputs:
       python-version:
-        description: "Python version for linting tools"
+        description: "Deprecated — unused; lintro runs in full py-lintro Docker image."
         required: false
         type: string
         default: "3.11"
       node-version:
-        description: "Node.js version for JS/TS linting"
+        description: "Deprecated — unused; lintro runs in full py-lintro Docker image."
         required: false
         type: string
         default: "20"
@@ -25,7 +25,7 @@ on:
         type: boolean
         default: true
       run-actionlint:
-        description: "Run actionlint on GitHub Actions"
+        description: "Deprecated — ignored; actionlint runs inside full py-lintro image."
         required: false
         type: boolean
         default: true
@@ -46,6 +46,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: read
+    env:
+      # Pinned digest — keep in sync with ci.yml / pyproject.toml lintro pin
+      # yamllint disable-line rule:line-length
+      LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro@sha256:6b6ee149e4daa0f17447b4c1c481e949277eb7a28453c5cb819dd95119ba42dc
 
     steps:
       - name: Harden runner
@@ -60,38 +65,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Python
-        uses: ./.github/actions/setup-python
-        with:
-          python-version: ${{ inputs.python-version }}
-          cache: "true"
-          install-dependencies: "true"
-          install-extras: "dev"
-
-      - name: Setup Node.js
-        # yamllint disable-line rule:line-length
-        if:
-          contains(inputs.lintro-tools, 'prettier') || contains(inputs.lintro-tools,
-          'biome') || inputs.lintro-tools == ''
-        uses: ./.github/actions/setup-node
-        with:
-          node-version: ${{ inputs.node-version }}
-          cache: "true"
-
-      - name: Install actionlint
-        if: inputs.run-actionlint
-        shell: bash
-        working-directory: ${{ inputs.working-directory }}
-        env:
-          STEP: install
-        run: ${{ github.workspace }}/scripts/ci/quality/actionlint-check.sh
-
       - name: Run quality checks
         uses: ./.github/actions/run-quality
         with:
+          lintro-image: ${{ env.LINTRO_IMAGE }}
           tools: ${{ inputs.lintro-tools }}
           fail-on-error: ${{ inputs.fail-on-error }}
-          run-actionlint: ${{ inputs.run-actionlint }}
           working-directory: ${{ inputs.working-directory }}
 
       - name: Upload linting report
@@ -102,5 +81,6 @@ jobs:
           name: linting-report
           path: |
             ${{ inputs.working-directory }}/.lintro/
+            ${{ inputs.working-directory }}/chk-output.txt
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -9,6 +9,11 @@ on:
         required: false
         type: string
         default: ""
+      lintro-tools:
+        description: "Deprecated alias for tools"
+        required: false
+        type: string
+        default: ""
       fail-on-error:
         description: "Fail workflow if linting errors found"
         required: false
@@ -54,7 +59,7 @@ jobs:
         uses: ./.github/actions/run-quality
         with:
           lintro-image: ${{ env.LINTRO_IMAGE }}
-          tools: ${{ inputs.tools }}
+          tools: ${{ inputs.tools != '' && inputs.tools || inputs.lintro-tools }}
           fail-on-error: ${{ inputs.fail-on-error }}
           working-directory: ${{ inputs.working-directory }}
 

--- a/.lintro-config.yaml
+++ b/.lintro-config.yaml
@@ -69,4 +69,4 @@ tools:
   mypy:
     enabled: true
   pytest:
-    enabled: true
+    enabled: false

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ image** so every bundled tool is available. Mirror CI locally:
 
 ```bash
 export STEP=check
-export LINTRO_IMAGE='ghcr.io/lgtm-hq/py-lintro@sha256:…' # match ci.yml / pyproject.toml note
+export LINTRO_IMAGE='ghcr.io/lgtm-hq/py-lintro@sha256:6b6ee149e4daa0f17447b4c1c481e949277eb7a28453c5cb819dd95119ba42dc'
 bash scripts/ci/quality/run-lintro-docker.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ jobs:
       contents: read
       packages: read # pull ghcr.io/lgtm-hq/py-lintro in reusable-quality
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@v1
+    # Optional: with: { tools: "ruff,yamllint", fail-on-error: true, working-directory: "." }
 ```
 
 ### Using Shell Libraries

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ jobs:
 ```yaml
 jobs:
   quality:
+    permissions:
+      contents: read
+      packages: read # pull ghcr.io/lgtm-hq/py-lintro in reusable-quality
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@v1
-    with:
-      python-version: "3.13"
 ```
 
 ### Using Shell Libraries
@@ -90,7 +91,7 @@ steps:
 
 | Action              | Description                              |
 | ------------------- | ---------------------------------------- |
-| `run-quality`       | Lintro quality checks with actionlint    |
+| `run-quality`       | Lintro via full py-lintro Docker image   |
 | `run-tests`         | Generic test runner                      |
 | `run-vitest`        | Vitest test execution                    |
 | `run-pytest`        | Pytest test execution                    |
@@ -141,26 +142,26 @@ steps:
 
 ### Reusable Workflows
 
-| Workflow                          | Description                          |
-| --------------------------------- | ------------------------------------ |
-| `reusable-quality.yml`            | Lintro + shellcheck + action pinning |
-| `reusable-sbom.yml`               | SBOM generation with Cosign signing  |
-| `reusable-release-version-pr.yml` | Release version PR with changelog    |
-| `reusable-release-auto-tag.yml`   | Tag + GitHub release on merge        |
-| `reusable-publish-pypi.yml`       | PyPI publishing with OIDC            |
-| `reusable-publish-npm.yml`        | npm publishing                       |
-| `reusable-publish-gem.yml`        | RubyGems publishing                  |
-| `reusable-publish-homebrew.yml`   | Homebrew formula publishing          |
-| `reusable-deploy-pages.yml`       | GitHub Pages deployment              |
-| `reusable-docker.yml`             | Docker build and publish             |
-| `reusable-coverage.yml`           | Test coverage collection             |
-| `reusable-test-python.yml`        | Python test execution                |
-| `reusable-test-node.yml`          | Node.js test execution               |
-| `reusable-test-shell.yml`         | Shell script testing with BATS       |
-| `reusable-test-e2e.yml`           | E2E testing with Playwright          |
-| `reusable-test-e2e-matrix.yml`    | Matrix E2E testing                   |
-| `reusable-pr-auto-assign.yml`     | PR auto-assignment                   |
-| `reusable-pr-labeler.yml`         | PR auto-labeling                     |
+| Workflow                          | Description                            |
+| --------------------------------- | -------------------------------------- |
+| `reusable-quality.yml`            | Lintro via full py-lintro Docker image |
+| `reusable-sbom.yml`               | SBOM generation with Cosign signing    |
+| `reusable-release-version-pr.yml` | Release version PR with changelog      |
+| `reusable-release-auto-tag.yml`   | Tag + GitHub release on merge          |
+| `reusable-publish-pypi.yml`       | PyPI publishing with OIDC              |
+| `reusable-publish-npm.yml`        | npm publishing                         |
+| `reusable-publish-gem.yml`        | RubyGems publishing                    |
+| `reusable-publish-homebrew.yml`   | Homebrew formula publishing            |
+| `reusable-deploy-pages.yml`       | GitHub Pages deployment                |
+| `reusable-docker.yml`             | Docker build and publish               |
+| `reusable-coverage.yml`           | Test coverage collection               |
+| `reusable-test-python.yml`        | Python test execution                  |
+| `reusable-test-node.yml`          | Node.js test execution                 |
+| `reusable-test-shell.yml`         | Shell script testing with BATS         |
+| `reusable-test-e2e.yml`           | E2E testing with Playwright            |
+| `reusable-test-e2e-matrix.yml`    | Matrix E2E testing                     |
+| `reusable-pr-auto-assign.yml`     | PR auto-assignment                     |
+| `reusable-pr-labeler.yml`         | PR auto-labeling                       |
 
 ### Shell Libraries
 
@@ -232,15 +233,22 @@ for working examples.
 
 ## 🔨 Development
 
+CI and `reusable-quality.yml` run **lintro inside the pinned `ghcr.io/lgtm-hq/py-lintro`
+image** so every bundled tool is available. Mirror CI locally:
+
+```bash
+export STEP=check
+export LINTRO_IMAGE='ghcr.io/lgtm-hq/py-lintro@sha256:…' # match ci.yml / pyproject.toml note
+bash scripts/ci/quality/run-lintro-docker.sh
+```
+
+Quick iteration without Docker (optional tools may SKIP — same as `lint-check.sh`):
+
 ```bash
 git clone https://github.com/lgtm-hq/lgtm-ci.git
 cd lgtm-ci
-
-# Lint
-uv run lintro chk
-
-# Auto-fix formatting
-uv run lintro fmt
+uv sync --dev
+STEP=check bash scripts/ci/quality/lint-check.sh
 ```
 
 ## 🤝 Community

--- a/scripts/ci/actions/generate-lintro-comment.sh
+++ b/scripts/ci/actions/generate-lintro-comment.sh
@@ -57,7 +57,7 @@ Checks run inside the pinned **py-lintro** container (same as the workflow quali
 ### Status: ${STATUS_EMOJI} ${STATUS_TEXT}
 
 **Workflow:**
-1. Performed code quality checks with \`lintro check\` (Docker)
+1. Performed code quality checks with \`lintro chk\` (Docker)
 
 ### Results:
 \`\`\`

--- a/scripts/ci/actions/generate-lintro-comment.sh
+++ b/scripts/ci/actions/generate-lintro-comment.sh
@@ -52,10 +52,12 @@ cat <<EOF
 
 This PR has been analyzed using **lintro** - our unified code quality tool.
 
+Checks run inside the pinned **py-lintro** container (same as the workflow quality job), so the summary reflects the full bundled toolchain.
+
 ### Status: ${STATUS_EMOJI} ${STATUS_TEXT}
 
 **Workflow:**
-1. Performed code quality checks with \`lintro check\`
+1. Performed code quality checks with \`lintro check\` (Docker)
 
 ### Results:
 \`\`\`

--- a/scripts/ci/quality/lint-check.sh
+++ b/scripts/ci/quality/lint-check.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
-# Purpose: Run lintro quality checks with configurable options
+# Purpose: Run lintro locally via uv (partial toolchains).
+#
+# GitHub Actions paths use scripts/ci/quality/run-lintro-docker.sh with the
+# full ghcr.io/lgtm-hq/py-lintro image so every bundled tool runs.
 #
 # Required environment variables:
 #   STEP - Which step to run: check or format

--- a/scripts/ci/quality/run-lintro-docker.sh
+++ b/scripts/ci/quality/run-lintro-docker.sh
@@ -50,9 +50,11 @@ fi
 log_info "Pulling Lintro image: ${LINTRO_IMAGE}"
 docker pull "${LINTRO_IMAGE}"
 
+# Do not pass --user: py-lintro entrypoint starts as root, adjusts PATH for bun/cargo,
+# then gosu(1)s to the UID owning /code (the workspace mount). Passing --user skips that
+# root entrypoint and caused many external CLIs to be missing from PATH inside the container.
 declare -a docker_args=(
 	docker run --rm
-	--user "$(id -u):$(id -g)"
 	-e HOME=/tmp
 	-e LINTRO_AUTO_INSTALL_DEPS=1
 	-v "${WORKSPACE}:/code"
@@ -73,7 +75,14 @@ check)
 	set +e
 	set -o pipefail
 	"${docker_args[@]}" "${lintro_args[@]}" 2>&1 | tee "${OUTPUT_LOG}"
-	EXIT_CODE="${PIPESTATUS[0]}"
+	DOCKER_EC="${PIPESTATUS[0]}"
+	TEE_EC="${PIPESTATUS[1]:-0}"
+	if [[ "${TEE_EC}" -ne 0 ]]; then
+		log_error "tee failed (exit ${TEE_EC}) while writing ${OUTPUT_LOG}"
+		EXIT_CODE="${TEE_EC}"
+	else
+		EXIT_CODE="${DOCKER_EC}"
+	fi
 	set +o pipefail
 	set -e
 	;;

--- a/scripts/ci/quality/run-lintro-docker.sh
+++ b/scripts/ci/quality/run-lintro-docker.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Run lintro chk/fmt via full ghcr.io/lgtm-hq/py-lintro image (lintro-tools stack).
+#
+# Required environment variables:
+#   STEP           check | format
+#   LINTRO_IMAGE   Pinned reference (e.g. ghcr.io/lgtm-hq/py-lintro@sha256:...)
+#
+# Optional environment variables:
+#   TOOLS          Comma-separated list passed to lintro --tools (empty = all)
+#   FAIL_ON_ERROR  true|false (default: true) — only for STEP=check
+#   WORKSPACE      Absolute path to mount at /code (default: current directory)
+#   OUTPUT_LOG     Log path for STEP=check tee (default: chk-output.txt)
+
+set -euo pipefail
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+run-lintro-docker.sh — run lintro inside the full py-lintro container.
+
+Requires: STEP=check|format, LINTRO_IMAGE=ghcr.io/lgtm-hq/py-lintro@sha256:...
+
+Optional: TOOLS, FAIL_ON_ERROR, WORKSPACE, OUTPUT_LOG
+
+Matches https://github.com/lgtm-hq/py-lintro documented docker invocation.
+EOF
+	exit 0
+fi
+
+: "${STEP:?STEP is required (check or format)}"
+: "${LINTRO_IMAGE:?LINTRO_IMAGE is required}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+if [[ -f "$LIB_DIR/log.sh" ]]; then
+	# shellcheck source=../lib/log.sh
+	source "$LIB_DIR/log.sh"
+else
+	log_info() { echo "[INFO] $*"; }
+	log_error() { echo "[ERROR] $*" >&2; }
+	log_success() { echo "[SUCCESS] $*"; }
+fi
+
+: "${TOOLS:=}"
+: "${FAIL_ON_ERROR:=true}"
+: "${WORKSPACE:=$(pwd)}"
+: "${OUTPUT_LOG:=chk-output.txt}"
+
+log_info "Pulling Lintro image: ${LINTRO_IMAGE}"
+docker pull "${LINTRO_IMAGE}"
+
+declare -a docker_args=(
+	docker run --rm
+	--user "$(id -u):$(id -g)"
+	-e HOME=/tmp
+	-e LINTRO_AUTO_INSTALL_DEPS=1
+	-v "${WORKSPACE}:/code"
+	-w /code
+	"${LINTRO_IMAGE}"
+)
+
+declare -a lintro_args=()
+
+case "$STEP" in
+check)
+	lintro_args+=(chk)
+	if [[ -n "$TOOLS" ]]; then
+		lintro_args+=(--tools "${TOOLS}")
+	fi
+	lintro_args+=(. --output-format grid)
+	log_info "Running lintro check in container..."
+	set +e
+	set -o pipefail
+	"${docker_args[@]}" "${lintro_args[@]}" 2>&1 | tee "${OUTPUT_LOG}"
+	EXIT_CODE="${PIPESTATUS[0]}"
+	set +o pipefail
+	set -e
+	;;
+format)
+	lintro_args+=(fmt)
+	if [[ -n "$TOOLS" ]]; then
+		lintro_args+=(--tools "${TOOLS}")
+	fi
+	lintro_args+=(.)
+	log_info "Running lintro format in container..."
+	set +e
+	"${docker_args[@]}" "${lintro_args[@]}"
+	EXIT_CODE=$?
+	set -e
+	;;
+*)
+	log_error "STEP must be check or format, got: ${STEP}"
+	exit 2
+	;;
+esac
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	{
+		echo "exit-code=${EXIT_CODE}"
+		if [[ "${EXIT_CODE}" -eq 0 ]]; then
+			echo "status=passed"
+		else
+			echo "status=failed"
+		fi
+	} >>"${GITHUB_OUTPUT}"
+fi
+
+if [[ "${EXIT_CODE}" -eq 0 ]]; then
+	log_success "Lintro ${STEP} completed successfully"
+else
+	log_error "Lintro ${STEP} failed with exit code ${EXIT_CODE}"
+	if [[ "${STEP}" == "check" ]] && [[ "${FAIL_ON_ERROR}" == "true" ]]; then
+		exit "${EXIT_CODE}"
+	fi
+	if [[ "${STEP}" == "format" ]]; then
+		exit "${EXIT_CODE}"
+	fi
+fi

--- a/scripts/ci/quality/run-lintro-docker.sh
+++ b/scripts/ci/quality/run-lintro-docker.sh
@@ -48,7 +48,15 @@ fi
 : "${OUTPUT_LOG:=chk-output.txt}"
 
 log_info "Pulling Lintro image: ${LINTRO_IMAGE}"
-docker pull "${LINTRO_IMAGE}"
+set +e
+PULL_OUTPUT="$(docker pull "${LINTRO_IMAGE}" 2>&1)"
+PULL_EC=$?
+set -e
+if [[ "${PULL_EC}" -ne 0 ]]; then
+	log_error "Failed to pull Lintro image ${LINTRO_IMAGE}: ${PULL_OUTPUT}"
+	exit "${PULL_EC}"
+fi
+printf '%s\n' "${PULL_OUTPUT}"
 
 # Do not pass --user: py-lintro entrypoint starts as root, adjusts PATH for bun/cargo,
 # then gosu(1)s to the UID owning /code (the workspace mount). Passing --user skips that
@@ -79,9 +87,13 @@ check)
 	TEE_EC="${PIPESTATUS[1]:-0}"
 	if [[ "${TEE_EC}" -ne 0 ]]; then
 		log_error "tee failed (exit ${TEE_EC}) while writing ${OUTPUT_LOG}"
+	fi
+	if [[ "${DOCKER_EC}" -ne 0 ]]; then
+		EXIT_CODE="${DOCKER_EC}"
+	elif [[ "${TEE_EC}" -ne 0 ]]; then
 		EXIT_CODE="${TEE_EC}"
 	else
-		EXIT_CODE="${DOCKER_EC}"
+		EXIT_CODE=0
 	fi
 	set +o pipefail
 	set -e

--- a/tests/bats/unit/quality/test_run_lintro_docker.bats
+++ b/tests/bats/unit/quality/test_run_lintro_docker.bats
@@ -75,3 +75,51 @@ teardown() {
 	local calls="${BATS_TEST_TMPDIR}/mock_calls_docker"
 	assert_file_contains "${calls}" "fmt ."
 }
+
+@test "run-lintro-docker.sh check fails when docker run exits non-zero and FAIL_ON_ERROR=true" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "${mock_bin}"
+	cat >"${mock_bin}/docker" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == pull ]]; then exit 0; fi
+if [[ "${1:-}" == run ]]; then exit 1; fi
+exit 0
+EOF
+	chmod +x "${mock_bin}/docker"
+	export PATH="${mock_bin}:${PATH}"
+
+	mkdir -p "${BATS_TEST_TMPDIR}/ws"
+	cd "${BATS_TEST_TMPDIR}/ws" || exit 1
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/gh_out"
+	: >"${GITHUB_OUTPUT}"
+
+	run env STEP=check LINTRO_IMAGE=img:tag FAIL_ON_ERROR=true bash "${SCRIPT}"
+
+	assert_failure
+	assert_file_contains "${GITHUB_OUTPUT}" "exit-code=1"
+	assert_file_contains "${GITHUB_OUTPUT}" "status=failed"
+}
+
+@test "run-lintro-docker.sh check exits zero when docker run fails but FAIL_ON_ERROR=false" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "${mock_bin}"
+	cat >"${mock_bin}/docker" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == pull ]]; then exit 0; fi
+if [[ "${1:-}" == run ]]; then exit 1; fi
+exit 0
+EOF
+	chmod +x "${mock_bin}/docker"
+	export PATH="${mock_bin}:${PATH}"
+
+	mkdir -p "${BATS_TEST_TMPDIR}/ws"
+	cd "${BATS_TEST_TMPDIR}/ws" || exit 1
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/gh_out"
+	: >"${GITHUB_OUTPUT}"
+
+	run env STEP=check LINTRO_IMAGE=img:tag FAIL_ON_ERROR=false bash "${SCRIPT}"
+
+	assert_success
+	assert_file_contains "${GITHUB_OUTPUT}" "exit-code=1"
+	assert_file_contains "${GITHUB_OUTPUT}" "status=failed"
+}

--- a/tests/bats/unit/quality/test_run_lintro_docker.bats
+++ b/tests/bats/unit/quality/test_run_lintro_docker.bats
@@ -30,6 +30,27 @@ teardown() {
 	assert_failure
 }
 
+@test "run-lintro-docker.sh reports docker pull failure" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "${mock_bin}"
+	cat >"${mock_bin}/docker" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == pull ]]; then
+	echo "pull denied" >&2
+	exit 3
+fi
+exit 0
+EOF
+	chmod +x "${mock_bin}/docker"
+	export PATH="${mock_bin}:${PATH}"
+
+	run env STEP=check LINTRO_IMAGE=img:tag bash "${SCRIPT}"
+
+	assert_failure
+	assert_equal "3" "$status"
+	assert_output --partial "Failed to pull Lintro image img:tag: pull denied"
+}
+
 @test "run-lintro-docker.sh check invokes docker pull and chk with grid" {
 	mock_command_record docker ""
 	mkdir -p "${BATS_TEST_TMPDIR}/ws"
@@ -58,7 +79,7 @@ teardown() {
 
 	assert_success
 	local calls="${BATS_TEST_TMPDIR}/mock_calls_docker"
-	assert_file_contains "${calls}" "--tools"
+	assert_file_contains_literal "${calls}" "--tools"
 	assert_file_contains "${calls}" "ruff,yamllint"
 }
 
@@ -97,6 +118,31 @@ EOF
 
 	assert_failure
 	assert_file_contains "${GITHUB_OUTPUT}" "exit-code=1"
+	assert_file_contains "${GITHUB_OUTPUT}" "status=failed"
+}
+
+@test "run-lintro-docker.sh check keeps docker exit code when tee also fails" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "${mock_bin}"
+	cat >"${mock_bin}/docker" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == pull ]]; then exit 0; fi
+if [[ "${1:-}" == run ]]; then exit 7; fi
+exit 0
+EOF
+	chmod +x "${mock_bin}/docker"
+	export PATH="${mock_bin}:${PATH}"
+
+	mkdir -p "${BATS_TEST_TMPDIR}/ws"
+	cd "${BATS_TEST_TMPDIR}/ws" || exit 1
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/gh_out"
+	: >"${GITHUB_OUTPUT}"
+
+	run env STEP=check LINTRO_IMAGE=img:tag FAIL_ON_ERROR=true OUTPUT_LOG=/ bash "${SCRIPT}"
+
+	assert_failure
+	assert_equal "7" "$status"
+	assert_file_contains "${GITHUB_OUTPUT}" "exit-code=7"
 	assert_file_contains "${GITHUB_OUTPUT}" "status=failed"
 }
 

--- a/tests/bats/unit/quality/test_run_lintro_docker.bats
+++ b/tests/bats/unit/quality/test_run_lintro_docker.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/quality/run-lintro-docker.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+
+setup() {
+	setup_temp_dir
+	export SCRIPT="${PROJECT_ROOT}/scripts/ci/quality/run-lintro-docker.sh"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "run-lintro-docker.sh --help exits zero" {
+	run bash "$SCRIPT" --help
+	assert_success
+	assert_output --partial "py-lintro"
+}
+
+@test "run-lintro-docker.sh requires LINTRO_IMAGE" {
+	run bash -c 'STEP=check "${SCRIPT:?}"'
+	assert_failure
+}
+
+@test "run-lintro-docker.sh requires STEP" {
+	run bash -c 'LINTRO_IMAGE=img:tag "${SCRIPT:?}"'
+	assert_failure
+}
+
+@test "run-lintro-docker.sh check invokes docker pull and chk with grid" {
+	mock_command_record docker ""
+	mkdir -p "${BATS_TEST_TMPDIR}/ws"
+	cd "${BATS_TEST_TMPDIR}/ws" || exit 1
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/gh_out"
+	: >"${GITHUB_OUTPUT}"
+
+	run env STEP=check LINTRO_IMAGE=ghcr.io/test/img:tag FAIL_ON_ERROR=true bash "${SCRIPT}"
+
+	assert_success
+	local calls="${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_file_contains "${calls}" "pull ghcr.io/test/img:tag"
+	assert_file_contains "${calls}" "chk . --output-format grid"
+	assert_file_contains "${GITHUB_OUTPUT}" "exit-code=0"
+	assert_file_exists "${BATS_TEST_TMPDIR}/ws/chk-output.txt"
+}
+
+@test "run-lintro-docker.sh check passes --tools when TOOLS is set" {
+	mock_command_record docker ""
+	mkdir -p "${BATS_TEST_TMPDIR}/ws"
+	cd "${BATS_TEST_TMPDIR}/ws" || exit 1
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/gh_out"
+	: >"${GITHUB_OUTPUT}"
+
+	run env STEP=check LINTRO_IMAGE=img:tag TOOLS=ruff,yamllint FAIL_ON_ERROR=true bash "${SCRIPT}"
+
+	assert_success
+	local calls="${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_file_contains "${calls}" "--tools"
+	assert_file_contains "${calls}" "ruff,yamllint"
+}
+
+@test "run-lintro-docker.sh format invokes docker with fmt" {
+	mock_command_record docker ""
+	mkdir -p "${BATS_TEST_TMPDIR}/ws"
+	cd "${BATS_TEST_TMPDIR}/ws" || exit 1
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/gh_out"
+	: >"${GITHUB_OUTPUT}"
+
+	run env STEP=format LINTRO_IMAGE=img:tag bash "${SCRIPT}"
+
+	assert_success
+	local calls="${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_file_contains "${calls}" "fmt ."
+}

--- a/tests/helpers/common.bash
+++ b/tests/helpers/common.bash
@@ -382,7 +382,7 @@ if ! _load_bats_library "file"; then
 	assert_file_contains() {
 		local file="$1"
 		local expected="$2"
-		if ! grep -q "$expected" "$file" 2>/dev/null; then
+		if ! grep -qF -- "$expected" "$file" 2>/dev/null; then
 			echo "# Expected file '$file' to contain: $expected" >&2
 			return 1
 		fi

--- a/tests/helpers/common.bash
+++ b/tests/helpers/common.bash
@@ -381,13 +381,22 @@ if ! _load_bats_library "file"; then
 
 fi
 
-# Override bats-file assert_file_contains: upstream forwards the pattern to grep in a
-# form where leading "-" is parsed as an option (e.g. "--tools"). Use fixed-string grep.
+# Override bats-file assert_file_contains: keep the existing regex semantics, but pass
+# "--" so patterns that start with "-" are not parsed as grep options.
 assert_file_contains() {
 	local file="$1"
 	local expected="$2"
-	if ! grep -qF -- "$expected" "$file" 2>/dev/null; then
+	if ! grep -qE -- "$expected" "$file" 2>/dev/null; then
 		echo "# Expected file '$file' to contain: $expected" >&2
+		return 1
+	fi
+}
+
+assert_file_contains_literal() {
+	local file="$1"
+	local expected="$2"
+	if ! grep -qF -- "$expected" "$file" 2>/dev/null; then
+		echo "# Expected file '$file' to contain literal: $expected" >&2
 		return 1
 	fi
 }

--- a/tests/helpers/common.bash
+++ b/tests/helpers/common.bash
@@ -379,15 +379,18 @@ if ! _load_bats_library "file"; then
 		fi
 	}
 
-	assert_file_contains() {
-		local file="$1"
-		local expected="$2"
-		if ! grep -qF -- "$expected" "$file" 2>/dev/null; then
-			echo "# Expected file '$file' to contain: $expected" >&2
-			return 1
-		fi
-	}
 fi
+
+# Override bats-file assert_file_contains: upstream forwards the pattern to grep in a
+# form where leading "-" is parsed as an option (e.g. "--tools"). Use fixed-string grep.
+assert_file_contains() {
+	local file="$1"
+	local expected="$2"
+	if ! grep -qF -- "$expected" "$file" 2>/dev/null; then
+		echo "# Expected file '$file' to contain: $expected" >&2
+		return 1
+	fi
+}
 
 # =============================================================================
 # Temporary directory management

--- a/uv.lock
+++ b/uv.lock
@@ -350,7 +350,7 @@ wheels = [
 
 [[package]]
 name = "lgtm-ci"
-version = "0.13.1"
+version = "0.13.2"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Run Lintro through the pinned **ghcr.io/lgtm-hq/py-lintro** image (`docker pull` + `docker run` with the repo mounted at `/code`) so **`ci.yml`**, the **`run-quality`** composite action, and **`reusable-quality`** match upstream guidance and every bundled tool runs. Removed runner-side Python/Node setup and standalone actionlint from the reusable quality path (actionlint remains inside the image).

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Changes Made

- Add `scripts/ci/quality/run-lintro-docker.sh` (pull + run with `LINTRO_AUTO_INSTALL_DEPS=1`, `chk . --output-format grid`, optional `--tools`, `chk-output.txt`).
- Switch **`ci.yml`** quality job to Ubuntu + GHCR login + script (add `packages: read`).
- Simplify **`reusable-quality.yml`** to Docker-only quality; deprecate unused Python/Node inputs and ignored `run-actionlint`.
- Update **`run-quality`** composite: GHCR login, required `lintro-image` input (default digest), drop duplicate actionlint step.
- Document consumer **`packages: read`**; clarify local `lint-check.sh` vs Docker path.
- Add BATS for `run-lintro-docker.sh`; fix `assert_file_contains` to use `grep -F --` for patterns starting with `-`.

## Testing

- [x] `uv run lintro fmt` and `uv run lintro chk` (full)
- [x] `bats --recursive tests/bats/` (1526 tests)

## Quality Checks

- [x] Lintro format/check (full toolchain available locally)
- [x] Shell tests (BATS)

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

Callers of **`reusable-quality`** must grant **`permissions.packages: read`** so the workflow can pull **`py-lintro`** from GHCR. Inputs **`python-version`**, **`node-version`**, and **`run-actionlint`** are deprecated or ignored but kept for compatibility.

## Closes

_No linked issue._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated docs and README to reflect running lint checks inside a pinned container image and to instruct callers to grant packages: read permission.
  * PR comment template and development instructions revised for containerized and local linting.

* **Tests**
  * Added comprehensive unit tests covering the containerized linting entrypoint and behavior.

* **Chores**
  * Switched CI/reusable workflows to invoke linting via the standardized container image.
  * Disabled pytest checks in the linting configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/147)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->