### PR TITLE
feat(docker): enterprise-grade reusable Docker workflow enhancements

### DIFF
--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -560,10 +560,44 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # Optional per-platform smoke test gate.
+      - name: Smoke test (${{ matrix.platform }})
+        if: >-
+          inputs.validate-on-pr && !inputs.push &&
+          (inputs.smoke-test != '' || inputs.smoke-test-script != '')
+        shell: bash
+        env:
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+          IMAGE: >-
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:validate-${{
+            matrix.slug }}
+          PLATFORM: ${{ matrix.platform }}
+          SMOKE_TEST: ${{ inputs.smoke-test }}
+          SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
+        run: |
+          export IMAGE PLATFORM REGISTRY
+          if [[ -n "$SMOKE_TEST_SCRIPT" ]]; then
+            if [[ ! -f "$SMOKE_TEST_SCRIPT" ]]; then
+              echo "::error::smoke-test-script not found: ${SMOKE_TEST_SCRIPT}"
+              exit 1
+            fi
+            echo "::group::${SMOKE_TEST_SCRIPT} (IMAGE=${IMAGE} PLATFORM=${PLATFORM})"
+            chmod +x "$SMOKE_TEST_SCRIPT"
+            "./${SMOKE_TEST_SCRIPT#./}"
+            echo "::endgroup::"
+          else
+            echo "::group::docker run --rm --platform ${PLATFORM} ${IMAGE} ${SMOKE_TEST}"
+            # Intentionally word-split SMOKE_TEST so callers can pass flags+args
+            # shellcheck disable=SC2086
+            docker run --rm --platform "${PLATFORM}" "${IMAGE}" ${SMOKE_TEST}
+            echo "::endgroup::"
+          fi
+
+  # Optional per-platform smoke test gate (push path only).
   # Runs against each staging image on its native runner before manifest
-  # merge. Any failure blocks the merge so partial multi-arch manifests are
-  # never published. Two modes:
+  # merge. PR validation smoke tests run inline in build-per-platform because
+  # locally-loaded images are not available across job boundaries.
+  # Two modes:
   #   - smoke-test (shorthand): `docker run --rm --platform <p> <image> <cmd>`
   #   - smoke-test-script: caller-owned script with env IMAGE/PLATFORM/REGISTRY
   verify-per-platform:
@@ -571,6 +605,7 @@ jobs:
     needs: [classify, build-per-platform]
     if: >-
       needs.classify.outputs.use-split == 'true' &&
+      inputs.push &&
       (inputs.smoke-test != '' || inputs.smoke-test-script != '')
     strategy:
       fail-fast: false
@@ -655,8 +690,6 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
           SMOKE_TEST: ${{ inputs.smoke-test }}
           SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
-          LOCAL_VALIDATE: ${{ inputs.validate-on-pr && !inputs.push }}
-          LOCAL_TAG: validate-${{ matrix.slug }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
   # Assemble multi-arch manifest from per-platform staging images

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -99,6 +99,46 @@ on:
         required: false
         type: string
         default: ""
+      validate-on-pr:
+        description: >-
+          When true AND push is false, use the split per-platform path (native
+          runners) without pushing staging images. Enables full Dockerfile
+          validation on PRs without QEMU overhead.
+        required: false
+        type: boolean
+        default: false
+      scan-exit-code:
+        description: >-
+          Exit code for Trivy when findings match severity filter. Set to "1"
+          to fail the workflow on CRITICAL/HIGH CVEs. Set to "0" for
+          advisory-only SARIF upload.
+        required: false
+        type: string
+        default: "0"
+      cache-registry-ref:
+        description: >-
+          Registry reference for cache fallback (e.g. ghcr.io/org/repo:cache).
+          When set, adds type=registry as a secondary cache-from source and
+          writes to it on push events. GHA cache remains primary. Per-platform
+          scope is appended automatically (-amd64, -arm64).
+        required: false
+        type: string
+        default: ""
+      cosign-sign:
+        description: >-
+          Sign the final image manifest with Sigstore Cosign (keyless OIDC).
+          Requires id-token: write permission in caller. Only runs when push
+          is true and a digest is available.
+        required: false
+        type: boolean
+        default: false
+      no-cache:
+        description: >-
+          Disable build cache entirely. Use for release builds to ensure fully
+          reproducible images. When true, cache-from and cache-to are omitted.
+        required: false
+        type: boolean
+        default: false
       tooling-ref:
         # yamllint disable-line rule:line-length
         description: "Git ref for lgtm-ci tooling checkout. Defaults to the reusable workflow commit."
@@ -135,8 +175,8 @@ on:
 
 jobs:
   # Classify platforms and determine build strategy.
-  # Outputs use-split=true and a per-platform matrix when push is enabled
-  # and two or more platforms are requested; otherwise use-split=false.
+  # Outputs use-split=true and a per-platform matrix when push or validate-on-pr
+  # is enabled and two or more platforms are requested; otherwise use-split=false.
   classify:
     name: Classify Platforms
     runs-on: ubuntu-24.04
@@ -204,6 +244,7 @@ jobs:
           STEP: classify
           PLATFORMS: ${{ inputs.platforms }}
           PUSH: ${{ inputs.push }}
+          VALIDATE_ON_PR: ${{ inputs.validate-on-pr }}
           RUNNER_MAP: ${{ inputs.runner-map }}
           SMOKE_TEST: ${{ inputs.smoke-test }}
           SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
@@ -320,17 +361,24 @@ jobs:
           file: ${{ inputs.file }}
           platforms: ${{ inputs.platforms }}
           push: ${{ inputs.push }}
+          load: ${{ inputs.validate-on-pr && !inputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ inputs.build-args }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # yamllint disable rule:line-length
+          cache-from: |
+            ${{ inputs.no-cache == false && 'type=gha' || '' }}
+            ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && format('type=registry,ref={0}', inputs.cache-registry-ref) || '' }}
+          cache-to: |
+            ${{ inputs.no-cache == false && 'type=gha,mode=max' || '' }}
+            ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && inputs.push && format('type=registry,ref={0},mode=max', inputs.cache-registry-ref) || '' }}
+          # yamllint enable rule:line-length
           provenance: ${{ inputs.provenance }}
           sbom: ${{ inputs.sbom }}
 
       - name: Extract digest
         id: metadata
-        if: inputs.push
+        if: inputs.push || inputs.validate-on-pr
         shell: bash
         env:
           STEP: set-output-digest
@@ -345,6 +393,35 @@ jobs:
           subject-name: ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
