### PR TITLE
fix(docker): skip attestations when loading images locally

### DIFF
--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -374,8 +374,8 @@ jobs:
             ${{ inputs.no-cache == false && 'type=gha,mode=max' || '' }}
             ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && inputs.push && format('type=registry,ref={0},mode=max', inputs.cache-registry-ref) || '' }}
           # yamllint enable rule:line-length
-          provenance: ${{ inputs.provenance }}
-          sbom: ${{ inputs.sbom }}
+          provenance: ${{ inputs.provenance && inputs.push }}
+          sbom: ${{ inputs.sbom && inputs.push }}
 
       - name: Extract digest
         id: metadata
@@ -569,7 +569,7 @@ jobs:
             ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && inputs.push && format('type=registry,ref={0}-{1},mode=max', inputs.cache-registry-ref, matrix.slug) || '' }}
           # yamllint enable rule:line-length
           provenance: false
-          sbom: ${{ inputs.sbom }}
+          sbom: ${{ inputs.sbom && inputs.push }}
 
       - name: Record staging digest
         shell: bash

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -283,6 +283,14 @@ jobs:
 | `cache-registry-ref` | `""` | Registry cache fallback (e.g. `ghcr.io/org/repo:cache`) |
 | `cosign-sign` | `false` | Keyless Cosign signature on pushed manifests |
 | `no-cache` | `false` | Disable GHA/registry cache for clean release builds |
+| `provenance` | `true` | Generate provenance attestation (only when `push: true`) |
+| `sbom` | `true` | Generate SBOM attestation (only when `push: true`) |
+
+`sbom` and `provenance` only apply when `push: true`. PR validation
+(`validate-on-pr` with `scan`) loads images locally via `--load`; buildx cannot
+export manifest lists from SBOM attestations, so attestations are intentionally
+skipped on that path. The publish path (main/tags with `push: true`) still
+receives full SBOM and provenance attestations.
 
 All inputs are opt-in; existing callers keep current behavior without changes.
 

--- a/tests/bats/integration/test_reusable_docker_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_workflow.bats
@@ -7,10 +7,10 @@ load "../../helpers/common"
 WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
 
 @test "reusable-docker: build job gates sbom and provenance on push" {
-	run grep -E '^\s+provenance: \$\{\{ inputs\.provenance && inputs\.push \}\}$' "$WORKFLOW"
+	run grep -E '^[[:space:]]+provenance: \$\{\{ inputs\.provenance && inputs\.push \}\}$' "$WORKFLOW"
 	assert_success
 
-	run grep -E '^\s+sbom: \$\{\{ inputs\.sbom && inputs\.push \}\}$' "$WORKFLOW"
+	run grep -E '^[[:space:]]+sbom: \$\{\{ inputs\.sbom && inputs\.push \}\}$' "$WORKFLOW"
 	assert_success
 }
 
@@ -24,6 +24,6 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
 }
 
 @test "reusable-docker: build job does not pass raw sbom or provenance inputs" {
-	run grep -E '^\s+(provenance|sbom): \$\{\{ inputs\.(provenance|sbom) \}\}$' "$WORKFLOW"
+	run grep -E '^[[:space:]]+(provenance|sbom): \$\{\{ inputs\.(provenance|sbom) \}\}$' "$WORKFLOW"
 	assert_failure
 }

--- a/tests/bats/integration/test_reusable_docker_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_workflow.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-docker workflow attestation gating
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
+
+@test "reusable-docker: build job gates sbom and provenance on push" {
+	run grep -E '^\s+provenance: \$\{\{ inputs\.provenance && inputs\.push \}\}$' "$WORKFLOW"
+	assert_success
+
+	run grep -E '^\s+sbom: \$\{\{ inputs\.sbom && inputs\.push \}\}$' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker: build-per-platform job gates sbom on push" {
+	run awk '
+		/provenance: false/ { in_split = 1 }
+		in_split && /sbom: \$\{\{ inputs\.sbom && inputs\.push \}\}/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker: build job does not pass raw sbom or provenance inputs" {
+	run grep -E '^\s+(provenance|sbom): \$\{\{ inputs\.(provenance|sbom) \}\}$' "$WORKFLOW"
+	assert_failure
+}


### PR DESCRIPTION
## Summary

Fixes PR validation failures when callers pass `sbom: true` alongside `push: false`, `validate-on-pr: true`, and `scan: true`. Buildx SBOM attestations create manifest lists that cannot be `--load`ed locally, causing `docker exporter does not currently support exporting manifest lists` and blocking Trivy SARIF upload.

Attestations are now gated on `push: true`, so PR validation still runs build + smoke + Trivy without attestations, while the publish path (main/tags) retains full SBOM and provenance.

Follow-up to Rustume PR #236 / lgtm-ci v0.17.0 validate-on-pr behavior.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. Callers that already set `push: false` for PR validation see attestations skipped (the correct behavior). Publish paths with `push: true` are unchanged.

## Closes

- Closes #196
- Relates to lgtm-hq/rustume#236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable `provenance` and `sbom` inputs for the Docker workflow, defaulting to `true` and now only emitting attestations when pushing images.

* **Documentation**
  * Clarified that provenance and SBOM attestations run on publish (push) and are skipped during PR validation due to workflow constraints.

* **Tests**
  * Added integration tests to verify the gating behavior of `provenance` and `sbom` for push vs PR runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->