### PR TITLE
fix: publish test results with official GitHub Pages actions

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -768,7 +768,8 @@ Generate coverage badge SVG/JSON for README display.
 
 ### publish-test-results
 
-Publish test results and coverage to GitHub Pages.
+Publish test results and coverage to GitHub Pages via official OIDC deploy
+actions.
 
 ```yaml
 - uses: lgtm-hq/lgtm-ci/.github/actions/publish-test-results@main
@@ -776,9 +777,7 @@ Publish test results and coverage to GitHub Pages.
     results-path: "test-results/" # optional
     coverage-path: "coverage/" # optional
     badge-path: "coverage/badge.svg" # optional
-    target-branch: "gh-pages" # optional
     target-dir: "." # optional
-    keep-history: "false" # optional
 ```
 
 **Outputs:**
@@ -787,14 +786,18 @@ Publish test results and coverage to GitHub Pages.
 
 **Features:**
 
-- Deploys to gh-pages branch
-- Optional historical report retention
-- Generates index.html for coverage reports
+- Stages coverage, badges, and test HTML under `target-dir`
+- Deploys with `actions/configure-pages`, `upload-pages-artifact`, `deploy-pages`
+- Generates index.html for coverage reports when missing
 
-**Required Permissions:**
+**Required Permissions (caller job):**
 
-- `contents: write` - For gh-pages deployment
-- `pages: write` - For GitHub Pages
+- `contents: read`
+- `pages: write`
+- `id-token: write`
+
+See [docs/pages-publishing.md](../../docs/pages-publishing.md) for concurrency and
+multi-publisher limits.
 
 ---
 
@@ -1560,11 +1563,11 @@ jobs:
 - `pages-url` - GitHub Pages URL
 - `passed` - Whether coverage meets threshold
 
-**Permissions Required:**
+**Permissions Required (publish job):**
 
-- `contents: write` - For gh-pages deployment
-- `pages: write` - For GitHub Pages
-- `id-token: write` - For pages deployment
+- `contents: read`
+- `pages: write`
+- `id-token: write`
 
 ---
 

--- a/.github/actions/publish-test-results/action.yml
+++ b/.github/actions/publish-test-results/action.yml
@@ -17,11 +17,11 @@ inputs:
     required: false
     default: ""
   target-branch:
-    description: "Branch to deploy to"
+    description: "Legacy gh-pages branch name (unused; kept for callers)"
     required: false
     default: "gh-pages"
   target-dir:
-    description: "Directory on target branch"
+    description: "Subdirectory under the Pages site root"
     required: false
     default: "."
   keep-history:
@@ -59,17 +59,17 @@ runs:
         RETENTION_DAYS: ${{ inputs.retention-days }}
       run: bash "$GITHUB_ACTION_PATH/../../../scripts/ci/actions/publish-test-results.sh"
 
-    - name: Deploy to GitHub Pages
-      id: deploy
-      # Pinned to SHA for supply chain security
-      uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
+    - name: Configure GitHub Pages
+      uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+    - name: Upload GitHub Pages artifact
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       with:
-        github_token: ${{ github.token }}
-        publish_dir: ${{ steps.prepare.outputs.staging-dir }}
-        publish_branch: ${{ inputs.target-branch }}
-        force_orphan: ${{ inputs.keep-history != 'true' }}
-        keep_files: ${{ inputs.keep-history == 'true' }}
-        commit_message: "Deploy test results and coverage [skip ci]"
+        path: ${{ steps.prepare.outputs.staging-dir }}
+
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
     - name: Get Pages URL
       id: pages-url
@@ -77,6 +77,7 @@ runs:
       env:
         STEP: pages-url
         TARGET_DIR: ${{ inputs.target-dir }}
+        BASE_PAGE_URL: ${{ steps.deployment.outputs.page_url }}
       run: bash "$GITHUB_ACTION_PATH/../../../scripts/ci/actions/publish-test-results.sh"
 
     - name: Generate summary

--- a/.github/actions/publish-test-results/action.yml
+++ b/.github/actions/publish-test-results/action.yml
@@ -16,22 +16,10 @@ inputs:
     description: "Path to badge files"
     required: false
     default: ""
-  target-branch:
-    description: "Legacy gh-pages branch name (unused; kept for callers)"
-    required: false
-    default: "gh-pages"
   target-dir:
     description: "Subdirectory under the Pages site root"
     required: false
     default: "."
-  keep-history:
-    description: "Keep historical reports (true/false)"
-    required: false
-    default: "false"
-  retention-days:
-    description: "Days to keep historical reports"
-    required: false
-    default: "30"
   working-directory:
     description: "Working directory"
     required: false
@@ -55,8 +43,6 @@ runs:
         COVERAGE_PATH: ${{ inputs.coverage-path }}
         BADGE_PATH: ${{ inputs.badge-path }}
         TARGET_DIR: ${{ inputs.target-dir }}
-        KEEP_HISTORY: ${{ inputs.keep-history }}
-        RETENTION_DAYS: ${{ inputs.retention-days }}
       run: bash "$GITHUB_ACTION_PATH/../../../scripts/ci/actions/publish-test-results.sh"
 
     - name: Configure GitHub Pages
@@ -85,7 +71,6 @@ runs:
       env:
         STEP: summary
         PAGES_URL: ${{ steps.pages-url.outputs.pages-url }}
-        TARGET_BRANCH: ${{ inputs.target-branch }}
       run: bash "$GITHUB_ACTION_PATH/../../../scripts/ci/actions/publish-test-results.sh"
 
 branding:

--- a/.github/workflows/reusable-coverage.yml
+++ b/.github/workflows/reusable-coverage.yml
@@ -170,8 +170,14 @@ jobs:
     needs: coverage
     if: inputs.publish-pages
     runs-on: ubuntu-latest
+    concurrency:
+      group: pages-${{ github.repository }}-${{ github.ref }}
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.publish.outputs.pages-url }}
     permissions:
-      contents: write
+      contents: read
       pages: write
       id-token: write
 

--- a/.github/workflows/reusable-deploy-pages.yml
+++ b/.github/workflows/reusable-deploy-pages.yml
@@ -68,7 +68,7 @@ on:
 
 # Allow only one deployment at a time
 concurrency:
