### PR TITLE
ci: standardize reusable workflow contract

### DIFF
--- a/.github/actions/post-pr-comment/action.yml
+++ b/.github/actions/post-pr-comment/action.yml
@@ -89,6 +89,8 @@ runs:
         FILE_PROVIDED: ${{ steps.read.outputs.file_provided }}
         BODY_FROM_FILE: ${{ steps.read.outputs.body }}
         BODY_FROM_INPUT: ${{ inputs.body }}
+        EVENT_NAME: ${{ github.event_name }}
+        EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
       run: $SCRIPTS_DIR/ci/actions/post-pr-comment.sh
 
 branding:

--- a/.github/actions/resolve-tooling-ref/action.yml
+++ b/.github/actions/resolve-tooling-ref/action.yml
@@ -1,0 +1,33 @@
+---
+name: "Resolve Tooling Ref"
+description: >-
+  Resolve the Git ref for lgtm-ci tooling checkout. Returns the caller-provided
+  tooling-ref if set, otherwise falls back to github.workflow_sha.
+author: "lgtm-hq"
+
+inputs:
+  tooling-ref:
+    description: "Caller-provided Git ref override (empty to use workflow SHA)"
+    required: false
+    default: ""
+
+outputs:
+  ref:
+    description: "Resolved Git ref for tooling checkout"
+    value: ${{ steps.resolve.outputs.ref }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve ref
+      id: resolve
+      shell: bash
+      env:
+        INPUT_REF: ${{ inputs.tooling-ref }}
+        WORKFLOW_SHA: ${{ github.workflow_sha }}
+      run: |
+        if [[ -n "$INPUT_REF" ]]; then
+          echo "ref=$INPUT_REF" >>"$GITHUB_OUTPUT"
+        else
+          echo "ref=$WORKFLOW_SHA" >>"$GITHUB_OUTPUT"
+        fi

--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -25,9 +25,25 @@ on:
         type: string
         default: ""
 
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      job-name:
+        description: "GitHub check name for CodeQL"
+        required: false
+        type: string
+        default: "CodeQL"
+
 jobs:
   codeql:
-    name: CodeQL
+    name: ${{ inputs.job-name }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,7 +53,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-coverage.yml
+++ b/.github/workflows/reusable-coverage.yml
@@ -179,6 +179,11 @@ jobs:
       pages-url: ${{ steps.publish.outputs.pages-url }}
 
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout repository
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -213,3 +218,77 @@ jobs:
             ${{ inputs.working-directory == '.' && 'coverage-report/coverage' ||
             format('coverage-report/{0}/coverage', inputs.working-directory) }}
           target-dir: coverage
+
+  comment-pr:
+    name: Coverage PR Comment
+    needs: coverage
+    if: >-
+      always()
+      && inputs.post-pr-comment
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.fork == false
+      && needs.coverage.outputs.coverage-percent != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/
+            scripts/ci/
+          persist-credentials: false
+
+      - name: Generate coverage comment body
+        id: body
+        shell: bash
+        env:
+          COVERAGE_PERCENT: ${{ needs.coverage.outputs.coverage-percent }}
+          THRESHOLD: ${{ inputs.threshold }}
+          COMMENT_TITLE: ${{ inputs.comment-title }}
+          PASSED: ${{ needs.coverage.outputs.passed }}
+        run: |
+          STATUS_EMOJI="✅"
+          if [[ "$PASSED" != "true" ]]; then
+            STATUS_EMOJI="❌"
+          fi
+          BODY="## ${COMMENT_TITLE}
+
+          ${STATUS_EMOJI} **Coverage: ${COVERAGE_PERCENT}%**"
+          if [[ "$THRESHOLD" -gt 0 ]]; then
+            BODY="${BODY} (threshold: ${THRESHOLD}%)"
+          fi
+          EOF_MARKER="LGTM_EOF_$$"
+          {
+            echo "comment-body<<${EOF_MARKER}"
+            echo "$BODY"
+            echo "${EOF_MARKER}"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Post PR comment
+        shell: bash
+        env:
+          STEP: post
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+          MARKER: ${{ inputs.comment-marker }}
+          MODE: upsert
+          DELETE_ON_EMPTY: "false"
+          FILE_PROVIDED: "false"
+          BODY_FROM_INPUT: ${{ steps.body.outputs.comment-body }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/post-pr-comment.sh

--- a/.github/workflows/reusable-coverage.yml
+++ b/.github/workflows/reusable-coverage.yml
@@ -267,7 +267,7 @@ jobs:
           BODY="## ${COMMENT_TITLE}
 
           ${STATUS_EMOJI} **Coverage: ${COVERAGE_PERCENT}%**"
-          if [[ "$THRESHOLD" -gt 0 ]]; then
+          if awk "BEGIN{exit(!($THRESHOLD > 0))}"; then
             BODY="${BODY} (threshold: ${THRESHOLD}%)"
           fi
           EOF_MARKER="LGTM_EOF_$$"

--- a/.github/workflows/reusable-coverage.yml
+++ b/.github/workflows/reusable-coverage.yml
@@ -40,6 +40,37 @@ on:
         required: false
         type: string
         default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      job-name:
+        description: "GitHub check name for the coverage job"
+        required: false
+        type: string
+        default: "Coverage"
+      post-pr-comment:
+        description: "Post a PR comment with coverage summary"
+        required: false
+        type: boolean
+        default: false
+      comment-marker:
+        description: "PR comment marker for coverage reports"
+        required: false
+        type: string
+        default: "coverage-report"
+      comment-title:
+        description: "PR comment title for coverage reports"
+        required: false
+        type: string
+        default: "Coverage Report"
+
     outputs:
       coverage-percent:
         description: "Overall coverage percentage"
@@ -56,7 +87,7 @@ on:
 
 jobs:
   coverage:
-    name: Collect Coverage
+    name: ${{ inputs.job-name }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -71,8 +102,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
-
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout repository
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-dependency-review.yml
+++ b/.github/workflows/reusable-dependency-review.yml
@@ -20,9 +20,25 @@ on:
         type: string
         default: ""
 
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      job-name:
+        description: "GitHub check name (only runs on pull_request events)"
+        required: false
+        type: string
+        default: "Dependency Review"
+
 jobs:
   dependency-review:
-    name: Dependency Review
+    name: ${{ inputs.job-name }}
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     permissions:
@@ -33,7 +49,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-deploy-pages.yml
+++ b/.github/workflows/reusable-deploy-pages.yml
@@ -50,16 +50,21 @@ on:
         type: string
         default: ""
 
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
     outputs:
       page-url:
         description: "URL of the deployed GitHub Pages site"
         value: ${{ jobs.deploy.outputs.page-url }}
-
-# Required permissions for GitHub Pages deployment with OIDC
-permissions:
-  contents: read
-  pages: write
-  id-token: write
 
 # Allow only one deployment at a time
 concurrency:
@@ -78,8 +83,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
-
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout repository
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -150,6 +155,12 @@ jobs:
       page-url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+
       - name: Deploy to GitHub Pages
         id: deployment
         # Pinned to SHA for supply chain security

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -106,6 +106,17 @@ on:
         type: string
         default: ""
 
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
     outputs:
       tags:
         description: "Generated image tags"
@@ -142,8 +153,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
-
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Resolve tooling ref
         id: tooling
         shell: bash
@@ -219,8 +230,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
-
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout repository
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -355,8 +366,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
-
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout repository
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -488,8 +499,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
-
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout repository (for smoke-test-script)
         if: inputs.smoke-test-script != ''
         # Pinned to SHA for supply chain security
@@ -583,8 +594,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
-
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/reusable-ghcr-cleanup.yml
+++ b/.github/workflows/reusable-ghcr-cleanup.yml
@@ -28,6 +28,17 @@ on:
         required: false
         type: string
         default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
     secrets:
       token:
         description: "GitHub token with packages:write scope"
@@ -50,8 +61,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
-
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout repository
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-link-check.yml
+++ b/.github/workflows/reusable-link-check.yml
@@ -50,19 +50,40 @@ on:
         type: string
         default: ""
 
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      job-name:
+        description: "GitHub check name for the link check job"
+        required: false
+        type: string
+        default: "Link Check"
+      comment-marker:
+        description: "PR comment marker for link check reports"
+        required: false
+        type: string
+        default: "lychee-report"
+
 jobs:
   link-check:
-    name: Link Check
+    name: ${{ inputs.job-name }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -98,13 +119,51 @@ jobs:
           token: ${{ github.token }}
           fail: ${{ inputs.fail-on-error }}
 
-      - name: Read comment from file
+      - name: Upload link report
         if: >-
           always()
           && inputs.comment-on-pr
-          && github.event_name == 'pull_request'
           && hashFiles('lychee-report.md') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lychee-report
+          path: lychee-report.md
+          retention-days: 1
+          if-no-files-found: ignore
+
+  comment-pr:
+    name: ${{ inputs.job-name }} Comment
+    needs: link-check
+    if: >-
+      always()
+      && inputs.comment-on-pr
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Download link report
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: lychee-report
+          path: .
+
+      - name: Read comment from file
         id: read
+        if: hashFiles('lychee-report.md') != ''
         shell: bash
         env:
           STEP: read-file
@@ -112,14 +171,16 @@ jobs:
         run: bash .lgtm-ci-tooling/scripts/ci/actions/post-pr-comment.sh
 
       - name: Post PR comment
-        if: always() && steps.read.outputs.file_provided == 'true'
+        if: steps.read.outputs.file_provided == 'true'
         shell: bash
         env:
           STEP: post
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          MARKER: lychee-report
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+          MARKER: ${{ inputs.comment-marker }}
           MODE: upsert
           DELETE_ON_EMPTY: "false"
           FILE_PROVIDED: ${{ steps.read.outputs.file_provided }}

--- a/.github/workflows/reusable-link-check.yml
+++ b/.github/workflows/reusable-link-check.yml
@@ -145,6 +145,11 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -156,14 +161,21 @@ jobs:
           persist-credentials: false
 
       - name: Download link report
+        id: download
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: lychee-report
           path: .
 
+      - name: Warn on missing report
+        if: steps.download.outcome != 'success'
+        shell: bash
+        run: echo "::warning::lychee-report artifact not found — link check may not have produced output"
+
       - name: Read comment from file
         id: read
-        if: hashFiles('lychee-report.md') != ''
+        if: steps.download.outcome == 'success' && hashFiles('lychee-report.md') != ''
         shell: bash
         env:
           STEP: read-file
@@ -171,7 +183,7 @@ jobs:
         run: bash .lgtm-ci-tooling/scripts/ci/actions/post-pr-comment.sh
 
       - name: Post PR comment
-        if: steps.read.outputs.file_provided == 'true'
+        if: steps.download.outcome == 'success' && steps.read.outputs.file_provided == 'true'
         shell: bash
         env:
           STEP: post

--- a/.github/workflows/reusable-pr-auto-assign.yml
+++ b/.github/workflows/reusable-pr-auto-assign.yml
@@ -12,30 +12,59 @@ name: Reusable PR Auto Assign
         required: false
         type: string
         default: ".github/CODEOWNERS"
-
-permissions:
-  contents: read
-  pull-requests: write
+      job-name:
+        description: "GitHub check name for the assign job"
+        required: false
+        type: string
+        default: "PR Auto Assign"
+      tooling-ref:
+        description: "Git ref for lgtm-ci tooling scripts"
+        required: false
+        type: string
+        default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   assign:
+    name: ${{ inputs.job-name }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Harden Runner
-        # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
-      - name: Checkout
-        # Pinned to SHA for supply chain security
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: scripts/ci/actions/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Checkout repository CODEOWNERS
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
             ${{ inputs.codeowners-path }}
-            scripts/ci/actions/assign-codeowner.sh
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - name: Assign random CODEOWNER
         env:
@@ -45,4 +74,4 @@ jobs:
           PR_AUTHOR_TYPE: ${{ github.event.pull_request.user.type }}
           CODEOWNERS_PATH: ${{ inputs.codeowners-path }}
         shell: bash
-        run: ${{ github.workspace }}/scripts/ci/actions/assign-codeowner.sh
+        run: .lgtm-ci-tooling/scripts/ci/actions/assign-codeowner.sh

--- a/.github/workflows/reusable-pr-labeler.yml
+++ b/.github/workflows/reusable-pr-labeler.yml
@@ -17,24 +17,37 @@ name: Reusable PR Auto Label
         required: false
         type: boolean
         default: false
-
-permissions:
-  contents: read
-  pull-requests: write
+      job-name:
+        description: "GitHub check name for the label job"
+        required: false
+        type: string
+        default: "PR Labeler"
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   label:
+    name: ${{ inputs.job-name }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Harden Runner
-        # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
-
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Apply labels based on changed files
-        # Pinned to SHA for supply chain security
         uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         with:
           repo-token: ${{ github.token }}

--- a/.github/workflows/reusable-publish-gem.yml
+++ b/.github/workflows/reusable-publish-gem.yml
@@ -39,6 +39,11 @@ on:
         required: false
         type: string
         default: ""
+      job-name:
+        description: "GitHub check name for the publish job"
+        required: false
+        type: string
+        default: "Publish to RubyGems"
 
     outputs:
       published:
@@ -56,7 +61,7 @@ on:
 
 jobs:
   publish:
-    name: Publish to RubyGems
+    name: ${{ inputs.job-name }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/reusable-publish-gem.yml
+++ b/.github/workflows/reusable-publish-gem.yml
@@ -29,6 +29,17 @@ on:
         required: false
         type: string
         default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
     outputs:
       published:
         description: "Whether the gem was published"
@@ -61,7 +72,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-publish-homebrew.yml
+++ b/.github/workflows/reusable-publish-homebrew.yml
@@ -60,6 +60,16 @@ on:
         required: false
         type: string
         default: "Update Homebrew Formula"
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 15
 
     outputs:
       updated:
@@ -75,7 +85,8 @@ on:
 jobs:
   update:
     name: ${{ inputs.job-name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       contents: write
 

--- a/.github/workflows/reusable-publish-homebrew.yml
+++ b/.github/workflows/reusable-publish-homebrew.yml
@@ -45,6 +45,17 @@ on:
         required: false
         type: string
         default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
     outputs:
       updated:
         description: "Whether the formula was updated"
@@ -72,7 +83,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-publish-homebrew.yml
+++ b/.github/workflows/reusable-publish-homebrew.yml
@@ -55,6 +55,11 @@ on:
         required: false
         type: string
         default: ""
+      job-name:
+        description: "GitHub check name for the publish job"
+        required: false
+        type: string
+        default: "Update Homebrew Formula"
 
     outputs:
       updated:
@@ -69,7 +74,7 @@ on:
 
 jobs:
   update:
-    name: Update Homebrew Formula
+    name: ${{ inputs.job-name }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/reusable-publish-npm.yml
+++ b/.github/workflows/reusable-publish-npm.yml
@@ -39,6 +39,17 @@ on:
         required: false
         type: string
         default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
     outputs:
       published:
         description: "Whether the package was published"
@@ -73,7 +84,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-publish-npm.yml
+++ b/.github/workflows/reusable-publish-npm.yml
@@ -49,6 +49,11 @@ on:
         required: false
         type: string
         default: ""
+      job-name:
+        description: "GitHub check name for the publish job"
+        required: false
+        type: string
+        default: "Publish to npm"
 
     outputs:
       published:
@@ -66,7 +71,7 @@ on:
 
 jobs:
   publish:
-    name: Publish to npm
+    name: ${{ inputs.job-name }}
     # CRITICAL: Must use GitHub-hosted runner for provenance attestation
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/reusable-publish-pypi.yml
+++ b/.github/workflows/reusable-publish-pypi.yml
@@ -49,6 +49,17 @@ on:
         required: false
         type: string
         default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
     outputs:
       published:
         description: "Whether the package was published"
@@ -78,7 +89,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -122,7 +134,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-publish-pypi.yml
+++ b/.github/workflows/reusable-publish-pypi.yml
@@ -59,6 +59,11 @@ on:
         required: false
         type: string
         default: ""
+      job-name:
+        description: "GitHub check name for the publish job"
+        required: false
+        type: string
+        default: "Publish to PyPI"
 
     outputs:
       published:
@@ -73,7 +78,7 @@ on:
 
 jobs:
   publish:
-    name: Publish to PyPI
+    name: ${{ inputs.job-name }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -140,6 +140,7 @@ jobs:
       !cancelled()
       && inputs.post-pr-comment
       && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.fork == false
     permissions:
       contents: read
       pull-requests: write
@@ -214,6 +215,8 @@ jobs:
           STEP: post
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           MARKER: lintro-report
           MODE: upsert

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -173,6 +173,11 @@ jobs:
           name: linting-report
           path: ${{ inputs.working-directory }}
 
+      - name: Warn on missing artifact
+        if: steps.download.outcome != 'success'
+        shell: bash
+        run: echo "::warning::Linting report artifact not found — quality job may have failed before producing output"
+
       - name: Generate PR comment
         if: steps.download.outcome == 'success'
         shell: bash

--- a/.github/workflows/reusable-release-auto-tag.yml
+++ b/.github/workflows/reusable-release-auto-tag.yml
@@ -21,10 +21,23 @@ name: "Reusable: Release Auto Tag"
         default: true
       tooling-ref:
         # yamllint disable-line rule:line-length
-        description: "Git ref for lgtm-ci tooling checkout. Same-repo callers default to github.sha; cross-repo callers default to main."
+        description: >-
+          Git ref for lgtm-ci tooling checkout. Defaults to caller workflow SHA
+          when unset.
         required: false
         type: string
         default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
     secrets:
       RELEASE_APP_ID:
         description: "GitHub App ID for creating release tokens"
@@ -51,7 +64,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
       - name: Create GitHub App installation token
         id: app-token
@@ -80,11 +94,9 @@ jobs:
             # Explicit override from caller
             echo "ref=$TOOLING_REF" >> "$GITHUB_OUTPUT"
           elif [[ "$GH_REPO" == "lgtm-hq/lgtm-ci" ]]; then
-            # Same repo: use the current commit
             echo "ref=$GH_SHA" >> "$GITHUB_OUTPUT"
           else
-            # Cross-repo caller: use main (github.sha is the caller's SHA)
-            echo "ref=main" >> "$GITHUB_OUTPUT"
+            echo "ref=${{ github.workflow_sha }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout lgtm-ci tooling

--- a/.github/workflows/reusable-release-auto-tag.yml
+++ b/.github/workflows/reusable-release-auto-tag.yml
@@ -42,6 +42,16 @@ name: "Reusable: Release Auto Tag"
         required: false
         type: string
         default: "Create Release"
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 20
 
     secrets:
       RELEASE_APP_ID:
@@ -54,8 +64,8 @@ name: "Reusable: Release Auto Tag"
 jobs:
   auto-tag:
     name: ${{ inputs.job-name }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     concurrency:
       # Distinct from the caller's workflow-level group to avoid
       # a self-deadlock when a same-repo caller also serializes on

--- a/.github/workflows/reusable-release-auto-tag.yml
+++ b/.github/workflows/reusable-release-auto-tag.yml
@@ -37,6 +37,11 @@ name: "Reusable: Release Auto Tag"
         required: false
         type: string
         default: ""
+      job-name:
+        description: "GitHub check name for the release job"
+        required: false
+        type: string
+        default: "Create Release"
 
     secrets:
       RELEASE_APP_ID:
@@ -48,7 +53,7 @@ name: "Reusable: Release Auto Tag"
 
 jobs:
   auto-tag:
-    name: Create Release
+    name: ${{ inputs.job-name }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     concurrency:

--- a/.github/workflows/reusable-release-version-pr.yml
+++ b/.github/workflows/reusable-release-version-pr.yml
@@ -74,6 +74,17 @@ name: "Reusable: Release Version PR"
         required: false
         type: string
         default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
     secrets:
       RELEASE_APP_ID:
         description: "GitHub App ID for creating release tokens"
@@ -102,8 +113,8 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
-
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Create GitHub App installation token
         id: app-token
         # yamllint disable-line rule:line-length
@@ -128,7 +139,7 @@ jobs:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
           # yamllint disable-line rule:line-length
-          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || (github.repository == 'lgtm-hq/lgtm-ci' && github.sha || 'main') }}
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
@@ -327,7 +338,7 @@ jobs:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
           # yamllint disable-line rule:line-length
-          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || (github.repository == 'lgtm-hq/lgtm-ci' && github.sha || 'main') }}
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false

--- a/.github/workflows/reusable-release-version-pr.yml
+++ b/.github/workflows/reusable-release-version-pr.yml
@@ -69,8 +69,8 @@ name: "Reusable: Release Version PR"
       tooling-ref:
         # yamllint disable-line rule:line-length
         description: >-
-          Git ref for lgtm-ci tooling checkout. Same-repo callers default
-          to github.sha; cross-repo callers default to main.
+          Git ref for lgtm-ci tooling checkout. Defaults to
+          github.workflow_sha when unset.
         required: false
         type: string
         default: ""

--- a/.github/workflows/reusable-rust-build.yml
+++ b/.github/workflows/reusable-rust-build.yml
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: MIT
+---
+name: Reusable Rust Build Workflow
+
+on:
+  workflow_call:
+    inputs:
+      job-name:
+        description: "GitHub check name for the workspace build job"
+        required: false
+        type: string
+        default: "Rust Build"
+      build-script:
+        description: "Path to workspace build script"
+        required: false
+        type: string
+        default: ""
+      tooling-ref:
+        description: "Git ref for lgtm-ci tooling and composite actions"
+        required: false
+        type: string
+        default: ""
+      draft-pr-skip:
+        description: "Skip jobs on draft pull requests"
+        required: false
+        type: boolean
+        default: true
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 30
+
+    outputs:
+      passed:
+        description: "Whether the build job succeeded"
+        value: ${{ jobs.build.outputs.passed }}
+
+jobs:
+  build:
+    uses: ./.github/workflows/reusable-test-rust-build.yml
+    with:
+      job-name: ${{ inputs.job-name }}
+      build-script: ${{ inputs.build-script }}
+      tooling-ref: ${{ inputs.tooling-ref }}
+      draft-pr-skip: ${{ inputs.draft-pr-skip }}
+      egress-policy: ${{ inputs.egress-policy }}
+      allowed-endpoints: ${{ inputs.allowed-endpoints }}
+      runner-image: ${{ inputs.runner-image }}
+      timeout-minutes: ${{ inputs.timeout-minutes }}
+    secrets: inherit

--- a/.github/workflows/reusable-rust-build.yml
+++ b/.github/workflows/reusable-rust-build.yml
@@ -63,4 +63,3 @@ jobs:
       allowed-endpoints: ${{ inputs.allowed-endpoints }}
       runner-image: ${{ inputs.runner-image }}
       timeout-minutes: ${{ inputs.timeout-minutes }}
-    secrets: inherit

--- a/.github/workflows/reusable-rust-coverage.yml
+++ b/.github/workflows/reusable-rust-coverage.yml
@@ -90,4 +90,3 @@ jobs:
       allowed-endpoints: ${{ inputs.allowed-endpoints }}
       runner-image: ${{ inputs.runner-image }}
       timeout-minutes: ${{ inputs.timeout-minutes }}
-    secrets: inherit

--- a/.github/workflows/reusable-rust-coverage.yml
+++ b/.github/workflows/reusable-rust-coverage.yml
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: MIT
+---
+name: Reusable Rust Coverage Workflow
+
+on:
+  workflow_call:
+    inputs:
+      job-name:
+        description: "GitHub check name for Rust coverage"
+        required: false
+        type: string
+        default: "Rust Coverage"
+      setup-script:
+        description: "Path to Rust coverage setup script"
+        required: false
+        type: string
+        default: ""
+      coverage-script:
+        description: "Path to Rust coverage run script"
+        required: false
+        type: string
+        default: ""
+      post-pr-comment:
+        description: "Post coverage summary comment on pull requests"
+        required: false
+        type: boolean
+        default: true
+      comment-marker:
+        description: "PR comment marker for Rust coverage"
+        required: false
+        type: string
+        default: "rust-coverage-report"
+      comment-title:
+        description: "Heading title for the Rust coverage PR comment"
+        required: false
+        type: string
+        default: "Rust Coverage Report"
+      tooling-ref:
+        description: "Git ref for lgtm-ci tooling and composite actions"
+        required: false
+        type: string
+        default: ""
+      draft-pr-skip:
+        description: "Skip jobs on draft pull requests"
+        required: false
+        type: boolean
+        default: true
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+      timeout-minutes:
+        description: "Coverage job timeout in minutes"
+        required: false
+        type: number
+        default: 45
+
+    outputs:
+      coverage-percent:
+        description: "Line coverage percentage from the LCOV report"
+        value: ${{ jobs.coverage.outputs.coverage-percent }}
+      passed:
+        description: "Whether coverage succeeded"
+        value: ${{ jobs.coverage.outputs.passed }}
+
+jobs:
+  coverage:
+    uses: ./.github/workflows/reusable-test-rust-coverage.yml
+    with:
+      job-name: ${{ inputs.job-name }}
+      setup-script: ${{ inputs.setup-script }}
+      coverage-script: ${{ inputs.coverage-script }}
+      post-pr-comment: ${{ inputs.post-pr-comment }}
+      comment-marker: ${{ inputs.comment-marker }}
+      comment-title: ${{ inputs.comment-title }}
+      tooling-ref: ${{ inputs.tooling-ref }}
+      draft-pr-skip: ${{ inputs.draft-pr-skip }}
+      egress-policy: ${{ inputs.egress-policy }}
+      allowed-endpoints: ${{ inputs.allowed-endpoints }}
+      runner-image: ${{ inputs.runner-image }}
+      timeout-minutes: ${{ inputs.timeout-minutes }}
+    secrets: inherit

--- a/.github/workflows/reusable-sbom.yml
+++ b/.github/workflows/reusable-sbom.yml
@@ -50,6 +50,17 @@ on:
         required: false
         type: string
         default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
     outputs:
       sbom-file:
         description: "Path to the generated SBOM file, or 'none' if not generated"
@@ -83,8 +94,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
-
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout repository
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-sbom.yml
+++ b/.github/workflows/reusable-sbom.yml
@@ -60,6 +60,11 @@ on:
         required: false
         type: string
         default: ""
+      job-name:
+        description: "GitHub check name for the SBOM job"
+        required: false
+        type: string
+        default: "SBOM & Supply Chain"
 
     outputs:
       sbom-file:
@@ -76,7 +81,7 @@ on:
 
 jobs:
   sbom:
-    name: SBOM & Supply Chain
+    name: ${{ inputs.job-name }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/reusable-scorecards.yml
+++ b/.github/workflows/reusable-scorecards.yml
@@ -20,9 +20,25 @@ on:
         type: boolean
         default: true
 
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      job-name:
+        description: "GitHub check name for OpenSSF Scorecard"
+        required: false
+        type: string
+        default: "OpenSSF Scorecard"
+
 jobs:
   scorecards:
-    name: OpenSSF Scorecard
+    name: ${{ inputs.job-name }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -33,7 +49,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-semantic-pr-title.yml
+++ b/.github/workflows/reusable-semantic-pr-title.yml
@@ -20,6 +20,17 @@ on:
         type: boolean
         default: false
 
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
 jobs:
   semantic-title:
     name: Semantic PR Title
@@ -31,7 +42,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
       - name: Validate semantic PR title
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1

--- a/.github/workflows/reusable-semantic-pr-title.yml
+++ b/.github/workflows/reusable-semantic-pr-title.yml
@@ -30,10 +30,15 @@ on:
         required: false
         type: string
         default: ""
+      job-name:
+        description: "GitHub check name for the semantic title check"
+        required: false
+        type: string
+        default: "Semantic PR Title"
 
 jobs:
   semantic-title:
-    name: Semantic PR Title
+    name: ${{ inputs.job-name }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read

--- a/.github/workflows/reusable-test-e2e-matrix.yml
+++ b/.github/workflows/reusable-test-e2e-matrix.yml
@@ -70,6 +70,11 @@ on:
         required: false
         type: string
         default: ""
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
 
     outputs:
       total-passed:
@@ -86,7 +91,7 @@ jobs:
   # Generate matrix from inputs
   setup:
     name: Setup Matrix
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
 
@@ -127,7 +132,7 @@ jobs:
   test:
     name: E2E ${{ matrix.suite }} (${{ matrix.browser }})
     needs: setup
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       contents: read
@@ -206,7 +211,7 @@ jobs:
     name: Merge Reports
     needs: test
     if: always() && inputs.upload-report
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     permissions:
       contents: read
 
@@ -215,6 +220,11 @@ jobs:
       total-failed: ${{ steps.merge.outputs.total-failed }}
 
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout repository
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -261,7 +271,7 @@ jobs:
     name: Publish Results
     needs: merge
     if: inputs.publish-results && !cancelled()
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     permissions:
       contents: write
       pages: write
@@ -270,6 +280,11 @@ jobs:
       pages-url: ${{ steps.publish.outputs.pages-url }}
 
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout repository
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-test-e2e-matrix.yml
+++ b/.github/workflows/reusable-test-e2e-matrix.yml
@@ -60,6 +60,17 @@ on:
         required: false
         type: string
         default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
     outputs:
       total-passed:
         description: "Total tests passed across all matrix jobs"
@@ -84,8 +95,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
-
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout for scripts
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -130,8 +141,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
-
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout repository
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-test-e2e.yml
+++ b/.github/workflows/reusable-test-e2e.yml
@@ -35,7 +35,9 @@ on:
         type: boolean
         default: true
       publish-results:
-        description: "Publish results to GitHub Pages"
+        description: >-
+          Deprecated: use a separate publish caller workflow instead. Ignored
+          by this workflow.
         required: false
         type: boolean
         default: false
@@ -55,6 +57,37 @@ on:
         required: false
         type: string
         default: ""
+      job-name:
+        description: "GitHub check name for the E2E test job"
+        required: false
+        type: string
+        default: "E2E Tests"
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      draft-pr-skip:
+        description: "Skip jobs on draft pull requests"
+        required: false
+        type: boolean
+        default: false
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 90
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
     outputs:
       tests-passed:
         description: "Number of tests passed"
@@ -62,28 +95,34 @@ on:
       tests-failed:
         description: "Number of tests failed"
         value: ${{ jobs.test.outputs.tests-failed }}
-      report-url:
-        description: "URL to test report"
-        value: ${{ jobs.publish.outputs.pages-url }}
+      passed:
+        description: "Whether E2E tests passed"
+        value: ${{ jobs.test.outputs.passed }}
 
 jobs:
   test:
-    name: E2E Tests
-    runs-on: ubuntu-latest
+    name: ${{ inputs.job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    if: >-
+      !inputs.draft-pr-skip ||
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
     permissions:
       contents: read
 
     outputs:
       tests-passed: ${{ steps.test.outputs.tests-passed }}
       tests-failed: ${{ steps.test.outputs.tests-failed }}
+      passed: ${{ steps.test.outputs.tests-failed == '0' }}
 
     steps:
       - name: Harden runner
         # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
-
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout repository
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -124,46 +163,3 @@ jobs:
             ${{ inputs.working-directory }}/test-results/
           retention-days: 30
           if-no-files-found: ignore
-
-  publish:
-    name: Publish Results
-    needs: test
-    if: inputs.publish-results && !cancelled()
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pages: write
-
-    outputs:
-      pages-url: ${{ steps.publish.outputs.pages-url }}
-
-    steps:
-      - name: Checkout repository
-        # Pinned to SHA for supply chain security
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Checkout lgtm-ci tooling
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: |
-            .github/actions/
-            scripts/ci/
-          persist-credentials: false
-      - name: Download report
-        # Pinned to SHA for supply chain security
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: playwright-report-${{ github.run_id }}
-          path: playwright-report
-
-      - name: Publish to GitHub Pages
-        id: publish
-        uses: ./.lgtm-ci-tooling/.github/actions/publish-test-results
-        with:
-          results-path: playwright-report
-          target-dir: playwright

--- a/.github/workflows/reusable-test-e2e.yml
+++ b/.github/workflows/reusable-test-e2e.yml
@@ -51,6 +51,11 @@ on:
         required: false
         type: string
         default: "."
+      package-manager:
+        description: "Package manager for dependency install: npm, bun, pnpm"
+        required: false
+        type: string
+        default: "npm"
 
       tooling-ref:
         description: "Git ref to use when checking out lgtm-ci tooling scripts"

--- a/.github/workflows/reusable-test-node-publish.yml
+++ b/.github/workflows/reusable-test-node-publish.yml
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: MIT
+---
+name: Reusable Node.js Test Publish Workflow
+
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        description: "Working directory for published results"
+        required: false
+        type: string
+        default: "."
+      coverage-percent:
+        description: "Coverage percentage for badge generation"
+        required: false
+        type: string
+        default: "0"
+      upload-coverage:
+        description: "Whether coverage artifacts were uploaded by the test workflow"
+        required: false
+        type: boolean
+        default: true
+      tooling-ref:
+        description: "Git ref to use when checking out lgtm-ci tooling scripts"
+        required: false
+        type: string
+        default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  publish:
+    name: Publish Results
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+
+    steps:
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Harden runner
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download coverage
+        if: inputs.upload-coverage
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: node-coverage-*
+          path: node-coverage-artifacts
+          merge-multiple: false
+
+      - name: Merge coverage report
+        if: inputs.upload-coverage
+        shell: bash
+        env:
+          ARTIFACTS_DIR: node-coverage-artifacts
+          OUTPUT_DIR: coverage-report
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/merge-node-coverage.sh
+
+      - name: Generate badge
+        if: inputs.upload-coverage
+        uses: ./.lgtm-ci-tooling/.github/actions/generate-coverage-badge
+        with:
+          coverage-percent: ${{ inputs.coverage-percent }}
+          format: svg
+          output-path: >-
+            ${{ inputs.working-directory == '.' && 'coverage-report/badge.svg' ||
+            format('coverage-report/{0}/badge.svg', inputs.working-directory) }}
+
+      - name: Publish to GitHub Pages
+        if: inputs.upload-coverage
+        uses: ./.lgtm-ci-tooling/.github/actions/publish-test-results
+        with:
+          results-path: >-
+            ${{ inputs.working-directory == '.' && 'coverage-report' ||
+            format('coverage-report/{0}', inputs.working-directory) }}
+          coverage-path: >-
+            ${{ inputs.working-directory == '.' && 'coverage-report' ||
+            format('coverage-report/{0}', inputs.working-directory) }}
+          badge-path: >-
+            ${{ inputs.working-directory == '.' && 'coverage-report' ||
+            format('coverage-report/{0}', inputs.working-directory) }}
+          target-dir: vitest

--- a/.github/workflows/reusable-test-node-publish.yml
+++ b/.github/workflows/reusable-test-node-publish.yml
@@ -35,11 +35,27 @@ on:
         required: false
         type: string
         default: ""
+      job-name:
+        description: "GitHub check name for the publish job"
+        required: false
+        type: string
+        default: "Publish Results"
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 30
 
 jobs:
   publish:
-    name: Publish Results
-    runs-on: ubuntu-latest
+    name: ${{ inputs.job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/reusable-test-node.yml
+++ b/.github/workflows/reusable-test-node.yml
@@ -40,7 +40,9 @@ on:
         type: boolean
         default: false
       publish-results:
-        description: "Publish results to GitHub Pages"
+        description: >-
+          Deprecated: use reusable-test-node-publish.yml in a separate caller job.
+          Ignored in this workflow so callers are not required to grant pages write.
         required: false
         type: boolean
         default: false
@@ -131,27 +133,54 @@ on:
         type: string
         default: ""
 
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Timeout for test jobs in minutes"
+        required: false
+        type: number
+        default: 60
+
     outputs:
       tests-passed:
         description: "Number of tests passed"
-        value: ${{ jobs.aggregate-tests.outputs.tests-passed }}
+        value: >-
+          ${{ inputs.test-command == '' && jobs.aggregate-tests.outputs.tests-passed || '' }}
       tests-failed:
         description: "Number of tests failed"
-        value: ${{ jobs.aggregate-tests.outputs.tests-failed }}
+        value: >-
+          ${{ inputs.test-command == '' && jobs.aggregate-tests.outputs.tests-failed || '' }}
       tests-total:
         description: "Total number of tests"
-        value: ${{ jobs.aggregate-tests.outputs.tests-total }}
+        value: >-
+          ${{ inputs.test-command == '' && jobs.aggregate-tests.outputs.tests-total || '' }}
       coverage-percent:
         description: "Coverage percentage"
-        value: ${{ jobs.aggregate-tests.outputs.coverage-percent }}
+        value: >-
+          ${{ inputs.test-command == '' && jobs.aggregate-tests.outputs.coverage-percent || '' }}
       passed:
         description: "Whether all tests passed"
-        value: ${{ jobs.aggregate-tests.outputs.passed }}
+        value: >-
+          ${{ inputs.test-command == '' && jobs.aggregate-tests.outputs.passed ||
+          (inputs.test-command != '' && jobs.test-custom.outputs.passed == 'true') }}
 
 jobs:
   prepare:
     name: Prepare Node Matrix
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     if: >-
       !inputs.draft-pr-skip ||
       github.event_name != 'pull_request' ||
@@ -165,7 +194,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
@@ -186,18 +216,22 @@ jobs:
           NODE_VERSIONS: ${{ inputs.node-versions }}
         run: bash .lgtm-ci-tooling/scripts/ci/actions/generate-node-matrix.sh
 
-  test:
+  test-vitest:
     name: >-
       ${{
         inputs.node-versions == '' && inputs.job-name ||
         format('{0} ({1})', inputs.job-name, matrix.node-version)
       }}
     needs: prepare
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     if: >-
-      !inputs.draft-pr-skip ||
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.draft == false
+      inputs.test-command == ''
+      && (
+        !inputs.draft-pr-skip ||
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.draft == false
+      )
     permissions:
       contents: read
     strategy:
@@ -216,8 +250,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
-
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout repository
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -299,7 +333,6 @@ jobs:
           if-no-files-found: error
 
       - name: Setup vitest
-        if: inputs.test-command == ''
         shell: bash
         env:
           STEP: setup
@@ -309,7 +342,6 @@ jobs:
 
       - name: Run vitest
         id: run
-        if: inputs.test-command == ''
         shell: bash
         env:
           STEP: run
@@ -321,19 +353,9 @@ jobs:
         run: bash .lgtm-ci-tooling/scripts/ci/actions/run-vitest.sh
         continue-on-error: true
 
-      - name: Run custom test command
-        id: custom-run
-        if: inputs.test-command != ''
-        shell: bash
-        env:
-          COMMAND: ${{ inputs.test-command }}
-          WORKING_DIRECTORY: ${{ inputs.working-directory }}
-        run: bash .lgtm-ci-tooling/scripts/ci/actions/run-command.sh
-        continue-on-error: true
-
       - name: Parse results
         id: parse
-        if: always() && inputs.test-command == ''
+        if: always()
         shell: bash
         env:
           STEP: parse
@@ -342,7 +364,7 @@ jobs:
         run: bash .lgtm-ci-tooling/scripts/ci/actions/run-vitest.sh
 
       - name: Generate summary
-        if: always() && inputs.test-command == ''
+        if: always()
         shell: bash
         env:
           STEP: summary
@@ -356,17 +378,14 @@ jobs:
 
       - name: Check coverage threshold
         id: coverage-gate
-        if: >-
-          inputs.test-command == ''
-          && inputs.coverage
-          && inputs.coverage-threshold > 0
+        if: inputs.coverage && inputs.coverage-threshold > 0
         uses: ./.lgtm-ci-tooling/.github/actions/check-coverage-threshold
         with:
           coverage-percent: ${{ steps.parse.outputs.coverage-percent }}
           threshold: ${{ inputs.coverage-threshold }}
 
       - name: Write matrix test summary
-        if: always() && inputs.test-command == ''
+        if: always()
         shell: bash
         env:
           NODE_VERSION: ${{ matrix.node-version }}
@@ -385,7 +404,7 @@ jobs:
         run: bash .lgtm-ci-tooling/scripts/ci/actions/write-node-summary.sh
 
       - name: Upload matrix test summary
-        if: always() && inputs.test-command == ''
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: node-results-${{ matrix.node-version }}
@@ -448,23 +467,176 @@ jobs:
 
       - name: Fail on vitest errors
         if: >-
-          inputs.test-command == ''
-          && steps.run.outputs.exit-code != ''
+          steps.run.outputs.exit-code != ''
           && steps.run.outputs.exit-code != '0'
         shell: bash
         env:
           EXIT_CODE: ${{ steps.run.outputs.exit-code }}
         run: bash .lgtm-ci-tooling/scripts/ci/actions/fail-with-exit-code.sh
 
+  test-custom:
+    name: >-
+      ${{
+        inputs.node-versions == '' && inputs.job-name ||
+        format('{0} ({1})', inputs.job-name, matrix.node-version)
+      }}
+    needs: prepare
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    if: >-
+      inputs.test-command != ''
+      && (
+        !inputs.draft-pr-skip ||
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.draft == false
+      )
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    outputs:
+      passed: ${{ steps.record.outputs.passed }}
+
+    steps:
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Harden runner
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Setup Bun
+        if: inputs.package-manager == 'bun'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Setup pnpm
+        if: inputs.package-manager == 'pnpm'
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Get bun cache directory
+        if: inputs.package-manager == 'bun'
+        id: bun-cache
+        shell: bash
+        env:
+          STEP: bun-cache
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/setup-node.sh
+
+      - name: Cache bun dependencies
+        if: inputs.package-manager == 'bun'
+        id: cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ${{ steps.bun-cache.outputs.dir }}
+            ${{ inputs.working-directory }}/node_modules
+          key: bun-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/bun.lock', '**/bun.lockb') }}
+          restore-keys: |
+            bun-${{ runner.os }}-${{ matrix.node-version }}-
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        shell: bash
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+          FROZEN_LOCKFILE: "true"
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/setup-package-manager.sh
+
+      - name: Run pre-test command
+        if: inputs.pre-test-command != ''
+        shell: bash
+        env:
+          COMMAND: ${{ inputs.pre-test-command }}
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/run-command.sh
+
+      - name: Run custom test command
+        id: custom-run
+        shell: bash
+        env:
+          COMMAND: ${{ inputs.test-command }}
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/run-command.sh
+
+      - name: Generate coverage PR comment
+        id: generate-coverage-comment
+        if: >-
+          always()
+          && inputs.coverage-pr-comment
+          && inputs.coverage
+          && github.event_name == 'pull_request'
+        uses: ./.lgtm-ci-tooling/.github/actions/generate-coverage-comment
+        with:
+          coverage-file: >-
+            ${{ inputs.working-directory }}/${{ inputs.coverage-summary-file }}
+          format: istanbul
+          threshold-lines: "0"
+          threshold-branches: "0"
+          threshold-functions: "0"
+
+      - name: Write coverage PR comment artifact
+        if: steps.generate-coverage-comment.outcome == 'success'
+        shell: bash
+        env:
+          COMMENT_BODY: ${{ steps.generate-coverage-comment.outputs.comment-body }}
+          COMMENT_TITLE: ${{ inputs.coverage-comment-title }}
+          COMMENT_OUTPUT: node-coverage-pr-comment.txt
+        run: >-
+          bash .lgtm-ci-tooling/scripts/ci/actions/prepare-coverage-comment.sh
+
+      - name: Upload coverage PR comment artifact
+        if: >-
+          steps.generate-coverage-comment.outcome == 'success' &&
+          github.event.pull_request.head.repo.fork == false
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: node-coverage-pr-comment-${{ matrix.node-version }}
+          path: node-coverage-pr-comment.txt
+
       - name: Fail on custom test command errors
-        if: inputs.test-command != '' && steps.custom-run.outcome == 'failure'
+        if: steps.custom-run.outcome == 'failure'
         run: exit 1
+
+      - name: Record custom test result
+        if: always()
+        id: record
+        shell: bash
+        run: |
+          if [[ "${{ job.status }}" == "success" ]]; then
+            echo "passed=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "passed=false" >>"$GITHUB_OUTPUT"
+          fi
 
   aggregate-tests:
     name: Aggregate Node.js Results
     needs:
       - prepare
-      - test
+      - test-vitest
     if: >-
       always()
       && inputs.test-command == ''
@@ -481,13 +653,14 @@ jobs:
       tests-failed: ${{ steps.aggregate.outputs.tests-failed }}
       tests-total: ${{ steps.aggregate.outputs.tests-total }}
       coverage-percent: ${{ steps.aggregate.outputs.coverage-percent }}
-      passed: ${{ needs.test.result == 'success' && steps.aggregate.outputs.passed == 'true' }}
+      passed: ${{ needs.test-vitest.result == 'success' && steps.aggregate.outputs.passed == 'true' }}
 
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
@@ -519,7 +692,8 @@ jobs:
     name: Node coverage PR comment
     needs:
       - prepare
-      - test
+      - test-vitest
+      - test-custom
     if: >-
       always()
       && inputs.coverage-pr-comment
@@ -528,11 +702,15 @@ jobs:
       && github.event.pull_request.head.repo.fork == false
       && inputs.post-pr-comment
       && (
+        needs.test-vitest.result == 'success'
+        || needs.test-custom.result == 'success'
+      )
+      && (
         !inputs.draft-pr-skip ||
         github.event_name != 'pull_request' ||
         github.event.pull_request.draft == false
       )
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     permissions:
       contents: read
       pull-requests: write
@@ -584,7 +762,7 @@ jobs:
       contents: read
       pull-requests: write
     with:
-      test-suite-name: Node.js Tests
+      test-suite-name: ${{ inputs.job-name }}
       comment-marker: ${{ inputs.comment-marker }}
       tests-passed: ${{ needs.aggregate-tests.outputs.tests-passed }}
       tests-failed: ${{ needs.aggregate-tests.outputs.tests-failed }}
@@ -594,78 +772,3 @@ jobs:
       job-result: ${{ needs.aggregate-tests.outputs.passed == 'true' && 'success' || 'failure' }}
       tooling-ref: ${{ inputs.tooling-ref }}
     secrets: inherit
-
-  publish:
-    name: Publish Results
-    needs: aggregate-tests
-    if: >-
-      inputs.test-command == ''
-      && inputs.publish-results
-      && !cancelled()
-      && needs.aggregate-tests.outputs.passed == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pages: write
-
-    steps:
-      - name: Checkout repository
-        # Pinned to SHA for supply chain security
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Checkout lgtm-ci tooling
-        # yamllint disable-line rule:line-length
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: |
-            .github/actions/
-            scripts/ci/
-          persist-credentials: false
-
-      - name: Download coverage
-        if: inputs.coverage && inputs.upload-coverage
-        # Pinned to SHA for supply chain security
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: node-coverage-*
-          path: node-coverage-artifacts
-          merge-multiple: false
-
-      - name: Merge coverage report
-        if: inputs.coverage && inputs.upload-coverage
-        shell: bash
-        env:
-          ARTIFACTS_DIR: node-coverage-artifacts
-          OUTPUT_DIR: coverage-report
-          WORKING_DIRECTORY: ${{ inputs.working-directory }}
-        run: bash .lgtm-ci-tooling/scripts/ci/actions/merge-node-coverage.sh
-
-      - name: Generate badge
-        if: inputs.coverage && inputs.upload-coverage
-        uses: ./.lgtm-ci-tooling/.github/actions/generate-coverage-badge
-        with:
-          coverage-percent: ${{ needs.aggregate-tests.outputs.coverage-percent }}
-          format: svg
-          output-path: >-
-            ${{ inputs.working-directory == '.' && 'coverage-report/badge.svg' ||
-            format('coverage-report/{0}/badge.svg', inputs.working-directory) }}
-
-      - name: Publish to GitHub Pages
-        if: inputs.coverage && inputs.upload-coverage
-        uses: ./.lgtm-ci-tooling/.github/actions/publish-test-results
-        with:
-          results-path: >-
-            ${{ inputs.working-directory == '.' && 'coverage-report' ||
-            format('coverage-report/{0}', inputs.working-directory) }}
-          coverage-path: >-
-            ${{ inputs.working-directory == '.' && 'coverage-report' ||
-            format('coverage-report/{0}', inputs.working-directory) }}
-          badge-path: >-
-            ${{ inputs.working-directory == '.' && 'coverage-report' ||
-            format('coverage-report/{0}', inputs.working-directory) }}
-          target-dir: vitest

--- a/.github/workflows/reusable-test-node.yml
+++ b/.github/workflows/reusable-test-node.yml
@@ -717,6 +717,11 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -750,6 +755,7 @@ jobs:
       always()
       && inputs.test-command == ''
       && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.fork == false
       && inputs.post-pr-comment
       && !inputs.coverage-pr-comment
       && (
@@ -771,4 +777,5 @@ jobs:
       coverage-threshold: ${{ inputs.coverage-threshold }}
       job-result: ${{ needs.aggregate-tests.outputs.passed == 'true' && 'success' || 'failure' }}
       tooling-ref: ${{ inputs.tooling-ref }}
-    secrets: inherit
+      egress-policy: ${{ inputs.egress-policy }}
+      allowed-endpoints: ${{ inputs.allowed-endpoints }}

--- a/.github/workflows/reusable-test-pr-comment.yml
+++ b/.github/workflows/reusable-test-pr-comment.yml
@@ -58,11 +58,22 @@ on:
         required: false
         type: string
         default: ""
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 10
 
 jobs:
   comment:
     name: ${{ inputs.test-suite-name }} PR Comment
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/reusable-test-pr-comment.yml
+++ b/.github/workflows/reusable-test-pr-comment.yml
@@ -48,6 +48,17 @@ on:
         type: string
         default: ""
 
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
 jobs:
   comment:
     name: ${{ inputs.test-suite-name }} PR Comment
@@ -60,7 +71,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
@@ -116,6 +128,8 @@ jobs:
           STEP: post
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           MARKER: ${{ inputs.comment-marker }}
           MODE: upsert

--- a/.github/workflows/reusable-test-python-publish.yml
+++ b/.github/workflows/reusable-test-python-publish.yml
@@ -30,11 +30,27 @@ on:
         required: false
         type: string
         default: ""
+      job-name:
+        description: "GitHub check name for the publish job"
+        required: false
+        type: string
+        default: "Publish Results"
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 30
 
 jobs:
   publish:
-    name: Publish Results
-    runs-on: ubuntu-latest
+    name: ${{ inputs.job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/reusable-test-python-publish.yml
+++ b/.github/workflows/reusable-test-python-publish.yml
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: MIT
+---
+name: Reusable Python Test Publish Workflow
+
+on:
+  workflow_call:
+    inputs:
+      coverage-percent:
+        description: "Coverage percentage for badge generation"
+        required: false
+        type: string
+        default: "0"
+      upload-coverage:
+        description: "Whether coverage artifacts were uploaded by the test workflow"
+        required: false
+        type: boolean
+        default: true
+      tooling-ref:
+        description: "Git ref to use when checking out lgtm-ci tooling scripts"
+        required: false
+        type: string
+        default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  publish:
+    name: Publish Results
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+
+    steps:
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Harden runner
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download coverage
+        if: inputs.upload-coverage
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-coverage
+          path: coverage-report
+
+      - name: Generate badge
+        if: inputs.upload-coverage
+        uses: ./.lgtm-ci-tooling/.github/actions/generate-coverage-badge
+        with:
+          coverage-percent: ${{ inputs.coverage-percent }}
+          format: svg
+          output-path: coverage-report/badge.svg
+
+      - name: Publish to GitHub Pages
+        if: inputs.upload-coverage
+        uses: ./.lgtm-ci-tooling/.github/actions/publish-test-results
+        with:
+          results-path: coverage-report
+          coverage-path: coverage-report
+          badge-path: coverage-report
+          target-dir: python

--- a/.github/workflows/reusable-test-python.yml
+++ b/.github/workflows/reusable-test-python.yml
@@ -284,6 +284,10 @@ jobs:
       && github.event_name == 'pull_request'
       && github.event.pull_request.head.repo.fork == false
       && inputs.post-pr-comment
+      && (
+        !inputs.draft-pr-skip ||
+        github.event.pull_request.draft == false
+      )
     uses: ./.github/workflows/reusable-test-pr-comment.yml
     permissions:
       contents: read
@@ -298,4 +302,5 @@ jobs:
       coverage-threshold: ${{ inputs.coverage-threshold }}
       job-result: ${{ needs.test.result }}
       tooling-ref: ${{ inputs.tooling-ref }}
-    secrets: inherit
+      egress-policy: ${{ inputs.egress-policy }}
+      allowed-endpoints: ${{ inputs.allowed-endpoints }}

--- a/.github/workflows/reusable-test-python.yml
+++ b/.github/workflows/reusable-test-python.yml
@@ -35,7 +35,9 @@ on:
         type: boolean
         default: false
       publish-results:
-        description: "Publish results to GitHub Pages"
+        description: >-
+          Deprecated: use reusable-test-python-publish.yml in a separate caller
+          job instead. Ignored by this workflow.
         required: false
         type: boolean
         default: false
@@ -70,6 +72,37 @@ on:
         type: string
         default: ""
 
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      job-name:
+        description: "GitHub check name for the test job"
+        required: false
+        type: string
+        default: "Python Tests"
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      draft-pr-skip:
+        description: "Skip jobs on draft pull requests"
+        required: false
+        type: boolean
+        default: false
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 60
+
     outputs:
       tests-passed:
         description: "Number of tests passed"
@@ -89,8 +122,13 @@ on:
 
 jobs:
   test:
-    name: Python Tests
-    runs-on: ubuntu-latest
+    name: ${{ inputs.job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    if: >-
+      !inputs.draft-pr-skip ||
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
     permissions:
       contents: read
 
@@ -106,8 +144,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
-
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout repository
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -244,13 +282,14 @@ jobs:
     if: >-
       always()
       && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.fork == false
       && inputs.post-pr-comment
     uses: ./.github/workflows/reusable-test-pr-comment.yml
     permissions:
       contents: read
       pull-requests: write
     with:
-      test-suite-name: Python Tests
+      test-suite-name: ${{ inputs.job-name }}
       comment-marker: ${{ inputs.comment-marker }}
       tests-passed: ${{ needs.test.outputs.tests-passed }}
       tests-failed: ${{ needs.test.outputs.tests-failed }}
@@ -260,56 +299,3 @@ jobs:
       job-result: ${{ needs.test.result }}
       tooling-ref: ${{ inputs.tooling-ref }}
     secrets: inherit
-
-  publish:
-    name: Publish Results
-    needs: test
-    if: inputs.publish-results && !cancelled()
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pages: write
-
-    steps:
-      - name: Checkout repository
-        # Pinned to SHA for supply chain security
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Checkout lgtm-ci tooling
-        # yamllint disable-line rule:line-length
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: |
-            .github/actions/
-            scripts/ci/
-          persist-credentials: false
-
-      - name: Download coverage
-        if: inputs.coverage && inputs.upload-coverage
-        # Pinned to SHA for supply chain security
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: python-coverage
-          path: coverage-report
-
-      - name: Generate badge
-        if: inputs.coverage && inputs.upload-coverage
-        uses: ./.lgtm-ci-tooling/.github/actions/generate-coverage-badge
-        with:
-          coverage-percent: ${{ needs.test.outputs.coverage-percent }}
-          format: svg
-          output-path: coverage-report/badge.svg
-
-      - name: Publish to GitHub Pages
-        if: inputs.coverage && inputs.upload-coverage
-        uses: ./.lgtm-ci-tooling/.github/actions/publish-test-results
-        with:
-          results-path: coverage-report
-          coverage-path: coverage-report
-          badge-path: coverage-report
-          target-dir: python

--- a/.github/workflows/reusable-test-rust-build.yml
+++ b/.github/workflows/reusable-test-rust-build.yml
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: MIT
+---
+name: Reusable Rust Build Only Workflow
+
+on:
+  workflow_call:
+    inputs:
+      job-name:
+        description: "GitHub check name for the workspace build job"
+        required: false
+        type: string
+        default: "Rust Build"
+      build-script:
+        description: "Path to workspace build script"
+        required: false
+        type: string
+        default: ""
+      tooling-ref:
+        description: "Git ref for lgtm-ci tooling and composite actions"
+        required: false
+        type: string
+        default: ""
+      draft-pr-skip:
+        description: "Skip jobs on draft pull requests"
+        required: false
+        type: boolean
+        default: true
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 30
+
+    outputs:
+      passed:
+        description: "Whether the build job succeeded"
+        value: ${{ jobs.build.outputs.passed == 'true' }}
+
+jobs:
+  build:
+    name: ${{ inputs.job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    if: >-
+      !inputs.draft-pr-skip ||
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
+    permissions:
+      contents: read
+    outputs:
+      passed: ${{ steps.record.outputs.passed }}
+    concurrency:
+      group: rust-build-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Harden runner
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: ./.lgtm-ci-tooling/.github/actions/setup-rust
+
+      - name: Build workspace
+        shell: bash
+        env:
+          RAW_SCRIPT_PATH: ${{ inputs.build-script }}
+          DEFAULT_SCRIPT_PATH: .lgtm-ci-tooling/scripts/ci/testing/rust/build-workspace.sh
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/run-caller-script.sh
+
+      - name: Record build result
+        if: always()
+        id: record
+        shell: bash
+        run: |
+          if [[ "${{ job.status }}" == "success" ]]; then
+            echo "passed=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "passed=false" >>"$GITHUB_OUTPUT"
+          fi

--- a/.github/workflows/reusable-test-rust-coverage.yml
+++ b/.github/workflows/reusable-test-rust-coverage.yml
@@ -1,34 +1,15 @@
+# SPDX-License-Identifier: MIT
 ---
-name: Reusable Rust Test Workflow
+name: Reusable Rust Coverage Only Workflow
 
 on:
   workflow_call:
     inputs:
-      job-name-build:
-        description: "GitHub check name for the workspace build job"
-        required: false
-        type: string
-        default: "Rust Build"
-      job-name-coverage:
+      job-name:
         description: "GitHub check name for Rust coverage"
         required: false
         type: string
         default: "Rust Coverage"
-      run-build:
-        description: "Run the workspace compile job"
-        required: false
-        type: boolean
-        default: true
-      run-coverage:
-        description: "Run Rust llvm-cov coverage and optional PR comment"
-        required: false
-        type: boolean
-        default: true
-      build-script:
-        description: "Path to workspace build script"
-        required: false
-        type: string
-        default: ""
       setup-script:
         description: "Path to Rust coverage setup script"
         required: false
@@ -79,94 +60,29 @@ on:
         required: false
         type: string
         default: "ubuntu-24.04"
+      timeout-minutes:
+        description: "Coverage job timeout in minutes"
+        required: false
+        type: number
+        default: 45
 
     outputs:
       coverage-percent:
         description: "Line coverage percentage from the LCOV report"
         value: ${{ jobs.coverage.outputs.coverage-percent }}
       passed:
-        description: "Whether build and coverage succeeded for enabled jobs"
-        value: >-
-          ${{ (inputs.run-build == false || jobs.build.outputs.passed == 'true')
-          && (inputs.run-coverage == false || jobs.coverage.outputs.passed == 'true') }}
+        description: "Whether coverage succeeded"
+        value: ${{ jobs.coverage.outputs.passed == 'true' }}
 
 jobs:
-  build:
-    name: ${{ inputs.job-name-build }}
-    runs-on: ${{ inputs.runner-image }}
-    timeout-minutes: 30
-    if: >-
-      inputs.run-build
-      && (
-        !inputs.draft-pr-skip ||
-        github.event_name != 'pull_request' ||
-        github.event.pull_request.draft == false
-      )
-    permissions:
-      contents: read
-    outputs:
-      passed: ${{ steps.record.outputs.passed }}
-    concurrency:
-      group: rust-build-${{ github.ref }}
-      cancel-in-progress: true
-
-    steps:
-      - name: Checkout lgtm-ci tooling
-        # yamllint disable-line rule:line-length
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: |
-            .github/actions/
-            scripts/ci/
-          sparse-checkout-cone-mode: true
-          persist-credentials: false
-
-      - name: Harden runner
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
-
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Setup Rust
-        uses: ./.lgtm-ci-tooling/.github/actions/setup-rust
-
-      - name: Build workspace
-        shell: bash
-        env:
-          RAW_SCRIPT_PATH: ${{ inputs.build-script }}
-          DEFAULT_SCRIPT_PATH: .lgtm-ci-tooling/scripts/ci/testing/rust/build-workspace.sh
-        run: bash .lgtm-ci-tooling/scripts/ci/actions/run-caller-script.sh
-
-      - name: Record build result
-        if: always()
-        id: record
-        shell: bash
-        run: |
-          if [[ "${{ job.status }}" == "success" ]]; then
-            echo "passed=true" >>"$GITHUB_OUTPUT"
-          else
-            echo "passed=false" >>"$GITHUB_OUTPUT"
-          fi
-
   coverage:
-    name: ${{ inputs.job-name-coverage }}
+    name: ${{ inputs.job-name }}
     runs-on: ${{ inputs.runner-image }}
-    timeout-minutes: 45
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     if: >-
-      inputs.run-coverage
-      && (
-        !inputs.draft-pr-skip ||
-        github.event_name != 'pull_request' ||
-        github.event.pull_request.draft == false
-      )
+      !inputs.draft-pr-skip ||
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
     permissions:
       contents: read
     outputs:
@@ -181,7 +97,6 @@ jobs:
 
     steps:
       - name: Checkout lgtm-ci tooling
-        # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: lgtm-hq/lgtm-ci
@@ -274,8 +189,7 @@ jobs:
     runs-on: ${{ inputs.runner-image }}
     needs: coverage
     if: >-
-      inputs.run-coverage
-      && always()
+      always()
       && inputs.post-pr-comment
       && github.event_name == 'pull_request'
       && github.event.pull_request.head.repo.fork == false
@@ -287,7 +201,6 @@ jobs:
 
     steps:
       - name: Checkout lgtm-ci tooling
-        # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: lgtm-hq/lgtm-ci

--- a/.github/workflows/reusable-test-rust.yml
+++ b/.github/workflows/reusable-test-rust.yml
@@ -79,6 +79,11 @@ on:
         required: false
         type: string
         default: "ubuntu-24.04"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 45
 
     outputs:
       coverage-percent:
@@ -94,7 +99,7 @@ jobs:
   build:
     name: ${{ inputs.job-name-build }}
     runs-on: ${{ inputs.runner-image }}
-    timeout-minutes: 30
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     if: >-
       inputs.run-build
       && (
@@ -159,7 +164,7 @@ jobs:
   coverage:
     name: ${{ inputs.job-name-coverage }}
     runs-on: ${{ inputs.runner-image }}
-    timeout-minutes: 45
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     if: >-
       inputs.run-coverage
       && (

--- a/.github/workflows/reusable-test-shell.yml
+++ b/.github/workflows/reusable-test-shell.yml
@@ -249,6 +249,10 @@ jobs:
       && github.event_name == 'pull_request'
       && github.event.pull_request.head.repo.fork == false
       && inputs.post-pr-comment
+      && (
+        !inputs.draft-pr-skip ||
+        github.event.pull_request.draft == false
+      )
     uses: ./.github/workflows/reusable-test-pr-comment.yml
     permissions:
       contents: read
@@ -263,4 +267,5 @@ jobs:
       coverage-threshold: ${{ inputs.coverage-threshold }}
       job-result: ${{ needs.test.result }}
       tooling-ref: ${{ inputs.tooling-ref }}
-    secrets: inherit
+      egress-policy: ${{ inputs.egress-policy }}
+      allowed-endpoints: ${{ inputs.allowed-endpoints }}

--- a/.github/workflows/reusable-test-shell.yml
+++ b/.github/workflows/reusable-test-shell.yml
@@ -59,6 +59,36 @@ on:
         required: false
         type: string
         default: ""
+      job-name:
+        description: "GitHub check name for the test job"
+        required: false
+        type: string
+        default: "Shell Tests"
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      draft-pr-skip:
+        description: "Skip jobs on draft pull requests"
+        required: false
+        type: boolean
+        default: false
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 60
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
 
     outputs:
       tests-passed:
@@ -79,8 +109,13 @@ on:
 
 jobs:
   test:
-    name: Shell Tests
-    runs-on: ubuntu-latest
+    name: ${{ inputs.job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    if: >-
+      !inputs.draft-pr-skip ||
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
     permissions:
       contents: read
 
@@ -99,8 +134,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
-
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout repository
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -212,13 +247,14 @@ jobs:
     if: >-
       always()
       && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.fork == false
       && inputs.post-pr-comment
     uses: ./.github/workflows/reusable-test-pr-comment.yml
     permissions:
       contents: read
       pull-requests: write
     with:
-      test-suite-name: Shell Tests
+      test-suite-name: ${{ inputs.job-name }}
       comment-marker: ${{ inputs.comment-marker }}
       tests-passed: ${{ needs.test.outputs.tests-passed }}
       tests-failed: ${{ needs.test.outputs.tests-failed }}

--- a/.github/workflows/reusable-validate-action-pinning.yml
+++ b/.github/workflows/reusable-validate-action-pinning.yml
@@ -25,6 +25,17 @@ on:
         type: string
         default: ""
 
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
 jobs:
   action-pinning:
     name: Validate Action Pinning
@@ -36,7 +47,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-validate.yml
+++ b/.github/workflows/reusable-validate.yml
@@ -9,7 +9,12 @@ on:
         required: true
         type: string
       name:
-        description: "Display name for the validation"
+        description: "Deprecated alias for job-name"
+        required: false
+        type: string
+        default: ""
+      job-name:
+        description: "Display name for the validation check"
         required: false
         type: string
         default: "Validation"
@@ -39,6 +44,17 @@ on:
         type: string
         default: ""
 
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
     outputs:
       exit-code:
         description: "Exit code from the validation script"
@@ -49,7 +65,9 @@ on:
 
 jobs:
   validate:
-    name: ${{ inputs.name }}
+    name: >-
+      ${{ inputs.job-name != '' && inputs.job-name ||
+      (inputs.name != '' && inputs.name || 'Validation') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -61,7 +79,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -130,7 +149,8 @@ jobs:
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
         with:
-          egress-policy: audit
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-validate.yml
+++ b/.github/workflows/reusable-validate.yml
@@ -110,7 +110,8 @@ jobs:
         shell: bash
         env:
           SCRIPT_PATH: ${{ inputs.script }}
-          VALIDATION_NAME: ${{ inputs.name }}
+          # yamllint disable-line rule:line-length
+          VALIDATION_NAME: ${{ inputs.job-name != '' && inputs.job-name || (inputs.name != '' && inputs.name || 'Validation') }}
           WORKING_DIRECTORY: ${{ inputs.working-directory }}
           COMMENT_OUTPUT: validation-comment.md
           OUTPUT_FILE: validation-output.txt
@@ -140,6 +141,7 @@ jobs:
       && inputs.comment-on-failure
       && needs.validate.outputs.status == 'failed'
       && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -170,6 +172,12 @@ jobs:
           name: validation-comment
           path: .
 
+      - name: Warn on missing artifact
+        if: steps.download.outcome != 'success'
+        shell: bash
+        # yamllint disable-line rule:line-length
+        run: echo "::warning::Validation comment artifact not found — upstream may have failed"
+
       - name: Read comment from file
         if: steps.download.outcome == 'success'
         id: read
@@ -187,6 +195,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
           MARKER: ${{ inputs.comment-marker }}
           MODE: upsert
           DELETE_ON_EMPTY: "false"

--- a/.lintro-config.yaml
+++ b/.lintro-config.yaml
@@ -70,3 +70,6 @@ tools:
     enabled: true
   pytest:
     enabled: false
+  bats:
+    enabled: true
+    path: "tests/bats"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: MIT
+
+.PHONY: test test-bats lint fmt
+
+test: test-bats
+
+test-bats:
+	bats --recursive tests/bats
+
+lint:
+	uv run lintro chk
+
+fmt:
+	uv run lintro fmt

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 
-.PHONY: test test-bats lint fmt
+.PHONY: all test test-bats lint fmt clean
+
+all: test
 
 test: test-bats
 
@@ -12,3 +14,6 @@ lint:
 
 fmt:
 	uv run lintro fmt
+
+clean:
+	rm -rf .lintro/ coverage-report/

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ jobs:
     # Optional: with: { tools: "ruff,yamllint", post-pr-comment: true }
 ```
 
+Reusable workflows share a standard contract (`tooling-ref`, `egress-policy`,
+`job-name`, permissions by mode). See [docs/workflow-contract.md](docs/workflow-contract.md).
+
 ### Using Shell Libraries
 
 ```yaml

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -15,6 +15,9 @@ jobs:
 Pass `tooling-ref` when testing an unreleased lgtm-ci branch. Production callers
 should pin the workflow ref to a commit SHA.
 
+See [workflow-contract.md](workflow-contract.md) for the standard input contract,
+permissions by mode, egress allowlists, and Rustume migration examples.
+
 ## Quality And Validation
 
 ```yaml
@@ -93,19 +96,30 @@ the language-specific test workflows.
 
 ### Rust
 
-`reusable-test-rust.yml` runs Cargo workspace build and/or `llvm-cov` coverage
-with an optional PR comment. Frontend packages use `reusable-test-node.yml`
-separately. See [rust-testing.md](rust-testing.md).
+Prefer `reusable-rust-build.yml` and `reusable-rust-coverage.yml` for separate
+required checks without skipped sibling jobs. `reusable-test-rust.yml` remains
+for backward compatibility. See [rust-testing.md](rust-testing.md).
 
 ```yaml
 jobs:
-  rust:
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-rust.yml@<sha>
+  rust-build:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-build.yml@<sha>
+    permissions:
+      contents: read
+    with:
+      tooling-ref: "<sha>"
+      job-name: "Rust Build"
+      egress-policy: block
+
+  rust-coverage:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-coverage.yml@<sha>
     permissions:
       contents: read
       pull-requests: write
     with:
       tooling-ref: "<sha>"
+      job-name: "Rust Coverage"
+      egress-policy: block
 ```
 
 ## Release

--- a/docs/rust-testing.md
+++ b/docs/rust-testing.md
@@ -7,7 +7,9 @@ stack**, composed in the consumer caller workflow.
 | --- | --- |
 | Python | `reusable-test-python.yml` |
 | Node / TypeScript | `reusable-test-node.yml` |
-| Rust | `reusable-test-rust.yml` |
+| Rust (build) | `reusable-rust-build.yml` |
+| Rust (coverage) | `reusable-rust-coverage.yml` |
+| Rust (legacy) | `reusable-test-rust.yml` |
 
 ## Rust-only repository
 
@@ -24,32 +26,32 @@ jobs:
 
 ## Build and coverage as separate checks
 
-`reusable-test-rust` exposes `run-build` and `run-coverage`. Call it twice when
-your org ruleset requires distinct check names:
+Use the split workflows so PR checks do not show skipped sibling jobs:
 
 ```yaml
 jobs:
   rust-build:
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-rust.yml@<sha>
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-build.yml@<sha>
     with:
       tooling-ref: "<sha>"
-      run-build: true
-      run-coverage: false
-      job-name-build: "Rust Build"
+      job-name: "Rust Build"
+      egress-policy: block
     permissions:
       contents: read
 
   rust-coverage:
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-rust.yml@<sha>
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-coverage.yml@<sha>
     with:
       tooling-ref: "<sha>"
-      run-build: false
-      run-coverage: true
-      job-name-coverage: "Rust Coverage"
+      job-name: "Rust Coverage"
+      egress-policy: block
     permissions:
       contents: read
       pull-requests: write
 ```
+
+`reusable-test-rust.yml` with `run-build` / `run-coverage` remains available but
+may leave skipped jobs in the PR UI when only one mode is enabled.
 
 ## Rust workspace with a frontend package
 

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -1,0 +1,170 @@
+# Reusable Workflow Contract
+
+All `lgtm-ci` reusable workflows share a common consumer contract.
+
+## Standard inputs
+
+Where applicable, workflows accept:
+
+| Input | Purpose |
+| --- | --- |
+| `tooling-ref` | Pin lgtm-ci scripts/actions (defaults to caller workflow SHA) |
+| `egress-policy` | `audit` or `block` for StepSecurity harden-runner |
+| `allowed-endpoints` | Allowlist when `egress-policy: block` |
+| `job-name` | Visible GitHub check name |
+| `runner-image` | Runner label for long-running jobs |
+| `timeout-minutes` | Job timeout |
+| `post-pr-comment` | Enable PR summary comments |
+| `comment-marker` / `comment-title` | PR comment identity |
+| `draft-pr-skip` | Skip PR jobs on draft pull requests |
+
+## Permissions by mode
+
+| Mode | Caller permissions |
+| --- | --- |
+| Test / quality only | `contents: read` |
+| PR comments | `contents: read`, `pull-requests: write` |
+| Publish to Pages | `contents: write`, `pages: write`, `id-token: write` (separate workflow) |
+| Release version PR | `contents: write`, `pull-requests: write` + app secrets |
+| Package publish | `contents: read`, `id-token: write`, `attestations: write` (as required) |
+
+`reusable-test-node.yml` no longer includes a publish job. Use
+`reusable-test-node-publish.yml` in a separate caller job when publishing is
+required.
+
+## Low-noise Rust and Node checks
+
+Prefer split workflows to avoid skipped checks in PR UI:
+
+| Use case | Workflow |
+| --- | --- |
+| Rust build only | `reusable-rust-build.yml` or `reusable-test-rust-build.yml` |
+| Rust coverage only | `reusable-rust-coverage.yml` or `reusable-test-rust-coverage.yml` |
+| Node Vitest tests | `reusable-test-node.yml` with `test-command` empty |
+| Node custom command | `reusable-test-node.yml` with `test-command` set |
+
+`reusable-test-rust.yml` remains for backward compatibility but may show
+skipped jobs when only build or only coverage is enabled.
+
+## Egress block examples
+
+### Node / Bun (web)
+
+```yaml
+egress-policy: block
+allowed-endpoints: >
+  github.com:443
+  api.github.com:443
+  codeload.github.com:443
+  objects.githubusercontent.com:443
+  registry.npmjs.org:443
+```
+
+### Rust
+
+```yaml
+egress-policy: block
+allowed-endpoints: >
+  github.com:443
+  api.github.com:443
+  codeload.github.com:443
+  static.rust-lang.org:443
+  sh.rustup.rs:443
+  crates.io:443
+  static.crates.io:443
+  index.crates.io:443
+```
+
+### Quality / Lintro
+
+```yaml
+egress-policy: block
+allowed-endpoints: >
+  github.com:443
+  api.github.com:443
+  ghcr.io:443
+  index.crates.io:443
+  registry.npmjs.org:443
+  api.osv.dev:443
+  semgrep.dev:443
+  metrics.semgrep.dev:443
+```
+
+## Dependency review
+
+`reusable-dependency-review.yml` only runs on `pull_request` events. Do not
+invoke it from `push` workflows unless you accept the job being skipped.
+
+## Fork PR comments
+
+PR comments are skipped automatically on fork PRs (`head.repo.fork == true`).
+This is enforced in `scripts/ci/actions/post-pr-comment.sh` and workflow `if`
+conditions.
+
+## Rustume migration example
+
+```yaml
+jobs:
+  quality:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@<sha>
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+    with:
+      tooling-ref: "<sha>"
+      job-name: "🛠️ Lintro Code Quality & Analysis"
+      egress-policy: block
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        ghcr.io:443
+        api.osv.dev:443
+        semgrep.dev:443
+        metrics.semgrep.dev:443
+
+  rust-build:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-build.yml@<sha>
+    permissions:
+      contents: read
+    with:
+      tooling-ref: "<sha>"
+      job-name: "🔨 Build Check"
+      egress-policy: block
+      allowed-endpoints: >
+        github.com:443
+        static.rust-lang.org:443
+        crates.io:443
+
+  rust-coverage:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-coverage.yml@<sha>
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      tooling-ref: "<sha>"
+      job-name: "🦀 Rust Coverage"
+      egress-policy: block
+      allowed-endpoints: >
+        github.com:443
+        static.rust-lang.org:443
+        crates.io:443
+
+  web-coverage:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@<sha>
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      tooling-ref: "<sha>"
+      job-name: "🌐 Web Coverage"
+      working-directory: apps/web
+      package-manager: bun
+      test-command: bun run test:coverage
+      coverage: true
+      coverage-pr-comment: true
+      egress-policy: block
+      allowed-endpoints: >
+        github.com:443
+        registry.npmjs.org:443
+```

--- a/scripts/ci/actions/post-pr-comment.sh
+++ b/scripts/ci/actions/post-pr-comment.sh
@@ -78,6 +78,15 @@ fi
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 : "${PR_NUMBER:?PR_NUMBER is required}"
 : "${MARKER:?MARKER is required}"
+
+if [[ "${EVENT_NAME:-}" == "pull_request" ]]; then
+	HEAD_REPO="${EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME:-}"
+	if [[ -n "$HEAD_REPO" && "$HEAD_REPO" != "$GITHUB_REPOSITORY" ]]; then
+		echo "action-taken=skipped" >>"$GITHUB_OUTPUT"
+		echo "Skipped: fork PR cannot receive workflow comments ($HEAD_REPO)"
+		exit 0
+	fi
+fi
 : "${MODE:=upsert}"
 : "${DELETE_ON_EMPTY:=false}"
 

--- a/scripts/ci/actions/skip-fork-pr-comment.sh
+++ b/scripts/ci/actions/skip-fork-pr-comment.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Exit 0 with skipped outputs when PR comments cannot be posted (fork PRs).
+
+set -euo pipefail
+
+: "${EVENT_NAME:=}"
+: "${EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME:=}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+if [[ "$EVENT_NAME" != "pull_request" ]]; then
+	echo "can-comment=false" >>"$GITHUB_OUTPUT"
+	echo "Fork guard: not a pull_request event"
+	exit 0
+fi
+
+if [[ -z "$EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME" ]]; then
+	echo "::error::EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME is required for pull_request events"
+	exit 1
+fi
+
+if [[ "$EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME" != "$GITHUB_REPOSITORY" ]]; then
+	echo "can-comment=false" >>"$GITHUB_OUTPUT"
+	echo "Fork guard: skipping comment on fork PR ($EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME)"
+	exit 0
+fi
+
+echo "can-comment=true" >>"$GITHUB_OUTPUT"

--- a/tests/bats/unit/actions/test_post_pr_comment_fork.bats
+++ b/tests/bats/unit/actions/test_post_pr_comment_fork.bats
@@ -25,7 +25,7 @@ teardown() {
 		STEP="post" \
 		EVENT_NAME="pull_request" \
 		EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME="fork-user/consumer" \
-		COMMENT_BODY="hello" \
+		BODY_FROM_INPUT="hello" \
 		bash "${PROJECT_ROOT}/scripts/ci/actions/post-pr-comment.sh"
 
 	assert_success
@@ -40,7 +40,7 @@ teardown() {
 		STEP="post" \
 		EVENT_NAME="pull_request" \
 		EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME="lgtm-hq/consumer" \
-		COMMENT_BODY="hello" \
+		BODY_FROM_INPUT="hello" \
 		bash "${PROJECT_ROOT}/scripts/ci/actions/post-pr-comment.sh"
 
 	assert_failure

--- a/tests/bats/unit/actions/test_post_pr_comment_fork.bats
+++ b/tests/bats/unit/actions/test_post_pr_comment_fork.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for fork PR guard in scripts/ci/actions/post-pr-comment.sh
+
+load "../../../helpers/common"
+
+setup() {
+	setup_temp_dir
+	export GH_TOKEN="test-token"
+	export GITHUB_REPOSITORY="lgtm-hq/consumer"
+	export PR_NUMBER="42"
+	export MARKER="test-marker"
+	export MODE="upsert"
+	export DELETE_ON_EMPTY="false"
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/github_output"
+	: >"$GITHUB_OUTPUT"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "post-pr-comment: skips posting on fork pull_request" {
+	run env \
+		STEP="post" \
+		EVENT_NAME="pull_request" \
+		EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME="fork-user/consumer" \
+		COMMENT_BODY="hello" \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/post-pr-comment.sh"
+
+	assert_success
+	assert_output --partial "Skipped: fork PR"
+	assert_file_exists "$GITHUB_OUTPUT"
+	grep -q 'action-taken=skipped' "$GITHUB_OUTPUT"
+}
+
+@test "post-pr-comment: allows posting on same-repo pull_request" {
+	# gh is not available in unit tests; expect failure after fork guard passes
+	run env \
+		STEP="post" \
+		EVENT_NAME="pull_request" \
+		EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME="lgtm-hq/consumer" \
+		COMMENT_BODY="hello" \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/post-pr-comment.sh"
+
+	assert_failure
+	refute_output --partial "Skipped: fork PR"
+}

--- a/tests/bats/unit/actions/test_skip_fork_pr_comment.bats
+++ b/tests/bats/unit/actions/test_skip_fork_pr_comment.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/skip-fork-pr-comment.sh
+
+load "../../../helpers/common"
+
+setup() {
+	setup_temp_dir
+	export GITHUB_REPOSITORY="lgtm-hq/consumer"
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/github_output"
+	: >"$GITHUB_OUTPUT"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "skip-fork-pr-comment: non-PR event outputs can-comment=false" {
+	run env \
+		EVENT_NAME="push" \
+		EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME="" \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/skip-fork-pr-comment.sh"
+
+	assert_success
+	grep -q 'can-comment=false' "$GITHUB_OUTPUT"
+}
+
+@test "skip-fork-pr-comment: fork PR outputs can-comment=false" {
+	run env \
+		EVENT_NAME="pull_request" \
+		EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME="fork-user/consumer" \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/skip-fork-pr-comment.sh"
+
+	assert_success
+	grep -q 'can-comment=false' "$GITHUB_OUTPUT"
+}
+
+@test "skip-fork-pr-comment: same-repo PR outputs can-comment=true" {
+	run env \
+		EVENT_NAME="pull_request" \
+		EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME="lgtm-hq/consumer" \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/skip-fork-pr-comment.sh"
+
+	assert_success
+	grep -q 'can-comment=true' "$GITHUB_OUTPUT"
+}
+
+@test "skip-fork-pr-comment: missing head repo on PR event is error" {
+	run env \
+		EVENT_NAME="pull_request" \
+		EVENT_PULL_REQUEST_HEAD_REPO_FULL_NAME="" \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/skip-fork-pr-comment.sh"
+
+	assert_failure
+}

--- a/uv.lock
+++ b/uv.lock
@@ -352,7 +352,7 @@ wheels = [
 
 [[package]]
 name = "lgtm-ci"
-version = "0.14.0"
+version = "0.15.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Standardizes all lgtm-ci reusable workflows behind one consumer contract:
egress controls, permissions-by-mode, fork-safe PR comments, stable check names,
and lower-noise job graphs for Rust/Node coverage paths.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

- `publish-results` on `reusable-test-node`, `reusable-test-python`, and
  `reusable-test-e2e` is deprecated (ignored). Use the new publish workflows:
  - `reusable-test-node-publish.yml`
  - `reusable-test-python-publish.yml`
- Callers no longer need `pages: write` / `contents: write` for test-only Node
  or Python coverage when not publishing.

## Closes

- Closes #189

## Highlights

- Fleet-wide `egress-policy` / `allowed-endpoints` inputs (no hardcoded audit)
- Split workflows: `reusable-rust-build`, `reusable-rust-coverage`,
  `reusable-test-rust-build`, `reusable-test-rust-coverage`
- Node Vitest vs custom-command split into separate jobs (less step skip noise)
- Link-check comments isolated to a `comment-pr` job (`pull-requests: write`
  only when `comment-on-pr: true`)
- Fork PR comment guard in `post-pr-comment.sh` + workflow `if` conditions
- New docs: [workflow-contract.md](docs/workflow-contract.md) with permissions,
  egress allowlists, and Rustume migration examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable network egress hardening and customizable job names across reusable workflows.
  * New reusable workflows for Rust build/coverage, Python/Node publish, and Node test-publish.
  * PR comment behavior: fork PRs skipped; comment gating and markers made configurable.

* **Documentation**
  * Added workflow contract and updated Rust CI and reusable-workflows guidance.

* **Tests**
  * Added Bats unit tests for PR-comment gating.

* **Chores**
  * Added Makefile and CI helper scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->