### PR TITLE
feat(ci): require Renovate version comments on all SHA-pinned actions

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -51,7 +51,7 @@ runs:
 
     - name: Install Rust toolchain
       # Pinned to SHA for supply chain security
-      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # v1
       with:
         toolchain: ${{ inputs.toolchain }}
         components: ${{ inputs.components }}

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -51,7 +51,7 @@ runs:
 
     - name: Install Rust toolchain
       # Pinned to SHA for supply chain security
-      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # v1
+      uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
       with:
         toolchain: ${{ inputs.toolchain }}
         components: ${{ inputs.components }}

--- a/.github/actions/validate-action-pinning/action.yml
+++ b/.github/actions/validate-action-pinning/action.yml
@@ -44,12 +44,12 @@ runs:
     - name: Validate action pinning
       id: validate
       shell: bash
-      run: |
-        export INPUT_ENFORCE="${{ inputs.enforce }}"
-        export INPUT_ALLOW_TAG_EXCEPTIONS="${{ inputs['allow-tag-exceptions'] != '' \
-          && inputs['allow-tag-exceptions'] || inputs['allow-org-versions'] }}"
-        export INPUT_SCAN_PATHS="${{ inputs['scan-paths'] }}"
-        "$SCRIPTS_DIR/ci/actions/validate-action-pinning.sh"
+      env:
+        INPUT_ENFORCE: ${{ inputs.enforce }}
+        INPUT_ALLOW_TAG_EXCEPTIONS: ${{ inputs['allow-tag-exceptions'] }}
+        INPUT_ALLOW_ORG_VERSIONS: ${{ inputs['allow-org-versions'] }}
+        INPUT_SCAN_PATHS: ${{ inputs['scan-paths'] }}
+      run: $SCRIPTS_DIR/ci/actions/validate-action-pinning.sh
 
 branding:
   icon: "shield"

--- a/.github/actions/validate-action-pinning/action.yml
+++ b/.github/actions/validate-action-pinning/action.yml
@@ -1,17 +1,23 @@
 ---
 name: "Validate Action Pinning"
-description: "Ensure all GitHub Actions references are pinned to commit SHAs"
+description: >-
+  Ensure GitHub Actions references use SHA pins with Renovate version comments
 author: "lgtm-hq"
 
 inputs:
   enforce:
-    description: "Fail if non-pinned actions are found"
+    description: "Fail if pinning policy violations are found"
     required: false
     default: "true"
+  allow-tag-exceptions:
+    description: >-
+      Comma-separated full action names allowed to use tag refs when no SHA is
+      available (e.g., some-org/action-without-shas)
+    required: false
+    default: ""
   allow-org-versions:
     description: >-
-      Comma-separated org/repo prefixes allowed to use version tags
-      (e.g., lgtm-hq/lgtm-ci)
+      Deprecated alias for allow-tag-exceptions. Prefer allow-tag-exceptions.
     required: false
     default: ""
   scan-paths:
@@ -23,7 +29,7 @@ inputs:
 
 outputs:
   offenders:
-    description: "Count of non-pinned action references found"
+    description: "Count of pinning policy violations found"
     value: ${{ steps.validate.outputs.offenders }}
 
 runs:
@@ -38,11 +44,12 @@ runs:
     - name: Validate action pinning
       id: validate
       shell: bash
-      env:
-        INPUT_ENFORCE: ${{ inputs.enforce }}
-        INPUT_ALLOW_ORG_VERSIONS: ${{ inputs['allow-org-versions'] }}
-        INPUT_SCAN_PATHS: ${{ inputs['scan-paths'] }}
-      run: $SCRIPTS_DIR/ci/actions/validate-action-pinning.sh
+      run: |
+        export INPUT_ENFORCE="${{ inputs.enforce }}"
+        export INPUT_ALLOW_TAG_EXCEPTIONS="${{ inputs['allow-tag-exceptions'] != '' \
+          && inputs['allow-tag-exceptions'] || inputs['allow-org-versions'] }}"
+        export INPUT_SCAN_PATHS="${{ inputs['scan-paths'] }}"
+        "$SCRIPTS_DIR/ci/actions/validate-action-pinning.sh"
 
 branding:
   icon: "shield"

--- a/.github/workflows/reusable-release-version-pr.yml
+++ b/.github/workflows/reusable-release-version-pr.yml
@@ -210,7 +210,7 @@ jobs:
           && steps.version.outputs.release-needed == 'true'
           && contains(format(',{0},', inputs.ecosystems), ',rust,')
         # yamllint disable-line rule:line-length
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
         with:
           toolchain: stable
 

--- a/.github/workflows/reusable-release-version-pr.yml
+++ b/.github/workflows/reusable-release-version-pr.yml
@@ -210,7 +210,7 @@ jobs:
           && steps.version.outputs.release-needed == 'true'
           && contains(format(',{0},', inputs.ecosystems), ',rust,')
         # yamllint disable-line rule:line-length
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
 

--- a/.github/workflows/reusable-validate-action-pinning.yml
+++ b/.github/workflows/reusable-validate-action-pinning.yml
@@ -9,8 +9,11 @@ on:
         required: false
         type: boolean
         default: true
-      allow-list:
-        description: "Comma-separated action prefixes exempt from SHA pinning"
+      allow-tag-exceptions:
+        description: >-
+          Comma-separated full action names allowed to use tag refs when no SHA
+          is available (narrow escape hatch; SHA + version comment is required
+          otherwise)
         required: false
         type: string
         default: ""
@@ -70,5 +73,5 @@ jobs:
         uses: ./.lgtm-ci-tooling/.github/actions/validate-action-pinning
         with:
           enforce: ${{ inputs.fail-on-error }}