-  group: pages-${{ github.ref }}
+  group: pages-${{ github.repository }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/reusable-test-e2e-matrix.yml
+++ b/.github/workflows/reusable-test-e2e-matrix.yml
@@ -272,9 +272,16 @@ jobs:
     needs: merge
     if: inputs.publish-results && !cancelled()
     runs-on: ${{ inputs.runner-image }}
+    concurrency:
+      group: pages-${{ github.repository }}-${{ github.ref }}
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.publish.outputs.pages-url }}
     permissions:
-      contents: write
+      contents: read
       pages: write
+      id-token: write
 
     outputs:
       pages-url: ${{ steps.publish.outputs.pages-url }}

--- a/.github/workflows/reusable-test-node-publish.yml
+++ b/.github/workflows/reusable-test-node-publish.yml
@@ -51,13 +51,20 @@ on:
         type: number
         default: 30
 
+concurrency:
+  group: pages-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: ${{ inputs.job-name }}
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    environment:
+      name: github-pages
+      url: ${{ steps.publish.outputs.pages-url }}
     permissions:
-      contents: write
+      contents: read
       pages: write
       id-token: write
 
@@ -118,6 +125,7 @@ jobs:
 
       - name: Publish to GitHub Pages
         if: inputs.upload-coverage
+        id: publish
         uses: ./.lgtm-ci-tooling/.github/actions/publish-test-results
         with:
           results-path: >-

--- a/.github/workflows/reusable-test-node-publish.yml
+++ b/.github/workflows/reusable-test-node-publish.yml
@@ -51,6 +51,11 @@ on:
         type: number
         default: 30
 