+
+      - name: Install Cosign
+        if: inputs.push && inputs.cosign-sign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign image
+        if: inputs.push && inputs.cosign-sign
+        shell: bash
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+        run: |
+          cosign sign --yes "${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
+
+      - name: Build summary
+        if: always()
+        shell: bash
+        env:
+          STEP: summary
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+          PLATFORMS: ${{ inputs.platforms }}
+          PUSH: ${{ inputs.push }}
+          DIGEST: ${{ steps.metadata.outputs.digest || '' }}
+          COSIGN_SIGNED: ${{ inputs.cosign-sign && inputs.push }}
+          SCAN_ENABLED: ${{ inputs.scan }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
   # Per-platform native build leg (multi-arch split path).
   # One matrix entry per platform; runner and QEMU config resolved by classify.
@@ -394,6 +471,7 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Validate registry
+        if: inputs.push
         shell: bash
         env:
           STEP: validate
@@ -403,7 +481,7 @@ jobs:
         run: .lgtm-ci-tooling/scripts/ci/actions/docker-login.sh
 
       - name: Login to GHCR
-        if: inputs.registry == 'ghcr.io'
+        if: inputs.push && inputs.registry == 'ghcr.io'
         # Pinned to SHA for supply chain security
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -412,7 +490,7 @@ jobs:
           password: ${{ github.token }}
 
       - name: Login to Docker Hub
-        if: inputs.registry == 'docker.io'
+        if: inputs.push && inputs.registry == 'docker.io'
         # Pinned to SHA for supply chain security
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -445,14 +523,22 @@ jobs:
           context: ${{ inputs.context }}
           file: ${{ inputs.file }}
           platforms: ${{ matrix.platform }}
-          push: true
+          push: ${{ inputs.push }}
+          load: ${{ inputs.validate-on-pr && !inputs.push }}
+          # yamllint disable rule:line-length
           tags: >-
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:build-${{
-            github.run_id }}-${{ matrix.slug }}
+            ${{ inputs.push
+              && format('{0}/{1}:build-{2}-{3}', inputs.registry, inputs.image-name || github.repository, github.run_id, matrix.slug)
+              || format('{0}/{1}:validate-{2}', inputs.registry, inputs.image-name || github.repository, matrix.slug) }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ inputs.build-args }}
-          cache-from: type=gha,scope=${{ matrix.slug }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.slug }}
+          cache-from: |
+            ${{ inputs.no-cache == false && format('type=gha,scope={0}', matrix.slug) || '' }}
+            ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && format('type=registry,ref={0}-{1}', inputs.cache-registry-ref, matrix.slug) || '' }}
+          cache-to: |
+            ${{ inputs.no-cache == false && format('type=gha,mode=max,scope={0}', matrix.slug) || '' }}
+            ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && inputs.push && format('type=registry,ref={0}-{1},mode=max', inputs.cache-registry-ref, matrix.slug) || '' }}
+          # yamllint enable rule:line-length
           provenance: false
           sbom: ${{ inputs.sbom }}
 
@@ -465,6 +551,7 @@ jobs:
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
       - name: Upload staging digest
+        if: inputs.push
         # Pinned to SHA for supply chain security
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -524,6 +611,7 @@ jobs:
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Validate registry
+        if: inputs.push
         shell: bash
         env:
           STEP: validate
@@ -533,7 +621,7 @@ jobs:
         run: .lgtm-ci-tooling/scripts/ci/actions/docker-login.sh
 
       - name: Login to GHCR
-        if: inputs.registry == 'ghcr.io'
+        if: inputs.push && inputs.registry == 'ghcr.io'
         # Pinned to SHA for supply chain security
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -542,7 +630,7 @@ jobs:
           password: ${{ github.token }}
 
       - name: Login to Docker Hub
-        if: inputs.registry == 'docker.io'
+        if: inputs.push && inputs.registry == 'docker.io'
         # Pinned to SHA for supply chain security
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -550,6 +638,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Download staging digest
+        if: inputs.push
         # Pinned to SHA for supply chain security
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -566,6 +655,8 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
           SMOKE_TEST: ${{ inputs.smoke-test }}
           SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
