### PR TITLE
fix(ci): resolve 3 main-branch failures after v0.18.2 adoption

### DIFF
--- a/.github/actions/attest-build/action.yml
+++ b/.github/actions/attest-build/action.yml
@@ -55,7 +55,7 @@ runs:
       # Pinned to SHA for supply chain security
       uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
       with:
-        subject-path: ${{ steps.prepare.outputs.subject-path }}
+        subject-path: ${{ steps.prepare.outputs.subject-digest == '' && steps.prepare.outputs.subject-path || '' }}
         subject-digest: ${{ steps.prepare.outputs.subject-digest }}
         subject-name: ${{ steps.prepare.outputs.subject-name }}
         push-to-registry: ${{ inputs.push-to-registry }}

--- a/.github/actions/attest-build/action.yml
+++ b/.github/actions/attest-build/action.yml
@@ -55,7 +55,7 @@ runs:
       # Pinned to SHA for supply chain security
       uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
       with:
-        subject-path: ${{ steps.prepare.outputs.subject-digest == '' && steps.prepare.outputs.subject-path || '' }}
+        subject-path: ${{ steps.prepare.outputs.subject-path }}
         subject-digest: ${{ steps.prepare.outputs.subject-digest }}
         subject-name: ${{ steps.prepare.outputs.subject-name }}
         push-to-registry: ${{ inputs.push-to-registry }}

--- a/.github/workflows/reusable-test-node-publish.yml
+++ b/.github/workflows/reusable-test-node-publish.yml
@@ -85,6 +85,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          clean: false
 
       - name: Download coverage
         if: inputs.upload-coverage

--- a/.github/workflows/reusable-test-python-publish.yml
+++ b/.github/workflows/reusable-test-python-publish.yml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          clean: false
 
       - name: Download coverage
         if: inputs.upload-coverage

--- a/scripts/ci/actions/attest-build.sh
+++ b/scripts/ci/actions/attest-build.sh
@@ -33,11 +33,8 @@ prepare)
 	USE_DIGEST=false
 	if [[ -n "$SUBJECT_DIGEST" ]]; then
 		USE_DIGEST=true
-	elif [[ -f "$SUBJECT_PATH" ]]; then
-		SUBJECT_DIGEST="sha256:$(sha256sum "$SUBJECT_PATH" | cut -d' ' -f1)"
-		log_info "Calculated digest: $SUBJECT_DIGEST"
-	else
-		log_warn "Cannot calculate digest for non-file subject"
+	elif [[ ! -f "$SUBJECT_PATH" ]]; then
+		log_warn "Non-file subject; passing subject-path to attest-build-provenance"
 	fi
 
 	# Determine subject name if not provided
@@ -47,7 +44,11 @@ prepare)
 
 	log_info "Subject: $SUBJECT_NAME"
 	log_info "Path: $SUBJECT_PATH"
-	log_info "Digest: ${SUBJECT_DIGEST:-not calculated}"
+	if [[ "$USE_DIGEST" == "true" ]]; then
+		log_info "Digest: $SUBJECT_DIGEST"
+	else
+		log_info "Attestation input: subject-path (digest computed by attest-build-provenance)"
+	fi
 
 	# actions/attest-build-provenance v4+ accepts only one subject parameter.
 	set_github_output "subject-name" "$SUBJECT_NAME"

--- a/scripts/ci/actions/attest-build.sh
+++ b/scripts/ci/actions/attest-build.sh
@@ -30,14 +30,14 @@ prepare)
 		exit 1
 	fi
 
-	# Calculate digest if not provided
-	if [[ -z "$SUBJECT_DIGEST" ]]; then
-		if [[ -f "$SUBJECT_PATH" ]]; then
-			SUBJECT_DIGEST="sha256:$(sha256sum "$SUBJECT_PATH" | cut -d' ' -f1)"
-			log_info "Calculated digest: $SUBJECT_DIGEST"
-		else
-			log_warn "Cannot calculate digest for non-file subject"
-		fi
+	USE_DIGEST=false
+	if [[ -n "$SUBJECT_DIGEST" ]]; then
+		USE_DIGEST=true
+	elif [[ -f "$SUBJECT_PATH" ]]; then
+		SUBJECT_DIGEST="sha256:$(sha256sum "$SUBJECT_PATH" | cut -d' ' -f1)"
+		log_info "Calculated digest: $SUBJECT_DIGEST"
+	else
+		log_warn "Cannot calculate digest for non-file subject"
 	fi
 
 	# Determine subject name if not provided