+# Shared Pages concurrency serializes deploys per repository/ref.
+# WARNING: Do not invoke this workflow alongside reusable-test-python-publish
+# (or another publish-test-results caller) on the same event unless all subtrees
+# are bundled in one publish job. Each deploy replaces the entire site; the
+# last queued job wins. See docs/pages-publishing.md and lgtm-hq/lgtm-ci#225.
 concurrency:
   group: pages-${{ github.repository }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/reusable-test-python-publish.yml
+++ b/.github/workflows/reusable-test-python-publish.yml
@@ -46,13 +46,20 @@ on:
         type: number
         default: 30
 
+concurrency:
+  group: pages-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: ${{ inputs.job-name }}
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    environment:
+      name: github-pages
+      url: ${{ steps.publish.outputs.pages-url }}
     permissions:
-      contents: write
+      contents: read
       pages: write
       id-token: write
 
@@ -101,6 +108,7 @@ jobs:
 
       - name: Publish to GitHub Pages
         if: inputs.upload-coverage
+        id: publish
         uses: ./.lgtm-ci-tooling/.github/actions/publish-test-results
         with:
           results-path: coverage-report

--- a/.github/workflows/reusable-test-python-publish.yml
+++ b/.github/workflows/reusable-test-python-publish.yml
@@ -46,6 +46,11 @@ on:
         type: number
         default: 30
 
+# Shared Pages concurrency serializes deploys per repository/ref.
+# WARNING: Do not invoke this workflow alongside reusable-test-node-publish
+# (or another publish-test-results caller) on the same event unless all subtrees
+# are bundled in one publish job. Each deploy replaces the entire site; the
+# last queued job wins. See docs/pages-publishing.md and lgtm-hq/lgtm-ci#225.
 concurrency:
   group: pages-${{ github.repository }}-${{ github.ref }}
   cancel-in-progress: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **docs**: GitHub Pages publishing guide (`docs/pages-publishing.md`)
+
 ### Changed
+
+- **ci**: migrate `publish-test-results` from `peaceiris/actions-gh-pages` to official
+  `configure-pages` / `upload-pages-artifact` / `deploy-pages` (#224)
+- **workflows**: align Pages publish jobs (`reusable-test-*-publish`, `reusable-coverage`,
+  `reusable-test-e2e-matrix`) with `github-pages` environment, OIDC permissions, and
+  shared concurrency group
+- **workflows**: unify `reusable-deploy-pages` concurrency with other Pages publishers
 
 ### Deprecated
 
 ### Removed
 
+- **actions**: `publish-test-results` inputs `target-branch`, `keep-history`, and
+  `retention-days` (peaceiris-only; no consumers)
+
 ### Fixed
+
+- **ci**: unblock org repos where third-party Pages actions are denied (#224)
 
 ### Security
 

--- a/docs/pages-publishing.md
+++ b/docs/pages-publishing.md
@@ -70,11 +70,14 @@ The old `peaceiris/actions-gh-pages` model pushed to one branch with
 `keep_files: true`, so `python/` and `vitest/` could coexist. The official
 artifact model cannot do that without an explicit merge step.
 
-| Mitigation                | When                                                                                               |
-| ------------------------- | -------------------------------------------------------------------------------------------------- |
-| One publish job per event | Combine subtrees in one `publish-test-results` call                                                |
-| Model B site bundle       | [lgtm-hq/lgtm-ci#226](https://github.com/lgtm-hq/lgtm-ci/issues/226) (turbo-themes-style)          |
-| Optional live-site merge  | [lgtm-hq/lgtm-ci#225](https://github.com/lgtm-hq/lgtm-ci/issues/225) (multiple Model A publishers) |
+| Mitigation                | When                                              |
+| ------------------------- | ------------------------------------------------- |
+| One publish job per event | One `publish-test-results` with combined subtrees |
+| Model B site bundle       | Issue #226 (turbo-style bundle) [226]             |
+| Optional live-site merge  | Issue #225 (multi Model A publishers) [225]       |
+
+[225]: https://github.com/lgtm-hq/lgtm-ci/issues/225
+[226]: https://github.com/lgtm-hq/lgtm-ci/issues/226
 
 **Current org usage:** py-lintro calls only `reusable-test-python-publish`—not
 affected.

--- a/docs/pages-publishing.md
+++ b/docs/pages-publishing.md
@@ -57,14 +57,27 @@ This serializes deployments to the same site on the same ref (including
 ## Multi-publisher limitation
 
 If a repository runs **more than one** publish workflow to the same GitHub Pages
-site in the same pipeline (for example `reusable-test-python-publish` and
-`reusable-test-node-publish` on one push), the **last** deployment wins and
-**removes** content from earlier jobs. The old gh-pages branch model could keep
-both `python/` and `vitest/` on one branch; the artifact model cannot without
-merging files in a single publish job.
+site in the same pipeline (for example `reusable-test-python-publish` deploying
+`python/` and `reusable-test-node-publish` deploying `vitest/` on one push),
+the shared concurrency group
+`pages-${{ github.repository }}-${{ github.ref }}` **queues** those jobs—but
+**does not merge** their artifacts. Each `upload-pages-artifact` +
+`deploy-pages` run replaces the **entire** site. The **last** job wins and
+**removes** subtrees from earlier jobs (for example only `vitest/` remains if
+node publish runs after python publish).
 
-**Mitigation:** Use one publish job per site per event, or merge all subtrees
-into one staging directory before calling `publish-test-results` once.
+The old `peaceiris/actions-gh-pages` model pushed to one branch with
+`keep_files: true`, so `python/` and `vitest/` could coexist. The official
+artifact model cannot do that without an explicit merge step.
+
+| Mitigation                | When                                                                                               |
+| ------------------------- | -------------------------------------------------------------------------------------------------- |
+| One publish job per event | Combine subtrees in one `publish-test-results` call                                                |
+| Model B site bundle       | [lgtm-hq/lgtm-ci#226](https://github.com/lgtm-hq/lgtm-ci/issues/226) (turbo-themes-style)          |
+| Optional live-site merge  | [lgtm-hq/lgtm-ci#225](https://github.com/lgtm-hq/lgtm-ci/issues/225) (multiple Model A publishers) |
+
+**Current org usage:** py-lintro calls only `reusable-test-python-publish`—not
+affected.
 
 ## Isolated publish jobs
 

--- a/docs/pages-publishing.md
+++ b/docs/pages-publishing.md
@@ -1,0 +1,70 @@
+# GitHub Pages Publishing
+
+lgtm-ci uses a single deployment model: **GitHub Actions OIDC** via
+`actions/configure-pages`, `actions/upload-pages-artifact`, and
+`actions/deploy-pages`. Third-party branch-push actions (for example
+`peaceiris/actions-gh-pages`) are not supported and are blocked by org policy.
+
+## Entry points
+
+| Workflow / action | Content | Typical `target-dir` |
+| --- | --- | --- |
+| `publish-test-results` | Coverage, badges, test HTML | `python`, `vitest`, `coverage`, `playwright` |
+| `deploy-pages` + `reusable-deploy-pages` | Built static sites | site root (`dist`) |
+
+Both paths upload a **full site artifact** per deployment. Each deploy replaces
+the entire published site with that artifact.
+
+## Caller permissions
+
+Publish jobs require:
+
+```yaml
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+```
+
+Do **not** grant `contents: write` for Pages publish; branch-push deploy is no
+longer used.
+
+When `egress-policy: block`, allow OIDC and artifact upload:
+
+```yaml
+allowed-endpoints: >
+  github.com:443
+  api.github.com:443
+  actions.githubusercontent.com:443
+  codeload.github.com:443
+  objects.githubusercontent.com:443
+```
+
+## Concurrency
+
+All Pages deploy jobs in lgtm-ci share:
+
+```text
+pages-${{ github.repository }}-${{ github.ref }}
+```
+
+This serializes deployments to the same site on the same ref (including
+`reusable-deploy-pages` and coverage/test publish workflows).
+
+## Multi-publisher limitation
+
+If a repository runs **more than one** publish workflow to the same GitHub Pages
+site in the same pipeline (for example `reusable-test-python-publish` and
+`reusable-test-node-publish` on one push), the **last** deployment wins and
+**removes** content from earlier jobs. The old gh-pages branch model could keep
+both `python/` and `vitest/` on one branch; the artifact model cannot without
+merging files in a single publish job.
+
+**Mitigation:** Use one publish job per site per event, or merge all subtrees
+into one staging directory before calling `publish-test-results` once.
+
+## Isolated publish jobs
+
+`reusable-test-python-publish` and `reusable-test-node-publish` run in a fresh
+workspace. Checkout order must be: harden runner → caller repo → lgtm-ci tooling.
+See [workflow-contract.md](workflow-contract.md).

--- a/docs/pages-publishing.md
+++ b/docs/pages-publishing.md
@@ -7,10 +7,13 @@ lgtm-ci uses a single deployment model: **GitHub Actions OIDC** via
 
 ## Entry points
 
-| Workflow / action | Content | Typical `target-dir` |
-| --- | --- | --- |
-| `publish-test-results` | Coverage, badges, test HTML | `python`, `vitest`, `coverage`, `playwright` |
-| `deploy-pages` + `reusable-deploy-pages` | Built static sites | site root (`dist`) |
+| Workflow / action                        | Content                     | `target-dir`       |
+| ---------------------------------------- | --------------------------- | ------------------ |
+| `publish-test-results`                   | Coverage, badges, test HTML | configurable       |
+| `deploy-pages` + `reusable-deploy-pages` | Built static sites          | `dist` (site root) |
+
+Typical `publish-test-results` directories include `python`, `vitest`,
+`coverage`, and `playwright`.
 
 Both paths upload a **full site artifact** per deployment. Each deploy replaces
 the entire published site with that artifact.

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -18,6 +18,9 @@ should pin the workflow ref to a commit SHA.
 See [workflow-contract.md](workflow-contract.md) for the standard input contract,
 permissions by mode, egress allowlists, and Rustume migration examples.
 
+For GitHub Pages (coverage, test reports, and static sites), see
+[pages-publishing.md](pages-publishing.md).
+
 ## Quality And Validation
 
 ```yaml

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -24,7 +24,7 @@ Where applicable, workflows accept:
 | --- | --- |
 | Test / quality only | `contents: read` |
 | PR comments | `contents: read`, `pull-requests: write` |
-| Publish to Pages | `contents: write`, `pages: write`, `id-token: write` (separate workflow) |
+| Publish to Pages | `contents: read`, `pages: write`, `id-token: write` (separate workflow/job) |
 | Release version PR | `contents: write`, `pull-requests: write` + app secrets |
 | Package publish | `contents: read`, `id-token: write`, `attestations: write` (as required) |
 
@@ -42,6 +42,10 @@ caller repository checkout must initialize `.git` before tooling is added:
 2. Checkout repository (caller repo at workspace root)
 3. Checkout lgtm-ci tooling (`.lgtm-ci-tooling/` alongside the repo)
 4. Download artifacts, badge generation, GitHub Pages publish (local tooling actions)
+
+Deploy uses official `actions/deploy-pages` (not gh-pages branch push). See
+[pages-publishing.md](pages-publishing.md) for permissions, egress, and
+multi-publisher limits.
 
 `clean: false` on the repository checkout does **not** help here: without an
 existing `.git`, `actions/checkout` wipes the workspace and deletes
@@ -104,6 +108,19 @@ allowed-endpoints: >
   api.osv.dev:443
   semgrep.dev:443
   metrics.semgrep.dev:443
+```
+
+### GitHub Pages publish (OIDC)
+
+```yaml
+egress-policy: block
+allowed-endpoints: >
+  github.com:443
+  api.github.com:443
+  actions.githubusercontent.com:443
+  codeload.github.com:443
+  objects.githubusercontent.com:443
+  release-assets.githubusercontent.com:443
 ```
 
 ## Action pinning policy

--- a/scripts/ci/actions/publish-test-results.sh
+++ b/scripts/ci/actions/publish-test-results.sh
@@ -9,10 +9,8 @@
 #   RESULTS_PATH - Path to test results directory
 #   COVERAGE_PATH - Path to coverage report directory
 #   BADGE_PATH - Path to badge files
-#   TARGET_BRANCH - Branch to deploy to (default: gh-pages)
-#   TARGET_DIR - Directory on target branch (default: .)
-#   KEEP_HISTORY - Keep historical reports (true/false, default: false)
-#   RETENTION_DAYS - Days to keep historical reports (default: 30)
+#   TARGET_DIR - Subdirectory under the Pages site root (default: .)
+#   BASE_PAGE_URL - Deployed site URL from actions/deploy-pages
 #   WORKING_DIRECTORY - Directory to run in
 
 set -euo pipefail
@@ -30,8 +28,12 @@ prepare)
 	: "${COVERAGE_PATH:=}"
 	: "${BADGE_PATH:=}"
 	: "${TARGET_DIR:=.}"
-	: "${KEEP_HISTORY:=false}"
 	: "${WORKING_DIRECTORY:=.}"
+
+	if [[ -n "${TARGET_BRANCH:-}" || -n "${KEEP_HISTORY:-}" || -n "${RETENTION_DAYS:-}" ]]; then
+		log_error "target-branch, keep-history, and retention-days were removed; use official Pages deploy only (see docs/pages-publishing.md)"
+		exit 1
+	fi
 
 	cd "$WORKING_DIRECTORY"
 
@@ -94,22 +96,6 @@ prepare)
 		fi
 	fi
 
-	# Add history directory if keeping history
-	if [[ "$KEEP_HISTORY" == "true" ]]; then
-		history_dir="$staging_dir/$TARGET_DIR/history/$(date +%Y-%m-%d)"
-		mkdir -p "$history_dir"
-
-		# Copy current results to history
-		if [[ -d "$staging_dir/$TARGET_DIR/tests" ]]; then
-			cp -r "$staging_dir/$TARGET_DIR/tests" "$history_dir/"
-		fi
-		if [[ -d "$staging_dir/$TARGET_DIR/coverage" ]]; then
-			cp -r "$staging_dir/$TARGET_DIR/coverage" "$history_dir/"
-		fi
-
-		log_info "Created history snapshot: $history_dir"
-	fi
-
 	# Create index.html if coverage report exists
 	if [[ -d "$staging_dir/$TARGET_DIR/coverage" ]]; then
 		if [[ ! -f "$staging_dir/$TARGET_DIR/coverage/index.html" ]]; then
@@ -143,75 +129,6 @@ EOF
 
 	set_github_output "staging-dir" "$staging_dir"
 	log_success "Staging directory prepared: $staging_dir"
-	;;
-
-deploy)
-	: "${STAGING_DIR:=}"
-	: "${TARGET_BRANCH:=gh-pages}"
-
-	if [[ -z "$STAGING_DIR" ]] || [[ ! -d "$STAGING_DIR" ]]; then
-		log_error "Staging directory not found: $STAGING_DIR"
-		exit 1
-	fi
-
-	log_info "Deploying to $TARGET_BRANCH branch..."
-
-	# Get repository info
-	repo_url=$(git config --get remote.origin.url)
-
-	# Configure git
-	configure_git_ci_user
-
-	# Create a new orphan branch or checkout existing
-	if git show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
-		# Branch exists
-		git fetch origin "$TARGET_BRANCH"
-		git checkout "$TARGET_BRANCH"
-		git reset --hard "origin/$TARGET_BRANCH"
-	else
-		# Create orphan branch
-		git checkout --orphan "$TARGET_BRANCH"
-		git reset --hard
-	fi
-
-	# Clean working tree (remove all except .git) to avoid stale files
-	find . -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} + 2>/dev/null || true
-
-	# Copy staging content (use /. to include dotfiles and handle empty dirs)
-	if [[ -n "$(ls -A "$STAGING_DIR" 2>/dev/null)" ]]; then
-		cp -r "$STAGING_DIR"/. .
-	fi
-
-	# Add and commit
-	git add -A
-	if git diff --staged --quiet; then
-		log_info "No changes to deploy"
-	else
-		git commit -m "Deploy test results and coverage [skip ci]"
-		git push origin "$TARGET_BRANCH" --force
-		log_success "Deployed to $TARGET_BRANCH"
-	fi
-
-	# Generate pages URL (respect TARGET_DIR if set)
-	: "${TARGET_DIR:=.}"
-	# Extract owner/repo from remote URL
-	if [[ "$repo_url" =~ github\.com[:/]([^/]+)/([^/.]+) ]]; then
-		owner="${BASH_REMATCH[1]}"
-		repo="${BASH_REMATCH[2]}"
-		# Clean up target_dir
-		target_dir="${TARGET_DIR#.}"
-		target_dir="${target_dir#/}"
-		if [[ -n "$target_dir" ]]; then
-			pages_url="https://${owner}.github.io/${repo}/${target_dir}/"
-		else
-			pages_url="https://${owner}.github.io/${repo}/"
-		fi
-		set_github_output "pages-url" "$pages_url"
-		log_info "GitHub Pages URL: $pages_url"
-	fi
-
-	# Cleanup staging directory
-	rm -rf "$STAGING_DIR"
 	;;
 
 pages-url)
@@ -271,7 +188,6 @@ pages-url)
 
 summary)
 	: "${PAGES_URL:=}"
-	: "${TARGET_BRANCH:=gh-pages}"
 
 	add_github_summary "## Published Test Results"
 	add_github_summary ""
@@ -283,7 +199,7 @@ summary)
 		add_github_summary "- **Test Results:** [${PAGES_URL}tests/](${PAGES_URL}tests/)"
 		add_github_summary "- **Coverage Badge:** [${PAGES_URL}coverage/badge.svg](${PAGES_URL}coverage/badge.svg)"
 	else