+          LOCAL_VALIDATE: ${{ inputs.validate-on-pr && !inputs.push }}
+          LOCAL_TAG: validate-${{ matrix.slug }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
   # Assemble multi-arch manifest from per-platform staging images
@@ -574,6 +665,7 @@ jobs:
     needs: [classify, build-per-platform, verify-per-platform]
     if: >-
       always() &&
+      inputs.push &&
       needs.classify.outputs.use-split == 'true' &&
       needs.build-per-platform.result == 'success' &&
       (needs.verify-per-platform.result == 'success' ||
@@ -692,6 +784,20 @@ jobs:
           subject-digest: ${{ steps.metadata.outputs.digest }}
           push-to-registry: true
 
+      - name: Install Cosign
+        if: inputs.cosign-sign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign image
+        if: inputs.cosign-sign
+        shell: bash
+        env:
+          DIGEST: ${{ steps.metadata.outputs.digest }}
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+        run: |
+          cosign sign --yes "${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
+
       - name: Delete staging manifests
         if: always() && inputs.registry == 'ghcr.io'
         shell: bash
@@ -703,14 +809,124 @@ jobs:
           MATRIX: ${{ needs.classify.outputs.matrix }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
-  scan:
-    name: Vulnerability Scan
-    needs: [build, merge]
+      - name: Build summary
+        if: always()
+        shell: bash
+        env:
+          STEP: summary
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+          PLATFORMS: ${{ inputs.platforms }}
+          PUSH: ${{ inputs.push }}
+          DIGEST: ${{ steps.metadata.outputs.digest || '' }}
+          COSIGN_SIGNED: ${{ inputs.cosign-sign && inputs.push }}
+          SCAN_ENABLED: ${{ inputs.scan }}
+          MATRIX: ${{ needs.classify.outputs.matrix }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+  scan-per-platform:
+    name: Scan ${{ matrix.platform }}
+    needs: [classify, build-per-platform]
     if: >-
       always() &&
-      (needs.build.result == 'success' || needs.merge.result == 'success') &&
+      needs.classify.outputs.use-split == 'true' &&
       inputs.scan &&
-      inputs.push
+      inputs.validate-on-pr &&
+      inputs.push == false &&
+      needs.build-per-platform.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.classify.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Harden runner
+        # Pinned to SHA for supply chain security
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+
+      - name: Run Trivy vulnerability scanner (${{ matrix.platform }})
+        # Pinned to SHA for supply chain security
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: >-
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:validate-${{
+            matrix.slug }}
+          format: "sarif"
+          output: "trivy-results-${{ matrix.slug }}.sarif"
+          severity: "CRITICAL,HIGH"
+          exit-code: ${{ inputs.scan-exit-code }}
+
+      - name: Upload Trivy scan results (${{ matrix.platform }})
+        if: always()
+        # Pinned to SHA for supply chain security
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        with:
+          sarif_file: "trivy-results-${{ matrix.slug }}.sarif"
+          category: "trivy-${{ matrix.slug }}"
+
+  summary-validate:
+    name: Validation Summary
+    needs: [classify, build-per-platform, verify-per-platform, scan-per-platform]
+    if: >-
+      always() &&
+      needs.classify.outputs.use-split == 'true' &&
+      inputs.validate-on-pr &&
+      inputs.push == false
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden runner
+        # Pinned to SHA for supply chain security
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ needs.classify.outputs.tooling-repository }}
+          path: .lgtm-ci-tooling
+          ref: ${{ needs.classify.outputs.tooling-ref }}
+          sparse-checkout: scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Build summary
+        if: always()
+        shell: bash
+        env:
+          STEP: summary
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+          PLATFORMS: ${{ inputs.platforms }}
+          PUSH: ${{ inputs.push }}
+          SCAN_ENABLED: ${{ inputs.scan }}
+          VALIDATE_ON_PR: true
+          MATRIX: ${{ needs.classify.outputs.matrix }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+  scan:
+    name: Vulnerability Scan
+    needs: [classify, build, merge]
+    if: >-
+      always() &&
+      inputs.scan &&
+      (inputs.push || (inputs.validate-on-pr && needs.classify.outputs.use-split == 'false')) &&
+      (
+        (needs.classify.outputs.use-split == 'false' && needs.build.result == 'success') ||
+        (needs.classify.outputs.use-split == 'true' && inputs.push && needs.merge.result == 'success')
+      )
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -727,6 +943,7 @@ jobs:
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH"
+          exit-code: ${{ inputs.scan-exit-code }}
 
       - name: Upload Trivy scan results
         # Pinned to SHA for supply chain security

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -437,6 +437,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
 
     steps:
       - name: Harden runner
@@ -550,16 +551,6 @@ jobs:
           DIGEST_FILE: ${{ runner.temp }}/staging-digest/digest.txt
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
-      - name: Upload staging digest
-        if: inputs.push
-        # Pinned to SHA for supply chain security
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: staging-digest-${{ matrix.slug }}
-          path: ${{ runner.temp }}/staging-digest/digest.txt
-          if-no-files-found: error
-          retention-days: 1
-
       - name: Smoke test (${{ matrix.platform }})
         if: >-
           inputs.validate-on-pr && !inputs.push &&
@@ -593,10 +584,42 @@ jobs:
             echo "::endgroup::"
           fi
 
+      - name: Run Trivy vulnerability scanner (${{ matrix.platform }})
+        if: inputs.validate-on-pr && !inputs.push && inputs.scan
+        # Pinned to SHA for supply chain security
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: >-
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:validate-${{
+            matrix.slug }}
+          format: "sarif"
+          output: "trivy-results-${{ matrix.slug }}.sarif"
+          severity: "CRITICAL,HIGH"
+          exit-code: ${{ inputs.scan-exit-code }}
+
+      - name: Upload Trivy scan results (${{ matrix.platform }})
+        if: always() && inputs.validate-on-pr && !inputs.push && inputs.scan
+        # Pinned to SHA for supply chain security
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        with:
+          sarif_file: "trivy-results-${{ matrix.slug }}.sarif"
+          category: "trivy-${{ matrix.slug }}"
+
+      - name: Upload staging digest
+        if: inputs.push
+        # Pinned to SHA for supply chain security
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: staging-digest-${{ matrix.slug }}
+          path: ${{ runner.temp }}/staging-digest/digest.txt
+          if-no-files-found: error
+          retention-days: 1
+
   # Optional per-platform smoke test gate (push path only).
   # Runs against each staging image on its native runner before manifest
-  # merge. PR validation smoke tests run inline in build-per-platform because
-  # locally-loaded images are not available across job boundaries.
+  # merge. PR validation smoke tests and Trivy scans run inline in
+  # build-per-platform because locally-loaded images are not available
+  # across job boundaries.
   # Two modes:
   #   - smoke-test (shorthand): `docker run --rm --platform <p> <image> <cmd>`
   #   - smoke-test-script: caller-owned script with env IMAGE/PLATFORM/REGISTRY
@@ -858,56 +881,9 @@ jobs:
           MATRIX: ${{ needs.classify.outputs.matrix }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
-  scan-per-platform:
-    name: Scan ${{ matrix.platform }}
-    needs: [classify, build-per-platform]
-    if: >-
-      always() &&
-      needs.classify.outputs.use-split == 'true' &&
-      inputs.scan &&
-      inputs.validate-on-pr &&
-      inputs.push == false &&
-      needs.build-per-platform.result == 'success'
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.classify.outputs.matrix) }}
-    runs-on: ${{ matrix.runner }}
-    permissions:
-      contents: read
-      security-events: write
-
-    steps:
-      - name: Harden runner
-        # Pinned to SHA for supply chain security
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
-
-      - name: Run Trivy vulnerability scanner (${{ matrix.platform }})
-        # Pinned to SHA for supply chain security
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: >-
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:validate-${{
-            matrix.slug }}
-          format: "sarif"
-          output: "trivy-results-${{ matrix.slug }}.sarif"
-          severity: "CRITICAL,HIGH"
-          exit-code: ${{ inputs.scan-exit-code }}
-
-      - name: Upload Trivy scan results (${{ matrix.platform }})
-        if: always()
-        # Pinned to SHA for supply chain security
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
-        with:
-          sarif_file: "trivy-results-${{ matrix.slug }}.sarif"
-          category: "trivy-${{ matrix.slug }}"
-
   summary-validate:
     name: Validation Summary
-    needs: [classify, build-per-platform, verify-per-platform, scan-per-platform]
+    needs: [classify, build-per-platform, verify-per-platform]
     if: >-
       always() &&
       needs.classify.outputs.use-split == 'true' &&

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -430,11 +430,11 @@ jobs:
         if: inputs.push && inputs.cosign-sign
         shell: bash
         env:
+          STEP: sign-image
           DIGEST: ${{ steps.build.outputs.digest }}
           REGISTRY: ${{ inputs.registry }}
           IMAGE_NAME: ${{ inputs.image-name || github.repository }}
-        run: |
-          cosign sign --yes "${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
       - name: Build summary
         if: always()
@@ -859,11 +859,11 @@ jobs:
         if: inputs.cosign-sign
         shell: bash
         env:
+          STEP: sign-image
           DIGEST: ${{ steps.metadata.outputs.digest }}
           REGISTRY: ${{ inputs.registry }}
           IMAGE_NAME: ${{ inputs.image-name || github.repository }}
-        run: |
-          cosign sign --yes "${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
       - name: Delete staging manifests
         if: always() && inputs.registry == 'ghcr.io'

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -261,6 +261,7 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      security-events: write
 
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
@@ -384,6 +385,38 @@ jobs:
           STEP: set-output-digest
           DIGEST: ${{ steps.build.outputs.digest }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Resolve local image for scan
+        if: inputs.validate-on-pr && !inputs.push && inputs.scan
+        id: local-scan-image
+        shell: bash
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          first_tag=$(echo "$TAGS" | head -1 | tr -d '[:space:]')
+          if [[ -z "$first_tag" ]]; then
+            echo "::error::No image tag available for local Trivy scan"
+            exit 1
+          fi
+          echo "ref=${first_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Run Trivy vulnerability scanner
+        if: inputs.validate-on-pr && !inputs.push && inputs.scan
+        # Pinned to SHA for supply chain security
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ steps.local-scan-image.outputs.ref }}
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH"
+          exit-code: ${{ inputs.scan-exit-code }}
+
+      - name: Upload Trivy scan results
+        if: always() && inputs.validate-on-pr && !inputs.push && inputs.scan
+        # Pinned to SHA for supply chain security
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        with:
+          sarif_file: "trivy-results.sarif"
 
       - name: Generate artifact attestation
         if: inputs.push && inputs.provenance
@@ -931,10 +964,10 @@ jobs:
     if: >-
       always() &&
       inputs.scan &&
-      (inputs.push || (inputs.validate-on-pr && needs.classify.outputs.use-split == 'false')) &&
+      inputs.push &&
       (
         (needs.classify.outputs.use-split == 'false' && needs.build.result == 'success') ||
-        (needs.classify.outputs.use-split == 'true' && inputs.push && needs.merge.result == 'success')
+        (needs.classify.outputs.use-split == 'true' && needs.merge.result == 'success')
       )
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -362,7 +362,7 @@ jobs:
           file: ${{ inputs.file }}
           platforms: ${{ inputs.platforms }}
           push: ${{ inputs.push }}
-          load: ${{ inputs.validate-on-pr && !inputs.push }}
+          load: ${{ inputs.push == false && (inputs.validate-on-pr || inputs.scan) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ inputs.build-args }}
@@ -387,21 +387,16 @@ jobs:
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
       - name: Resolve local image for scan
-        if: inputs.validate-on-pr && !inputs.push && inputs.scan
+        if: inputs.scan && inputs.push == false
         id: local-scan-image
         shell: bash
         env:
