### PR TITLE
ci: extract reusable release workflow helpers

### DIFF
--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: quality
     if: >-
-      always()
+      !cancelled()
       && inputs.post-pr-comment
       && github.event_name == 'pull_request'
     permissions:

--- a/.github/workflows/reusable-release-version-pr.yml
+++ b/.github/workflows/reusable-release-version-pr.yml
@@ -104,30 +104,14 @@ jobs:
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}
 
-      # Runs before tooling checkout — must be inline (bootstrap)
-      - name: Resolve tooling ref
-        id: tooling
-        shell: bash
-        env:
-          TOOLING_REF: ${{ inputs.tooling-ref }}
-          GH_REPO: ${{ github.repository }}
-          GH_SHA: ${{ github.sha }}
-        run: |
-          if [[ -n "$TOOLING_REF" ]]; then
-            echo "ref=$TOOLING_REF" >> "$GITHUB_OUTPUT"
-          elif [[ "$GH_REPO" == "lgtm-hq/lgtm-ci" ]]; then
-            echo "ref=$GH_SHA" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=main" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: ${{ steps.tooling.outputs.ref }}
+          # yamllint disable-line rule:line-length
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || (github.repository == 'lgtm-hq/lgtm-ci' && github.sha || 'main') }}
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
@@ -226,24 +210,7 @@ jobs:
         shell: bash
         env:
           RAW_SCRIPT_PATH: ${{ inputs.version-update-script }}
