### PR TITLE
fix(ci): use newline-delimited types in reusable-semantic-pr-title

### DIFF
--- a/.github/workflows/reusable-semantic-pr-title.yml
+++ b/.github/workflows/reusable-semantic-pr-title.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+      tooling-ref:
+        description: "Git ref to use when checking out lgtm-ci tooling scripts"
+        required: false
+        type: string
+        default: ""
 
       egress-policy:
         description: "harden-runner egress policy (audit or block)"
@@ -56,48 +61,22 @@ jobs:
           egress-policy: ${{ inputs.egress-policy }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            scripts/ci/
+          persist-credentials: false
+
       - name: Prepare semantic PR lists
         id: prepare
-        shell: bash
         env:
           TYPES_INPUT: ${{ inputs.types }}
           SCOPES_INPUT: ${{ inputs.scopes }}
-        run: |
-          set -euo pipefail
-
-          normalize_list() {
-            local value="$1"
-            if [[ -z "${value//[[:space:]]/}" ]]; then
-              printf ''
-              return
-            fi
-            if [[ "$value" != *$'\n'* ]] && [[ "$value" == *","* ]]; then
-              value="${value//,/$'\n'}"
-            fi
-            printf '%s' "$value"
-          }
-
-          write_output() {
-            local name="$1"
-            local value="$2"
-            {
-              echo "${name}<<EOF"
-              printf '%s\n' "$value"
-              echo EOF
-            } >>"$GITHUB_OUTPUT"
-          }
-
-          default_types=$'feat\nfix\ndocs\nstyle\nrefactor\nperf\ntest\nbuild\nci\nchore\nrevert'
-
-          if [[ -z "${TYPES_INPUT//[[:space:]]/}" ]]; then
-            types="$default_types"
-          else
-            types="$(normalize_list "$TYPES_INPUT")"
-          fi
-          write_output types "$types"
-
-          scopes="$(normalize_list "$SCOPES_INPUT")"
-          write_output scopes "$scopes"
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/prepare-semantic-pr-lists.sh
 
       - name: Validate semantic PR title
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1

--- a/.github/workflows/reusable-semantic-pr-title.yml
+++ b/.github/workflows/reusable-semantic-pr-title.yml
@@ -5,12 +5,17 @@ on:
   workflow_call:
     inputs:
       types:
-        description: "Allowed conventional commit types"
+        description: >-
+          Allowed conventional commit types (newline-delimited; legacy
+          comma-separated values are normalized automatically). Leave empty
+          for the default list.
         required: false
         type: string
-        default: "feat,fix,docs,style,refactor,perf,test,build,ci,chore,revert"
+        default: ""
       scopes:
-        description: "Allowed scopes, comma-separated. Empty allows any scope."
+        description: >-
+          Allowed scopes (newline-delimited; legacy comma-separated values are
+          normalized automatically). Empty allows any scope.
         required: false
         type: string
         default: ""
@@ -51,11 +56,54 @@ jobs:
           egress-policy: ${{ inputs.egress-policy }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
+      - name: Prepare semantic PR lists
+        id: prepare
+        shell: bash
+        env:
+          TYPES_INPUT: ${{ inputs.types }}
+          SCOPES_INPUT: ${{ inputs.scopes }}
+        run: |
+          set -euo pipefail
+
+          normalize_list() {
+            local value="$1"
+            if [[ -z "${value//[[:space:]]/}" ]]; then
+              printf ''
+              return
+            fi
+            if [[ "$value" != *$'\n'* ]] && [[ "$value" == *","* ]]; then
+              value="${value//,/$'\n'}"
+            fi
+            printf '%s' "$value"
+          }
+
+          write_output() {
+            local name="$1"
+            local value="$2"
+            {
+              echo "${name}<<EOF"
+              printf '%s\n' "$value"
+              echo EOF
+            } >>"$GITHUB_OUTPUT"
+          }
+
+          default_types=$'feat\nfix\ndocs\nstyle\nrefactor\nperf\ntest\nbuild\nci\nchore\nrevert'
+
+          if [[ -z "${TYPES_INPUT//[[:space:]]/}" ]]; then
+            types="$default_types"
+          else
+            types="$(normalize_list "$TYPES_INPUT")"
+          fi
+          write_output types "$types"
+
+          scopes="$(normalize_list "$SCOPES_INPUT")"
+          write_output scopes "$scopes"
+
       - name: Validate semantic PR title
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          types: ${{ inputs.types }}
-          scopes: ${{ inputs.scopes }}
+          types: ${{ steps.prepare.outputs.types }}
+          scopes: ${{ steps.prepare.outputs.scopes }}
           requireScope: ${{ inputs.require-scope }}

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -299,6 +299,30 @@ All inputs are opt-in; existing callers keep current behavior without changes.
 
 ## PR Automation And Security
 
+### Semantic PR title
+
+`amannn/action-semantic-pull-request` expects **newline-delimited** `types` and
+`scopes`. The reusable workflow normalizes legacy comma-separated overrides and
+ships a correct default when `types` is omitted.
+
+Callers must grant `pull-requests: read` (workflow root `permissions: {}`
+otherwise strips PR access from the reusable job).
+
+```yaml
+jobs:
+  semantic-title:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@<sha>
+    permissions:
+      pull-requests: read
+    with:
+      egress-policy: audit
+      # Optional: override types (newline-delimited; CSV is normalized)
+      # types: |
+      #   feat
+      #   fix
+      #   ci
+```
+
 ```yaml
 jobs:
   label:
@@ -315,7 +339,9 @@ jobs:
   semantic-title:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@<sha>
     permissions:
-      contents: read
+      pull-requests: read
+    with:
+      egress-policy: audit
 
   action-pinning:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@<sha>

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -336,13 +336,6 @@ jobs:
     permissions:
       pull-requests: write
 
-  semantic-title:
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-semantic-pr-title.yml@<sha>
-    permissions:
-      pull-requests: read
-    with:
-      egress-policy: audit
-
   action-pinning:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-validate-action-pinning.yml@<sha>
     permissions:

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -175,9 +175,10 @@ caller workflows alongside `pull_request:`.
 Semantic title validation is intentionally skipped in the merge queue because
 `amannn/action-semantic-pull-request` requires pull request context.
 
-Callers need `pull-requests: read`. The workflow passes newline-delimited
-`types`/`scopes` to the action (empty `types` uses the built-in default;
-comma-separated overrides are normalized).
+Callers need `pull-requests: read`. Tooling is loaded from `lgtm-ci` via
+`prepare-semantic-pr-lists.sh` (supports `tooling-ref` for unreleased fixes).
+The workflow passes newline-delimited `types`/`scopes` to the action (empty
+`types` uses the built-in default; comma-separated overrides are normalized).
 
 ## Fork PR comments
 

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -175,6 +175,10 @@ caller workflows alongside `pull_request:`.
 Semantic title validation is intentionally skipped in the merge queue because
 `amannn/action-semantic-pull-request` requires pull request context.
 
+Callers need `pull-requests: read`. The workflow passes newline-delimited
+`types`/`scopes` to the action (empty `types` uses the built-in default;
+comma-separated overrides are normalized).
+
 ## Fork PR comments
 
 PR comments are skipped automatically on fork PRs (`head.repo.fork == true`).

--- a/scripts/ci/actions/prepare-semantic-pr-lists.sh
+++ b/scripts/ci/actions/prepare-semantic-pr-lists.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Normalize semantic PR types/scopes for action-semantic-pull-request
+#
+# Required environment variables:
+#   GITHUB_OUTPUT - GitHub Actions output file
+#   TYPES_INPUT   - Caller override for allowed types (optional)
+#   SCOPES_INPUT  - Caller override for allowed scopes (optional)
+
+set -euo pipefail
+
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+: "${TYPES_INPUT:=}"
+: "${SCOPES_INPUT:=}"
+
+normalize_list() {
+	local value="$1"
+	if [[ -z "${value//[[:space:]]/}" ]]; then
+		printf ''
+		return
+	fi
+	if [[ "$value" != *$'\n'* ]] && [[ "$value" == *","* ]]; then
+		value="${value//,/$'\n'}"
+	fi
+	printf '%s' "$value"
+}
+
+write_output() {
+	local name="$1"
+	local value="$2"
+	{
+		echo "${name}<<EOF"
+		printf '%s\n' "$value"
+		echo EOF
+	} >>"$GITHUB_OUTPUT"
+}
+
+default_types=$'feat\nfix\ndocs\nstyle\nrefactor\nperf\ntest\nbuild\nci\nchore\nrevert'
+
+if [[ -z "${TYPES_INPUT//[[:space:]]/}" ]]; then
+	types="$default_types"
+else
+	types="$(normalize_list "$TYPES_INPUT")"
+fi
+write_output types "$types"
+
+scopes="$(normalize_list "$SCOPES_INPUT")"
+write_output scopes "$scopes"

--- a/scripts/ci/actions/prepare-semantic-pr-lists.sh
+++ b/scripts/ci/actions/prepare-semantic-pr-lists.sh
@@ -9,30 +9,47 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+if [[ -f "$LIB_DIR/github/output.sh" ]]; then
+	# shellcheck source=../lib/github/output.sh
+	source "$LIB_DIR/github/output.sh"
+fi
+
 : "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
 : "${TYPES_INPUT:=}"
 : "${SCOPES_INPUT:=}"
 
 normalize_list() {
 	local value="$1"
+	local -a lines=()
+	local line trimmed
+
 	if [[ -z "${value//[[:space:]]/}" ]]; then
 		printf ''
 		return
 	fi
-	if [[ "$value" != *$'\n'* ]] && [[ "$value" == *","* ]]; then
+
+	if [[ "$value" == *","* ]]; then
 		value="${value//,/$'\n'}"
 	fi
-	printf '%s' "$value"
-}
 
-write_output() {
-	local name="$1"
-	local value="$2"
-	{
-		echo "${name}<<EOF"
-		printf '%s\n' "$value"
-		echo EOF
-	} >>"$GITHUB_OUTPUT"
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		trimmed="${line#"${line%%[![:space:]]*}"}"
+		trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+		if [[ -n "$trimmed" ]]; then
+			lines+=("$trimmed")
+		fi
+	done <<<"$value"
+
+	if ((${#lines[@]} == 0)); then
+		printf ''
+		return
+	fi
+
+	local IFS=$'\n'
+	printf '%s' "${lines[*]}"
 }
 
 default_types=$'feat\nfix\ndocs\nstyle\nrefactor\nperf\ntest\nbuild\nci\nchore\nrevert'
@@ -42,7 +59,9 @@ if [[ -z "${TYPES_INPUT//[[:space:]]/}" ]]; then
 else
 	types="$(normalize_list "$TYPES_INPUT")"
 fi
-write_output types "$types"
+set_github_output_multiline types "$types"
 
 scopes="$(normalize_list "$SCOPES_INPUT")"
-write_output scopes "$scopes"
+if [[ -n "${scopes//[[:space:]]/}" ]]; then
+	set_github_output_multiline scopes "$scopes"
+fi

--- a/scripts/ci/actions/prepare-semantic-pr-lists.sh
+++ b/scripts/ci/actions/prepare-semantic-pr-lists.sh
@@ -56,6 +56,9 @@ if [[ -z "${TYPES_INPUT//[[:space:]]/}" ]]; then
 	types="$default_types"
 else
 	types="$(normalize_list "$TYPES_INPUT")"
+	if [[ -z "${types//[[:space:]]/}" ]]; then
+		types="$default_types"
+	fi
 fi
 set_github_output_multiline types "$types"
 

--- a/scripts/ci/actions/prepare-semantic-pr-lists.sh
+++ b/scripts/ci/actions/prepare-semantic-pr-lists.sh
@@ -12,10 +12,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
 LIB_DIR="$SCRIPT_DIR/../lib"
 
-if [[ -f "$LIB_DIR/github/output.sh" ]]; then
-	# shellcheck source=../lib/github/output.sh
-	source "$LIB_DIR/github/output.sh"
-fi
+# shellcheck source=../lib/github/output.sh
+source "$LIB_DIR/github/output.sh"
 
 : "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
 : "${TYPES_INPUT:=}"

--- a/tests/bats/integration/test_reusable_semantic_pr_title_workflow.bats
+++ b/tests/bats/integration/test_reusable_semantic_pr_title_workflow.bats
@@ -51,4 +51,16 @@ SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/prepare-semantic-pr-lists.sh"
 @test "prepare-semantic-pr-lists: normalizes comma-separated lists" {
 	run grep -F 'value="${value//,/$'\''\n'\''}"' "$SCRIPT"
 	assert_success
+	run grep -F 'set_github_output_multiline' "$SCRIPT"
+	assert_success
+}
+
+@test "prepare-semantic-pr-lists: writes scopes only when non-empty" {
+	run awk '
+		/set_github_output_multiline scopes/ { found = 1 }
+		END { exit !found }
+	' "$SCRIPT"
+	assert_success
+	run grep -F 'if [[ -n "${scopes//[[:space:]]/}" ]]; then' "$SCRIPT"
+	assert_success
 }

--- a/tests/bats/integration/test_reusable_semantic_pr_title_workflow.bats
+++ b/tests/bats/integration/test_reusable_semantic_pr_title_workflow.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-semantic-pr-title workflow
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-semantic-pr-title.yml"
+
+@test "reusable-semantic-pr-title: passes types via prepare step output" {
+	run grep -E '^[[:space:]]+types: \$\{\{ steps\.prepare\.outputs\.types \}\}$' \
+		"$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-semantic-pr-title: does not pass raw types input to action" {
+	run grep -E '^[[:space:]]+types: \$\{\{ inputs\.types \}\}$' "$WORKFLOW"
+	assert_failure
+}
+
+@test "reusable-semantic-pr-title: prepare step normalizes comma-separated lists" {
+	run grep -F 'value="${value//,/$'\''\n'\''}"' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-semantic-pr-title: default types are newline-delimited" {
+	run grep -F "default_types=\$'feat\\nfix\\n" "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-semantic-pr-title: types input default is empty" {
+	run awk '/^      types:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: ""'
+}
+
+@test "reusable-semantic-pr-title: job grants pull-requests read" {
+	run grep -E '^[[:space:]]+pull-requests: read$' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_semantic_pr_title_workflow.bats
+++ b/tests/bats/integration/test_reusable_semantic_pr_title_workflow.bats
@@ -53,11 +53,16 @@ SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/prepare-semantic-pr-lists.sh"
 }
 
 @test "reusable-semantic-pr-title: checks out tooling scripts via sparse-checkout" {
-	local expected='          sparse-checkout: |'
+	local expected_key='          sparse-checkout: |'
+	local expected_entry='            scripts/ci/'
 
 	run grep -F 'sparse-checkout: |' "$WORKFLOW"
 	assert_success
-	assert_equal "$expected" "$output"
+	assert_equal "$expected_key" "$output"
+
+	run grep -E '^            scripts/ci/$' "$WORKFLOW"
+	assert_success
+	assert_equal "$expected_entry" "$output"
 }
 
 @test "reusable-semantic-pr-title: types input default is empty" {

--- a/tests/bats/integration/test_reusable_semantic_pr_title_workflow.bats
+++ b/tests/bats/integration/test_reusable_semantic_pr_title_workflow.bats
@@ -8,9 +8,12 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-semantic-pr-title.yml"
 SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/prepare-semantic-pr-lists.sh"
 
 @test "reusable-semantic-pr-title: passes types via prepare step output" {
+	local expected='          types: ${{ steps.prepare.outputs.types }}'
+
 	run grep -E '^[[:space:]]+types: \$\{\{ steps\.prepare\.outputs\.types \}\}$' \
 		"$WORKFLOW"
 	assert_success
+	assert_equal "$expected" "$output"
 }
 
 @test "reusable-semantic-pr-title: does not pass raw types input to action" {
@@ -18,17 +21,43 @@ SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/prepare-semantic-pr-lists.sh"
 	assert_failure
 }
 
+@test "reusable-semantic-pr-title: passes scopes via prepare step output" {
+	local expected='          scopes: ${{ steps.prepare.outputs.scopes }}'
+
+	run grep -E '^[[:space:]]+scopes: \$\{\{ steps\.prepare\.outputs\.scopes \}\}$' \
+		"$WORKFLOW"
+	assert_success
+	assert_equal "$expected" "$output"
+}
+
+@test "reusable-semantic-pr-title: does not pass raw scopes input to action" {
+	run grep -E '^[[:space:]]+scopes: \$\{\{ inputs\.scopes \}\}$' "$WORKFLOW"
+	assert_failure
+}
+
 @test "reusable-semantic-pr-title: prepare step runs tooling script" {
+	local expected='        run: bash .lgtm-ci-tooling/scripts/ci/actions/prepare-semantic-pr-lists.sh'
+
 	run grep -F 'bash .lgtm-ci-tooling/scripts/ci/actions/prepare-semantic-pr-lists.sh' \
 		"$WORKFLOW"
 	assert_success
+	assert_equal "$expected" "$output"
 }
 
-@test "reusable-semantic-pr-title: checks out lgtm-ci tooling scripts" {
+@test "reusable-semantic-pr-title: checks out lgtm-ci tooling path" {
+	local expected='          path: .lgtm-ci-tooling'
+
 	run grep -F 'path: .lgtm-ci-tooling' "$WORKFLOW"
 	assert_success
+	assert_equal "$expected" "$output"
+}
+
+@test "reusable-semantic-pr-title: checks out tooling scripts via sparse-checkout" {
+	local expected='          sparse-checkout: |'
+
 	run grep -F 'sparse-checkout: |' "$WORKFLOW"
 	assert_success
+	assert_equal "$expected" "$output"
 }
 
 @test "reusable-semantic-pr-title: types input default is empty" {
@@ -39,20 +68,35 @@ SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/prepare-semantic-pr-lists.sh"
 }
 
 @test "reusable-semantic-pr-title: job grants pull-requests read" {
+	local expected='      pull-requests: read'
+
 	run grep -E '^[[:space:]]+pull-requests: read$' "$WORKFLOW"
 	assert_success
+	assert_equal "$expected" "$output"
 }
 
 @test "prepare-semantic-pr-lists: default types are newline-delimited" {
+	local expected=$'default_types=$\'feat\\nfix\\ndocs\\nstyle\\nrefactor\\nperf\\ntest\\nbuild\\nci\\nchore\\nrevert\''
+
 	run grep -F "default_types=\$'feat\\nfix\\n" "$SCRIPT"
 	assert_success
+	assert_equal "$expected" "$output"
 }
 
 @test "prepare-semantic-pr-lists: normalizes comma-separated lists" {
+	local expected='		value="${value//,/$'\''\n'\''}"'
+
 	run grep -F 'value="${value//,/$'\''\n'\''}"' "$SCRIPT"
 	assert_success
-	run grep -F 'set_github_output_multiline' "$SCRIPT"
+	assert_equal "$expected" "$output"
+}
+
+@test "prepare-semantic-pr-lists: uses shared multiline output helper" {
+	local expected='set_github_output_multiline types "$types"'
+
+	run grep -F 'set_github_output_multiline types "$types"' "$SCRIPT"
 	assert_success
+	assert_equal "$expected" "$output"
 }
 
 @test "prepare-semantic-pr-lists: writes scopes only when non-empty" {
@@ -61,6 +105,10 @@ SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/prepare-semantic-pr-lists.sh"
 		END { exit !found }
 	' "$SCRIPT"
 	assert_success
+
+	local expected='if [[ -n "${scopes//[[:space:]]/}" ]]; then'
+
 	run grep -F 'if [[ -n "${scopes//[[:space:]]/}" ]]; then' "$SCRIPT"
 	assert_success
+	assert_equal "$expected" "$output"
 }

--- a/tests/bats/integration/test_reusable_semantic_pr_title_workflow.bats
+++ b/tests/bats/integration/test_reusable_semantic_pr_title_workflow.bats
@@ -5,6 +5,7 @@
 load "../../helpers/common"
 
 WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-semantic-pr-title.yml"
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/prepare-semantic-pr-lists.sh"
 
 @test "reusable-semantic-pr-title: passes types via prepare step output" {
 	run grep -E '^[[:space:]]+types: \$\{\{ steps\.prepare\.outputs\.types \}\}$' \
@@ -17,13 +18,16 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-semantic-pr-title.yml"
 	assert_failure
 }
 
-@test "reusable-semantic-pr-title: prepare step normalizes comma-separated lists" {
-	run grep -F 'value="${value//,/$'\''\n'\''}"' "$WORKFLOW"
+@test "reusable-semantic-pr-title: prepare step runs tooling script" {
+	run grep -F 'bash .lgtm-ci-tooling/scripts/ci/actions/prepare-semantic-pr-lists.sh' \
+		"$WORKFLOW"
 	assert_success
 }
 
-@test "reusable-semantic-pr-title: default types are newline-delimited" {
-	run grep -F "default_types=\$'feat\\nfix\\n" "$WORKFLOW"
+@test "reusable-semantic-pr-title: checks out lgtm-ci tooling scripts" {
+	run grep -F 'path: .lgtm-ci-tooling' "$WORKFLOW"
+	assert_success
+	run grep -F 'sparse-checkout: |' "$WORKFLOW"
 	assert_success
 }
 
@@ -36,5 +40,15 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-semantic-pr-title.yml"
 
 @test "reusable-semantic-pr-title: job grants pull-requests read" {
 	run grep -E '^[[:space:]]+pull-requests: read$' "$WORKFLOW"
+	assert_success
+}
+
+@test "prepare-semantic-pr-lists: default types are newline-delimited" {
+	run grep -F "default_types=\$'feat\\nfix\\n" "$SCRIPT"
+	assert_success
+}
+
+@test "prepare-semantic-pr-lists: normalizes comma-separated lists" {
+	run grep -F 'value="${value//,/$'\''\n'\''}"' "$SCRIPT"
 	assert_success
 }

--- a/tests/bats/unit/ci/test_prepare_semantic_pr_lists.bats
+++ b/tests/bats/unit/ci/test_prepare_semantic_pr_lists.bats
@@ -16,27 +16,43 @@ teardown() {
 @test "prepare-semantic-pr-lists: uses built-in default when types input empty" {
 	TYPES_INPUT="" SCOPES_INPUT="" run bash "$SCRIPT"
 	assert_success
-	types="$(get_github_output types)"
-	[[ "$types" == $'feat\nfix\ndocs\nstyle\nrefactor\nperf\ntest\nbuild\nci\nchore\nrevert' ]]
+	assert_github_output types $'feat\nfix\ndocs\nstyle\nrefactor\nperf\ntest\nbuild\nci\nchore\nrevert'
+	run grep -E '^scopes(=|<<)' "$GITHUB_OUTPUT"
+	assert_failure
 }
 
 @test "prepare-semantic-pr-lists: normalizes comma-separated types" {
 	TYPES_INPUT="feat,fix,ci" SCOPES_INPUT="" run bash "$SCRIPT"
 	assert_success
-	types="$(get_github_output types)"
-	[[ "$types" == $'feat\nfix\nci' ]]
+	assert_github_output types $'feat\nfix\nci'
+}
+
+@test "prepare-semantic-pr-lists: trims whitespace around CSV entries" {
+	TYPES_INPUT="feat, fix, docs" SCOPES_INPUT="" run bash "$SCRIPT"
+	assert_success
+	assert_github_output types $'feat\nfix\ndocs'
 }
 
 @test "prepare-semantic-pr-lists: preserves newline-delimited types" {
 	TYPES_INPUT=$'feat\nfix' SCOPES_INPUT="" run bash "$SCRIPT"
 	assert_success
-	types="$(get_github_output types)"
-	[[ "$types" == $'feat\nfix' ]]
+	assert_github_output types $'feat\nfix'
+}
+
+@test "prepare-semantic-pr-lists: normalizes commas in mixed-format input" {
+	TYPES_INPUT=$'feat,fix\n ci' SCOPES_INPUT="" run bash "$SCRIPT"
+	assert_success
+	assert_github_output types $'feat\nfix\nci'
 }
 
 @test "prepare-semantic-pr-lists: normalizes comma-separated scopes" {
 	TYPES_INPUT="" SCOPES_INPUT="ci,deps" run bash "$SCRIPT"
 	assert_success
-	scopes="$(get_github_output scopes)"
-	[[ "$scopes" == $'ci\ndeps' ]]
+	assert_github_output scopes $'ci\ndeps'
+}
+
+@test "prepare-semantic-pr-lists: preserves delimiter when value contains EOF line" {
+	TYPES_INPUT=$'feat\nEOF\nfix' SCOPES_INPUT="" run bash "$SCRIPT"
+	assert_success
+	assert_github_output types $'feat\nEOF\nfix'
 }

--- a/tests/bats/unit/ci/test_prepare_semantic_pr_lists.bats
+++ b/tests/bats/unit/ci/test_prepare_semantic_pr_lists.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+
+load "../../../helpers/common"
+load "../../../helpers/github_env"
+
+setup() {
+	setup_github_env
+	export SCRIPT="$PROJECT_ROOT/scripts/ci/actions/prepare-semantic-pr-lists.sh"
+}
+
+teardown() {
+	teardown_github_env
+}
+
+@test "prepare-semantic-pr-lists: uses built-in default when types input empty" {
+	TYPES_INPUT="" SCOPES_INPUT="" run bash "$SCRIPT"
+	assert_success
+	types="$(get_github_output types)"
+	[[ "$types" == $'feat\nfix\ndocs\nstyle\nrefactor\nperf\ntest\nbuild\nci\nchore\nrevert' ]]
+}
+
+@test "prepare-semantic-pr-lists: normalizes comma-separated types" {
+	TYPES_INPUT="feat,fix,ci" SCOPES_INPUT="" run bash "$SCRIPT"
+	assert_success
+	types="$(get_github_output types)"
+	[[ "$types" == $'feat\nfix\nci' ]]
+}
+
+@test "prepare-semantic-pr-lists: preserves newline-delimited types" {
+	TYPES_INPUT=$'feat\nfix' SCOPES_INPUT="" run bash "$SCRIPT"
+	assert_success
+	types="$(get_github_output types)"
+	[[ "$types" == $'feat\nfix' ]]
+}
+
+@test "prepare-semantic-pr-lists: normalizes comma-separated scopes" {
+	TYPES_INPUT="" SCOPES_INPUT="ci,deps" run bash "$SCRIPT"
+	assert_success
+	scopes="$(get_github_output scopes)"
+	[[ "$scopes" == $'ci\ndeps' ]]
+}

--- a/tests/bats/unit/ci/test_prepare_semantic_pr_lists.bats
+++ b/tests/bats/unit/ci/test_prepare_semantic_pr_lists.bats
@@ -21,6 +21,12 @@ teardown() {
 	assert_failure
 }
 
+@test "prepare-semantic-pr-lists: falls back to default when types normalize empty" {
+	TYPES_INPUT="," SCOPES_INPUT="" run bash "$SCRIPT"
+	assert_success
+	assert_github_output types $'feat\nfix\ndocs\nstyle\nrefactor\nperf\ntest\nbuild\nci\nchore\nrevert'
+}
+
 @test "prepare-semantic-pr-lists: normalizes comma-separated types" {
 	TYPES_INPUT="feat,fix,ci" SCOPES_INPUT="" run bash "$SCRIPT"
 	assert_success


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Fixes semantic PR title validation for consumers of `reusable-semantic-pr-title.yml`.
The reusable workflow now prepares newline-delimited `types` and `scopes` for
`amannn/action-semantic-pull-request` v6 (including CSV normalization for legacy
overrides) instead of passing a single comma-separated string.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. Callers passing multiline `types` (e.g. py-lintro workaround) continue to work;
callers relying on the old CSV default should remove the override or pass
newline-delimited values.

## Closes

- Closes #228

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `reusable-semantic-pr-title` workflow to use newline-delimited types and scopes
> - Adds a prepare step that runs [`prepare-semantic-pr-lists.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/229/files#diff-025c1ec7a2fb58f8a84c3accddef39af68c2e35b15d9dd23eea120e5fae4ec30) to normalize caller-provided `types` and `scopes` inputs (CSV or newline-delimited) before passing them to `amannn/action-semantic-pull-request`.
> - When `types` is omitted or normalizes to empty, a built-in default list is used; `scopes` output is omitted entirely when empty.
> - Adds a checkout step to pull lgtm-ci tooling via sparse-checkout, with an optional `tooling-ref` input to select the git ref.
> - Updates docs and adds unit and integration tests for the normalization logic and workflow wiring.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12940f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support newline-delimited semantic PR types/scopes; legacy comma-separated values are auto-normalized.
  * `types` default changed to empty so built-in defaults apply when omitted.
  * Added a tooling-ref option and a prepare step that normalizes inputs before validation.

* **Documentation**
  * Clarified input formats, normalization behavior, default handling, and requirement to grant pull-requests: read.

* **Tests**
  * Added unit and integration tests covering normalization, defaults, and workflow behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes semantic PR title validation for consumers of `reusable-semantic-pr-title.yml` by introducing a `prepare-semantic-pr-lists.sh` helper script that normalizes `types` and `scopes` inputs into the newline-delimited format required by `amannn/action-semantic-pull-request` v6, replacing the previous raw CSV passthrough.

- Adds `prepare-semantic-pr-lists.sh` that converts CSV inputs to newline-delimited format, trims whitespace, handles mixed CSV+newline inputs, and defaults to a built-in type list when `types` is omitted.
- Updates the reusable workflow to checkout the lgtm-ci tooling (pinned to `github.workflow_sha` by default, overridable via `tooling-ref`), run the prepare script, and feed its outputs to the action.
- Adds unit and integration Bats tests covering normalization, whitespace trimming, delimiter safety, and workflow wiring; the shared `set_github_output_multiline` helper already uses a unique `LGTM_CI_EOF_<PID>_<timestamp>` delimiter, making the earlier EOF-collision concern moot.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the normalization logic is correct, the shared output helper uses a collision-resistant delimiter, and the workflow wiring is verified by both unit and integration tests.

The prepare script correctly handles all input variants (pure CSV, pure newline-delimited, mixed, empty, whitespace-only) and falls back to a sensible default. The `set_github_output_multiline` function in the shared lib already uses a unique PID+timestamp delimiter, so the earlier EOF-collision concern is fully resolved. Mixed-format inputs are handled because the comma check fires independently of the newline check, and the dedicated test confirms this. The workflow correctly uses `github.workflow_sha` as the tooling ref fallback, ensuring the scripts always match the pinned workflow version.

No files require special attention. The integration tests use grep-based structural assertions that are sensitive to YAML indentation, but they correctly reflect current formatting and guard the critical wiring.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/actions/prepare-semantic-pr-lists.sh | New normalization script; logic is correct — comma-to-newline conversion handles mixed-format inputs, whitespace trimming is safe, and empty-types fallback to built-in defaults works as expected. |
| .github/workflows/reusable-semantic-pr-title.yml | Adds checkout of lgtm-ci tooling (sparse, no persisted credentials), runs prepare script, and passes normalized outputs to the action; ternary fallback to github.workflow_sha is correct for version consistency. |
| tests/bats/unit/ci/test_prepare_semantic_pr_lists.bats | Unit tests use assert_github_output for readable failure diagnostics; covers defaults, CSV normalization, whitespace trimming, mixed-format, and EOF-in-value edge case. |
| tests/bats/integration/test_reusable_semantic_pr_title_workflow.bats | Contract tests verify workflow wiring via grep/awk against the YAML and script files; correct but brittle to whitespace/indentation changes. |
| docs/reusable-workflows.md | Adds a usage example for the semantic-title job with correct pull-requests: read permission; removes the old contents: read entry that no longer applies. |
| docs/workflow-contract.md | Brief addendum documenting the pull-requests: read requirement, tooling-ref support, and newline-delimited format — accurate and consistent with implementation. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Caller Workflow
    participant RW as reusable-semantic-pr-title
    participant Checkout as actions/checkout
    participant Prepare as prepare-semantic-pr-lists.sh
    participant Action as amannn/action-semantic-pull-request

    Caller->>RW: workflow_call (types?, scopes?, tooling-ref?)
    RW->>Checkout: "clone lgtm-hq/lgtm-ci@workflow_sha (sparse: scripts/ci/)"
    Checkout-->>RW: .lgtm-ci-tooling/scripts/ci/
    RW->>Prepare: TYPES_INPUT, SCOPES_INPUT
    Note over Prepare: normalize CSV to newline-delimited, trim whitespace, fallback to built-in default
    Prepare-->>RW: GITHUB_OUTPUT types (always), scopes (if non-empty)
    RW->>Action: types, scopes, requireScope, GITHUB_TOKEN
    Action-->>RW: pass / fail PR title check
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(ci): fallback empty normalized types..."](https://github.com/lgtm-hq/lgtm-ci/commit/12940f590441e18e174b41bb9262c9595ddbdcd2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33934993)</sub>

<!-- /greptile_comment -->