### PR TITLE
fix(ci): map host user and pass tool-options in run-lintro-docker

### DIFF
--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -54,6 +54,13 @@ on:
         required: false
         type: string
         default: ""
+      lintro-tool-options:
+        description: >-
+          Comma-separated lintro --tool-options passed to the quality check
+          (e.g. pydoclint:timeout=120,osv_scanner:check_suppressions=false)
+        required: false
+        type: string
+        default: ""
       lintro-image:
         description: "Pinned ghcr.io/lgtm-hq/py-lintro image (digest strongly recommended)"
         required: false
@@ -120,7 +127,9 @@ jobs:
         env:
           STEP: check
           TOOLS: ${{ inputs.tools != '' && inputs.tools || inputs.lintro-tools }}
+          TOOL_OPTIONS: ${{ inputs.lintro-tool-options }}
           FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
+          MAP_HOST_USER: "true"
         run: bash "${{ github.workspace }}/.lgtm-ci-tooling/scripts/ci/quality/run-lintro-docker.sh"
 
       - name: Upload linting report

--- a/scripts/ci/quality/run-lintro-docker.sh
+++ b/scripts/ci/quality/run-lintro-docker.sh
@@ -8,9 +8,12 @@
 #
 # Optional environment variables:
 #   TOOLS          Comma-separated list passed to lintro --tools (empty = all)
+#   TOOL_OPTIONS   Comma-separated lintro --tool-options (check only; empty = none)
 #   FAIL_ON_ERROR  true|false (default: true) — only for STEP=check
 #   WORKSPACE      Absolute path to mount at /code (default: current directory)
 #   OUTPUT_LOG     Log path for STEP=check tee (default: chk-output.txt)
+#   MAP_HOST_USER  true|false — map host UID/GID via docker --user (default: true
+#                  when GITHUB_ACTIONS=true, otherwise unset/false)
 
 set -euo pipefail
 
@@ -20,7 +23,10 @@ run-lintro-docker.sh — run lintro inside the full py-lintro container.
 
 Requires: STEP=check|format, LINTRO_IMAGE=ghcr.io/lgtm-hq/py-lintro@sha256:...
 
-Optional: TOOLS, FAIL_ON_ERROR, WORKSPACE, OUTPUT_LOG
+Optional: TOOLS, TOOL_OPTIONS, FAIL_ON_ERROR, WORKSPACE, OUTPUT_LOG, MAP_HOST_USER
+
+MAP_HOST_USER defaults to true on GitHub Actions so the workspace mount is writable.
+Local runs omit --user so the py-lintro entrypoint can gosu to the mount owner.
 
 Matches https://github.com/lgtm-hq/py-lintro documented docker invocation.
 EOF
@@ -43,9 +49,14 @@ else
 fi
 
 : "${TOOLS:=}"
+: "${TOOL_OPTIONS:=}"
 : "${FAIL_ON_ERROR:=true}"
 : "${WORKSPACE:=$(pwd)}"
 : "${OUTPUT_LOG:=chk-output.txt}"
+: "${MAP_HOST_USER:=}"
+if [[ -z "${MAP_HOST_USER}" ]] && [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+	MAP_HOST_USER=true
+fi
 
 log_info "Pulling Lintro image: ${LINTRO_IMAGE}"
 set +e
@@ -58,17 +69,20 @@ if [[ "${PULL_EC}" -ne 0 ]]; then
 fi
 printf '%s\n' "${PULL_OUTPUT}"
 
-# Do not pass --user: py-lintro entrypoint starts as root, adjusts PATH for bun/cargo,
-# then gosu(1)s to the UID owning /code (the workspace mount). Passing --user skips that
-# root entrypoint and caused many external CLIs to be missing from PATH inside the container.
+# MAP_HOST_USER=true (default on GitHub Actions) maps the host UID/GID so bun install
+# and tool caches can write to the mounted checkout. Local runs omit --user so the
+# py-lintro entrypoint can start as root, adjust PATH, then gosu to the mount owner.
 declare -a docker_args=(
 	docker run --rm
 	-e HOME=/tmp
 	-e LINTRO_AUTO_INSTALL_DEPS=1
 	-v "${WORKSPACE}:/code"
 	-w /code
-	"${LINTRO_IMAGE}"
 )
+if [[ "${MAP_HOST_USER}" == "true" ]]; then
+	docker_args+=(--user "$(id -u):$(id -g)")
+fi
+docker_args+=("${LINTRO_IMAGE}")
 
 declare -a lintro_args=()
 
@@ -77,6 +91,9 @@ check)
 	lintro_args+=(chk)
 	if [[ -n "$TOOLS" ]]; then
 		lintro_args+=(--tools "${TOOLS}")