-          allow-org-versions: ${{ inputs.allow-list }}
+          allow-tag-exceptions: ${{ inputs.allow-tag-exceptions }}
           scan-paths: ${{ inputs.scan-paths }}

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -106,6 +106,33 @@ allowed-endpoints: >
   metrics.semgrep.dev:443
 ```
 
+## Action pinning policy
+
+Org repos must pin GitHub Actions to **commit SHAs only** and add a trailing
+Renovate version comment on the same line. Tag refs (for example `@v4`) fail
+`reusable-validate-action-pinning.yml` unless the action is listed in the narrow
+`allow-tag-exceptions` input.
+
+| Pin | Result |
+| --- | --- |
+| `uses: org/action@sha` | Fail — missing `# vX.Y.Z` |
+| `uses: org/action@v1.2.3` | Fail — tag pin |
+| `uses: org/action@sha # v1.2.3` | Pass |
+| `tooling-ref: 'sha'` | Fail — missing `# vX.Y.Z` |
+| `tooling-ref: 'sha' # v0.18.4` | Pass |
+| `ref: 'sha'` under `repository: lgtm-hq/lgtm-ci` checkout | Same rule as `tooling-ref` |
+
+Canonical examples:
+
+```yaml
+uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+tooling-ref: '95e202aed67142e8429bd8d37a0e45886f0d6218' # v0.18.4
+```
+
+Template expressions (for example `${{ inputs.tooling-ref }}`) are ignored.
+Bare SHA pins without version comments are invisible to Renovate and are blocked
+by design.
+
 ## Dependency review
 
 `reusable-dependency-review.yml` runs on `pull_request` and `merge_group`

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -122,11 +122,15 @@ Renovate version comment on the same line. Tag refs (for example `@v4`) fail
 | `tooling-ref: 'sha' # v0.18.4` | Pass |
 | `ref: 'sha'` under `repository: lgtm-hq/lgtm-ci` checkout | Same rule as `tooling-ref` |
 
+Use the **release commit SHA** for `tooling-ref` and lgtm-ci checkout `ref` pins, not the
+annotated tag object SHA. For example, `v0.18.4` resolves to release commit
+`d3736367191ddaf56c41804d2dd5174732ed2d2b`, not tag object `95e202ae…`.
+
 Canonical examples:
 
 ```yaml
 uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
-tooling-ref: '95e202aed67142e8429bd8d37a0e45886f0d6218' # v0.18.4
+tooling-ref: 'd3736367191ddaf56c41804d2dd5174732ed2d2b' # v0.18.4
 ```
 
 Template expressions (for example `${{ inputs.tooling-ref }}`) are ignored.

--- a/scripts/ci/actions/validate-action-pinning.sh
+++ b/scripts/ci/actions/validate-action-pinning.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
-# Purpose: Validate that GitHub Actions references are pinned to commit SHAs
+# Purpose: Validate GitHub Actions SHA pinning with Renovate version comments
 #
 # Environment variables:
-#   INPUT_ENFORCE           - Fail if non-pinned actions are found (true/false)
-#   INPUT_ALLOW_ORG_VERSIONS - Comma-separated org/repo prefixes allowed to use version tags
-#   INPUT_SCAN_PATHS        - Space-separated paths to scan for workflow files
+#   INPUT_ENFORCE              - Fail if violations are found (true/false)
+#   INPUT_ALLOW_TAG_EXCEPTIONS - Comma-separated action names allowed to use tag refs
+#   INPUT_ALLOW_ORG_VERSIONS   - Deprecated alias for INPUT_ALLOW_TAG_EXCEPTIONS
+#   INPUT_SCAN_PATHS           - Space-separated paths to scan for workflow files
 
 set -euo pipefail
 
 : "${INPUT_ENFORCE:=true}"
+: "${INPUT_ALLOW_TAG_EXCEPTIONS:=}"
 : "${INPUT_ALLOW_ORG_VERSIONS:=}"
 : "${INPUT_SCAN_PATHS:=.github/workflows .github/actions}"
 
@@ -17,57 +19,111 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
 # shellcheck source=../lib/actions.sh
 source "$SCRIPT_DIR/../lib/actions.sh"
 
+readonly VERSION_COMMENT_PATTERN='#[[:space:]]*v[0-9]+(\.[0-9]+)*'
+readonly LGTM_CI_REPOSITORY_PATTERN='repository:[[:space:]]*['\''"]?lgtm-hq/lgtm-ci['\''"]?'
+
 # =============================================================================
-# Parse allowed org prefixes
+# Parse allowed tag exceptions (exact action names)
 # =============================================================================
-ALLOWED_PREFIXES=()
-if [[ -n "$INPUT_ALLOW_ORG_VERSIONS" ]]; then
-	IFS=',' read -ra ALLOWED_PREFIXES <<<"$INPUT_ALLOW_ORG_VERSIONS"
-	# Trim whitespace from each prefix
-	for i in "${!ALLOWED_PREFIXES[@]}"; do
-		ALLOWED_PREFIXES[i]="$(echo "${ALLOWED_PREFIXES[i]}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-	done
+TAG_EXCEPTIONS=()
+if [[ -n "$INPUT_ALLOW_TAG_EXCEPTIONS" ]]; then
+	IFS=',' read -ra TAG_EXCEPTIONS <<<"$INPUT_ALLOW_TAG_EXCEPTIONS"
+elif [[ -n "$INPUT_ALLOW_ORG_VERSIONS" ]]; then
+	log_warn "INPUT_ALLOW_ORG_VERSIONS is deprecated; use INPUT_ALLOW_TAG_EXCEPTIONS instead"
+	IFS=',' read -ra TAG_EXCEPTIONS <<<"$INPUT_ALLOW_ORG_VERSIONS"
 fi
 
