### PR TITLE
fix(workflows): merge per-version coverage artifacts for publish workflow

### DIFF
--- a/.github/workflows/reusable-test-python.yml
+++ b/.github/workflows/reusable-test-python.yml
@@ -389,7 +389,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
-      actions: read
+      actions: write  # upload-artifact/merge re-uploads merged python-coverage (artifact write)
       contents: read
     outputs:
       tests-passed: ${{ steps.aggregate.outputs.tests-passed }}

--- a/.github/workflows/reusable-test-python.yml
+++ b/.github/workflows/reusable-test-python.yml
@@ -438,7 +438,6 @@ jobs:
         with:
           name: python-coverage
           pattern: python-coverage-*
-          delete-merged: true
           retention-days: 7
 
   comment-pr:

--- a/.github/workflows/reusable-test-python.yml
+++ b/.github/workflows/reusable-test-python.yml
@@ -389,6 +389,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     outputs:
       tests-passed: ${{ steps.aggregate.outputs.tests-passed }}
@@ -429,6 +430,16 @@ jobs:
           RESULTS_DIR: python-results
           MATRIX_JSON: ${{ needs.prepare.outputs.matrix }}
         run: bash .lgtm-ci-tooling/scripts/ci/actions/aggregate-python-results.sh
+
+      - name: Merge per-version coverage artifacts
+        if: inputs.upload-coverage && inputs.coverage
+        # yamllint disable-line rule:line-length
+        uses: actions/upload-artifact/merge@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-coverage
+          pattern: python-coverage-*
+          delete-merged: true
+          retention-days: 7
 
   comment-pr:
     needs:

--- a/.github/workflows/reusable-test-python.yml
+++ b/.github/workflows/reusable-test-python.yml
@@ -433,6 +433,7 @@ jobs:
 
       - name: Merge per-version coverage artifacts
         if: inputs.upload-coverage && inputs.coverage
+        continue-on-error: true
         # yamllint disable-line rule:line-length
         uses: actions/upload-artifact/merge@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/tests/bats/integration/test_reusable_test_python_workflow.bats
+++ b/tests/bats/integration/test_reusable_test_python_workflow.bats
@@ -44,7 +44,7 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-python.yml"
 	assert_success
 }
 