+	fi
+	if [[ -n "$TOOL_OPTIONS" ]]; then
+		lintro_args+=(--tool-options "${TOOL_OPTIONS}")
 	fi
 	lintro_args+=(. --output-format grid)
 	log_info "Running lintro check in container..."

--- a/tests/bats/unit/quality/test_run_lintro_docker.bats
+++ b/tests/bats/unit/quality/test_run_lintro_docker.bats
@@ -75,7 +75,7 @@ EOF
 	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/gh_out"
 	: >"${GITHUB_OUTPUT}"
 
-	run env STEP=check LINTRO_IMAGE=img:tag TOOL_OPTIONS="pydoclint:timeout=120" FAIL_ON_ERROR=true bash "${SCRIPT}"
+	run env STEP=check LINTRO_IMAGE=img:tag TOOL_OPTIONS="pydoclint:timeout=120" FAIL_ON_ERROR=true MAP_HOST_USER=false bash "${SCRIPT}"
 
 	assert_success
 	local calls="${BATS_TEST_TMPDIR}/mock_calls_docker"

--- a/tests/bats/unit/quality/test_run_lintro_docker.bats
+++ b/tests/bats/unit/quality/test_run_lintro_docker.bats
@@ -58,7 +58,7 @@ EOF
 	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/gh_out"
 	: >"${GITHUB_OUTPUT}"
 
-	run env STEP=check LINTRO_IMAGE=ghcr.io/test/img:tag FAIL_ON_ERROR=true bash "${SCRIPT}"
+	run env STEP=check LINTRO_IMAGE=ghcr.io/test/img:tag FAIL_ON_ERROR=true MAP_HOST_USER=false bash "${SCRIPT}"
 
 	assert_success
 	local calls="${BATS_TEST_TMPDIR}/mock_calls_docker"
@@ -68,6 +68,64 @@ EOF
 	assert_file_exists "${BATS_TEST_TMPDIR}/ws/chk-output.txt"
 }
 