-# =============================================================================
-# Check if an action reference is allowed to use version tags
-# =============================================================================
-is_allowed_prefix() {
-	local action_ref="$1"
-	for prefix in "${ALLOWED_PREFIXES[@]}"; do
-		if [[ -z "$prefix" ]]; then
-			continue
-		fi
-		if [[ "$action_ref" == "$prefix" || "$action_ref" == "$prefix"/* ]]; then
-			return 0
-		fi
-	done
-	return 1
-}
+for i in "${!TAG_EXCEPTIONS[@]}"; do
+	TAG_EXCEPTIONS[i]="$(echo "${TAG_EXCEPTIONS[i]}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+done
 
 # =============================================================================
-# Check if a version ref is a valid SHA (40-char hex)
+# Validation helpers
 # =============================================================================
 is_valid_sha() {
 	local ref="$1"
 	[[ "$ref" =~ ^[0-9a-fA-F]{40}$ ]]
 }
 
+has_renovate_version_comment() {
+	local line="$1"
+	[[ "$line" =~ $VERSION_COMMENT_PATTERN ]]
+}
+
+is_tag_exception() {
+	local action_name="$1"
+	local exception
+
+	if [[ ${#TAG_EXCEPTIONS[@]} -eq 0 ]]; then
+		return 1
+	fi
+
+	for exception in "${TAG_EXCEPTIONS[@]}"; do
+		if [[ -z "$exception" ]]; then
+			continue
+		fi
+		if [[ "$action_name" == "$exception" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+contains_template_expression() {
+	local value="$1"
+	# shellcheck disable=SC2016
+	[[ "$value" == *'${{'* ]]
+}
+
+extract_literal_ref() {
+	local line="$1"
+	local key="$2"
+	local value=""
+	local field_pattern="^[[:space:]]*${key}:[[:space:]]*(.*)$"
+
+	if [[ ! "$line" =~ $field_pattern ]]; then
+		return 1
+	fi
+
+	value="${BASH_REMATCH[1]}"
+	value="${value%"${value##*[![:space:]]}"}"
+	value="${value#\"}"
+	value="${value%\"}"
+	value="${value#\'}"
+	value="${value%\'}"
+
+	if contains_template_expression "$value"; then
+		return 1
+	fi
+
+	if ! is_valid_sha "$value"; then
+		return 1
+	fi
+
+	printf '%s' "$value"
+}
+
 # =============================================================================
-# Scan workflow files for unpinned action references
+# Scan workflow files
 # =============================================================================
 offender_count=0
 offender_details=()
 
-log_info "Scanning for unpinned action references..."
+record_offender() {
+	local file="$1"
+	local line_number="$2"
+	local detail="$3"
+	offender_count=$((offender_count + 1))
+	offender_details+=("  ${file}:${line_number}: ${detail}")
+}
+
+log_info "Scanning for action pinning policy violations..."
 log_info "Scan paths: $INPUT_SCAN_PATHS"
-if [[ ${#ALLOWED_PREFIXES[@]} -gt 0 ]]; then
-	log_info "Allowed org prefixes: ${ALLOWED_PREFIXES[*]}"
+if [[ ${#TAG_EXCEPTIONS[@]} -gt 0 ]]; then
+	log_info "Tag pin exceptions: ${TAG_EXCEPTIONS[*]}"
 fi
 
-# Collect YAML files from all scan paths
 yaml_files=()
-# Split space-separated paths into array for safe iteration
 read -ra scan_paths <<<"$INPUT_SCAN_PATHS"
 for scan_path in "${scan_paths[@]}"; do
 	if [[ ! -d "$scan_path" ]]; then
@@ -87,68 +143,99 @@ fi
 
 log_info "Found ${#yaml_files[@]} workflow file(s) to scan"
 
-for file in "${yaml_files[@]}"; do
-	line_number=0
+scan_uses_line() {
+	local file="$1"
+	local line_number="$2"
+	local line="$3"
+
+	if ! [[ "$line" =~ ^[[:space:]]*-?[[:space:]]*uses:[[:space:]]* ]]; then
+		return 0
+	fi
+
+	local action_ref
+	action_ref="$(echo "$line" | sed -E 's/^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*//' | sed 's/#.*//' | sed 's/[[:space:]]*$//')"
+	action_ref="$(echo "$action_ref" | sed -E "s/^['\"]//;s/['\"]$//")"
+
+	if [[ -z "$action_ref" || "$action_ref" == ./* || "$action_ref" == docker://* ]]; then
+		return 0
+	fi
+
+	# shellcheck disable=SC2016
+	if contains_template_expression "$action_ref"; then
+		return 0
+	fi
+
+	if [[ "$action_ref" != *@* ]]; then
+		record_offender "$file" "$line_number" "${action_ref} (no version specified)"
+		return 0
+	fi
+
+	local action_name="${action_ref%@*}"
+	local version_ref="${action_ref##*@}"
+
+	if is_valid_sha "$version_ref"; then
+		if ! has_renovate_version_comment "$line"; then
+			record_offender "$file" "$line_number" \
+				"${action_ref} (SHA pin missing Renovate version comment; add \"# vX.Y.Z\")"
+		fi
+		return 0
+	fi
+
+	if is_tag_exception "$action_name"; then
+		return 0
+	fi
+
+	record_offender "$file" "$line_number" \
+		"${action_ref} (tag pin not allowed; pin to SHA with \"# vX.Y.Z\" comment)"
+}
+
+scan_literal_sha_field() {
+	local file="$1"
+	local line_number="$2"
+	local line="$3"
+	local field_name="$4"
+	local sha_ref
+
+	if ! sha_ref="$(extract_literal_ref "$line" "$field_name")"; then
+		return 0
+	fi
+
+	if has_renovate_version_comment "$line"; then
+		return 0
+	fi
+
+	record_offender "$file" "$line_number" \
+		"${field_name}: ${sha_ref} (SHA pin missing Renovate version comment; add \"# vX.Y.Z\")"
+}
+
+scan_file() {
+	local file="$1"
+	local line_number=0
+	local in_lgtm_ci_checkout=false
+
+	# shellcheck disable=SC2094
 	while IFS= read -r line || [[ -n "$line" ]]; do
 		line_number=$((line_number + 1))
 
-		# Match lines containing "uses:" (with optional leading whitespace/dash)
-		if ! [[ "$line" =~ ^[[:space:]]*-?[[:space:]]*uses:[[:space:]]* ]]; then
-			continue
+		if [[ "$line" =~ ^[[:space:]]*-?[[:space:]]*(uses|name):[[:space:]]* ]]; then
+			in_lgtm_ci_checkout=false
 		fi
 
-		# Extract the action reference (remove "uses:" prefix and inline comments)
-		action_ref="$(echo "$line" | sed -E 's/^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*//' | sed 's/#.*//' | sed 's/[[:space:]]*$//')"
-
-		# Remove surrounding quotes if present
-		action_ref="$(echo "$action_ref" | sed -E "s/^['\"]//;s/['\"]$//")"
-
-		# Skip empty references
-		if [[ -z "$action_ref" ]]; then
-			continue
+		if [[ "$line" =~ $LGTM_CI_REPOSITORY_PATTERN ]]; then
+			in_lgtm_ci_checkout=true
 		fi
 
-		# Skip local action references (./)
-		if [[ "$action_ref" == ./* ]]; then
-			continue
+		scan_uses_line "$file" "$line_number" "$line"
+		scan_literal_sha_field "$file" "$line_number" "$line" "tooling-ref"
+
+		if [[ "$in_lgtm_ci_checkout" == true ]]; then
+			scan_literal_sha_field "$file" "$line_number" "$line" "ref"
 		fi
-
-		# Skip docker:// references
-		if [[ "$action_ref" == docker://* ]]; then
-			continue
-		fi
-
-		# Skip template expressions (${{ }}) — single quotes are intentional
-		# shellcheck disable=SC2016
-		if [[ "$action_ref" == *'${'* ]]; then
-			continue
-		fi
-
-		# Parse action and version: org/repo@version or org/repo/path@version
-		if [[ "$action_ref" != *@* ]]; then
-			# No @ sign means no version pinning at all
-			offender_count=$((offender_count + 1))
-			offender_details+=("  ${file}:${line_number}: ${action_ref} (no version specified)")
-			continue
-		fi
-
-		action_name="${action_ref%@*}"
-		version_ref="${action_ref##*@}"
-
-		# Check if the version ref is a valid 40-char SHA
-		if is_valid_sha "$version_ref"; then
-			continue
-		fi
-
-		# Check if the action is from an allowed org prefix
-		if [[ ${#ALLOWED_PREFIXES[@]} -gt 0 ]] && is_allowed_prefix "$action_name"; then
-			continue
-		fi
-
-		# Not pinned to SHA and not in allow list
-		offender_count=$((offender_count + 1))
-		offender_details+=("  ${file}:${line_number}: ${action_ref}")
 	done <"$file"
+}
+
+for file in "${yaml_files[@]}"; do
+	scan_file "$file"
 done
 
 # =============================================================================
@@ -157,17 +244,18 @@ done
 set_github_output "offenders" "$offender_count"
 
 if [[ $offender_count -gt 0 ]]; then
-	log_error "Found $offender_count unpinned action reference(s):"
+	log_error "Found $offender_count action pinning violation(s):"
 	for detail in "${offender_details[@]}"; do
 		echo "$detail" >&2
 	done
 	echo "" >&2
-	log_info "Pin actions to full commit SHAs for security."
-	log_info "Example: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4"
+	log_info "LGTM HQ policy: SHA-only pins with a trailing Renovate version comment."
+	log_info "Example uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4"
+	log_info "Example tooling-ref: '95e202aed67142e8429bd8d37a0e45886f0d6218' # v0.18.4"
 
 	if [[ "$INPUT_ENFORCE" == "true" ]]; then
 		exit 1
 	fi
 else
-	log_success "All action references are properly pinned"
+	log_success "All action references follow SHA pinning with Renovate version comments"
 fi

--- a/scripts/ci/actions/validate-action-pinning.sh
+++ b/scripts/ci/actions/validate-action-pinning.sh
@@ -21,6 +21,7 @@ source "$SCRIPT_DIR/../lib/actions.sh"
 
 readonly VERSION_COMMENT_PATTERN='#[[:space:]]*v[0-9]+(\.[0-9]+)*'
 readonly LGTM_CI_REPOSITORY_PATTERN='repository:[[:space:]]*['\''"]?lgtm-hq/lgtm-ci['\''"]?'
+readonly LGTM_CI_RELEASE_COMMIT_SHA='d3736367191ddaf56c41804d2dd5174732ed2d2b'
 
 # =============================================================================
 # Parse allowed tag exceptions (exact action names)
@@ -218,6 +219,11 @@ scan_file() {
 	while IFS= read -r line || [[ -n "$line" ]]; do
 		line_number=$((line_number + 1))
 
+		if [[ "$line" =~ ^jobs:[[:space:]]*$ ]] ||
+			[[ "$line" =~ ^[[:space:]]{2}[a-zA-Z_][a-zA-Z0-9_-]*:[[:space:]]*($|[[:space:]]*#) ]]; then
+			in_lgtm_ci_checkout=false
+		fi
+
 		if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+(uses|name):[[:space:]]* ]]; then
 			in_lgtm_ci_checkout=false
 		fi
@@ -252,7 +258,7 @@ if [[ $offender_count -gt 0 ]]; then
 	echo "" >&2
 	log_info "LGTM HQ policy: SHA-only pins with a trailing Renovate version comment."
 	log_info "Example uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4"
-	log_info "Example tooling-ref: '95e202aed67142e8429bd8d37a0e45886f0d6218' # v0.18.4"
+	log_info "Example tooling-ref: '${LGTM_CI_RELEASE_COMMIT_SHA}' # v0.18.4"
 
 	if [[ "$INPUT_ENFORCE" == "true" ]]; then
 		exit 1

--- a/scripts/ci/actions/validate-action-pinning.sh
+++ b/scripts/ci/actions/validate-action-pinning.sh
@@ -86,6 +86,7 @@ extract_literal_ref() {
 	fi
 
 	value="${BASH_REMATCH[1]}"
+	value="${value%%#*}"
 	value="${value%"${value##*[![:space:]]}"}"
 	value="${value#\"}"
 	value="${value%\"}"
@@ -217,7 +218,7 @@ scan_file() {
 	while IFS= read -r line || [[ -n "$line" ]]; do
 		line_number=$((line_number + 1))
 
-		if [[ "$line" =~ ^[[:space:]]*-?[[:space:]]*(uses|name):[[:space:]]* ]]; then
+		if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+(uses|name):[[:space:]]* ]]; then
 			in_lgtm_ci_checkout=false
 		fi
 

--- a/tests/bats/integration/test_validate_action_pinning.bats
+++ b/tests/bats/integration/test_validate_action_pinning.bats
@@ -323,7 +323,7 @@ jobs:
   build:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@a5ac7e51b41094c92402da3b24376905380afc29 # v4
     with:
-      tooling-ref: '"'"'95e202aed67142e8429bd8d37a0e45886f0d6218'"'"' # v0.18.4
+      tooling-ref: '"'"'d3736367191ddaf56c41804d2dd5174732ed2d2b'"'"' # v0.18.4
 '
 
 	run bash -c '
@@ -349,7 +349,7 @@ jobs:
   build:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@a5ac7e51b41094c92402da3b24376905380afc29 # v4
     with:
-      tooling-ref: '"'"'95e202aed67142e8429bd8d37a0e45886f0d6218'"'"'
+      tooling-ref: '"'"'d3736367191ddaf56c41804d2dd5174732ed2d2b'"'"'
 '
 
 	run bash -c '
@@ -359,7 +359,7 @@ jobs:
 		bash "$SCRIPT" 2>&1
 	'
 	assert_failure
-	assert_output --partial "tooling-ref: 95e202aed67142e8429bd8d37a0e45886f0d6218"
+	assert_output --partial "tooling-ref: d3736367191ddaf56c41804d2dd5174732ed2d2b"
 	assert_output --partial "missing Renovate version comment"
 	assert_github_output "offenders" "1"
 }
@@ -377,7 +377,7 @@ jobs:
   build:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@a5ac7e51b41094c92402da3b24376905380afc29 # v4
     with:
-      tooling-ref: '"'"'95e202aed67142e8429bd8d37a0e45886f0d6218'"'"' # stable
+      tooling-ref: '"'"'d3736367191ddaf56c41804d2dd5174732ed2d2b'"'"' # stable
 '
 
 	run bash -c '
@@ -387,7 +387,7 @@ jobs:
 		bash "$SCRIPT" 2>&1
 	'
 	assert_failure
-	assert_output --partial "tooling-ref: 95e202aed67142e8429bd8d37a0e45886f0d6218"
+	assert_output --partial "tooling-ref: d3736367191ddaf56c41804d2dd5174732ed2d2b"
 	assert_output --partial "missing Renovate version comment"
 	assert_github_output "offenders" "1"
 }
@@ -405,7 +405,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: '"'"'95e202aed67142e8429bd8d37a0e45886f0d6218'"'"' # v0.18.4
+          ref: '"'"'d3736367191ddaf56c41804d2dd5174732ed2d2b'"'"' # v0.18.4
 '
 
 	run bash -c '
@@ -431,7 +431,7 @@ jobs:
         with:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
-          ref: '"'"'95e202aed67142e8429bd8d37a0e45886f0d6218'"'"'
+          ref: '"'"'d3736367191ddaf56c41804d2dd5174732ed2d2b'"'"'
 '
 
 	run bash -c '
@@ -441,7 +441,7 @@ jobs:
 		bash "$SCRIPT" 2>&1
 	'
 	assert_failure
-	assert_output --partial "ref: 95e202aed67142e8429bd8d37a0e45886f0d6218"
+	assert_output --partial "ref: d3736367191ddaf56c41804d2dd5174732ed2d2b"
 	assert_output --partial "missing Renovate version comment"
 	assert_github_output "offenders" "1"
 }
@@ -460,7 +460,7 @@ jobs:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
           name: custom-checkout-name
-          ref: '"'"'95e202aed67142e8429bd8d37a0e45886f0d6218'"'"' # main
+          ref: '"'"'d3736367191ddaf56c41804d2dd5174732ed2d2b'"'"' # main
 '
 
 	run bash -c '
@@ -470,9 +470,39 @@ jobs:
 		bash "$SCRIPT" 2>&1
 	'
 	assert_failure
-	assert_output --partial "ref: 95e202aed67142e8429bd8d37a0e45886f0d6218"
+	assert_output --partial "ref: d3736367191ddaf56c41804d2dd5174732ed2d2b"
 	assert_output --partial "missing Renovate version comment"
 	assert_github_output "offenders" "1"
+}
+
+@test "validate-action-pinning: lgtm-ci checkout context does not leak across jobs" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on: push
+jobs:
+  tooling:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: '"'"'d3736367191ddaf56c41804d2dd5174732ed2d2b'"'"' # v0.18.4
+  caller:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+    with:
+      ref: '"'"'d3736367191ddaf56c41804d2dd5174732ed2d2b'"'"'
+'
+
+	run bash -c '
+		export INPUT_ENFORCE=true
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	assert_github_output "offenders" "0"
 }
 
 # =============================================================================

--- a/tests/bats/integration/test_validate_action_pinning.bats
+++ b/tests/bats/integration/test_validate_action_pinning.bats
@@ -364,6 +364,34 @@ jobs:
 	assert_github_output "offenders" "1"
 }
 
+@test "validate-action-pinning: non-Renovate tooling-ref comment fails validation" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on:
+  workflow_call:
+    inputs:
+      tooling-ref:
+        type: string
+jobs:
+  build:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+    with:
+      tooling-ref: '"'"'95e202aed67142e8429bd8d37a0e45886f0d6218'"'"' # stable
+'
+
+	run bash -c '
+		export INPUT_ENFORCE=true
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_failure
+	assert_output --partial "tooling-ref: 95e202aed67142e8429bd8d37a0e45886f0d6218"
+	assert_output --partial "missing Renovate version comment"
+	assert_github_output "offenders" "1"
+}
+
 @test "validate-action-pinning: lgtm-ci checkout ref requires version comment" {
 	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
 	create_workflow "$scan_dir" "ci.yml" '
@@ -404,6 +432,35 @@ jobs:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
           ref: '"'"'95e202aed67142e8429bd8d37a0e45886f0d6218'"'"'
+'
+
+	run bash -c '
+		export INPUT_ENFORCE=true
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_failure
+	assert_output --partial "ref: 95e202aed67142e8429bd8d37a0e45886f0d6218"
+	assert_output --partial "missing Renovate version comment"
+	assert_github_output "offenders" "1"
+}
+
+@test "validate-action-pinning: non-Renovate lgtm-ci checkout ref comment fails validation" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          name: custom-checkout-name
+          ref: '"'"'95e202aed67142e8429bd8d37a0e45886f0d6218'"'"' # main
 '
 
 	run bash -c '

--- a/tests/bats/integration/test_validate_action_pinning.bats
+++ b/tests/bats/integration/test_validate_action_pinning.bats
@@ -34,10 +34,34 @@ create_workflow() {
 }
 
 # =============================================================================
-# SHA-pinned actions pass
+# SHA-pinned actions with version comments pass
 # =============================================================================
 
-@test "validate-action-pinning: SHA-pinned actions pass validation" {
+@test "validate-action-pinning: annotated SHA-pinned actions pass validation" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - uses: actions/setup-node@1a4442cacd436585916f16a2e5b1385ca3b5e13c # v4
+'
+
+	run bash -c '
+		export INPUT_ENFORCE=true
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	assert_output --partial "All action references follow SHA pinning with Renovate version comments"
+	assert_github_output "offenders" "0"
+}
+
+@test "validate-action-pinning: bare SHA pins fail without Renovate version comment" {
 	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
 	create_workflow "$scan_dir" "ci.yml" '
 name: CI
@@ -47,25 +71,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
-      - uses: actions/setup-node@1a4442cacd436585916f16a2e5b1385ca3b5e13c
+      - uses: actions/setup-node@1a4442cacd436585916f16a2e5b1385ca3b5e13c # v4
 '
 
 	run bash -c '
 		export INPUT_ENFORCE=true
-		export INPUT_ALLOW_ORG_VERSIONS=""
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
 		export INPUT_SCAN_PATHS="'"$scan_dir"'"
 		bash "$SCRIPT" 2>&1
 	'
-	assert_success
-	assert_output --partial "All action references are properly pinned"
-	assert_github_output "offenders" "0"
+	assert_failure
+	assert_output --partial "missing Renovate version comment"
+	assert_output --partial "actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29"
+	refute_output --partial "actions/setup-node"
+	assert_github_output "offenders" "1"
 }
 
 # =============================================================================
 # Version-tagged actions fail
 # =============================================================================
 
-@test "validate-action-pinning: version-tagged actions fail when not in allow list" {
+@test "validate-action-pinning: version-tagged actions fail when not in exception list" {
 	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
 	create_workflow "$scan_dir" "ci.yml" '
 name: CI
@@ -80,12 +106,12 @@ jobs:
 
 	run bash -c '
 		export INPUT_ENFORCE=true
-		export INPUT_ALLOW_ORG_VERSIONS=""
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
 		export INPUT_SCAN_PATHS="'"$scan_dir"'"
 		bash "$SCRIPT" 2>&1
 	'
 	assert_failure
-	assert_output --partial "unpinned action reference"
+	assert_output --partial "action pinning violation"
 	assert_output --partial "actions/checkout@v4"
 	assert_output --partial "actions/setup-node@v3"
 	assert_github_output "offenders" "2"
@@ -105,12 +131,12 @@ jobs:
 
 	run bash -c '
 		export INPUT_ENFORCE=false
-		export INPUT_ALLOW_ORG_VERSIONS=""
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
 		export INPUT_SCAN_PATHS="'"$scan_dir"'"
 		bash "$SCRIPT" 2>&1
 	'
 	assert_success
-	assert_output --partial "unpinned action reference"
+	assert_output --partial "action pinning violation"
 	assert_github_output "offenders" "1"
 }
 
@@ -133,12 +159,12 @@ jobs:
 
 	run bash -c '
 		export INPUT_ENFORCE=true
-		export INPUT_ALLOW_ORG_VERSIONS=""
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
 		export INPUT_SCAN_PATHS="'"$scan_dir"'"
 		bash "$SCRIPT" 2>&1
 	'
 	assert_success
-	assert_output --partial "All action references are properly pinned"
+	assert_output --partial "All action references follow SHA pinning with Renovate version comments"
 	assert_github_output "offenders" "0"
 }
 
@@ -161,20 +187,20 @@ jobs:
 
 	run bash -c '
 		export INPUT_ENFORCE=true
-		export INPUT_ALLOW_ORG_VERSIONS=""
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
 		export INPUT_SCAN_PATHS="'"$scan_dir"'"
 		bash "$SCRIPT" 2>&1
 	'
 	assert_success
-	assert_output --partial "All action references are properly pinned"
+	assert_output --partial "All action references follow SHA pinning with Renovate version comments"
 	assert_github_output "offenders" "0"
 }
 
 # =============================================================================
-# Allowed org prefixes are respected
+# Tag pin exceptions are respected
 # =============================================================================
 
-@test "validate-action-pinning: allowed org prefixes bypass SHA requirement" {
+@test "validate-action-pinning: tag pin exceptions bypass SHA requirement" {
 	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
 	create_workflow "$scan_dir" "ci.yml" '
 name: CI
@@ -190,20 +216,19 @@ jobs:
 
 	run bash -c '
 		export INPUT_ENFORCE=true
-		export INPUT_ALLOW_ORG_VERSIONS="lgtm-hq/lgtm-ci"
+		export INPUT_ALLOW_TAG_EXCEPTIONS="lgtm-hq/lgtm-ci/.github/actions/setup-env,lgtm-hq/lgtm-ci/.github/actions/run-tests"
 		export INPUT_SCAN_PATHS="'"$scan_dir"'"
 		bash "$SCRIPT" 2>&1
 	'
 	assert_failure
-	assert_output --partial "unpinned action reference"
+	assert_output --partial "action pinning violation"
 	assert_output --partial "actions/checkout@v4"
-	# lgtm-hq actions should not appear in offender lines
 	refute_output --partial "lgtm-hq/lgtm-ci/.github/actions/setup-env@v1"
 	refute_output --partial "lgtm-hq/lgtm-ci/.github/actions/run-tests@main"
 	assert_github_output "offenders" "1"
 }
 
-@test "validate-action-pinning: allow-list prefix does not match colliding repo names" {
+@test "validate-action-pinning: tag exceptions require exact action name match" {
 	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
 	create_workflow "$scan_dir" "ci.yml" '
 name: CI
@@ -218,18 +243,18 @@ jobs:
 
 	run bash -c '
 		export INPUT_ENFORCE=true
-		export INPUT_ALLOW_ORG_VERSIONS="org/repo"
+		export INPUT_ALLOW_TAG_EXCEPTIONS="org/repo"
 		export INPUT_SCAN_PATHS="'"$scan_dir"'"
 		bash "$SCRIPT" 2>&1
 	'
 	assert_failure
-	assert_output --partial "unpinned action reference"
+	assert_output --partial "action pinning violation"
 	assert_output --partial "org/repo-evil@v1"
 	refute_output --partial "ci.yml:8: org/repo@v1"
 	assert_github_output "offenders" "1"
 }
 
-@test "validate-action-pinning: multiple allowed org prefixes work" {
+@test "validate-action-pinning: multiple tag pin exceptions work" {
 	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
 	create_workflow "$scan_dir" "ci.yml" '
 name: CI
@@ -244,12 +269,12 @@ jobs:
 
 	run bash -c '
 		export INPUT_ENFORCE=true
-		export INPUT_ALLOW_ORG_VERSIONS="lgtm-hq/lgtm-ci, my-org/my-action"
+		export INPUT_ALLOW_TAG_EXCEPTIONS="lgtm-hq/lgtm-ci/.github/actions/setup-env, my-org/my-action"
 		export INPUT_SCAN_PATHS="'"$scan_dir"'"
 		bash "$SCRIPT" 2>&1
 	'
 	assert_success
-	assert_output --partial "All action references are properly pinned"
+	assert_output --partial "All action references follow SHA pinning with Renovate version comments"
 	assert_github_output "offenders" "0"
 }
 
@@ -272,13 +297,125 @@ jobs:
 
 	run bash -c '
 		export INPUT_ENFORCE=true
-		export INPUT_ALLOW_ORG_VERSIONS=""
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
 		export INPUT_SCAN_PATHS="'"$scan_dir"'"
 		bash "$SCRIPT" 2>&1
 	'
 	assert_success
-	assert_output --partial "All action references are properly pinned"
+	assert_output --partial "All action references follow SHA pinning with Renovate version comments"
 	assert_github_output "offenders" "0"
+}
+
+# =============================================================================
+# tooling-ref and lgtm-ci checkout ref scanning
+# =============================================================================
+
+@test "validate-action-pinning: annotated tooling-ref passes validation" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on:
+  workflow_call:
+    inputs:
+      tooling-ref:
+        type: string
+jobs:
+  build:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+    with:
+      tooling-ref: '"'"'95e202aed67142e8429bd8d37a0e45886f0d6218'"'"' # v0.18.4
+'
+
+	run bash -c '
+		export INPUT_ENFORCE=true
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	assert_github_output "offenders" "0"
+}
+
+@test "validate-action-pinning: bare tooling-ref fails without version comment" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on:
+  workflow_call:
+    inputs:
+      tooling-ref:
+        type: string
+jobs:
+  build:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality.yml@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+    with:
+      tooling-ref: '"'"'95e202aed67142e8429bd8d37a0e45886f0d6218'"'"'
+'
+
+	run bash -c '
+		export INPUT_ENFORCE=true
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_failure
+	assert_output --partial "tooling-ref: 95e202aed67142e8429bd8d37a0e45886f0d6218"
+	assert_output --partial "missing Renovate version comment"
+	assert_github_output "offenders" "1"
+}
+
+@test "validate-action-pinning: lgtm-ci checkout ref requires version comment" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: '"'"'95e202aed67142e8429bd8d37a0e45886f0d6218'"'"' # v0.18.4
+'
+
+	run bash -c '
+		export INPUT_ENFORCE=true
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	assert_github_output "offenders" "0"
+}
+
+@test "validate-action-pinning: bare lgtm-ci checkout ref fails without version comment" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: '"'"'95e202aed67142e8429bd8d37a0e45886f0d6218'"'"'
+'
+
+	run bash -c '
+		export INPUT_ENFORCE=true
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_failure
+	assert_output --partial "ref: 95e202aed67142e8429bd8d37a0e45886f0d6218"
+	assert_output --partial "missing Renovate version comment"
+	assert_github_output "offenders" "1"
 }
 
 # =============================================================================
@@ -294,7 +431,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
       - uses: actions/setup-node@v3
       - uses: ./local-action
       - uses: docker://alpine:3.18
@@ -303,14 +440,13 @@ jobs:
 
 	run bash -c '
 		export INPUT_ENFORCE=true
-		export INPUT_ALLOW_ORG_VERSIONS=""
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
 		export INPUT_SCAN_PATHS="'"$scan_dir"'"
 		bash "$SCRIPT" 2>&1
 	'
 	assert_failure
 	assert_output --partial "actions/setup-node@v3"
 	assert_output --partial "some-org/some-action@main"
-	# Pinned actions, local refs, and docker refs should not appear in offender lines
 	refute_output --partial "ci.yml:8: actions/checkout"
 	refute_output --partial "ci.yml:10: ./local-action"
 	refute_output --partial "ci.yml:11: docker://"
@@ -345,7 +481,7 @@ runs:
 
 	run bash -c '
 		export INPUT_ENFORCE=true
-		export INPUT_ALLOW_ORG_VERSIONS=""
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
 		export INPUT_SCAN_PATHS="'"$workflows_dir"' '"$actions_dir"'"
 		bash "$SCRIPT" 2>&1
 	'
@@ -365,7 +501,7 @@ runs:
 
 	run bash -c '
 		export INPUT_ENFORCE=true
-		export INPUT_ALLOW_ORG_VERSIONS=""
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
 		export INPUT_SCAN_PATHS="'"$scan_dir"'"
 		bash "$SCRIPT" 2>&1
 	'
@@ -377,7 +513,7 @@ runs:
 @test "validate-action-pinning: warns when scan path does not exist" {
 	run bash -c '
 		export INPUT_ENFORCE=true
-		export INPUT_ALLOW_ORG_VERSIONS=""
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
 		export INPUT_SCAN_PATHS="/nonexistent/path"
 		bash "$SCRIPT" 2>&1
 	'
@@ -400,7 +536,7 @@ jobs:
 
 	run bash -c '
 		export INPUT_ENFORCE=true
-		export INPUT_ALLOW_ORG_VERSIONS=""
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
 		export INPUT_SCAN_PATHS="'"$scan_dir"'"
 		bash "$SCRIPT" 2>&1
 	'
@@ -416,7 +552,7 @@ jobs:
 
 	run bash -c '
 		export INPUT_ENFORCE=true
-		export INPUT_ALLOW_ORG_VERSIONS=""
+		export INPUT_ALLOW_TAG_EXCEPTIONS=""
 		export INPUT_SCAN_PATHS="'"$scan_dir"'"
 		bash "$SCRIPT" 2>&1
 	'


### PR DESCRIPTION
## Summary

Extend `validate-action-pinning` to enforce LGTM HQ's SHA-only pinning policy with
trailing Renovate version comments (`# vX.Y.Z`) on every pin. Bare SHA pins and tag
refs now fail by default, and the validator also scans `tooling-ref:` and literal
lgtm-ci checkout `ref:` fields.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

Callers using `allow-list` on `reusable-validate-action-pinning.yml` must migrate
to `allow-tag-exceptions` with exact action names. Tag refs are no longer allowed
via broad org-prefix allowlists.

## Closes

- Closes #220
- Relates to #98

## Testing

- [x] Added/updated BATS integration tests for bare SHA, annotated SHA, tag pins,
  `tooling-ref`, and lgtm-ci checkout `ref` scanning
- [x] Full BATS suite (1632 tests)
- [x] `lintro chk` (all tools)
- [x] Validated lgtm-ci workflows pass the updated policy locally

## Quality Checks

- [x] `uv run lintro chk`
- [x] `uv run lintro tst`
- [x] `make test-bats`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive GitHub Actions pinning policy documentation with pass/fail examples.

* **Chores**
  * Updated GitHub Actions configurations to enforce commit SHA pinning with Renovate version comments.
  * Introduced new `allow-tag-exceptions` input for specifying actions permitted to use tag references.
  * Refactored action pinning validation to enforce stricter SHA-only pin requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends `validate-action-pinning` to enforce SHA-only pinning **with** a trailing Renovate version comment (`# vX.Y.Z`) on every pin, and adds scanning of `tooling-ref:` fields and lgtm-ci checkout `ref:` fields. Bare SHA pins and tag refs now fail by default; the old `allow-list`/`allow-org-versions` prefix-based escape hatch is replaced by the narrower `allow-tag-exceptions` (exact action name match only).

- `validate-action-pinning.sh` is refactored into per-line scan helpers (`scan_uses_line`, `scan_literal_sha_field`) and a line-by-line state machine (`scan_file`) that tracks whether the current `with:` block is an lgtm-ci checkout, resetting correctly at each new step and job boundary.
- `action.yml` and the reusable workflow add the `allow-tag-exceptions` input wired safely through the `env:` block; `allow-org-versions` is kept as a deprecated alias with a runtime warning.
- Existing SHA pins in `setup-rust` and `reusable-release-version-pr` are updated from non-Renovate comments (`# master`, `# stable`) to `# v1` to comply with the new policy.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the refactored validator is logically sound and the three issues flagged in earlier review rounds are all addressed in the current code.

The `extract_literal_ref` function now strips the inline comment before quote-stripping, so annotated SHAs are correctly extracted. The `env:` block in `action.yml` keeps input expansion safe. The step-delimiter reset requires a literal `-` prefix so `name:` keys inside `with:` blocks no longer clear the lgtm-ci checkout context. The only remaining note is that `LGTM_CI_REPOSITORY_PATTERN` lacks a `^` line-start anchor, which is a minor edge-case concern rather than a present defect under normal workflow file content.

scripts/ci/actions/validate-action-pinning.sh — the `LGTM_CI_REPOSITORY_PATTERN` substring-match edge case is worth a quick look before the next release.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/actions/validate-action-pinning.sh | Core validator refactored: adds `extract_literal_ref` (comment-strip-then-quote-strip ordering is now correct), `scan_literal_sha_field` for tooling-ref/ref, and an `in_lgtm_ci_checkout` state machine. `LGTM_CI_REPOSITORY_PATTERN` lacks a `^` line-start anchor, risking false-positive context activation from string values. |
| .github/actions/validate-action-pinning/action.yml | Adds `allow-tag-exceptions` input; all new inputs wired through the `env:` block safely (no shell injection risk). Deprecates `allow-org-versions` with backward-compat fallback in the script. |
| .github/workflows/reusable-validate-action-pinning.yml | Renames `allow-list` to `allow-tag-exceptions` (breaking change documented in PR); passes input correctly to composite action. All action pins are SHA + version comment compliant. |
| tests/bats/integration/test_validate_action_pinning.bats | Comprehensive new BATS tests for bare-SHA failure, annotated-SHA pass, tag-pin exceptions, tooling-ref validation, lgtm-ci checkout ref, and cross-job context isolation. Coverage is thorough. |
| docs/workflow-contract.md | New Action pinning policy section accurately documents pass/fail table, canonical examples, and the distinction between release-commit SHA and tag-object SHA. No issues. |
| .github/actions/setup-rust/action.yml | SHA updated for `dtolnay/rust-toolchain`; comment updated from `# master` to `# v1` to comply with the new policy. |
| .github/workflows/reusable-release-version-pr.yml | Same `dtolnay/rust-toolchain` SHA update; comment changes from `# stable` to `# v1` to satisfy the Renovate version-comment requirement. |

</details>

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fvalidate-action-pinning.sh%3A23%0AThe%20%60LGTM_CI_REPOSITORY_PATTERN%60%20constant%20has%20no%20line-start%20anchor%2C%20so%20%60%3D~%60%20matches%20it%20anywhere%20inside%20a%20line.%20A%20YAML%20line%20whose%20string%20value%20happens%20to%20contain%20the%20substring%20%60repository%3A%20lgtm-hq%2Flgtm-ci%60%20%28e.g.%20a%20%60description%3A%60%20field%20or%20a%20multi-line%20string%29%20would%20silently%20set%20%60in_lgtm_ci_checkout%3Dtrue%60%2C%20causing%20any%20subsequent%20bare-SHA%20%60ref%3A%60%20field%20in%20that%20same%20step%20or%20the%20next%20few%20lines%20to%20be%20flagged%20as%20a%20false%20positive.%20Adding%20%60%5E%5B%5B%3Aspace%3A%5D%5D*%60%20anchors%20the%20match%20to%20the%20actual%20YAML%20key%20position.%0A%0A&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fvalidate-action-pinning.sh%3A23%0AThe%20%60LGTM_CI_REPOSITORY_PATTERN%60%20constant%20has%20no%20line-start%20anchor%2C%20so%20%60%3D~%60%20matches%20it%20anywhere%20inside%20a%20line.%20A%20YAML%20line%20whose%20string%20value%20happens%20to%20contain%20the%20substring%20%60repository%3A%20lgtm-hq%2Flgtm-ci%60%20%28e.g.%20a%20%60description%3A%60%20field%20or%20a%20multi-line%20string%29%20would%20silently%20set%20%60in_lgtm_ci_checkout%3Dtrue%60%2C%20causing%20any%20subsequent%20bare-SHA%20%60ref%3A%60%20field%20in%20that%20same%20step%20or%20the%20next%20few%20lines%20to%20be%20flagged%20as%20a%20false%20positive.%20Adding%20%60%5E%5B%5B%3Aspace%3A%5D%5D*%60%20anchors%20the%20match%20to%20the%20actual%20YAML%20key%20position.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F220-require-renovate-version-comments-sha-pinned-actions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F220-require-renovate-version-comments-sha-pinned-actions%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fvalidate-action-pinning.sh%3A23%0AThe%20%60LGTM_CI_REPOSITORY_PATTERN%60%20constant%20has%20no%20line-start%20anchor%2C%20so%20%60%3D~%60%20matches%20it%20anywhere%20inside%20a%20line.%20A%20YAML%20line%20whose%20string%20value%20happens%20to%20contain%20the%20substring%20%60repository%3A%20lgtm-hq%2Flgtm-ci%60%20%28e.g.%20a%20%60description%3A%60%20field%20or%20a%20multi-line%20string%29%20would%20silently%20set%20%60in_lgtm_ci_checkout%3Dtrue%60%2C%20causing%20any%20subsequent%20bare-SHA%20%60ref%3A%60%20field%20in%20that%20same%20step%20or%20the%20next%20few%20lines%20to%20be%20flagged%20as%20a%20false%20positive.%20Adding%20%60%5E%5B%5B%3Aspace%3A%5D%5D*%60%20anchors%20the%20match%20to%20the%20actual%20YAML%20key%20position.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): pin rust-toolchain to v1 releas..."](https://github.com/lgtm-hq/lgtm-ci/commit/a68461bd393ee6467df7f7288ca1fd6538236cec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33807164)</sub>

<!-- /greptile_comment -->