-		add_github_summary "Results deployed to \`$TARGET_BRANCH\` branch."
+		add_github_summary "Pages URL was not available from the deployment step."
 	fi
 
 	add_github_summary ""

--- a/scripts/ci/actions/publish-test-results.sh
+++ b/scripts/ci/actions/publish-test-results.sh
@@ -216,6 +216,23 @@ deploy)
 
 pages-url)
 	: "${TARGET_DIR:=.}"
+	: "${BASE_PAGE_URL:=}"
+
+	# Prefer deploy-pages output when available (official Pages workflow)
+	if [[ -n "$BASE_PAGE_URL" ]]; then
+		base="${BASE_PAGE_URL%/}/"
+		target_dir="${TARGET_DIR#.}"
+		target_dir="${target_dir%/}"
+		target_dir="${target_dir#/}"
+		if [[ -n "$target_dir" && "$target_dir" != "." ]]; then
+			pages_url="${base}${target_dir}/"
+		else
+			pages_url="$base"
+		fi
+		set_github_output "pages-url" "$pages_url"
+		log_info "GitHub Pages URL: $pages_url"
+		exit 0
+	fi
 
 	owner=""
 	repo=""

--- a/tests/bats/integration/test_reusable_test_publish_workflows.bats
+++ b/tests/bats/integration/test_reusable_test_publish_workflows.bats
@@ -62,3 +62,11 @@ _publish_tooling_actions_ok() {
 	run grep -q 'clean: false' "$workflow"
 	assert_failure
 }