+@test "run-lintro-docker.sh check passes --tool-options when TOOL_OPTIONS is set" {
+	mock_command_record docker ""
+	mkdir -p "${BATS_TEST_TMPDIR}/ws"
+	cd "${BATS_TEST_TMPDIR}/ws" || exit 1
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/gh_out"
+	: >"${GITHUB_OUTPUT}"
+
+	run env STEP=check LINTRO_IMAGE=img:tag TOOL_OPTIONS="pydoclint:timeout=120" FAIL_ON_ERROR=true bash "${SCRIPT}"
+
+	assert_success
+	local calls="${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_file_contains_literal "${calls}" "--tool-options"
+	assert_file_contains "${calls}" "pydoclint:timeout=120"
+}
+
+@test "run-lintro-docker.sh check maps host user when MAP_HOST_USER=true" {
+	mock_command_record docker ""
+	mkdir -p "${BATS_TEST_TMPDIR}/ws"
+	cd "${BATS_TEST_TMPDIR}/ws" || exit 1
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/gh_out"
+	: >"${GITHUB_OUTPUT}"
+
+	run env STEP=check LINTRO_IMAGE=img:tag MAP_HOST_USER=true FAIL_ON_ERROR=true bash "${SCRIPT}"
+
+	assert_success
+	local calls="${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_file_contains "${calls}" "--user $(id -u):$(id -g)"
+}
+
+@test "run-lintro-docker.sh check maps host user by default on GitHub Actions" {
+	mock_command_record docker ""
+	mkdir -p "${BATS_TEST_TMPDIR}/ws"
+	cd "${BATS_TEST_TMPDIR}/ws" || exit 1
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/gh_out"
+	: >"${GITHUB_OUTPUT}"
+
+	run env STEP=check LINTRO_IMAGE=img:tag GITHUB_ACTIONS=true FAIL_ON_ERROR=true bash "${SCRIPT}"
+
+	assert_success
+	local calls="${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_file_contains "${calls}" "--user $(id -u):$(id -g)"
+}
+
+@test "run-lintro-docker.sh check omits --user when MAP_HOST_USER is unset locally" {
+	mock_command_record docker ""
+	mkdir -p "${BATS_TEST_TMPDIR}/ws"
+	cd "${BATS_TEST_TMPDIR}/ws" || exit 1
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/gh_out"
+	: >"${GITHUB_OUTPUT}"
+
+	run env -u GITHUB_ACTIONS STEP=check LINTRO_IMAGE=img:tag FAIL_ON_ERROR=true bash "${SCRIPT}"
+
+	assert_success
+	local calls="${BATS_TEST_TMPDIR}/mock_calls_docker"
+	run grep -qF -- "--user" "$calls"
+	assert_failure
+}
+
 @test "run-lintro-docker.sh check passes --tools when TOOLS is set" {
 	mock_command_record docker ""
 	mkdir -p "${BATS_TEST_TMPDIR}/ws"
@@ -75,7 +133,7 @@ EOF
 	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/gh_out"
 	: >"${GITHUB_OUTPUT}"
 
-	run env STEP=check LINTRO_IMAGE=img:tag TOOLS=ruff,yamllint FAIL_ON_ERROR=true bash "${SCRIPT}"
+	run env STEP=check LINTRO_IMAGE=img:tag TOOLS=ruff,yamllint FAIL_ON_ERROR=true MAP_HOST_USER=false bash "${SCRIPT}"
 
 	assert_success
 	local calls="${BATS_TEST_TMPDIR}/mock_calls_docker"


### PR DESCRIPTION
## Summary

Restore CI-specific docker invocation behavior in `run-lintro-docker.sh` that was dropped during the reusable-quality migration. The workspace mount is writable again via host UID/GID mapping, and consumers can pass lintro `--tool-options` through `reusable-quality.yml`.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Changes Made

- Add `MAP_HOST_USER` env to `run-lintro-docker.sh` (defaults to `true` on GitHub Actions)
- Add `TOOL_OPTIONS` env passthrough to `lintro chk --tool-options`
- Expose `lintro-tool-options` input on `reusable-quality.yml`
- Set `MAP_HOST_USER: "true"` on the quality workflow step
- Add BATS coverage for user mapping and tool-options behavior

## Closes

- Closes #205

## Testing

- [x] `uv run lintro chk` — 0 issues
- [x] `bats tests/bats/unit/quality/test_run_lintro_docker.bats` — 14/14 pass

## Quality Checks

- [x] `uv run lintro fmt`
- [x] `uv run lintro chk`
- [x] BATS unit tests for changed script

## Breaking Changes

None. Local usage without `MAP_HOST_USER` or `GITHUB_ACTIONS` preserves the existing gosu entrypoint path.

## Deployment Notes

After merge, py-lintro can consume via:

```yaml
lintro-tool-options: pydoclint:timeout=120,osv_scanner:check_suppressions=false
```

Bump `reusable-quality.yml` pin and `tooling-ref` to the merge commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow and quality script now accept custom linting tool options and improve container user-mapping for more reliable checks in CI vs. local runs.
* **Tests**
  * Updated unit tests to reflect the new environment behavior and argument forwarding for quality checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores host UID/GID mapping (`--user`) to the `run-lintro-docker.sh` CI invocation and adds `TOOL_OPTIONS` passthrough so consumers can pass per-tool lintro options through `reusable-quality.yml`.

- `MAP_HOST_USER` env var controls `docker --user` injection; defaults to `true` on GitHub Actions (and is hardcoded `true` in the reusable workflow step) so the mounted workspace is writable.
- `TOOL_OPTIONS` is forwarded as `--tool-options` to `lintro chk` only; the new `lintro-tool-options` input in the reusable workflow wires callers through to the script.
- Four new BATS tests cover user-mapping and tool-options scenarios, with existing tests updated to set `MAP_HOST_USER=false` to isolate behavior.
</details>


<h3>Confidence Score: 3/5</h3>

The functional change is intentional but reverses a previously documented decision — worth explicit sign-off that the py-lintro image is compatible before merging.

The original script contained an explicit warning that passing `--user` to `docker run` bypasses the py-lintro container's root entrypoint phase, which adjusts `PATH` for `bun`, `cargo`, and other CLIs before calling `gosu`. This PR hardcodes `MAP_HOST_USER: "true"` in the reusable workflow, meaning every CI run now skips that entrypoint. If the py-lintro image hasn't been updated to expose those tools to non-root users, lintro checks that depend on bun or cargo will silently fail or use wrong binaries.

scripts/ci/quality/run-lintro-docker.sh — the interaction between `--user` and the py-lintro container entrypoint PATH setup is the key risk area.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/ci/quality/run-lintro-docker.sh | Adds `MAP_HOST_USER` and `TOOL_OPTIONS` env vars; hardcodes `--user` for CI runs. The original code explicitly warned against passing `--user` because it skips the entrypoint PATH setup for bun/cargo — this PR reverses that decision without confirming the py-lintro image handles non-root PATH correctly. |
| .github/workflows/reusable-quality.yml | Adds `lintro-tool-options` input and passes it as `TOOL_OPTIONS` env; hardcodes `MAP_HOST_USER: "true"` on the quality step. Changes are straightforward and consistent with the script update. |
| tests/bats/unit/quality/test_run_lintro_docker.bats | Adds 4 new BATS tests covering `MAP_HOST_USER=true`, `GITHUB_ACTIONS=true` auto-detection, `TOOL_OPTIONS` passthrough, and the no-`--user` local case. The `format` test is missing the `MAP_HOST_USER=false` guard added to all other updated tests. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[reusable-quality.yml\nlintro-tool-options input] -->|TOOL_OPTIONS env| B[run-lintro-docker.sh]
    A -->|MAP_HOST_USER=true| B

    B --> C{MAP_HOST_USER\n== true?}
    C -->|Yes| D[docker run --user uid:gid\nskips gosu entrypoint]
    C -->|No| E[docker run as root\nentrypoint gosu to mount owner]

    D --> F[lintro chk]
    E --> F

    B --> G{TOOL_OPTIONS\nset?}
    G -->|Yes| H[lintro chk --tool-options VALUE]
    G -->|No| I[lintro chk standard]

    B --> J{GITHUB_ACTIONS\n== true AND\nMAP_HOST_USER empty?}
    J -->|Yes| K[auto-set\nMAP_HOST_USER=true]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/bats/unit/quality/test_run_lintro_docker.bats`, line 151 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/3188ed90d41f950818df0093518aa2d78f39b2de/tests/bats/unit/quality/test_run_lintro_docker.bats#L151)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `format` test doesn't set `MAP_HOST_USER=false`, unlike every other updated test in this PR. In a CI environment where `GITHUB_ACTIONS=true` is inherited, the `--user` flag will be appended to the docker call, which changes the behavior under test. The test still passes because it only asserts `fmt .` is present, but the actual invocation will differ between local and CI runs.

   

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Fbats%2Funit%2Fquality%2Ftest_run_lintro_docker.bats%0ALine%3A%20151%0A%0AComment%3A%0AThe%20%60format%60%20test%20doesn't%20set%20%60MAP_HOST_USER%3Dfalse%60%2C%20unlike%20every%20other%20updated%20test%20in%20this%20PR.%20In%20a%20CI%20environment%20where%20%60GITHUB_ACTIONS%3Dtrue%60%20is%20inherited%2C%20the%20%60--user%60%20flag%20will%20be%20appended%20to%20the%20docker%20call%2C%20which%20changes%20the%20behavior%20under%20test.%20The%20test%20still%20passes%20because%20it%20only%20asserts%20%60fmt%20.%60%20is%20present%2C%20but%20the%20actual%20invocation%20will%20differ%20between%20local%20and%20CI%20runs.%0A%0A%60%60%60suggestion%0A%09run%20env%20STEP%3Dformat%20LINTRO_IMAGE%3Dimg%3Atag%20MAP_HOST_USER%3Dfalse%20bash%20%22%24%7BSCRIPT%7D%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=206&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Fbats%2Funit%2Fquality%2Ftest_run_lintro_docker.bats%0ALine%3A%20151%0A%0AComment%3A%0AThe%20%60format%60%20test%20doesn't%20set%20%60MAP_HOST_USER%3Dfalse%60%2C%20unlike%20every%20other%20updated%20test%20in%20this%20PR.%20In%20a%20CI%20environment%20where%20%60GITHUB_ACTIONS%3Dtrue%60%20is%20inherited%2C%20the%20%60--user%60%20flag%20will%20be%20appended%20to%20the%20docker%20call%2C%20which%20changes%20the%20behavior%20under%20test.%20The%20test%20still%20passes%20because%20it%20only%20asserts%20%60fmt%20.%60%20is%20present%2C%20but%20the%20actual%20invocation%20will%20differ%20between%20local%20and%20CI%20runs.%0A%0A%60%60%60suggestion%0A%09run%20env%20STEP%3Dformat%20LINTRO_IMAGE%3Dimg%3Atag%20MAP_HOST_USER%3Dfalse%20bash%20%22%24%7BSCRIPT%7D%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=206&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22fix%2F205-map-host-user-tool-options%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F205-map-host-user-tool-options%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Fbats%2Funit%2Fquality%2Ftest_run_lintro_docker.bats%0ALine%3A%20151%0A%0AComment%3A%0AThe%20%60format%60%20test%20doesn't%20set%20%60MAP_HOST_USER%3Dfalse%60%2C%20unlike%20every%20other%20updated%20test%20in%20this%20PR.%20In%20a%20CI%20environment%20where%20%60GITHUB_ACTIONS%3Dtrue%60%20is%20inherited%2C%20the%20%60--user%60%20flag%20will%20be%20appended%20to%20the%20docker%20call%2C%20which%20changes%20the%20behavior%20under%20test.%20The%20test%20still%20passes%20because%20it%20only%20asserts%20%60fmt%20.%60%20is%20present%2C%20but%20the%20actual%20invocation%20will%20differ%20between%20local%20and%20CI%20runs.%0A%0A%60%60%60suggestion%0A%09run%20env%20STEP%3Dformat%20LINTRO_IMAGE%3Dimg%3Atag%20MAP_HOST_USER%3Dfalse%20bash%20%22%24%7BSCRIPT%7D%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Fquality%2Frun-lintro-docker.sh%3A72-84%0A**%60--user%60%20flag%20may%20still%20break%20PATH-dependent%20tools**%0A%0AThe%20original%20code%20included%20an%20explicit%20warning%20that%20passing%20%60--user%60%20to%20%60docker%20run%60%20bypasses%20the%20py-lintro%20entrypoint's%20root%20phase%2C%20which%20adjusts%20%60PATH%60%20for%20tools%20like%20%60bun%60%20and%20%60cargo%60%20before%20calling%20%60gosu%60.%20With%20%60MAP_HOST_USER%3A%20%22true%22%60%20now%20hardcoded%20in%20CI%2C%20if%20the%20py-lintro%20container%20hasn't%20been%20updated%20to%20set%20up%20those%20PATH%20entries%20for%20non-root%20users%2C%20any%20tool%20relying%20on%20the%20entrypoint-patched%20%60PATH%60%20will%20silently%20fail%20or%20fall%20back%20to%20a%20wrong%20binary.%20The%20PR%20description%20says%20this%20is%20%22restoring%22%20prior%20behavior%2C%20but%20the%20warning%20comment%20was%20added%20*after*%20the%20migration%20specifically%20because%20this%20pattern%20was%20observed%20to%20break%20tools%20%E2%80%94%20worth%20confirming%20the%20py-lintro%20image%20now%20handles%20the%20non-root%20case%20before%20landing.%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Fbats%2Funit%2Fquality%2Ftest_run_lintro_docker.bats%3A151%0AThe%20%60format%60%20test%20doesn't%20set%20%60MAP_HOST_USER%3Dfalse%60%2C%20unlike%20every%20other%20updated%20test%20in%20this%20PR.%20In%20a%20CI%20environment%20where%20%60GITHUB_ACTIONS%3Dtrue%60%20is%20inherited%2C%20the%20%60--user%60%20flag%20will%20be%20appended%20to%20the%20docker%20call%2C%20which%20changes%20the%20behavior%20under%20test.%20The%20test%20still%20passes%20because%20it%20only%20asserts%20%60fmt%20.%60%20is%20present%2C%20but%20the%20actual%20invocation%20will%20differ%20between%20local%20and%20CI%20runs.%0A%0A%60%60%60suggestion%0A%09run%20env%20STEP%3Dformat%20LINTRO_IMAGE%3Dimg%3Atag%20MAP_HOST_USER%3Dfalse%20bash%20%22%24%7BSCRIPT%7D%22%0A%60%60%60%0A%0A&pr=206&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Fquality%2Frun-lintro-docker.sh%3A72-84%0A**%60--user%60%20flag%20may%20still%20break%20PATH-dependent%20tools**%0A%0AThe%20original%20code%20included%20an%20explicit%20warning%20that%20passing%20%60--user%60%20to%20%60docker%20run%60%20bypasses%20the%20py-lintro%20entrypoint's%20root%20phase%2C%20which%20adjusts%20%60PATH%60%20for%20tools%20like%20%60bun%60%20and%20%60cargo%60%20before%20calling%20%60gosu%60.%20With%20%60MAP_HOST_USER%3A%20%22true%22%60%20now%20hardcoded%20in%20CI%2C%20if%20the%20py-lintro%20container%20hasn't%20been%20updated%20to%20set%20up%20those%20PATH%20entries%20for%20non-root%20users%2C%20any%20tool%20relying%20on%20the%20entrypoint-patched%20%60PATH%60%20will%20silently%20fail%20or%20fall%20back%20to%20a%20wrong%20binary.%20The%20PR%20description%20says%20this%20is%20%22restoring%22%20prior%20behavior%2C%20but%20the%20warning%20comment%20was%20added%20*after*%20the%20migration%20specifically%20because%20this%20pattern%20was%20observed%20to%20break%20tools%20%E2%80%94%20worth%20confirming%20the%20py-lintro%20image%20now%20handles%20the%20non-root%20case%20before%20landing.%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Fbats%2Funit%2Fquality%2Ftest_run_lintro_docker.bats%3A151%0AThe%20%60format%60%20test%20doesn't%20set%20%60MAP_HOST_USER%3Dfalse%60%2C%20unlike%20every%20other%20updated%20test%20in%20this%20PR.%20In%20a%20CI%20environment%20where%20%60GITHUB_ACTIONS%3Dtrue%60%20is%20inherited%2C%20the%20%60--user%60%20flag%20will%20be%20appended%20to%20the%20docker%20call%2C%20which%20changes%20the%20behavior%20under%20test.%20The%20test%20still%20passes%20because%20it%20only%20asserts%20%60fmt%20.%60%20is%20present%2C%20but%20the%20actual%20invocation%20will%20differ%20between%20local%20and%20CI%20runs.%0A%0A%60%60%60suggestion%0A%09run%20env%20STEP%3Dformat%20LINTRO_IMAGE%3Dimg%3Atag%20MAP_HOST_USER%3Dfalse%20bash%20%22%24%7BSCRIPT%7D%22%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=206&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22fix%2F205-map-host-user-tool-options%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F205-map-host-user-tool-options%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Fquality%2Frun-lintro-docker.sh%3A72-84%0A**%60--user%60%20flag%20may%20still%20break%20PATH-dependent%20tools**%0A%0AThe%20original%20code%20included%20an%20explicit%20warning%20that%20passing%20%60--user%60%20to%20%60docker%20run%60%20bypasses%20the%20py-lintro%20entrypoint's%20root%20phase%2C%20which%20adjusts%20%60PATH%60%20for%20tools%20like%20%60bun%60%20and%20%60cargo%60%20before%20calling%20%60gosu%60.%20With%20%60MAP_HOST_USER%3A%20%22true%22%60%20now%20hardcoded%20in%20CI%2C%20if%20the%20py-lintro%20container%20hasn't%20been%20updated%20to%20set%20up%20those%20PATH%20entries%20for%20non-root%20users%2C%20any%20tool%20relying%20on%20the%20entrypoint-patched%20%60PATH%60%20will%20silently%20fail%20or%20fall%20back%20to%20a%20wrong%20binary.%20The%20PR%20description%20says%20this%20is%20%22restoring%22%20prior%20behavior%2C%20but%20the%20warning%20comment%20was%20added%20*after*%20the%20migration%20specifically%20because%20this%20pattern%20was%20observed%20to%20break%20tools%20%E2%80%94%20worth%20confirming%20the%20py-lintro%20image%20now%20handles%20the%20non-root%20case%20before%20landing.%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Fbats%2Funit%2Fquality%2Ftest_run_lintro_docker.bats%3A151%0AThe%20%60format%60%20test%20doesn't%20set%20%60MAP_HOST_USER%3Dfalse%60%2C%20unlike%20every%20other%20updated%20test%20in%20this%20PR.%20In%20a%20CI%20environment%20where%20%60GITHUB_ACTIONS%3Dtrue%60%20is%20inherited%2C%20the%20%60--user%60%20flag%20will%20be%20appended%20to%20the%20docker%20call%2C%20which%20changes%20the%20behavior%20under%20test.%20The%20test%20still%20passes%20because%20it%20only%20asserts%20%60fmt%20.%60%20is%20present%2C%20but%20the%20actual%20invocation%20will%20differ%20between%20local%20and%20CI%20runs.%0A%0A%60%60%60suggestion%0A%09run%20env%20STEP%3Dformat%20LINTRO_IMAGE%3Dimg%3Atag%20MAP_HOST_USER%3Dfalse%20bash%20%22%24%7BSCRIPT%7D%22%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["ci: trigger workflow run"](https://github.com/lgtm-hq/lgtm-ci/commit/3188ed90d41f950818df0093518aa2d78f39b2de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33666207)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->