+          STEP: resolve-local-scan-image
           TAGS: ${{ steps.meta.outputs.tags }}
-        run: |
-          first_tag=$(echo "$TAGS" | head -1 | tr -d '[:space:]')
-          if [[ -z "$first_tag" ]]; then
-            echo "::error::No image tag available for local Trivy scan"
-            exit 1
-          fi
-          echo "ref=${first_tag}" >> "$GITHUB_OUTPUT"
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
       - name: Run Trivy vulnerability scanner
-        if: inputs.validate-on-pr && !inputs.push && inputs.scan
+        if: inputs.scan && inputs.push == false
         # Pinned to SHA for supply chain security
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -412,7 +407,7 @@ jobs:
           exit-code: ${{ inputs.scan-exit-code }}
 
       - name: Upload Trivy scan results
-        if: always() && inputs.validate-on-pr && !inputs.push && inputs.scan
+        if: always() && inputs.scan && inputs.push == false
         # Pinned to SHA for supply chain security
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:
@@ -558,7 +553,7 @@ jobs:
           file: ${{ inputs.file }}
           platforms: ${{ matrix.platform }}
           push: ${{ inputs.push }}
-          load: ${{ inputs.validate-on-pr && !inputs.push }}
+          load: ${{ inputs.push == false && (inputs.validate-on-pr || inputs.scan) }}
           # yamllint disable rule:line-length
           tags: >-
             ${{ inputs.push
@@ -586,39 +581,22 @@ jobs:
 
       - name: Smoke test (${{ matrix.platform }})
         if: >-
-          inputs.validate-on-pr && !inputs.push &&
+          inputs.validate-on-pr && inputs.push == false &&
           (inputs.smoke-test != '' || inputs.smoke-test-script != '')
         shell: bash
         env:
+          STEP: smoke-test-local
           REGISTRY: ${{ inputs.registry }}
-          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
           IMAGE: >-
             ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:validate-${{
             matrix.slug }}
           PLATFORM: ${{ matrix.platform }}
           SMOKE_TEST: ${{ inputs.smoke-test }}
           SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
-        run: |
-          export IMAGE PLATFORM REGISTRY
-          if [[ -n "$SMOKE_TEST_SCRIPT" ]]; then
-            if [[ ! -f "$SMOKE_TEST_SCRIPT" ]]; then
-              echo "::error::smoke-test-script not found: ${SMOKE_TEST_SCRIPT}"
-              exit 1
-            fi
-            echo "::group::${SMOKE_TEST_SCRIPT} (IMAGE=${IMAGE} PLATFORM=${PLATFORM})"
-            chmod +x "$SMOKE_TEST_SCRIPT"
-            "./${SMOKE_TEST_SCRIPT#./}"
-            echo "::endgroup::"
-          else
-            echo "::group::docker run --rm --platform ${PLATFORM} ${IMAGE} ${SMOKE_TEST}"
-            # Intentionally word-split SMOKE_TEST so callers can pass flags+args
-            # shellcheck disable=SC2086
-            docker run --rm --platform "${PLATFORM}" "${IMAGE}" ${SMOKE_TEST}
-            echo "::endgroup::"
-          fi
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
       - name: Run Trivy vulnerability scanner (${{ matrix.platform }})
-        if: inputs.validate-on-pr && !inputs.push && inputs.scan
+        if: inputs.scan && inputs.push == false
         # Pinned to SHA for supply chain security
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -631,7 +609,7 @@ jobs:
           exit-code: ${{ inputs.scan-exit-code }}
 
       - name: Upload Trivy scan results (${{ matrix.platform }})
-        if: always() && inputs.validate-on-pr && !inputs.push && inputs.scan
+        if: always() && inputs.scan && inputs.push == false
         # Pinned to SHA for supply chain security
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **workflows**: enterprise Docker CI enhancements for `reusable-docker.yml` (#193)
+  - `validate-on-pr` — native split builds on PRs without registry push
+  - `scan-exit-code` — block PRs on CRITICAL/HIGH Trivy findings
+  - `cache-registry-ref` — registry cache fallback when GHA cache evicts
+  - `cosign-sign` — keyless Sigstore image signing on push
+  - `no-cache` — clean release builds without cache layers
+  - Build observability via `$GITHUB_STEP_SUMMARY`
+
 ### Changed
 
 ### Deprecated

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -188,6 +188,49 @@ jobs:
 
 ## Build, Coverage, And Supply Chain
 
+### Push (publish to registry)
+
+```yaml
+jobs:
+  docker:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@<sha>
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      security-events: write
+    with:
+      push: true
+      scan: true
+      scan-exit-code: "1"
+      cosign-sign: true
+      cache-registry-ref: ghcr.io/org/repo:cache
+      no-cache: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
+```
+
+### PR validation (build-only, no push)
+
+```yaml
+jobs:
+  docker:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@<sha>
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      file: docker/Dockerfile
+      push: false
+      validate-on-pr: true
+      runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
+      scan: true
+      scan-exit-code: "1"
+      smoke-test: --version
+```
+
+### Combined push and PR validation
+
 ```yaml
 jobs:
   docker:

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -199,7 +199,7 @@ jobs:
       attestations: write
       security-events: write
     with:
-      push: true
+      push: ${{ github.event_name != 'pull_request' }}
       validate-on-pr: ${{ github.event_name == 'pull_request' }}
       scan: true
       scan-exit-code: "1"

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -197,8 +197,16 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      security-events: write
     with:
       push: true
+      validate-on-pr: ${{ github.event_name == 'pull_request' }}
+      scan: true
+      scan-exit-code: "1"
+      cosign-sign: true
+      cache-registry-ref: ghcr.io/org/repo:cache
+      no-cache: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
 
   sbom:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@<sha>
@@ -222,6 +230,18 @@ jobs:
       package-name: my-image
     secrets: inherit
 ```
+
+### Docker workflow inputs
+
+| Input | Default | Description |
+| ----- | ------- | ----------- |
+| `validate-on-pr` | `false` | Use native split builds on PRs without pushing staging images |
+| `scan-exit-code` | `"0"` | Trivy exit code; set `"1"` to block PRs on CRITICAL/HIGH CVEs |
+| `cache-registry-ref` | `""` | Registry cache fallback (e.g. `ghcr.io/org/repo:cache`) |
+| `cosign-sign` | `false` | Keyless Cosign signature on pushed manifests |
+| `no-cache` | `false` | Disable GHA/registry cache for clean release builds |
+
+All inputs are opt-in; existing callers keep current behavior without changes.
 
 ## PR Automation And Security
 

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -5,7 +5,7 @@
 # Required environment variables:
 #   STEP - Which step to run: setup, build, push, metadata, parse-tags, summary,
 #          set-output-digest, classify, record-digest, smoke-test, smoke-test-local,
-#          resolve-local-scan-image, merge-manifests, cleanup-staging
+#          resolve-local-scan-image, sign-image, merge-manifests, cleanup-staging
 #
 # Optional environment variables:
 #   CONTEXT - Build context path (default: .)
@@ -665,6 +665,35 @@ cleanup-staging)
 			log_warn "Could not locate staging manifest version for tag ${tag} — skipping deletion"
 		fi
 	done < <(echo "$MATRIX" | jq -r '.[].slug')
+	;;
+
+sign-image)
+	# Sign a pushed image manifest with Cosign keyless signing.
+	#
+	# Required environment variables:
+	#   DIGEST     - Image digest (sha256:...)
+	#   REGISTRY   - Container registry URL
+	#   IMAGE_NAME - Registry-relative image name
+	: "${DIGEST:?DIGEST is required}"
+	: "${REGISTRY:?REGISTRY is required}"
+	: "${IMAGE_NAME:?IMAGE_NAME is required}"
+
+	if [[ -z "$DIGEST" ]]; then
+		die "DIGEST is empty — cannot sign image"
+	fi
+
+	if ! [[ "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+		die "DIGEST is not a valid sha256 digest: ${DIGEST}"
+	fi
+
+	if ! command -v cosign >/dev/null 2>&1; then
+		die "cosign not found. Install via sigstore/cosign-installer action."
+	fi
+
+	image_ref="${REGISTRY}/${IMAGE_NAME}@${DIGEST}"
+	log_info "Signing image: ${image_ref}"
+	cosign sign --yes "${image_ref}"
+	log_success "Signed image: ${image_ref}"
 	;;
 
 summary)

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -678,10 +678,6 @@ sign-image)
 	: "${REGISTRY:?REGISTRY is required}"
 	: "${IMAGE_NAME:?IMAGE_NAME is required}"
 
-	if [[ -z "$DIGEST" ]]; then
-		die "DIGEST is empty — cannot sign image"
-	fi
-
 	if ! [[ "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
 		die "DIGEST is not a valid sha256 digest: ${DIGEST}"
 	fi

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -458,18 +458,12 @@ smoke-test)
 	#   SMOKE_TEST        - Shorthand command + args; word-split into `docker run`
 	#   SMOKE_TEST_SCRIPT - Path to caller-owned script; receives IMAGE, PLATFORM,
 	#                       REGISTRY in the environment and owns the docker run
-	#
-	# Optional environment variables:
-	#   LOCAL_VALIDATE - When "true", use a locally loaded image tag (no registry pull)
-	#   LOCAL_TAG      - Local tag suffix when LOCAL_VALIDATE is true (e.g. validate-amd64)
 	: "${REGISTRY:?REGISTRY is required}"
 	: "${IMAGE_NAME:?IMAGE_NAME is required}"
 	: "${PLATFORM:?PLATFORM is required}"
-	: "${DIGEST_FILE:=}"
+	: "${DIGEST_FILE:?DIGEST_FILE is required}"
 	: "${SMOKE_TEST:=}"
 	: "${SMOKE_TEST_SCRIPT:=}"
-	: "${LOCAL_VALIDATE:=false}"
-	: "${LOCAL_TAG:=}"
 
 	if [[ -n "$SMOKE_TEST" && -n "$SMOKE_TEST_SCRIPT" ]]; then
 		die "SMOKE_TEST and SMOKE_TEST_SCRIPT are mutually exclusive"
@@ -477,32 +471,21 @@ smoke-test)
 	if [[ -z "$SMOKE_TEST" && -z "$SMOKE_TEST_SCRIPT" ]]; then
 		die "One of SMOKE_TEST or SMOKE_TEST_SCRIPT is required"
 	fi
-
-	if [[ "$LOCAL_VALIDATE" == "true" ]]; then
-		if [[ -z "$LOCAL_TAG" ]]; then
-			die "LOCAL_TAG is required when LOCAL_VALIDATE is true"
-		fi
-		IMAGE="${REGISTRY}/${IMAGE_NAME}:${LOCAL_TAG}"
-	else
-		: "${DIGEST_FILE:?DIGEST_FILE is required}"
-		if [[ ! -s "$DIGEST_FILE" ]]; then
-			die "DIGEST_FILE missing or empty: ${DIGEST_FILE}"
-		fi
-
-		digest=$(<"$DIGEST_FILE")
-		if ! [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-			die "Invalid digest in ${DIGEST_FILE}: ${digest}"
-		fi
-
-		IMAGE="${REGISTRY}/${IMAGE_NAME}@${digest}"
+	if [[ ! -s "$DIGEST_FILE" ]]; then
+		die "DIGEST_FILE missing or empty: ${DIGEST_FILE}"
 	fi
+
+	digest=$(<"$DIGEST_FILE")
+	if ! [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+		die "Invalid digest in ${DIGEST_FILE}: ${digest}"
+	fi
+
+	IMAGE="${REGISTRY}/${IMAGE_NAME}@${digest}"
 	export IMAGE PLATFORM REGISTRY
 
-	if [[ "$LOCAL_VALIDATE" != "true" ]]; then
-		echo "::group::Pulling ${IMAGE} (${PLATFORM})"
-		docker pull --platform "${PLATFORM}" "${IMAGE}"
-		echo "::endgroup::"
-	fi
+	echo "::group::Pulling ${IMAGE} (${PLATFORM})"
+	docker pull --platform "${PLATFORM}" "${IMAGE}"
+	echo "::endgroup::"
 
 	if [[ -n "$SMOKE_TEST_SCRIPT" ]]; then
 		if [[ ! -f "$SMOKE_TEST_SCRIPT" ]]; then

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -458,8 +458,6 @@ smoke-test)
 	#   SMOKE_TEST        - Shorthand command + args; word-split into `docker run`
 	#   SMOKE_TEST_SCRIPT - Path to caller-owned script; receives IMAGE, PLATFORM,
 	#                       REGISTRY in the environment and owns the docker run
-	#   SMOKE_TEST_SCRIPT - Path to caller-owned script; receives IMAGE, PLATFORM,
-	#                       REGISTRY in the environment and owns the docker run
 	#
 	# Optional environment variables:
 	#   LOCAL_VALIDATE - When "true", use a locally loaded image tag (no registry pull)
@@ -679,13 +677,17 @@ summary)
 	fi
 
 	if [[ "$COSIGN_SIGNED" == "true" && -n "$DIGEST" ]]; then
+		# Default identity matches the signing repo; callers may tighten further.
+		: "${GITHUB_REPOSITORY:=ORG/REPO}"
+		cosign_identity="https://github.com/${GITHUB_REPOSITORY}/.*"
+
 		add_github_summary "### Image signature"
 		add_github_summary ""
 		add_github_summary "Verify with:"
 		add_github_summary ""
 		add_github_summary "\`\`\`bash"
 		add_github_summary "cosign verify ${full_image}@${DIGEST} \\"
-		add_github_summary "  --certificate-identity-regexp='.*' \\"
+		add_github_summary "  --certificate-identity-regexp='${cosign_identity}' \\"
 		add_github_summary "  --certificate-oidc-issuer='https://token.actions.githubusercontent.com'"
 		add_github_summary "\`\`\`"
 		add_github_summary ""

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -4,8 +4,8 @@
 #
 # Required environment variables:
 #   STEP - Which step to run: setup, build, push, metadata, parse-tags, summary,
-#          set-output-digest, classify, record-digest, smoke-test,
-#          merge-manifests, cleanup-staging
+#          set-output-digest, classify, record-digest, smoke-test, smoke-test-local,
+#          resolve-local-scan-image, merge-manifests, cleanup-staging
 #
 # Optional environment variables:
 #   CONTEXT - Build context path (default: .)
@@ -486,6 +486,70 @@ smoke-test)
 	echo "::group::Pulling ${IMAGE} (${PLATFORM})"
 	docker pull --platform "${PLATFORM}" "${IMAGE}"
 	echo "::endgroup::"