+
+@test "publish-test-results: uses official GitHub Pages actions" {
+	local action="${PROJECT_ROOT}/.github/actions/publish-test-results/action.yml"
+	run grep -E 'peaceiris|actions-gh-pages' "$action"
+	assert_failure
+	run grep -qE 'actions/(configure-pages|upload-pages-artifact|deploy-pages)@' "$action"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_test_publish_workflows.bats
+++ b/tests/bats/integration/test_reusable_test_publish_workflows.bats
@@ -70,3 +70,59 @@ _publish_tooling_actions_ok() {
 	run grep -qE 'actions/(configure-pages|upload-pages-artifact|deploy-pages)@' "$action"
 	assert_success
 }
+
+@test "publish-test-results: no legacy gh-pages branch inputs" {
+	local action="${PROJECT_ROOT}/.github/actions/publish-test-results/action.yml"
+	run grep -qE 'target-branch|keep-history|retention-days' "$action"
+	assert_failure
+}
+
+@test "reusable-test-python-publish: official Pages job contract" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-test-python-publish.yml"
+	run grep -q 'group: pages-${{ github.repository }}-${{ github.ref }}' "$workflow"
+	assert_success
+	run grep -q 'name: github-pages' "$workflow"
+	assert_success
+	run grep -q 'id-token: write' "$workflow"
+	assert_success
+	run grep -q 'contents: read' "$workflow"
+	assert_success
+	run grep -q 'contents: write' "$workflow"
+	assert_failure
+}
+
+@test "reusable-test-node-publish: official Pages job contract" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-test-node-publish.yml"
+	run grep -q 'group: pages-${{ github.repository }}-${{ github.ref }}' "$workflow"
+	assert_success
+	run grep -q 'name: github-pages' "$workflow"
+	assert_success
+	run grep -q 'id-token: write' "$workflow"
+	assert_success
+	run grep -q 'contents: read' "$workflow"
+	assert_success
+	run grep -q 'contents: write' "$workflow"
+	assert_failure
+}
+
+@test "reusable-coverage: publish job uses official Pages contract" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-coverage.yml"
+	run awk '/^  publish:/{p=1} p&&/name: github-pages/{e=1} p&&/id-token: write/{i=1} p&&/contents: read/{r=1} p&&/group: pages-\$\{\{ github.repository \}\}-\$\{\{ github.ref \}\}/{c=1} END{exit !(e&&i&&r&&c)}' "$workflow"
+	assert_success
+	run awk '/^  publish:/{p=1} p&&/contents: write/{exit 1} END{exit 0}' "$workflow"
+	assert_success
+}
+
+@test "reusable-test-e2e-matrix: publish job uses official Pages contract" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-test-e2e-matrix.yml"
+	run awk '/^  publish:/{p=1} p&&/name: github-pages/{e=1} p&&/id-token: write/{i=1} p&&/contents: read/{r=1} p&&/group: pages-\$\{\{ github.repository \}\}-\$\{\{ github.ref \}\}/{c=1} END{exit !(e&&i&&r&&c)}' "$workflow"
+	assert_success
+	run awk '/^  publish:/{p=1} p&&/contents: write/{exit 1} END{exit 0}' "$workflow"
+	assert_success
+}
+
+@test "reusable-deploy-pages: shares Pages concurrency group" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-deploy-pages.yml"
+	run grep -q 'group: pages-${{ github.repository }}-${{ github.ref }}' "$workflow"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_test_publish_workflows.bats
+++ b/tests/bats/integration/test_reusable_test_publish_workflows.bats
@@ -27,6 +27,29 @@ _publish_tooling_actions_ok() {
 	' "$workflow"
 }
 
+_publish_pages_contract_ok() {
+	local workflow="$1"
+	awk '
+		/^  publish:/ { in_publish = 1 }
+		in_publish && /name: github-pages/ { env = 1 }
+		in_publish && /id-token: write/ { id_token = 1 }
+		in_publish && /contents: read/ { contents_read = 1 }
+		in_publish && /group: pages-\$\{\{ github.repository \}\}-\$\{\{ github.ref \}\}/ {
+			concurrency = 1
+		}
+		END { exit !(env && id_token && contents_read && concurrency) }
+	' "$workflow"
+}
+
+_publish_no_contents_write_ok() {
+	local workflow="$1"
+	awk '
+		/^  publish:/ { in_publish = 1 }
+		in_publish && /contents: write/ { exit 1 }
+		END { exit 0 }
+	' "$workflow"
+}
+
 @test "reusable-test-python-publish: checkout order preserves tooling in isolated jobs" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-test-python-publish.yml"
 	run _publish_checkout_order_ok "$workflow"