-        run: |
-          if [[ ! -f "$RAW_SCRIPT_PATH" ]]; then
-            echo "::error::version-update-script not found: $RAW_SCRIPT_PATH"
-            exit 1
-          fi
-          # Fully canonicalize the script path (resolves symlinks too) so
-          # a symlink inside the repo can't point at a file outside the
-          # workspace.
-          RESOLVED=$(readlink -f -- "$RAW_SCRIPT_PATH")
-          WORKSPACE=$(readlink -f -- "$GITHUB_WORKSPACE")
-          if [[ "$RESOLVED" != "$WORKSPACE"/* ]]; then
-            echo "::error::version-update-script resolves outside the workspace: $RESOLVED"
-            exit 1
-          fi
-          if [[ ! -x "$RESOLVED" ]]; then
-            chmod +x "$RESOLVED"
-          fi
-          echo "resolved=$RESOLVED" >> "$GITHUB_OUTPUT"
+        run: .lgtm-ci-tooling/scripts/ci/release/validate-version-update-script.sh
 
       - name: Run repo-specific version update script
         # yamllint disable-line rule:line-length
@@ -256,7 +223,7 @@ jobs:
         env:
           NEXT_VERSION: ${{ steps.version.outputs.next-version }}
           SCRIPT_PATH: ${{ steps.validate-script.outputs.resolved }}
-        run: "$SCRIPT_PATH"
+        run: .lgtm-ci-tooling/scripts/ci/release/run-version-update-script.sh
 
       - name: Check for version file changes
         # yamllint disable-line rule:line-length
@@ -281,7 +248,7 @@ jobs:
           && steps.version.outputs.release-needed == 'true'
           && steps.changes.outputs.has-pr-changes == 'true'
         shell: bash
-        run: rm -rf .lgtm-ci-tooling
+        run: .lgtm-ci-tooling/scripts/ci/release/remove-tooling-checkout.sh
 
       - name: Create or update version PR
         # yamllint disable-line rule:line-length
@@ -340,7 +307,8 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: ${{ steps.tooling.outputs.ref }}
+          # yamllint disable-line rule:line-length
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || (github.repository == 'lgtm-hq/lgtm-ci' && github.sha || 'main') }}
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false

--- a/scripts/ci/release/remove-tooling-checkout.sh
+++ b/scripts/ci/release/remove-tooling-checkout.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Remove the temporary lgtm-ci tooling checkout before PR creation.
+
+set -euo pipefail
+
+rm -rf .lgtm-ci-tooling
+printf 'Removed temporary lgtm-ci tooling checkout\n'

--- a/scripts/ci/release/remove-tooling-checkout.sh
+++ b/scripts/ci/release/remove-tooling-checkout.sh
@@ -4,5 +4,12 @@
 
 set -euo pipefail
 
-rm -rf .lgtm-ci-tooling
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+
+if [[ ! -d "$GITHUB_WORKSPACE" ]]; then
+	printf '::error::GITHUB_WORKSPACE does not exist: %s\n' "$GITHUB_WORKSPACE" >&2
+	exit 1
+fi
+
+rm -rf -- "$GITHUB_WORKSPACE/.lgtm-ci-tooling"
 printf 'Removed temporary lgtm-ci tooling checkout\n'

--- a/scripts/ci/release/run-version-update-script.sh
+++ b/scripts/ci/release/run-version-update-script.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Run a validated repo-specific version update script.
+#
+# Environment variables:
+#   SCRIPT_PATH - Validated script path
+#   NEXT_VERSION - Version passed through to the script
+
+set -euo pipefail
+
+: "${SCRIPT_PATH:?SCRIPT_PATH is required}"
+: "${NEXT_VERSION:?NEXT_VERSION is required}"
+
+"$SCRIPT_PATH"

--- a/scripts/ci/release/validate-version-update-script.sh
+++ b/scripts/ci/release/validate-version-update-script.sh
@@ -28,6 +28,7 @@ resolved="$(resolve_path "$RAW_SCRIPT_PATH")"
 workspace="$(cd "$GITHUB_WORKSPACE" && pwd -P)"
 
 case "$resolved" in
+"$workspace") ;;
 "$workspace"/*) ;;
 *)
 	printf '::error::version-update-script resolves outside the workspace: %s\n' "$resolved" >&2

--- a/scripts/ci/release/validate-version-update-script.sh
+++ b/scripts/ci/release/validate-version-update-script.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Validate and canonicalize a repo-specific version update script.
+#
+# Environment variables:
+#   RAW_SCRIPT_PATH - Script path supplied by the caller
+#   GITHUB_WORKSPACE - Repository workspace root
+#   GITHUB_OUTPUT - GitHub Actions output file
+
+set -euo pipefail
+
+: "${RAW_SCRIPT_PATH:?RAW_SCRIPT_PATH is required}"
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+if [[ ! -f "$RAW_SCRIPT_PATH" ]]; then
+	printf '::error::version-update-script not found: %s\n' "$RAW_SCRIPT_PATH" >&2
+	exit 1
+fi
+
+resolve_path() {
+	local path="$1"
+
+	python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$path"
+}
+
+resolved="$(resolve_path "$RAW_SCRIPT_PATH")"
+workspace="$(cd "$GITHUB_WORKSPACE" && pwd -P)"
+
+case "$resolved" in
+"$workspace"/*) ;;
+*)
+	printf '::error::version-update-script resolves outside the workspace: %s\n' "$resolved" >&2
+	exit 1
+	;;
+esac
+
+if [[ ! -x "$resolved" ]]; then
+	chmod +x "$resolved"
+fi
+
+printf 'resolved=%s\n' "$resolved" >>"$GITHUB_OUTPUT"
+printf 'Validated version update script: %s\n' "$resolved"

--- a/tests/bats/unit/release/test_validate_version_update_script.bats
+++ b/tests/bats/unit/release/test_validate_version_update_script.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/release/validate-version-update-script.sh
+
+load "../../../helpers/common"
+load "../../../helpers/github_env"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+	export GITHUB_WORKSPACE="$BATS_TEST_TMPDIR/workspace"
+	mkdir -p "$GITHUB_WORKSPACE/scripts/ci"
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+run_validator() {
+	run bash "$PROJECT_ROOT/scripts/ci/release/validate-version-update-script.sh"
+}
+
+@test "validate-version-update-script: resolves script inside workspace" {
+	local script="$GITHUB_WORKSPACE/scripts/ci/update-version.sh"
+	local expected
+	printf '#!/usr/bin/env bash\n' >"$script"
+	expected="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$script")"
+
+	export RAW_SCRIPT_PATH="$script"
+
+	run_validator
+
+	assert_success
+	assert_output --partial "Validated version update script: $expected"
+	assert_file_contains "$GITHUB_OUTPUT" "resolved=$expected"
+	[[ -x "$script" ]]
+}
+
+@test "validate-version-update-script: fails when script is missing" {
+	export RAW_SCRIPT_PATH="$GITHUB_WORKSPACE/scripts/ci/missing.sh"
+
+	run_validator
+
+	assert_failure
+	assert_output --partial "version-update-script not found"
+}
+
+@test "validate-version-update-script: rejects script outside workspace" {
+	local script="$BATS_TEST_TMPDIR/outside.sh"
+	printf '#!/usr/bin/env bash\n' >"$script"
+
+	export RAW_SCRIPT_PATH="$script"
+
+	run_validator
+
+	assert_failure
+	assert_output --partial "version-update-script resolves outside the workspace"
+}
+
+@test "validate-version-update-script: rejects symlink to script outside workspace" {
+	local outside="$BATS_TEST_TMPDIR/outside.sh"
+	local script="$GITHUB_WORKSPACE/scripts/ci/update-version.sh"
+	printf '#!/usr/bin/env bash\n' >"$outside"
+	ln -s "$outside" "$script"
+
+	export RAW_SCRIPT_PATH="$script"
+
+	run_validator
+
+	assert_failure
+	assert_output --partial "version-update-script resolves outside the workspace"
+}


### PR DESCRIPTION
## Summary

Extract the remaining shell logic from the reusable release version PR workflow into dedicated scripts, keeping the workflow aligned with the no-inline-shell CI standard while preserving the existing release behavior.

This PR is stacked on #161.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Relates to #55

## Testing

- `bats tests/bats/unit/release/test_validate_version_update_script.bats`
- `uv run lintro chk`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved release workflow to use consolidated tooling checks and safer validation steps for version updates
  * Replaced ad-hoc deletion with a dedicated cleanup step for tooling checkouts

* **New Features**
  * Added small utilities to validate and run repository-specific version-update scripts with stricter checks

* **Tests**
  * Added unit tests covering script validation, success and multiple failure scenarios

* **Bug Fixes**
  * Adjusted PR comment logic to skip posting when a run is cancelled

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/162)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->