### PR TITLE
fix(ci): reverse checkout order in test publish workflows for Pages deploy

### DIFF
--- a/.github/workflows/reusable-test-node-publish.yml
+++ b/.github/workflows/reusable-test-node-publish.yml
@@ -62,6 +62,17 @@ jobs:
       id-token: write
 
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -74,18 +85,6 @@ jobs:
             scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
-
-      - name: Harden runner
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
-
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          clean: false
 
       - name: Download coverage
         if: inputs.upload-coverage

--- a/.github/workflows/reusable-test-node-publish.yml
+++ b/.github/workflows/reusable-test-node-publish.yml
@@ -62,11 +62,14 @@ jobs:
       id-token: write
 
     steps:
+      # Direct call before tooling checkout; SHA matches .github/actions/harden-runner/action.yml
       - name: Harden runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: ${{ inputs.egress-policy }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          disable-sudo: false
+          disable-telemetry: false
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-test-python-publish.yml
+++ b/.github/workflows/reusable-test-python-publish.yml
@@ -57,6 +57,17 @@ jobs:
       id-token: write
 
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -69,18 +80,6 @@ jobs:
             scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
-
-      - name: Harden runner
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
-
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-          clean: false
 
       - name: Download coverage
         if: inputs.upload-coverage

--- a/.github/workflows/reusable-test-python-publish.yml
+++ b/.github/workflows/reusable-test-python-publish.yml
@@ -57,11 +57,14 @@ jobs:
       id-token: write
 
     steps:
+      # Direct call before tooling checkout; SHA matches .github/actions/harden-runner/action.yml
       - name: Harden runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: ${{ inputs.egress-policy }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          disable-sudo: false
+          disable-telemetry: false
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **workflows**: reverse checkout order in test publish workflows so Pages deploy keeps tooling (#217)
+- **workflows**: reverse checkout order in test publish workflows so Pages deploy keeps tooling (#218)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **workflows**: reverse checkout order in test publish workflows so Pages deploy keeps tooling (#217)
+
 ### Security
 
 ## [0.18.3] - 2026-05-25

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -32,6 +32,22 @@ Where applicable, workflows accept:
 `reusable-test-node-publish.yml` in a separate caller job when publishing is
 required.
 
+### Isolated publish jobs (Pages / coverage badge)
+
+`reusable-test-python-publish.yml` and `reusable-test-node-publish.yml` run in a
+**fresh workspace** (separate reusable-workflow job from the test matrix). The
+caller repository checkout must initialize `.git` before tooling is added:
+
+1. Harden runner (`step-security/harden-runner` — no tooling checkout yet)
+2. Checkout repository (caller repo at workspace root)
+3. Checkout lgtm-ci tooling (`.lgtm-ci-tooling/` alongside the repo)
+4. Download artifacts, badge generation, GitHub Pages publish (local tooling actions)
+
+`clean: false` on the repository checkout does **not** help here: without an
+existing `.git`, `actions/checkout` wipes the workspace and deletes
+`.lgtm-ci-tooling/` if tooling was checked out first. Match
+`reusable-publish-pypi.yml` and `reusable-pr-auto-assign.yml`.
+
 ## Low-noise Rust and Node checks
 
 Prefer split workflows to avoid skipped checks in PR UI:

--- a/tests/bats/integration/test_reusable_test_publish_workflows.bats
+++ b/tests/bats/integration/test_reusable_test_publish_workflows.bats
@@ -4,24 +4,61 @@
 
 load "../../helpers/common"
 
-@test "reusable-test-python-publish: preserves .lgtm-ci-tooling on repo checkout" {
-	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-test-python-publish.yml"
-	run awk '
-		/Checkout repository/ { in_step = 1 }
-		in_step && /clean: false/ { found = 1; exit }
-		in_step && /^      - name:/ && !/Checkout repository/ { exit }
-		END { exit !found }
+_publish_checkout_order_ok() {
+	local workflow="$1"
+	awk '
+		/^    steps:/ { in_steps = 1 }
+		in_steps && /^      - name: Harden runner/ { harden = NR }
+		in_steps && /^      - name: Checkout repository/ { repo = NR }
+		in_steps && /^      - name: Checkout lgtm-ci tooling/ { tooling = NR }
+		END {
+			ok = (harden > 0 && repo > 0 && tooling > 0 && harden < repo && repo < tooling)
+			exit !ok
+		}
 	' "$workflow"
+}
+
+_publish_tooling_actions_ok() {
+	local workflow="$1"
+	awk '
+		/\.\/\.lgtm-ci-tooling\/\.github\/actions\/generate-coverage-badge/ { badge = 1 }
+		/\.\/\.lgtm-ci-tooling\/\.github\/actions\/publish-test-results/ { publish = 1 }
+		END { exit !(badge && publish) }
+	' "$workflow"
+}
+
+@test "reusable-test-python-publish: checkout order preserves tooling in isolated jobs" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-test-python-publish.yml"
+	run _publish_checkout_order_ok "$workflow"
 	assert_success
 }
 
-@test "reusable-test-node-publish: preserves .lgtm-ci-tooling on repo checkout" {
-	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-test-node-publish.yml"
-	run awk '
-		/Checkout repository/ { in_step = 1 }
-		in_step && /clean: false/ { found = 1; exit }
-		in_step && /^      - name:/ && !/Checkout repository/ { exit }
-		END { exit !found }
-	' "$workflow"
+@test "reusable-test-python-publish: uses local tooling actions for badge and Pages publish" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-test-python-publish.yml"
+	run _publish_tooling_actions_ok "$workflow"
 	assert_success
+}
+
+@test "reusable-test-python-publish: does not rely on clean: false workaround" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-test-python-publish.yml"
+	run grep -q 'clean: false' "$workflow"
+	assert_failure
+}
+
+@test "reusable-test-node-publish: checkout order preserves tooling in isolated jobs" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-test-node-publish.yml"
+	run _publish_checkout_order_ok "$workflow"
+	assert_success
+}
+
+@test "reusable-test-node-publish: uses local tooling actions for badge and Pages publish" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-test-node-publish.yml"
+	run _publish_tooling_actions_ok "$workflow"
+	assert_success
+}
+
+@test "reusable-test-node-publish: does not rely on clean: false workaround" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-test-node-publish.yml"
+	run grep -q 'clean: false' "$workflow"
+	assert_failure
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Reorders steps in `reusable-test-python-publish.yml` and `reusable-test-node-publish.yml` so isolated publish jobs keep `.lgtm-ci-tooling/` on disk through badge generation and GitHub Pages deploy. The v0.18.3 `clean: false` workaround is insufficient on fresh workspaces because `actions/checkout` wipes the workspace before initializing the caller repo when no `.git` exists yet.

Canonical order (aligned with `reusable-publish-pypi.yml` and `reusable-pr-auto-assign.yml`):

1. Harden runner (`step-security/harden-runner`)
2. Checkout repository
3. Checkout lgtm-ci tooling
4. Download artifacts, badge, Pages publish

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Hardened workflows by adopting pinned upstream runner-security and checkout steps; revised publish job sequencing for isolated Pages/coverage jobs
* **Documentation**
  * Added workflow contract guidance describing isolated publish job behavior and required checkout sequence
* **Tests**
  * Updated integration tests to assert publish-step ordering and local-tooling usage; removed prior clean: false checks
* **Fixed**
  * CHANGELOG entry noting workflow checkout/sequencing fix (Unreleased, PR `#218`)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a workspace ordering bug in the isolated publish jobs for Python and Node.js: `actions/checkout` was wiping `.lgtm-ci-tooling/` when it ran second on a fresh workspace with no existing `.git`, making subsequent local action references fail.

- **Reorder in both publish workflows**: Harden runner → Checkout caller repo → Checkout lgtm-ci tooling, matching the canonical pattern used by `reusable-publish-pypi.yml` and `reusable-pr-auto-assign.yml`. The `clean: false` workaround is removed.
- **Direct `harden-runner` call**: Because tooling isn't on disk yet at that point, `step-security/harden-runner` is called directly with pinned SHA instead of through the composite wrapper.
- **Tests and docs updated**: BATS integration tests now assert the correct checkout sequence and absence of `clean: false`; `workflow-contract.md` documents the required step order.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the reordering correctly fixes the workspace wipe on fresh runners and all downstream local action references remain intact.

The change is a targeted step reorder in two isolated publish jobs. The root cause (actions/checkout wiping the workspace before .git exists) is well understood and the fix aligns both workflows with the existing canonical pattern already used in reusable-publish-pypi.yml. Tests assert the new order and the absence of the clean: false workaround. No functional logic is altered beyond the checkout sequence.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-test-node-publish.yml | Moves harden-runner and caller-repo checkout before tooling checkout; removes clean: false. Direct step-security call is necessary and commented correctly. |
| .github/workflows/reusable-test-python-publish.yml | Same reordering as the node workflow; direct harden-runner call with explicit disable-sudo/disable-telemetry defaults. |
| tests/bats/integration/test_reusable_test_publish_workflows.bats | Replaces clean:false assertion with order-verification helper; adds tooling-actions and no-clean-false contract tests for both workflows. |
| docs/workflow-contract.md | Adds an Isolated publish jobs section documenting the required step order and why clean: false is insufficient on a fresh workspace. |
| CHANGELOG.md | Adds a Fixed entry for this PR in the Unreleased section, correctly placed above the Security section. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant R as Runner (fresh workspace)
    participant HR as step-security/harden-runner
    participant CR as actions/checkout (caller repo)
    participant CT as actions/checkout (lgtm-ci tooling)
    participant LA as Local Actions (.lgtm-ci-tooling/)

    Note over R: Before this PR (broken order)
    R->>CT: Checkout lgtm-ci tooling → .lgtm-ci-tooling/
    R->>HR: ./.lgtm-ci-tooling/.github/actions/harden-runner
    R->>CR: Checkout repo (clean:false, but no .git → wipes workspace)
    Note over R: .lgtm-ci-tooling/ deleted ❌
    R--xLA: Local action refs fail

    Note over R: After this PR (fixed order)
    R->>HR: step-security/harden-runner (direct, tooling not yet on disk)
    R->>CR: Checkout caller repo (initialises .git at workspace root)
    R->>CT: Checkout lgtm-ci tooling → .lgtm-ci-tooling/ (safe, .git exists)
    R->>LA: Generate badge, Publish to Pages ✅
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): address CR feedback on harden-r..."](https://github.com/lgtm-hq/lgtm-ci/commit/76a4866818a997b2b3b3fb6d91fb385bc0c02c76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33783150)</sub>

<!-- /greptile_comment -->