-@test "reusable-test-python: coverage merge omits delete-merged to avoid actions write" {
+@test "reusable-test-python: coverage merge omits delete-merged so sources expire via retention-days" {
 	run awk '
 		/^  aggregate:/ { in_aggregate = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  aggregate:/ { in_aggregate = 0 }
@@ -54,11 +54,11 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-python.yml"
 	assert_success
 }
 
-@test "reusable-test-python: aggregate job grants actions read for artifact merge" {
+@test "reusable-test-python: aggregate job grants actions write for artifact merge" {
 	run awk '
 		/^  aggregate:/ { in_aggregate = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  aggregate:/ { in_aggregate = 0 }
-		in_aggregate && /actions: read/ { found = 1; exit }
+		in_aggregate && /actions: write/ { found = 1; exit }
 		END { exit !found }
 	' "$WORKFLOW"
 	assert_success

--- a/tests/bats/integration/test_reusable_test_python_workflow.bats
+++ b/tests/bats/integration/test_reusable_test_python_workflow.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-test-python workflow coverage merge
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-python.yml"
+
+@test "reusable-test-python: aggregate job merges per-version coverage artifacts" {
+	run awk '
+		/^  aggregate:/ { in_aggregate = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  aggregate:/ { in_aggregate = 0 }
+		in_aggregate && /uses: actions\/upload-artifact\/merge@/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-test-python: coverage merge uses python-coverage pattern" {
+	run awk '
+		/^  aggregate:/ { in_aggregate = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  aggregate:/ { in_aggregate = 0 }
+		in_aggregate && /pattern: python-coverage-\*/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-test-python: coverage merge produces python-coverage artifact" {
+	run awk '
+		/^  aggregate:/ { in_aggregate = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  aggregate:/ { in_aggregate = 0 }
+		in_aggregate && /name: python-coverage$/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-test-python: coverage merge gated on upload-coverage and coverage" {
+	run awk '
+		/Merge per-version coverage artifacts/ { getline; if ($0 ~ /inputs\.upload-coverage && inputs\.coverage/) found = 1 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_test_python_workflow.bats
+++ b/tests/bats/integration/test_reusable_test_python_workflow.bats
@@ -63,3 +63,13 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-python.yml"
 	' "$WORKFLOW"
 	assert_success
 }
+
+@test "reusable-test-python: coverage merge continues on error when no artifacts exist" {
+	run awk '
+		/Merge per-version coverage artifacts/ { in_step = 1 }
+		in_step && /continue-on-error: true/ { found = 1; exit }
+		in_step && /^      - name:/ && !/Merge per-version coverage artifacts/ { exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_test_python_workflow.bats
+++ b/tests/bats/integration/test_reusable_test_python_workflow.bats
@@ -43,3 +43,23 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-python.yml"
 	' "$WORKFLOW"
 	assert_success
 }
+
+@test "reusable-test-python: coverage merge omits delete-merged to avoid actions write" {
+	run awk '
+		/^  aggregate:/ { in_aggregate = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  aggregate:/ { in_aggregate = 0 }
+		in_aggregate && /delete-merged:/ { found = 1; exit }
+		END { exit found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-test-python: aggregate job grants actions read for artifact merge" {
+	run awk '
+		/^  aggregate:/ { in_aggregate = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  aggregate:/ { in_aggregate = 0 }
+		in_aggregate && /actions: read/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}


### PR DESCRIPTION
## Summary

When `reusable-test-python.yml` runs with a multi-version matrix, each cell uploads
`python-coverage-{version}` artifacts, but `reusable-test-python-publish.yml`
downloads a single `python-coverage` artifact. This adds a merge step in the
existing `aggregate` job so callers no longer need their own merge job.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now merges per-Python-version coverage artifacts into a single python-coverage artifact (7-day retention) when coverage upload is enabled; workflow permissions adjusted to support this.
* **Tests**
  * Added integration tests validating the artifact-merge behavior, gating conditions, retention approach, and required workflow permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a mismatch between `reusable-test-python.yml` (which uploads per-version `python-coverage-{version}` artifacts in a matrix run) and `reusable-test-python-publish.yml` (which expects a single `python-coverage` artifact) by adding a merge step in the existing `aggregate` job.

- Adds `actions: write` to the `aggregate` job's permissions and a new `actions/upload-artifact/merge@v7.0.1` step (pinned by SHA) gated on `inputs.upload-coverage && inputs.coverage`, with `continue-on-error: true` and 7-day retention to survive the case where no per-version artifacts were produced.
- Adds seven bats contract tests covering step presence, artifact naming, gating condition, absence of `delete-merged`, required permission, and the `continue-on-error` guard.
- Source artifacts are also uploaded with `retention-days: 7`, so omitting `delete-merged: true` is intentional — both sets expire on the same schedule without needing an immediate delete.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to the aggregate job and all three concerns from the prior review round have been addressed.

The permission was correctly upgraded to `actions: write`, `continue-on-error: true` prevents aggregate-job failure when no coverage artifacts exist, and the source artifacts already carry `retention-days: 7` so omitting `delete-merged` is intentional and harmless. The bats tests validate every structural property of the new step. No new defects found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-test-python.yml | Adds `actions: write` permission, a merge step for per-version coverage artifacts with `continue-on-error: true`, and a 7-day retention; all three previous review concerns are addressed. |
| tests/bats/integration/test_reusable_test_python_workflow.bats | New bats integration tests covering merge step presence, pattern/name correctness, gating condition, absence of delete-merged, actions: write permission, and continue-on-error guard. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant M as test (matrix cell)
    participant A as aggregate job
    participant P as reusable-test-python-publish

    M->>M: Run pytest + collect coverage
    M->>GHA: "upload-artifact: python-coverage-{version} (retention 7d)"
    M->>GHA: "upload-artifact: python-results-{version}"

    A->>GHA: "download-artifact: python-results-*"
    A->>A: aggregate-python-results.sh
    alt "inputs.upload-coverage && inputs.coverage"
        A->>GHA: "upload-artifact/merge: python-coverage-* → python-coverage (retention 7d, continue-on-error)"
    end

    P->>GHA: download-artifact: python-coverage
    P->>P: publish coverage report
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(workflows): continue coverage merge ..."](https://github.com/lgtm-hq/lgtm-ci/commit/11c97c74d2de0617f28d541414087ac04db3d766) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33679237)</sub>

<!-- /greptile_comment -->