### PR TITLE
chore: add SECURITY.md and .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Reporting Security Issues
+
+Found a security vulnerability? Here's how to report it:
+
+### **Private Reporting Only**
+
+Please **do not** create public GitHub issues for security vulnerabilities. This helps
+prevent potential exploitation while we work on a fix.
+
+### **How to Report**
+
+1. **Email**: Send details to `turbocoder13@gmail.com`
+2. **Subject**: Include "SECURITY: LGTM CI" in the subject line
+3. **Details**: Provide a clear description of the issue
+
+### **What to Include**
+
+- Description of the vulnerability
+- Steps to reproduce (if possible)
+- Potential impact assessment
+- Any suggested fixes you might have
+
+### **Response Timeline**
+
+- **Acknowledgment**: Within 24-48 hours
+- **Investigation**: We'll look into it promptly
+- **Updates**: You'll be kept informed of progress
+- **Fix**: We'll work on a solution and coordinate disclosure
+
+## For Contributors
+
+- Review dependencies regularly
+- Test security-related changes thoroughly
+- Never commit sensitive data (API keys, passwords, etc.)
+- Follow secure coding practices
+
+## Contact
+
+- **Primary**: `turbocoder13@gmail.com`


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD013 -->

## Commit Summary (Conventional Commits)

- Type:
  - [x] chore

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What's Changing

Adds org-standard SECURITY.md for vulnerability disclosure and .gitattributes for LF line-ending normalization.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Docs updated if user-facing

## Related Issues

N/A

## Details

Aligns lgtm-ci with org-wide standardization. No code changes.