@@ -111,17 +134,17 @@ _publish_tooling_actions_ok() {
 
 @test "reusable-coverage: publish job uses official Pages contract" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-coverage.yml"
-	run awk '/^  publish:/{p=1} p&&/name: github-pages/{e=1} p&&/id-token: write/{i=1} p&&/contents: read/{r=1} p&&/group: pages-\$\{\{ github.repository \}\}-\$\{\{ github.ref \}\}/{c=1} END{exit !(e&&i&&r&&c)}' "$workflow"
+	run _publish_pages_contract_ok "$workflow"
 	assert_success
-	run awk '/^  publish:/{p=1} p&&/contents: write/{exit 1} END{exit 0}' "$workflow"
+	run _publish_no_contents_write_ok "$workflow"
 	assert_success
 }
 
 @test "reusable-test-e2e-matrix: publish job uses official Pages contract" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-test-e2e-matrix.yml"
-	run awk '/^  publish:/{p=1} p&&/name: github-pages/{e=1} p&&/id-token: write/{i=1} p&&/contents: read/{r=1} p&&/group: pages-\$\{\{ github.repository \}\}-\$\{\{ github.ref \}\}/{c=1} END{exit !(e&&i&&r&&c)}' "$workflow"
+	run _publish_pages_contract_ok "$workflow"
 	assert_success
-	run awk '/^  publish:/{p=1} p&&/contents: write/{exit 1} END{exit 0}' "$workflow"
+	run _publish_no_contents_write_ok "$workflow"
 	assert_success
 }
 

--- a/tests/bats/integration/test_reusable_test_publish_workflows.bats
+++ b/tests/bats/integration/test_reusable_test_publish_workflows.bats
@@ -67,7 +67,11 @@ _publish_tooling_actions_ok() {
 	local action="${PROJECT_ROOT}/.github/actions/publish-test-results/action.yml"
 	run grep -E 'peaceiris|actions-gh-pages' "$action"
 	assert_failure
-	run grep -qE 'actions/(configure-pages|upload-pages-artifact|deploy-pages)@' "$action"
+	run grep -q 'actions/configure-pages@' "$action"
+	assert_success
+	run grep -q 'actions/upload-pages-artifact@' "$action"
+	assert_success
+	run grep -q 'actions/deploy-pages@' "$action"
 	assert_success
 }
 


### PR DESCRIPTION
## Summary

Unify all lgtm-ci GitHub Pages publishing on official OIDC actions (`configure-pages`, `upload-pages-artifact`, `deploy-pages`). Replaces blocked `peaceiris/actions-gh-pages` and aligns test/coverage publish with `reusable-deploy-pages` / turbo-themes.

Closes #224.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Changes Made

- **`publish-test-results`**: official Pages deploy; removed `target-branch`, `keep-history`, `retention-days`; removed dead `deploy)` shell path
- **Publish workflows**: `reusable-test-python-publish`, `reusable-test-node-publish`, `reusable-coverage`, `reusable-test-e2e-matrix` — `github-pages` environment, `contents: read`, `id-token: write`, shared concurrency
- **`reusable-deploy-pages`**: same concurrency group as publishers
- **Docs**: `docs/pages-publishing.md`, `workflow-contract.md`, actions README, `reusable-workflows.md`
- **Tests**: BATS contract tests for all four publish paths + deploy-pages concurrency
- **CHANGELOG**: `[Unreleased]` entries

## Breaking Changes

- Removed `publish-test-results` inputs: `target-branch`, `keep-history`, `retention-days` (no in-repo or org consumers; peaceiris-only)
- Callers must use `contents: read` (not `write`) on Pages publish jobs
- Multiple publish workflows to the same site in one event overwrite each other (documented in `docs/pages-publishing.md`)

## Testing

- [x] BATS: `test_reusable_test_publish_workflows.bats` (13 tests)
- [x] `validate-action-pinning.sh`

## Test plan

- [ ] Merge and tag v0.19.1
- [ ] Repin consumer repos (e.g. py-lintro) to release SHA
- [ ] Confirm `Deploy Coverage to Pages` on py-lintro main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GitHub Pages deployments now use official GitHub Actions for improved reliability and security.
  * Added automatic concurrency controls to prevent conflicting simultaneous Pages deployments.

* **Documentation**
  * Added comprehensive GitHub Pages publishing guide covering permissions, configuration, and multi-publisher behavior.

* **Chores**
  * Simplified Pages configuration by removing legacy deployment inputs.
  * Updated workflow permissions to follow security best practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR migrates all lgtm-ci GitHub Pages publishing from `peaceiris/actions-gh-pages` to the official OIDC trio (`configure-pages`, `upload-pages-artifact`, `deploy-pages`), aligns permissions to `contents: read`, and introduces a shared concurrency group (`pages-${{ github.repository }}-${{ github.ref }}`) across every publish path.

- **`publish-test-results` composite action**: replaces the single `peaceiris` step with three official Pages steps; removes `target-branch`, `keep-history`, and `retention-days` inputs; derives the Pages URL directly from `actions/deploy-pages` output, falling back to `GITHUB_REPOSITORY` parsing for local runs.
- **Publish workflows** (`reusable-test-python-publish`, `reusable-test-node-publish`, `reusable-coverage`, `reusable-test-e2e-matrix`): each gains a `github-pages` environment block, `id-token: write`, and the shared concurrency group; `reusable-deploy-pages` concurrency group is widened to include the repository name so it serialises correctly with the test publishers.
- **Tests**: 10 new BATS contract tests verify the official Pages action references, absence of legacy inputs, permission shape, and concurrency group across all publish paths.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the migration is mechanically straightforward, all changed workflows have been updated consistently, and the breaking last-writer-wins behavior is explicitly documented.

The core action swap (peaceiris to three official steps) is correct and the permissions, concurrency groups, and environment blocks are consistently applied across all five publish paths. The two findings are test-quality nits with no impact on the deployed workflows or CI correctness.