@@ -49,10 +49,13 @@ prepare)
 	log_info "Path: $SUBJECT_PATH"
 	log_info "Digest: ${SUBJECT_DIGEST:-not calculated}"
 
-	# Set outputs for the attestation action
-	set_github_output "subject-path" "$SUBJECT_PATH"
+	# actions/attest-build-provenance v4+ accepts only one subject parameter.
 	set_github_output "subject-name" "$SUBJECT_NAME"
-	[[ -n "$SUBJECT_DIGEST" ]] && set_github_output "subject-digest" "$SUBJECT_DIGEST"
+	if [[ "$USE_DIGEST" == "true" ]]; then
+		set_github_output "subject-digest" "$SUBJECT_DIGEST"
+	else
+		set_github_output "subject-path" "$SUBJECT_PATH"
+	fi
 	;;
 
 summary)

--- a/scripts/ci/release/ecosystems/python.sh
+++ b/scripts/ci/release/ecosystems/python.sh
@@ -110,7 +110,12 @@ write_file_atomic "$INIT_FILE" \
 	sed "s|^__version__[[:space:]]*=.*|__version__ = \"$NEXT_VERSION\"|" "$INIT_FILE"
 
 # Verify the write
-ACTUAL=$(awk '/^__version__[[:space:]]*=/ { gsub(/.*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$INIT_FILE")
+ACTUAL=$(awk '/^__version__[[:space:]]*=/ {
+		gsub(/^__version__[[:space:]]*=[[:space:]]*["'"'"']/, "")
+		gsub(/["'"'"'].*/, "")
+		print
+		exit
+	}' "$INIT_FILE")
 if [[ "$ACTUAL" != "$NEXT_VERSION" ]]; then
 	log_error "[python] __init__.py verification failed: expected $NEXT_VERSION, got $ACTUAL"
 	exit 1

--- a/tests/bats/integration/test_ecosystem_updaters.bats
+++ b/tests/bats/integration/test_ecosystem_updaters.bats
@@ -304,7 +304,7 @@ run_runner() {
 	run_ecosystem "python.sh" "$BATS_TEST_TMPDIR"
 	assert_success
 
-	ACTUAL=$(awk '/^__version__[[:space:]]*=/ { gsub(/.*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$BATS_TEST_TMPDIR/test_pkg/__init__.py")
+	ACTUAL=$(awk '/^__version__[[:space:]]*=/ { gsub(/^__version__[[:space:]]*=[[:space:]]*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$BATS_TEST_TMPDIR/test_pkg/__init__.py")
 	[[ "$ACTUAL" == "9.8.7" ]]
 }
 
@@ -320,7 +320,7 @@ run_runner() {
 	run_ecosystem "python.sh" "$BATS_TEST_TMPDIR"
 	assert_success
 
-	ACTUAL=$(awk '/^__version__[[:space:]]*=/ { gsub(/.*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$BATS_TEST_TMPDIR/test_pkg/__init__.py")
+	ACTUAL=$(awk '/^__version__[[:space:]]*=/ { gsub(/^__version__[[:space:]]*=[[:space:]]*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$BATS_TEST_TMPDIR/test_pkg/__init__.py")
 	[[ "$ACTUAL" == "9.8.7" ]]
 }
 
@@ -335,7 +335,7 @@ run_runner() {
 	run_ecosystem "python.sh" "$BATS_TEST_TMPDIR"
 	assert_success
 
-	ACTUAL=$(awk '/^__version__[[:space:]]*=/ { gsub(/.*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$BATS_TEST_TMPDIR/my_app/__init__.py")
+	ACTUAL=$(awk '/^__version__[[:space:]]*=/ { gsub(/^__version__[[:space:]]*=[[:space:]]*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$BATS_TEST_TMPDIR/my_app/__init__.py")
 	[[ "$ACTUAL" == "9.8.7" ]]
 }
 
@@ -356,7 +356,27 @@ EOF
 	run_ecosystem "python.sh" "$BATS_TEST_TMPDIR"
 	assert_success
 
-	ACTUAL=$(awk '/^__version__[[:space:]]*=/ { gsub(/.*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$BATS_TEST_TMPDIR/src/my_app/__init__.py")
+	ACTUAL=$(awk '/^__version__[[:space:]]*=/ { gsub(/^__version__[[:space:]]*=[[:space:]]*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$BATS_TEST_TMPDIR/src/my_app/__init__.py")
+	[[ "$ACTUAL" == "9.8.7" ]]
+}
+
+@test "python: verifies __init__.py after update when file has leading docstring" {
+	if ! python3 -c 'import tomlkit' 2>/dev/null; then
+		skip "tomlkit not available"
+	fi
+
+	create_pyproject_toml "$BATS_TEST_TMPDIR" "0.64.2" "lintro"
+	mkdir -p "$BATS_TEST_TMPDIR/lintro"
+	cat >"$BATS_TEST_TMPDIR/lintro/__init__.py" <<EOF
+"""Lintro - A unified CLI core for code formatting, linting, and quality assurance."""
+
+__version__ = "0.64.2"
+EOF
+
+	run_ecosystem "python.sh" "$BATS_TEST_TMPDIR"
+	assert_success
+
+	ACTUAL=$(awk '/^__version__[[:space:]]*=/ { gsub(/^__version__[[:space:]]*=[[:space:]]*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$BATS_TEST_TMPDIR/lintro/__init__.py")
 	[[ "$ACTUAL" == "9.8.7" ]]
 }
 
@@ -372,7 +392,7 @@ EOF
 	run_ecosystem "python.sh" "$BATS_TEST_TMPDIR"
 	assert_success
 
-	ACTUAL=$(awk '/^__version__[[:space:]]*=/ { gsub(/.*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$BATS_TEST_TMPDIR/my_cool_pkg/__init__.py")
+	ACTUAL=$(awk '/^__version__[[:space:]]*=/ { gsub(/^__version__[[:space:]]*=[[:space:]]*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$BATS_TEST_TMPDIR/my_cool_pkg/__init__.py")
 	[[ "$ACTUAL" == "9.8.7" ]]
 }
 
@@ -428,11 +448,11 @@ EOF
 	[[ "$ACTUAL" == "9.8.7" ]]
 
 	# Verify the override init file was updated
-	ACTUAL=$(awk '/^__version__[[:space:]]*=/ { gsub(/.*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$BATS_TEST_TMPDIR/custom/lib/version_info.py")
+	ACTUAL=$(awk '/^__version__[[:space:]]*=/ { gsub(/^__version__[[:space:]]*=[[:space:]]*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$BATS_TEST_TMPDIR/custom/lib/version_info.py")
 	[[ "$ACTUAL" == "9.8.7" ]]
 
 	# Verify the auto-discoverable decoy was NOT touched
-	DECOY=$(awk '/^__version__[[:space:]]*=/ { gsub(/.*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$BATS_TEST_TMPDIR/custom/turbo_themes/__init__.py")
+	DECOY=$(awk '/^__version__[[:space:]]*=/ { gsub(/^__version__[[:space:]]*=[[:space:]]*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$BATS_TEST_TMPDIR/custom/turbo_themes/__init__.py")
 	[[ "$DECOY" == "0.0.0" ]]
 }
 
@@ -665,7 +685,7 @@ EOF
 	[[ "$ACTUAL" == "9.8.7" ]]
 
 	# Verify the custom init file was updated
-	ACTUAL=$(awk '/^__version__[[:space:]]*=/ { gsub(/.*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$BATS_TEST_TMPDIR/custom/lib/ver.py")
+	ACTUAL=$(awk '/^__version__[[:space:]]*=/ { gsub(/^__version__[[:space:]]*=[[:space:]]*["'"'"']/, ""); gsub(/["'"'"'].*/, ""); print; exit }' "$BATS_TEST_TMPDIR/custom/lib/ver.py")
 	[[ "$ACTUAL" == "9.8.7" ]]
 }
 

--- a/tests/bats/integration/test_reusable_test_publish_workflows.bats
+++ b/tests/bats/integration/test_reusable_test_publish_workflows.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for publish workflows that reuse lgtm-ci tooling
+
+load "../../helpers/common"
+
+@test "reusable-test-python-publish: preserves .lgtm-ci-tooling on repo checkout" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-test-python-publish.yml"
+	run awk '
+		/Checkout repository/ { in_step = 1 }
+		in_step && /clean: false/ { found = 1; exit }
+		in_step && /^      - name:/ && !/Checkout repository/ { exit }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-test-node-publish: preserves .lgtm-ci-tooling on repo checkout" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-test-node-publish.yml"
+	run awk '
+		/Checkout repository/ { in_step = 1 }
+		in_step && /clean: false/ { found = 1; exit }
+		in_step && /^      - name:/ && !/Checkout repository/ { exit }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+}

--- a/tests/bats/unit/actions/test_attest_build.bats
+++ b/tests/bats/unit/actions/test_attest_build.bats
@@ -32,16 +32,18 @@ _run_prepare() {
 	_run_prepare
 
 	assert_success
-	grep -q '^subject-path=' "$GITHUB_OUTPUT"
-	grep -q '^subject-name=' "$GITHUB_OUTPUT"
-	! grep -q '^subject-digest=' "$GITHUB_OUTPUT"
+	assert_file_contains "$GITHUB_OUTPUT" '^subject-path='
+	assert_file_contains "$GITHUB_OUTPUT" '^subject-name='
+	run grep -qE -- '^subject-digest=' "$GITHUB_OUTPUT"
+	assert_failure
 }
 
 @test "attest-build prepare: outputs subject-digest when digest provided" {
 	_run_prepare "${BATS_TEST_TMPDIR}/artifact.txt" "sha256:deadbeef"
 
 	assert_success
-	grep -q '^subject-digest=sha256:deadbeef' "$GITHUB_OUTPUT"
-	grep -q '^subject-name=' "$GITHUB_OUTPUT"
-	! grep -q '^subject-path=' "$GITHUB_OUTPUT"
+	assert_file_contains "$GITHUB_OUTPUT" '^subject-digest=sha256:deadbeef'
+	assert_file_contains "$GITHUB_OUTPUT" '^subject-name='
+	run grep -qE -- '^subject-path=' "$GITHUB_OUTPUT"
+	assert_failure
 }

--- a/tests/bats/unit/actions/test_attest_build.bats
+++ b/tests/bats/unit/actions/test_attest_build.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/attest-build.sh prepare step
+
+load "../../../helpers/common"
+load "../../../helpers/github_env"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+	printf 'artifact-contents\n' >"${BATS_TEST_TMPDIR}/artifact.txt"
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+_run_prepare() {
+	local subject_path="${1:-${BATS_TEST_TMPDIR}/artifact.txt}"
+	local subject_digest="${2:-}"
+	local subject_name="${3:-}"
+	run env \
+		STEP=prepare \
+		SUBJECT_PATH="$subject_path" \
+		SUBJECT_DIGEST="$subject_digest" \
+		SUBJECT_NAME="$subject_name" \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/attest-build.sh"
+}
+
+@test "attest-build prepare: outputs subject-path when digest not provided" {
+	_run_prepare
+
+	assert_success
+	grep -q '^subject-path=' "$GITHUB_OUTPUT"
+	grep -q '^subject-name=' "$GITHUB_OUTPUT"
+	! grep -q '^subject-digest=' "$GITHUB_OUTPUT"
+}
+
+@test "attest-build prepare: outputs subject-digest when digest provided" {
+	_run_prepare "${BATS_TEST_TMPDIR}/artifact.txt" "sha256:deadbeef"
+
+	assert_success
+	grep -q '^subject-digest=sha256:deadbeef' "$GITHUB_OUTPUT"
+	grep -q '^subject-name=' "$GITHUB_OUTPUT"
+	! grep -q '^subject-path=' "$GITHUB_OUTPUT"
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Fix three main-branch CI failures observed on py-lintro after adopting
lgtm-ci v0.18.2 (`e42d374f`). All three are bugs in lgtm-ci reusable
workflows or composite actions — not caller-side issues.

1. **Checkout order wipes `.lgtm-ci-tooling`** — publish workflows check
   out lgtm-ci tooling, then `actions/checkout` for the repo with
   `clean: true` (default) deletes it. Fixed by adding `clean: false`.
2. **`attest-build` passes both `subject-path` and `subject-digest`** —
   `actions/attest-build-provenance@v4.1.0` rejects multiple subject
   parameters. Fixed by emitting only one from the prepare script.
3. **Python `__init__.py` verification reads back empty** — the awk
   pattern `gsub(/.*["']/, "")` is greedy and strips the entire line
   when both opening and closing quotes exist. Fixed by anchoring the
   gsub to the `__version__ =` prefix.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Preserve workspace state during reusable publish runs (checkout no longer cleans by default).
  * Make artifact attestation emit a single, clear subject identifier (either digest or path) and always include a subject name.
  * Make release version verification more robust when reading package version metadata.

* **Tests**
  * Added integration tests for publish workflows and updated ecosystem version tests.
  * Added unit tests covering attestation prepare behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes three confirmed CI failures introduced by the v0.18.2 adoption of lgtm-ci reusable workflows. Each fix is a surgical one-liner or small block change with a corresponding regression test.

- **Checkout ordering** (`reusable-test-{node,python}-publish.yml`): adds `clean: false` to prevent the second `actions/checkout` call from deleting the previously fetched `.lgtm-ci-tooling` directory; a new bats contract test asserts the flag stays present.
- **Dual subject parameter** (`attest-build.sh`): restructures output emission so `actions/attest-build-provenance` receives exactly one subject param — either `subject-digest` (when a digest is explicitly supplied) or `subject-path` (otherwise) — along with unit tests for both branches.
- **Greedy awk pattern** (`python.sh`): anchors the first `gsub` to the `^__version__ =` prefix so it strips only the leading assignment rather than consuming the entire line through the closing quote; all existing test assertions and a new docstring-file regression test apply the same corrected pattern.
</details>

<h3>Confidence Score: 5/5</h3>

All three fixes are targeted, well-understood, and directly verified by new or updated tests — safe to merge.

Each fix addresses a concrete, reproducible failure: a workspace-wipe from a default git clean, a rejected dual-parameter API call, and a greedy regex stripping version strings to empty. The changes are minimal and each is covered by a new bats test that would catch a future regression. No new code paths are introduced beyond the fixes themselves.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/actions/attest-build.sh | Removes dual-subject-parameter bug: now emits only subject-digest or subject-path (never both), satisfying actions/attest-build-provenance v4+ contract. Also removes the previously-computed-but-unused sha256 calculation. |
| scripts/ci/release/ecosystems/python.sh | Fixes greedy awk gsub that stripped entire lines containing both opening and closing quotes; anchors the first gsub to the __version__ prefix so the version string is correctly extracted during post-write verification. |
| .github/workflows/reusable-test-node-publish.yml | Adds clean: false to the repo checkout step so the previously checked-out .lgtm-ci-tooling directory is not wiped by the default git clean behaviour. |
| .github/workflows/reusable-test-python-publish.yml | Same clean: false fix as the node publish workflow; prevents .lgtm-ci-tooling from being deleted when the caller repo is checked out. |
| tests/bats/unit/actions/test_attest_build.bats | New unit tests directly exercising the prepare step: verifies subject-path-only output when no digest is given, and subject-digest-only output when a digest is supplied. |
| tests/bats/integration/test_reusable_test_publish_workflows.bats | New contract test file that asserts clean: false is present in the Checkout repository step of both publish workflows, preventing future regressions. |
| tests/bats/integration/test_ecosystem_updaters.bats | Updates all inline awk snippets in the test assertions to use the same anchored gsub pattern as the production fix; adds a new docstring-leading-file test that directly reproduces the originally reported failure. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[attest-build.sh prepare] --> B{SUBJECT_DIGEST\nprovided?}
    B -- Yes --> C[USE_DIGEST=true]
    B -- No --> D{SUBJECT_PATH\nis a file?}
    D -- Yes --> E[USE_DIGEST=false]
    D -- No --> F[USE_DIGEST=false\n+ warn: non-file subject]
    C --> G[emit subject-digest]
    E --> H[emit subject-path]
    F --> H
    G --> I[emit subject-name]
    H --> I
    I --> J[actions/attest-build-provenance\nreceives exactly ONE subject param]

    style J fill:#22c55e,color:#fff
    style G fill:#3b82f6,color:#fff
    style H fill:#3b82f6,color:#fff
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(attest-build): drop unused digest co..."](https://github.com/lgtm-hq/lgtm-ci/commit/7cc4d484bc9b5fd3a4d1f0f4bfbd064af2c250a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33717978)</sub>

<!-- /greptile_comment -->