+
+	if [[ -n "$SMOKE_TEST_SCRIPT" ]]; then
+		if [[ ! -f "$SMOKE_TEST_SCRIPT" ]]; then
+			echo "::error::smoke-test-script not found: ${SMOKE_TEST_SCRIPT}"
+			exit 1
+		fi
+		echo "::group::${SMOKE_TEST_SCRIPT} (IMAGE=${IMAGE} PLATFORM=${PLATFORM})"
+		chmod +x "$SMOKE_TEST_SCRIPT"
+		"./${SMOKE_TEST_SCRIPT#./}"
+		echo "::endgroup::"
+	else
+		echo "::group::docker run --rm --platform ${PLATFORM} ${IMAGE} ${SMOKE_TEST}"
+		# Intentionally word-split SMOKE_TEST so callers can pass flags+args
+		# shellcheck disable=SC2086
+		docker run --rm --platform "${PLATFORM}" "${IMAGE}" ${SMOKE_TEST}
+		echo "::endgroup::"
+	fi
+	;;
+
+resolve-local-scan-image)
+	# Resolve the first metadata tag for scanning a locally loaded image.
+	#
+	# Required environment variables:
+	#   TAGS - Newline-separated image tags from docker/metadata-action
+	#
+	# Outputs:
+	#   ref - First tag suitable for Trivy image-ref
+	: "${TAGS:?TAGS is required}"
+
+	first_tag=$(echo "$TAGS" | head -1 | tr -d '[:space:]')
+	if [[ -z "$first_tag" ]]; then
+		die "No image tag available for local Trivy scan"
+	fi
+
+	set_github_output "ref" "$first_tag"
+	log_info "Local scan image: ${first_tag}"
+	;;
+
+smoke-test-local)
+	# Run a smoke test against a locally loaded image (no registry pull).
+	#
+	# Required environment variables:
+	#   IMAGE     - Full local image reference (registry/name:tag)
+	#   PLATFORM  - Target platform (e.g. linux/arm64)
+	#   REGISTRY  - Container registry URL
+	#
+	# Optional environment variables (mutually exclusive; at least one required):
+	#   SMOKE_TEST        - Shorthand command + args; word-split into `docker run`
+	#   SMOKE_TEST_SCRIPT - Path to caller-owned script; receives IMAGE, PLATFORM,
+	#                       REGISTRY in the environment and owns the docker run
+	: "${IMAGE:?IMAGE is required}"
+	: "${PLATFORM:?PLATFORM is required}"
+	: "${REGISTRY:?REGISTRY is required}"
+	: "${SMOKE_TEST:=}"
+	: "${SMOKE_TEST_SCRIPT:=}"
+
+	if [[ -n "$SMOKE_TEST" && -n "$SMOKE_TEST_SCRIPT" ]]; then
+		die "SMOKE_TEST and SMOKE_TEST_SCRIPT are mutually exclusive"
+	fi
+	if [[ -z "$SMOKE_TEST" && -z "$SMOKE_TEST_SCRIPT" ]]; then
+		die "One of SMOKE_TEST or SMOKE_TEST_SCRIPT is required"
+	fi
+
+	export IMAGE PLATFORM REGISTRY
 
 	if [[ -n "$SMOKE_TEST_SCRIPT" ]]; then
 		if [[ ! -f "$SMOKE_TEST_SCRIPT" ]]; then

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -305,6 +305,7 @@ classify)
 	#   PUSH       - Whether images will be pushed ("true"/"false")
 	#
 	# Optional environment variables:
