### PR TITLE
fix: repair Renovate custom manager config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,7 @@
         "ghcr\\.io/lgtm-hq/py-lintro@(?<currentDigest>sha256:[a-f0-9]+)"
       ],
       "depNameTemplate": "ghcr.io/lgtm-hq/py-lintro",
+      "currentValueTemplate": "latest",
       "datasourceTemplate": "docker"
     }
   ],


### PR DESCRIPTION
## Summary

Fixes the Renovate regex custom manager so Renovate can validate the repository configuration and resume dependency PRs.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #163

## Testing

- `uv run lintro chk`
- `uv run lintro tst` (pytest skipped because it is disabled in this repo's lintro config)
- `bunx --package renovate --yes renovate-config-validator renovate.json`