No files require special attention for merge safety. The BATS helper in test_reusable_test_publish_workflows.bats has a minor robustness gap worth fixing in a follow-up.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/publish-test-results/action.yml | Replaces peaceiris/actions-gh-pages with three official Pages actions; removes target-branch, keep-history, retention-days inputs; wires BASE_PAGE_URL output from deploy-pages into the pages-url step. |
| scripts/ci/actions/publish-test-results.sh | Removes the deploy) case and keep-history logic; adds a removed-input guard; pages-url case now prefers BASE_PAGE_URL from deploy-pages and falls back to GITHUB_REPOSITORY parsing. |
| .github/workflows/reusable-test-node-publish.yml | Adds workflow-level concurrency group, github-pages environment block, id: publish on the Publish step, and downgrades contents: write to contents: read. |
| .github/workflows/reusable-test-python-publish.yml | Same changes as node-publish: workflow-level concurrency, environment block, id: publish, contents: read. |
| .github/workflows/reusable-coverage.yml | Adds job-level concurrency group, environment block, and downgrades contents permission in the publish job. |
| .github/workflows/reusable-test-e2e-matrix.yml | Adds job-level concurrency group, environment block, and id-token: write to the publish job. |
| .github/workflows/reusable-deploy-pages.yml | Fixes concurrency group from pages-ref-only to pages-repository-ref to match all other publishers. |
| tests/bats/integration/test_reusable_test_publish_workflows.bats | Adds 10 new contract tests; introduces _publish_pages_contract_ok and _publish_no_contents_write_ok helpers with an unbounded scope concern in the latter. |
| docs/pages-publishing.md | New doc covering caller permissions, egress allowlists, concurrency group, and the last-writer-wins multi-publisher limitation. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Caller Workflow
    participant PTP as reusable-test-*-publish / reusable-coverage
    participant PTR as publish-test-results (composite)
    participant CP as actions/configure-pages
    participant UPA as actions/upload-pages-artifact
    participant DP as actions/deploy-pages
    participant GH as GitHub Pages

    Caller->>PTP: workflow_call (contents:read, pages:write, id-token:write)
    Note over PTP: concurrency: pages-repo-ref (cancel-in-progress: false)
    PTP->>PTR: uses publish-test-results
    PTR->>CP: configure-pages (OIDC)
    CP-->>PTR: Pages configured
    PTR->>UPA: "upload-pages-artifact(path=staging-dir)"
    UPA-->>PTR: "artifact=github-pages uploaded"
    PTR->>DP: deploy-pages
    DP-->>GH: site deployed
    DP-->>PTR: page_url output
    PTR-->>PTP: pages-url output
    PTP-->>Caller: report-url / pages-url
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atests%2Fbats%2Fintegration%2Ftest_reusable_test_publish_workflows.bats%3A44-51%0A**%60_publish_no_contents_write_ok%60%20scope%20is%20unbounded%20past%20the%20%60publish%3A%60%20job**%0A%0AOnce%20%60in_publish%60%20is%20set%20on%20the%20%60%5E%20%20publish%3A%60%20pattern%20it%20is%20never%20reset%2C%20so%20every%20line%20in%20the%20file%20after%20that%20point%20is%20checked.%20Both%20currently%20tested%20files%20%28%60reusable-coverage.yml%60%2C%20%60reusable-test-e2e-matrix.yml%60%29%20happen%20to%20have%20%60publish%60%20as%20their%20last%20job%2C%20so%20the%20test%20passes%20today.%20If%20a%20job%20is%20ever%20appended%20after%20%60publish%3A%60%20with%20a%20legitimate%20%60contents%3A%20write%60%20permission%20%28e.g.%2C%20a%20%60notify%3A%60%20or%20%60cleanup%3A%60%20job%29%2C%20the%20helper%20would%20flag%20a%20false%20positive%20and%20block%20CI%20without%20a%20clear%20explanation.%20A%20simple%20counter%20or%20a%20sentinel%20pattern%20on%20the%20next%20top-level%20job%20key%20would%20bound%20the%20check%20to%20the%20intended%20block.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Factions%2Fpublish-test-results.sh%3A33-36%0A**Removed-input%20guard%20may%20fire%20on%20unrelated%20%60%24GITHUB_ENV%60%20exports**%0A%0AThe%20guard%20checks%20%60TARGET_BRANCH%60%2C%20%60KEEP_HISTORY%60%2C%20and%20%60RETENTION_DAYS%60%20using%20%60%5B%5B%20-n%20%22%24%7BVAR%3A-%7D%22%20%5D%5D%60%2C%20which%20matches%20any%20non-empty%20value%20%E2%80%94%20including%20variables%20exported%20to%20%60%24GITHUB_ENV%60%20by%20earlier%20steps%20in%20the%20same%20job%20for%20completely%20unrelated%20purposes.%20%60RETENTION_DAYS%60%20in%20particular%20is%20a%20natural%20name%20for%20artifact%20retention%20settings%2C%20and%20%60TARGET_BRANCH%60%20is%20common%20in%20PR%20automation%20scripts.%20Any%20caller%20that%20uses%20this%20action%20directly%20%28rather%20than%20through%20the%20reusable%20publish%20workflows%29%20and%20happens%20to%20export%20one%20of%20these%20names%20earlier%20in%20the%20same%20job%20will%20get%20an%20unexpected%20failure.%20Since%20the%20inputs%20are%20already%20removed%20from%20%60action.yml%60%20%E2%80%94%20so%20no%20caller%20can%20pass%20them%20through%20the%20normal%20input%20mechanism%20%E2%80%94%20the%20guard%20primarily%20catches%20env-level%20pollution.%20Renaming%20the%20env%20vars%20checked%20to%20something%20action-specific%20%28e.g.%2C%20%60LGTM_TARGET_BRANCH%60%29%20or%20simply%20removing%20the%20guard%20would%20avoid%20the%20false-positive%20risk.%0A%0A&pr=223&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atests%2Fbats%2Fintegration%2Ftest_reusable_test_publish_workflows.bats%3A44-51%0A**%60_publish_no_contents_write_ok%60%20scope%20is%20unbounded%20past%20the%20%60publish%3A%60%20job**%0A%0AOnce%20%60in_publish%60%20is%20set%20on%20the%20%60%5E%20%20publish%3A%60%20pattern%20it%20is%20never%20reset%2C%20so%20every%20line%20in%20the%20file%20after%20that%20point%20is%20checked.%20Both%20currently%20tested%20files%20%28%60reusable-coverage.yml%60%2C%20%60reusable-test-e2e-matrix.yml%60%29%20happen%20to%20have%20%60publish%60%20as%20their%20last%20job%2C%20so%20the%20test%20passes%20today.%20If%20a%20job%20is%20ever%20appended%20after%20%60publish%3A%60%20with%20a%20legitimate%20%60contents%3A%20write%60%20permission%20%28e.g.%2C%20a%20%60notify%3A%60%20or%20%60cleanup%3A%60%20job%29%2C%20the%20helper%20would%20flag%20a%20false%20positive%20and%20block%20CI%20without%20a%20clear%20explanation.%20A%20simple%20counter%20or%20a%20sentinel%20pattern%20on%20the%20next%20top-level%20job%20key%20would%20bound%20the%20check%20to%20the%20intended%20block.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Factions%2Fpublish-test-results.sh%3A33-36%0A**Removed-input%20guard%20may%20fire%20on%20unrelated%20%60%24GITHUB_ENV%60%20exports**%0A%0AThe%20guard%20checks%20%60TARGET_BRANCH%60%2C%20%60KEEP_HISTORY%60%2C%20and%20%60RETENTION_DAYS%60%20using%20%60%5B%5B%20-n%20%22%24%7BVAR%3A-%7D%22%20%5D%5D%60%2C%20which%20matches%20any%20non-empty%20value%20%E2%80%94%20including%20variables%20exported%20to%20%60%24GITHUB_ENV%60%20by%20earlier%20steps%20in%20the%20same%20job%20for%20completely%20unrelated%20purposes.%20%60RETENTION_DAYS%60%20in%20particular%20is%20a%20natural%20name%20for%20artifact%20retention%20settings%2C%20and%20%60TARGET_BRANCH%60%20is%20common%20in%20PR%20automation%20scripts.%20Any%20caller%20that%20uses%20this%20action%20directly%20%28rather%20than%20through%20the%20reusable%20publish%20workflows%29%20and%20happens%20to%20export%20one%20of%20these%20names%20earlier%20in%20the%20same%20job%20will%20get%20an%20unexpected%20failure.%20Since%20the%20inputs%20are%20already%20removed%20from%20%60action.yml%60%20%E2%80%94%20so%20no%20caller%20can%20pass%20them%20through%20the%20normal%20input%20mechanism%20%E2%80%94%20the%20guard%20primarily%20catches%20env-level%20pollution.%20Renaming%20the%20env%20vars%20checked%20to%20something%20action-specific%20%28e.g.%2C%20%60LGTM_TARGET_BRANCH%60%29%20or%20simply%20removing%20the%20guard%20would%20avoid%20the%20false-positive%20risk.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=223&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22fix%2Fpages-deploy-official-actions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpages-deploy-official-actions%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atests%2Fbats%2Fintegration%2Ftest_reusable_test_publish_workflows.bats%3A44-51%0A**%60_publish_no_contents_write_ok%60%20scope%20is%20unbounded%20past%20the%20%60publish%3A%60%20job**%0A%0AOnce%20%60in_publish%60%20is%20set%20on%20the%20%60%5E%20%20publish%3A%60%20pattern%20it%20is%20never%20reset%2C%20so%20every%20line%20in%20the%20file%20after%20that%20point%20is%20checked.%20Both%20currently%20tested%20files%20%28%60reusable-coverage.yml%60%2C%20%60reusable-test-e2e-matrix.yml%60%29%20happen%20to%20have%20%60publish%60%20as%20their%20last%20job%2C%20so%20the%20test%20passes%20today.%20If%20a%20job%20is%20ever%20appended%20after%20%60publish%3A%60%20with%20a%20legitimate%20%60contents%3A%20write%60%20permission%20%28e.g.%2C%20a%20%60notify%3A%60%20or%20%60cleanup%3A%60%20job%29%2C%20the%20helper%20would%20flag%20a%20false%20positive%20and%20block%20CI%20without%20a%20clear%20explanation.%20A%20simple%20counter%20or%20a%20sentinel%20pattern%20on%20the%20next%20top-level%20job%20key%20would%20bound%20the%20check%20to%20the%20intended%20block.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Factions%2Fpublish-test-results.sh%3A33-36%0A**Removed-input%20guard%20may%20fire%20on%20unrelated%20%60%24GITHUB_ENV%60%20exports**%0A%0AThe%20guard%20checks%20%60TARGET_BRANCH%60%2C%20%60KEEP_HISTORY%60%2C%20and%20%60RETENTION_DAYS%60%20using%20%60%5B%5B%20-n%20%22%24%7BVAR%3A-%7D%22%20%5D%5D%60%2C%20which%20matches%20any%20non-empty%20value%20%E2%80%94%20including%20variables%20exported%20to%20%60%24GITHUB_ENV%60%20by%20earlier%20steps%20in%20the%20same%20job%20for%20completely%20unrelated%20purposes.%20%60RETENTION_DAYS%60%20in%20particular%20is%20a%20natural%20name%20for%20artifact%20retention%20settings%2C%20and%20%60TARGET_BRANCH%60%20is%20common%20in%20PR%20automation%20scripts.%20Any%20caller%20that%20uses%20this%20action%20directly%20%28rather%20than%20through%20the%20reusable%20publish%20workflows%29%20and%20happens%20to%20export%20one%20of%20these%20names%20earlier%20in%20the%20same%20job%20will%20get%20an%20unexpected%20failure.%20Since%20the%20inputs%20are%20already%20removed%20from%20%60action.yml%60%20%E2%80%94%20so%20no%20caller%20can%20pass%20them%20through%20the%20normal%20input%20mechanism%20%E2%80%94%20the%20guard%20primarily%20catches%20env-level%20pollution.%20Renaming%20the%20env%20vars%20checked%20to%20something%20action-specific%20%28e.g.%2C%20%60LGTM_TARGET_BRANCH%60%29%20or%20simply%20removing%20the%20guard%20would%20avoid%20the%20false-positive%20risk.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (6): Last reviewed commit: ["test: extract Pages contract awk helpers..."](https://github.com/lgtm-hq/lgtm-ci/commit/75a2d95d815d582be22db722f7a840244bab3f57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33883942)</sub>

<!-- /greptile_comment -->