+	#   VALIDATE_ON_PR    - Enable split builds without push for PR validation
 	#   RUNNER_MAP        - JSON object mapping platform → runner label (default: "{}")
 	#                       Platforms not in the map default to ubuntu-24.04 with QEMU.
 	#                       Example: {"linux/arm64":"ubuntu-24.04-arm"}
@@ -317,6 +318,7 @@ classify)
 	#   matrix    - JSON array of {platform, runner, slug, qemu} entries
 	: "${PLATFORMS:?PLATFORMS is required}"
 	: "${PUSH:?PUSH is required}"
+	: "${VALIDATE_ON_PR:=false}"
 	: "${RUNNER_MAP:={}}"
 	: "${SMOKE_TEST:=}"
 	: "${SMOKE_TEST_SCRIPT:=}"
@@ -355,11 +357,11 @@ classify)
 		die "PLATFORMS is empty or contains only whitespace"
 	fi
 
-	# push=false → always use the QEMU build job (imagetools requires a registry)
-	if [[ "$PUSH" != "true" ]]; then
+	# push=false and validate-on-pr=false → use the QEMU build job
+	if [[ "$PUSH" != "true" && "$VALIDATE_ON_PR" != "true" ]]; then
 		set_github_output "use-split" "false"
 		set_github_output "matrix" "[]"
-		log_info "Split disabled: push=${PUSH}"
+		log_info "Split disabled: push=${PUSH}, validate-on-pr=${VALIDATE_ON_PR}"
 		exit 0
 	fi
 
@@ -456,12 +458,20 @@ smoke-test)
 	#   SMOKE_TEST        - Shorthand command + args; word-split into `docker run`
 	#   SMOKE_TEST_SCRIPT - Path to caller-owned script; receives IMAGE, PLATFORM,
 	#                       REGISTRY in the environment and owns the docker run
+	#   SMOKE_TEST_SCRIPT - Path to caller-owned script; receives IMAGE, PLATFORM,
+	#                       REGISTRY in the environment and owns the docker run
+	#
+	# Optional environment variables:
+	#   LOCAL_VALIDATE - When "true", use a locally loaded image tag (no registry pull)
+	#   LOCAL_TAG      - Local tag suffix when LOCAL_VALIDATE is true (e.g. validate-amd64)
 	: "${REGISTRY:?REGISTRY is required}"
 	: "${IMAGE_NAME:?IMAGE_NAME is required}"
 	: "${PLATFORM:?PLATFORM is required}"
-	: "${DIGEST_FILE:?DIGEST_FILE is required}"
+	: "${DIGEST_FILE:=}"
 	: "${SMOKE_TEST:=}"
 	: "${SMOKE_TEST_SCRIPT:=}"
+	: "${LOCAL_VALIDATE:=false}"
+	: "${LOCAL_TAG:=}"
 
 	if [[ -n "$SMOKE_TEST" && -n "$SMOKE_TEST_SCRIPT" ]]; then
 		die "SMOKE_TEST and SMOKE_TEST_SCRIPT are mutually exclusive"
@@ -469,21 +479,32 @@ smoke-test)
 	if [[ -z "$SMOKE_TEST" && -z "$SMOKE_TEST_SCRIPT" ]]; then
 		die "One of SMOKE_TEST or SMOKE_TEST_SCRIPT is required"
 	fi
-	if [[ ! -s "$DIGEST_FILE" ]]; then
-		die "DIGEST_FILE missing or empty: ${DIGEST_FILE}"
-	fi
 
-	digest=$(<"$DIGEST_FILE")
-	if ! [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-		die "Invalid digest in ${DIGEST_FILE}: ${digest}"
-	fi
+	if [[ "$LOCAL_VALIDATE" == "true" ]]; then
+		if [[ -z "$LOCAL_TAG" ]]; then
+			die "LOCAL_TAG is required when LOCAL_VALIDATE is true"
+		fi
+		IMAGE="${REGISTRY}/${IMAGE_NAME}:${LOCAL_TAG}"
+	else
+		: "${DIGEST_FILE:?DIGEST_FILE is required}"
+		if [[ ! -s "$DIGEST_FILE" ]]; then
+			die "DIGEST_FILE missing or empty: ${DIGEST_FILE}"
+		fi
 
-	IMAGE="${REGISTRY}/${IMAGE_NAME}@${digest}"
+		digest=$(<"$DIGEST_FILE")
+		if ! [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+			die "Invalid digest in ${DIGEST_FILE}: ${digest}"
+		fi
+
+		IMAGE="${REGISTRY}/${IMAGE_NAME}@${digest}"
+	fi
 	export IMAGE PLATFORM REGISTRY
 
-	echo "::group::Pulling ${IMAGE} (${PLATFORM})"
-	docker pull --platform "${PLATFORM}" "${IMAGE}"
-	echo "::endgroup::"
+	if [[ "$LOCAL_VALIDATE" != "true" ]]; then
+		echo "::group::Pulling ${IMAGE} (${PLATFORM})"
+		docker pull --platform "${PLATFORM}" "${IMAGE}"
+		echo "::endgroup::"
+	fi
 
 	if [[ -n "$SMOKE_TEST_SCRIPT" ]]; then
 		if [[ ! -f "$SMOKE_TEST_SCRIPT" ]]; then
@@ -602,33 +623,79 @@ cleanup-staging)
 	;;
 
 summary)
+	: "${REGISTRY:=ghcr.io}"
 	: "${IMAGE_NAME:=}"
 	: "${TAGS:=}"
 	: "${PLATFORMS:=}"
 	: "${PUSH:=false}"
+	: "${DIGEST:=}"
+	: "${COSIGN_SIGNED:=false}"
+	: "${SCAN_ENABLED:=false}"
+	: "${VALIDATE_ON_PR:=false}"
+	: "${MATRIX:=}"
+
+	full_image="${REGISTRY}/${IMAGE_NAME}"
 
 	add_github_summary "## Docker Build Results"
 	add_github_summary ""
 
 	add_github_summary "| Property | Value |"
 	add_github_summary "|----------|-------|"
-	add_github_summary "| Image | \`$IMAGE_NAME\` |"
-	add_github_summary "| Platforms | \`$PLATFORMS\` |"
-	add_github_summary "| Pushed | $PUSH |"
+	add_github_summary "| Image | \`${full_image}\` |"
+	add_github_summary "| Platforms | \`${PLATFORMS}\` |"
+	add_github_summary "| Pushed | ${PUSH} |"
+	if [[ "$VALIDATE_ON_PR" == "true" ]]; then
+		add_github_summary "| PR validation | enabled |"
+	fi
 	add_github_summary ""
+
+	if [[ -n "$DIGEST" ]]; then
+		add_github_summary "### Digest"
+		add_github_summary ""
+		add_github_summary "\`${DIGEST}\`"
+		add_github_summary ""
+	fi
+
+	if [[ -n "$MATRIX" && "$MATRIX" != "[]" ]]; then
+		add_github_summary "### Per-platform build matrix"
+		add_github_summary ""
+		while IFS= read -r platform; do
+			[[ -n "$platform" ]] && add_github_summary "- \`${platform}\`"
+		done < <(echo "$MATRIX" | jq -r '.[].platform')
+		add_github_summary ""
+	fi
 
 	if [[ -n "$TAGS" ]]; then
 		add_github_summary "### Tags"
 		add_github_summary ""
-		# TAGS is newline-separated, read into array properly
 		readarray -t tag_array <<<"$TAGS"
 		for tag in "${tag_array[@]}"; do
-			# Trim whitespace
 			tag=$(echo "$tag" | xargs)
 			if [[ -n "$tag" ]]; then
 				add_github_summary "- \`$tag\`"
 			fi
 		done
+		add_github_summary ""
+	fi
+
+	if [[ "$COSIGN_SIGNED" == "true" && -n "$DIGEST" ]]; then
+		add_github_summary "### Image signature"
+		add_github_summary ""
+		add_github_summary "Verify with:"
+		add_github_summary ""
+		add_github_summary "\`\`\`bash"
+		add_github_summary "cosign verify ${full_image}@${DIGEST} \\"
+		add_github_summary "  --certificate-identity-regexp='.*' \\"
+		add_github_summary "  --certificate-oidc-issuer='https://token.actions.githubusercontent.com'"
+		add_github_summary "\`\`\`"
+		add_github_summary ""
+	fi
+
+	if [[ "$SCAN_ENABLED" == "true" ]]; then
+		add_github_summary "### Vulnerability scan"
+		add_github_summary ""
+		add_github_summary "Trivy scanned CRITICAL/HIGH findings. Review the Security tab for SARIF results."
+		add_github_summary ""
 	fi
 
 	add_github_summary ""

--- a/tests/bats/integration/test_build_docker.bats
+++ b/tests/bats/integration/test_build_docker.bats
@@ -125,6 +125,8 @@ _run_script_any_bash() {
 	[[ "$(echo "$matrix" | jq 'length')" -eq 1 ]]
 	[[ "$(echo "$matrix" | jq -r '.[0].platform')" == "linux/arm64" ]]
 	[[ "$(echo "$matrix" | jq -r '.[0].runner')" == "ubuntu-24.04-arm" ]]
+	[[ "$(echo "$matrix" | jq -r '.[0].slug')" == "linux-arm64" ]]
+	[[ "$(echo "$matrix" | jq -r '.[0].qemu')" == "false" ]]
 }
 
 @test "build-docker summary: writes digest and cosign verify command" {

--- a/tests/bats/integration/test_build_docker.bats
+++ b/tests/bats/integration/test_build_docker.bats
@@ -118,6 +118,13 @@ _run_script_any_bash() {
 	_run_script
 	assert_success
 	assert_github_output "use-split" "true"
+
+	local matrix
+	matrix=$(get_github_output "matrix")
+	[[ "$matrix" == *"linux/arm64"* ]]
+	[[ "$(echo "$matrix" | jq 'length')" -eq 1 ]]
+	[[ "$(echo "$matrix" | jq -r '.[0].platform')" == "linux/arm64" ]]
+	[[ "$(echo "$matrix" | jq -r '.[0].runner')" == "ubuntu-24.04-arm" ]]
 }
 
 @test "build-docker summary: writes digest and cosign verify command" {
@@ -129,6 +136,7 @@ _run_script_any_bash() {
 	export DIGEST="sha256:abc123"
 	export COSIGN_SIGNED="true"
 	export SCAN_ENABLED="true"
+	export GITHUB_REPOSITORY="lgtm-hq/example"
 
 	_run_script_any_bash
 	assert_success
@@ -137,6 +145,7 @@ _run_script_any_bash() {
 	summary=$(get_github_step_summary)
 	[[ "$summary" == *"sha256:abc123"* ]]
 	[[ "$summary" == *"cosign verify"* ]]
+	[[ "$summary" == *"https://github.com/lgtm-hq/example/.*"* ]]
 	[[ "$summary" == *"Vulnerability scan"* ]]
 }
 

--- a/tests/bats/integration/test_build_docker.bats
+++ b/tests/bats/integration/test_build_docker.bats
@@ -87,6 +87,77 @@ _run_script_any_bash() {
 	assert_github_output "use-split" "true"
 }
 
+@test "build-docker classify: disables split when push is false and validate-on-pr is false" {
+	export PUSH="false"
+
+	_run_script
+	assert_success
+	assert_github_output "use-split" "false"
+	assert_github_output "matrix" "[]"
+}
+
+@test "build-docker classify: enables split when push is false and validate-on-pr is true" {
+	export PUSH="false"
+	export VALIDATE_ON_PR="true"
+
+	_run_script
+	assert_success
+	assert_github_output "use-split" "true"
+
+	local matrix
+	matrix=$(get_github_output "matrix")
+	[[ "$matrix" == *"linux/amd64"* ]]
+	[[ "$matrix" == *"linux/arm64"* ]]
+}
+
+@test "build-docker classify: validate-on-pr with single mapped platform enables split" {
+	export PLATFORMS="linux/arm64"
+	export PUSH="false"
+	export VALIDATE_ON_PR="true"
+
+	_run_script
+	assert_success
+	assert_github_output "use-split" "true"
+}
+
+@test "build-docker summary: writes digest and cosign verify command" {
+	export STEP="summary"
+	export REGISTRY="ghcr.io"
+	export IMAGE_NAME="lgtm-hq/example"
+	export PLATFORMS="linux/amd64,linux/arm64"
+	export PUSH="true"
+	export DIGEST="sha256:abc123"
+	export COSIGN_SIGNED="true"
+	export SCAN_ENABLED="true"
+
+	_run_script_any_bash
+	assert_success
+
+	local summary
+	summary=$(get_github_step_summary)
+	[[ "$summary" == *"sha256:abc123"* ]]
+	[[ "$summary" == *"cosign verify"* ]]
+	[[ "$summary" == *"Vulnerability scan"* ]]
+}
+
+@test "build-docker summary: includes per-platform matrix when provided" {
+	export STEP="summary"
+	export REGISTRY="ghcr.io"
+	export IMAGE_NAME="lgtm-hq/example"
+	export PLATFORMS="linux/amd64,linux/arm64"
+	export VALIDATE_ON_PR="true"
+	export MATRIX='[{"platform":"linux/amd64","runner":"ubuntu-24.04","slug":"linux-amd64","qemu":false},{"platform":"linux/arm64","runner":"ubuntu-24.04-arm","slug":"linux-arm64","qemu":false}]'
+
+	_run_script_any_bash
+	assert_success
+
+	local summary
+	summary=$(get_github_step_summary)
+	[[ "$summary" == *"linux/amd64"* ]]
+	[[ "$summary" == *"linux/arm64"* ]]
+	[[ "$summary" == *"PR validation"* ]]
+}
+
 # =============================================================================
 # Sanity: required-input validation is unchanged by the smoke additions
 # =============================================================================

--- a/tests/bats/integration/test_build_docker.bats
+++ b/tests/bats/integration/test_build_docker.bats
@@ -337,3 +337,40 @@ _run_script_any_bash() {
 	assert_failure
 	assert_output --partial "No image tag available"
 }
+
+# =============================================================================
+# sign-image step
+# =============================================================================
+
+@test "build-docker sign-image: fails when DIGEST is unset" {
+	export STEP="sign-image"
+	unset DIGEST
+	export REGISTRY="ghcr.io"
+	export IMAGE_NAME="org/repo"
+
+	_run_script_any_bash
+	assert_failure
+	assert_output --partial "DIGEST"
+}
+
+@test "build-docker sign-image: fails when DIGEST is empty" {
+	export STEP="sign-image"
+	export DIGEST=""
+	export REGISTRY="ghcr.io"
+	export IMAGE_NAME="org/repo"
+
+	_run_script_any_bash
+	assert_failure
+	assert_output --partial "DIGEST"
+}
+
+@test "build-docker sign-image: fails when DIGEST is invalid" {
+	export STEP="sign-image"
+	export DIGEST="not-a-digest"
+	export REGISTRY="ghcr.io"
+	export IMAGE_NAME="org/repo"
+
+	_run_script_any_bash
+	assert_failure
+	assert_output --partial "not a valid sha256 digest"
+}

--- a/tests/bats/integration/test_build_docker.bats
+++ b/tests/bats/integration/test_build_docker.bats
@@ -156,6 +156,7 @@ _run_script_any_bash() {
 	export REGISTRY="ghcr.io"
 	export IMAGE_NAME="lgtm-hq/example"
 	export PLATFORMS="linux/amd64,linux/arm64"
+	export PUSH="false"
 	export VALIDATE_ON_PR="true"
 	export MATRIX='[{"platform":"linux/amd64","runner":"ubuntu-24.04","slug":"linux-amd64","qemu":false},{"platform":"linux/arm64","runner":"ubuntu-24.04-arm","slug":"linux-arm64","qemu":false}]'
 

--- a/tests/bats/integration/test_build_docker.bats
+++ b/tests/bats/integration/test_build_docker.bats
@@ -306,3 +306,34 @@ _run_script_any_bash() {
 	assert_failure
 	assert_output --partial "DIGEST"
 }
+
+# =============================================================================
+# resolve-local-scan-image step
+# =============================================================================
+
+@test "build-docker resolve-local-scan-image: writes first tag to GITHUB_OUTPUT" {
+	export STEP="resolve-local-scan-image"
+	export TAGS=$'ghcr.io/org/repo:sha-abc123\nghcr.io/org/repo:main'
+
+	_run_script_any_bash
+	assert_success
+	assert_github_output "ref" "ghcr.io/org/repo:sha-abc123"
+}
+
+@test "build-docker resolve-local-scan-image: fails when TAGS is unset" {
+	export STEP="resolve-local-scan-image"
+	unset TAGS
+
+	_run_script_any_bash
+	assert_failure
+	assert_output --partial "TAGS"
+}
+
+@test "build-docker resolve-local-scan-image: fails when TAGS has no usable tag" {
+	export STEP="resolve-local-scan-image"
+	export TAGS=$' \n '
+
+	_run_script_any_bash
+	assert_failure
+	assert_output --partial "No image tag available"
+}

--- a/uv.lock
+++ b/uv.lock
@@ -352,7 +352,7 @@ wheels = [
 
 [[package]]
 name = "lgtm-ci"
-version = "0.16.0"
+version = "0.15.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -352,7 +352,7 @@ wheels = [
 
 [[package]]
 name = "lgtm-ci"
-version = "0.15.0"
+version = "0.16.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Add six opt-in capabilities to `reusable-docker.yml` so consumer repos get PR-level Docker validation, blocking vulnerability scans, registry cache fallback, Cosign signing, clean release builds, and build summaries without forking the workflow.

All new inputs default to current behavior — existing callers require no changes.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Changes Made

- Add `validate-on-pr`, `scan-exit-code`, `cache-registry-ref`, `cosign-sign`, and `no-cache` inputs
- Enable native split builds on PRs without registry push; skip merge when not pushing
- Run per-platform Trivy scans on validate path with configurable exit code
- Add Cosign keyless signing after attestation in build and merge jobs
- Wire `$GITHUB_STEP_SUMMARY` via build/merge/summary-validate jobs
- Extend `build-docker.sh` classify, smoke-test local mode, and summary output
- Document new inputs and add unreleased CHANGELOG entry

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. All features are opt-in with backward-compatible defaults.

## Closes

- Closes #193
- Relates to #168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional PR-only and per-platform Docker validation; configurable vulnerability scan exit behavior; registry-backed cache fallback and cache-disable; optional keyless image signing. PR-validation builds now run local scans (SARIF upload), per-platform scans, smoke tests, and include enriched build summaries with digests, signing and scan status.

* **Documentation**
  * Updated reusable workflow docs and changelog with new inputs, examples, permissions, and guidance.

* **Tests**
  * Added integration tests covering classification, summaries, local-scan resolution, signing, and validation flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->