### PR TITLE
feat(workflows): consolidate Python release publish reusables

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1631,7 +1631,7 @@ jobs:
     with:
       python-version: "3.12"
       artifact-name: python-dist
-      tooling-ref: "<sha> # vX.Y.Z"
+      tooling-ref: "<sha>" # vX.Y.Z
 ```
 
 Pair with `reusable-github-release.yml` using the same `artifact-name`. See

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1614,6 +1614,58 @@ jobs:
 
 ---
 
+### reusable-publish-pypi-release.yml
+
+Split build and publish jobs for production tag releases. Uploads a distribution
+artifact from the build job and publishes it with OIDC + provenance attestation
+in a separate job.
+
+```yaml
+jobs:
+  publish:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@main
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    with:
+      python-version: "3.12"
+      artifact-name: python-dist
+      tooling-ref: "<sha> # vX.Y.Z"
+```
+
+Pair with `reusable-github-release.yml` using the same `artifact-name`. See
+[docs/python-release-publish.md](../../docs/python-release-publish.md).
+
+**Outputs:** `published`, `version`, `package-name`
+
+---
+
+### reusable-github-release.yml
+
+Download a workflow artifact and create a GitHub Release with attached assets
+via `softprops/action-gh-release`.
+
+```yaml
+jobs:
+  github-release:
+    needs: publish
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@main
+    permissions:
+      contents: write
+    with:
+      artifact-name: python-dist
+      generate-release-notes: true
+```
+
+**Outputs:** `release-url`, `release-id`
+
+**Permissions Required:**
+
+- `contents: write` - Create release and upload assets
+
+---
+
 ### reusable-publish-npm.yml
 
 Publish Node.js packages to npm with provenance attestation.

--- a/.github/workflows/reusable-github-release.yml
+++ b/.github/workflows/reusable-github-release.yml
@@ -105,6 +105,30 @@ jobs:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.artifact-path }}
 
+      - name: Verify release assets exist
+        shell: bash
+        env:
+          FILES: >-
+            ${{ inputs.files != '' && inputs.files ||
+            format('{0}/*', inputs.artifact-path) }}
+          ARTIFACT_PATH: ${{ inputs.artifact-path }}
+        run: |
+          shopt -s nullglob
+          count=0
+          while IFS= read -r pattern || [[ -n "$pattern" ]]; do
+            [[ -z "${pattern// /}" ]] && continue
+            for file in $pattern; do
+              if [[ -f "$file" ]]; then
+                count=$((count + 1))
+              fi
+            done
+          done <<< "$FILES"
+          if (( count == 0 )); then
+            echo "::error::No release assets matched FILES patterns (artifact-path=${ARTIFACT_PATH})"
+            exit 1
+          fi
+          echo "Found ${count} release asset(s)"
+
       - name: Create GitHub Release
         id: gh-release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2

--- a/.github/workflows/reusable-github-release.yml
+++ b/.github/workflows/reusable-github-release.yml
@@ -56,6 +56,11 @@ on:
         required: false
         type: string
         default: ""
+      tooling-ref:
+        description: "Git ref to use when checking out lgtm-ci tooling scripts"
+        required: false
+        type: string
+        default: ""
       job-name:
         description: "GitHub check name for the release job"
         required: false
@@ -99,6 +104,17 @@ jobs:
           egress-policy: ${{ inputs.egress-policy }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
 
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
       - name: Download release assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -112,22 +128,8 @@ jobs:
             ${{ inputs.files != '' && inputs.files ||
             format('{0}/*', inputs.artifact-path) }}
           ARTIFACT_PATH: ${{ inputs.artifact-path }}
-        run: |
-          shopt -s nullglob
-          count=0
-          while IFS= read -r pattern || [[ -n "$pattern" ]]; do
-            [[ -z "${pattern// /}" ]] && continue
-            for file in $pattern; do
-              if [[ -f "$file" ]]; then
-                count=$((count + 1))
-              fi
-            done
-          done <<< "$FILES"
-          if (( count == 0 )); then
-            echo "::error::No release assets matched FILES patterns (artifact-path=${ARTIFACT_PATH})"
-            exit 1
-          fi
-          echo "Found ${count} release asset(s)"
+        run: >-
+          .lgtm-ci-tooling/scripts/ci/release/verify-release-assets.sh
 
       - name: Create GitHub Release
         id: gh-release

--- a/.github/workflows/reusable-github-release.yml
+++ b/.github/workflows/reusable-github-release.yml
@@ -1,0 +1,119 @@
+---
+name: Reusable GitHub Release Workflow
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: "Artifact to download and attach to the release"
+        required: false
+        type: string
+        default: "python-dist"
+      artifact-path:
+        description: "Directory to extract the artifact into"
+        required: false
+        type: string
+        default: "dist"
+      tag-name:
+        description: "Release tag (defaults to github.ref_name)"
+        required: false
+        type: string
+        default: ""
+      release-name:
+        description: "Release title (defaults to tag name)"
+        required: false
+        type: string
+        default: ""
+      generate-release-notes:
+        description: "Use GitHub auto-generated release notes"
+        required: false
+        type: boolean
+        default: true
+      files:
+        description: "Newline-separated asset globs for softprops/action-gh-release"
+        required: false
+        type: string
+        default: |
+          dist/*
+      draft:
+        description: "Create as draft release"
+        required: false
+        type: boolean
+        default: false
+      prerelease:
+        description: "Mark as prerelease"
+        required: false
+        type: boolean
+        default: false
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      job-name:
+        description: "GitHub check name for the release job"
+        required: false
+        type: string
+        default: "Create GitHub Release"
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 15
+
+    outputs:
+      release-url:
+        description: "URL of the created GitHub release"
+        value: ${{ jobs.release.outputs.release-url }}
+      release-id:
+        description: "ID of the created GitHub release"
+        value: ${{ jobs.release.outputs.release-id }}
+
+jobs:
+  release:
+    name: ${{ inputs.job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: write
+
+    outputs:
+      release-url: ${{ steps.gh-release.outputs.url }}
+      release-id: ${{ steps.gh-release.outputs.id }}
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+
+      - name: Download release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.artifact-path }}
+
+      - name: Create GitHub Release
+        id: gh-release
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        with:
+          tag_name: >-
+            ${{ inputs.tag-name != '' && inputs.tag-name || github.ref_name }}
+          name: >-
+            ${{ inputs.release-name != '' && inputs.release-name ||
+            (inputs.tag-name != '' && inputs.tag-name || github.ref_name) }}
+          generate_release_notes: ${{ inputs.generate-release-notes }}
+          draft: ${{ inputs.draft }}
+          prerelease: ${{ inputs.prerelease }}
+          files: ${{ inputs.files }}

--- a/.github/workflows/reusable-github-release.yml
+++ b/.github/workflows/reusable-github-release.yml
@@ -86,7 +86,7 @@ jobs:
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
-      contents: write
+      contents: write # create GitHub releases and upload release assets
 
     outputs:
       release-url: ${{ steps.gh-release.outputs.url }}

--- a/.github/workflows/reusable-github-release.yml
+++ b/.github/workflows/reusable-github-release.yml
@@ -30,11 +30,12 @@ on:
         type: boolean
         default: true
       files:
-        description: "Newline-separated asset globs for softprops/action-gh-release"
+        description: >-
+          Newline-separated asset globs for softprops/action-gh-release.
+          Defaults to "{artifact-path}/*" when empty.
         required: false
         type: string
-        default: |
-          dist/*
+        default: ""
       draft:
         description: "Create as draft release"
         required: false
@@ -116,4 +117,6 @@ jobs:
           generate_release_notes: ${{ inputs.generate-release-notes }}
           draft: ${{ inputs.draft }}
           prerelease: ${{ inputs.prerelease }}
-          files: ${{ inputs.files }}
+          files: >-
+            ${{ inputs.files != '' && inputs.files ||
+            format('{0}/*', inputs.artifact-path) }}

--- a/.github/workflows/reusable-publish-pypi-release.yml
+++ b/.github/workflows/reusable-publish-pypi-release.yml
@@ -166,8 +166,8 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       contents: read
-      id-token: write
-      attestations: write
+      id-token: write # OIDC token for PyPI Trusted Publishing
+      attestations: write # build provenance attestation
 
     outputs:
       published: ${{ steps.set-published.outputs.published }}

--- a/.github/workflows/reusable-publish-pypi-release.yml
+++ b/.github/workflows/reusable-publish-pypi-release.yml
@@ -212,9 +212,8 @@ jobs:
         env:
           STEP: validate-dist
           WORKING_DIRECTORY: ${{ inputs.working-directory }}
-        run: |
-          uv pip install --system twine
-          bash .lgtm-ci-tooling/scripts/ci/actions/publish-pypi.sh
+        run: >-
+          .lgtm-ci-tooling/scripts/ci/actions/publish-pypi.sh
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
@@ -232,4 +231,7 @@ jobs:
       - name: Set publish output
         id: set-published
         shell: bash
-        run: echo "published=true" >> "$GITHUB_OUTPUT"
+        env:
+          STEP: set-published
+        run: >-
+          .lgtm-ci-tooling/scripts/ci/actions/publish-pypi.sh

--- a/.github/workflows/reusable-publish-pypi-release.yml
+++ b/.github/workflows/reusable-publish-pypi-release.yml
@@ -215,12 +215,12 @@ jobs:
             'https://upload.pypi.org/legacy/' }}
           packages-dir: ${{ inputs.working-directory }}/dist/
 
-      - name: Set publish output
-        id: set-published
-        shell: bash
-        run: echo "published=true" >> "$GITHUB_OUTPUT"
-
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: ${{ inputs.working-directory }}/dist/*
+
+      - name: Set publish output
+        id: set-published
+        shell: bash
+        run: echo "published=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable-publish-pypi-release.yml
+++ b/.github/workflows/reusable-publish-pypi-release.yml
@@ -193,6 +193,13 @@ jobs:
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
+      - name: Setup Python
+        uses: ./.lgtm-ci-tooling/.github/actions/setup-python
+        with:
+          python-version: ${{ inputs.python-version }}
+          working-directory: ${{ inputs.working-directory }}
+          install-dependencies: "false"
+
       - name: Download Python distribution
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -205,7 +212,9 @@ jobs:
         env:
           STEP: validate-dist
           WORKING_DIRECTORY: ${{ inputs.working-directory }}
-        run: bash .lgtm-ci-tooling/scripts/ci/actions/publish-pypi.sh
+        run: |
+          uv pip install twine
+          bash .lgtm-ci-tooling/scripts/ci/actions/publish-pypi.sh
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/reusable-publish-pypi-release.yml
+++ b/.github/workflows/reusable-publish-pypi-release.yml
@@ -1,5 +1,5 @@
 ---
-name: Reusable PyPI Publishing Workflow
+name: Reusable PyPI Release Publishing Workflow
 
 on:
   workflow_call:
@@ -16,26 +16,6 @@ on:
         default: true
       test-pypi:
         description: "Publish to TestPyPI instead of PyPI"
-        required: false
-        type: boolean
-        default: false
-      update-homebrew:
-        description: "Update Homebrew formula after publishing"
-        required: false
-        type: boolean
-        default: false
-      homebrew-tap:
-        description: "Homebrew tap repository (owner/repo)"
-        required: false
-        type: string
-        default: ""
-      homebrew-formula:
-        description: "Homebrew formula name"
-        required: false
-        type: string
-        default: ""
-      dry-run:
-        description: "Build only, do not publish"
         required: false
         type: boolean
         default: false
@@ -59,6 +39,16 @@ on:
         required: false
         type: string
         default: "."
+      artifact-name:
+        description: "Name of the uploaded Python distribution artifact"
+        required: false
+        type: string
+        default: "python-dist"
+      artifact-retention-days:
+        description: "Days to retain the distribution artifact"
+        required: false
+        type: number
+        default: 7
       tooling-ref:
         description: "Git ref to use when checking out lgtm-ci tooling scripts"
         required: false
@@ -74,11 +64,26 @@ on:
         required: false
         type: string
         default: ""
-      job-name:
+      build-job-name:
+        description: "GitHub check name for the build job"
+        required: false
+        type: string
+        default: "Build Python distribution"
+      publish-job-name:
         description: "GitHub check name for the publish job"
         required: false
         type: string
-        default: "Publish to PyPI"
+        default: "Upload to PyPI"
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 15
 
     outputs:
       published:
@@ -92,16 +97,14 @@ on:
         value: ${{ jobs.publish.outputs.package-name }}
 
 jobs:
-  publish:
-    name: ${{ inputs.job-name }}
-    runs-on: ubuntu-latest
+  build-artifacts:
+    name: ${{ inputs.build-job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       contents: read
-      id-token: write
-      attestations: write
 
     outputs:
-      published: ${{ steps.pypi.outputs.published }}
       version: ${{ steps.pypi.outputs.version }}
       package-name: ${{ steps.pypi.outputs.package-name }}
 
@@ -137,33 +140,39 @@ jobs:
           working-directory: ${{ inputs.working-directory }}
           install-dependencies: "false"
 
-      - name: Publish to PyPI
+      - name: Build Python distribution
         id: pypi
         uses: ./.lgtm-ci-tooling/.github/actions/publish-pypi
         with:
           validate: ${{ inputs.validate }}
-          test-pypi: ${{ inputs.test-pypi }}
-          dry-run: ${{ inputs.dry-run }}
+          dry-run: true
           verify-tag-version: ${{ inputs.verify-tag-version }}
           ensure-tag-on-default-branch: ${{ inputs.ensure-tag-on-default-branch }}
           default-branch: ${{ inputs.default-branch }}
           working-directory: ${{ inputs.working-directory }}
 
-      - name: Attest build provenance
-        if: inputs.dry-run == false
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      - name: Upload Python distribution
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          subject-path: ${{ inputs.working-directory }}/dist/*
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.working-directory }}/dist/
+          retention-days: ${{ inputs.artifact-retention-days }}
+          if-no-files-found: error
 
-  update-homebrew:
-    name: Update Homebrew Formula
-    needs: publish
-    if: >-
-      inputs.update-homebrew && inputs.dry-run == false &&
-      needs.publish.outputs.published == 'true'
-    runs-on: ubuntu-latest
+  publish:
+    name: ${{ inputs.publish-job-name }}
+    needs: build-artifacts
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
-      contents: write
+      contents: read
+      id-token: write
+      attestations: write
+
+    outputs:
+      published: ${{ steps.set-published.outputs.published }}
+      version: ${{ needs.build-artifacts.outputs.version }}
+      package-name: ${{ needs.build-artifacts.outputs.package-name }}
 
     steps:
       - name: Harden runner
@@ -171,9 +180,6 @@ jobs:
         with:
           egress-policy: ${{ inputs.egress-policy }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
-
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -184,13 +190,37 @@ jobs:
           sparse-checkout: |
             .github/actions/
             scripts/ci/
+          sparse-checkout-cone-mode: true
           persist-credentials: false
-      - name: Update Homebrew formula
-        uses: ./.lgtm-ci-tooling/.github/actions/update-homebrew
+
+      - name: Download Python distribution
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          tap-repository: ${{ inputs.homebrew-tap }}
-          formula: ${{ inputs.homebrew-formula }}
-          package-name: ${{ needs.publish.outputs.package-name }}
-          version: ${{ needs.publish.outputs.version }}
-          wait-for-availability: "true"
-          test-pypi: ${{ inputs.test-pypi }}
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.working-directory }}/dist
+
+      - name: Validate distribution
+        if: inputs.validate
+        shell: bash
+        env:
+          STEP: validate-dist
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/publish-pypi.sh
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: >-
+            ${{ inputs.test-pypi == true && 'https://test.pypi.org/legacy/' ||
+            'https://upload.pypi.org/legacy/' }}
+          packages-dir: ${{ inputs.working-directory }}/dist/
+
+      - name: Set publish output
+        id: set-published
+        shell: bash
+        run: echo "published=true" >> "$GITHUB_OUTPUT"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: ${{ inputs.working-directory }}/dist/*

--- a/.github/workflows/reusable-publish-pypi-release.yml
+++ b/.github/workflows/reusable-publish-pypi-release.yml
@@ -213,7 +213,7 @@ jobs:
           STEP: validate-dist
           WORKING_DIRECTORY: ${{ inputs.working-directory }}
         run: |
-          uv pip install twine
+          uv pip install --system twine
           bash .lgtm-ci-tooling/scripts/ci/actions/publish-pypi.sh
 
       - name: Publish to PyPI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **workflows**: `reusable-publish-pypi.yml` installs Python via `setup-python`
   before building (#232)
 
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
-
 ## [0.20.0] - 2026-05-27
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **workflows**: `reusable-publish-pypi-release.yml` and
+  `reusable-github-release.yml` for split Python release publishing (#232)
+- **docs**: Python release publishing guide (`docs/python-release-publish.md`) (#232)
+
 ### Changed
+
+- **workflows**: `reusable-publish-pypi.yml` installs Python via `setup-python`
+  before building (#232)
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ steps:
 | `reusable-release-version-pr.yml`      | Release version PR with changelog      |
 | `reusable-release-auto-tag.yml`        | Tag + GitHub release on merge          |
 | `reusable-publish-pypi.yml`            | PyPI publishing with OIDC              |
+| `reusable-publish-pypi-release.yml`    | Split PyPI build and publish           |
+| `reusable-github-release.yml`          | GitHub Release with artifact assets    |
 | `reusable-publish-npm.yml`             | npm publishing                         |
 | `reusable-publish-gem.yml`             | RubyGems publishing                    |
 | `reusable-publish-homebrew.yml`        | Homebrew formula publishing            |

--- a/docs/python-release-publish.md
+++ b/docs/python-release-publish.md
@@ -79,6 +79,7 @@ jobs:
         fulcio.sigstore.dev:443
         rekor.sigstore.dev:443
         tuf-repo-cdn.sigstore.dev:443
+        oauth2.sigstore.dev:443
 
   github-release:
     needs: [publish]
@@ -93,6 +94,9 @@ jobs:
         github.com:443
         api.github.com:443
         uploads.github.com:443
+        codeload.github.com:443
+        release-assets.githubusercontent.com:443
+        objects.githubusercontent.com:443
 ```
 
 Use the same `artifact-name` for `reusable-publish-pypi-release.yml` and

--- a/docs/python-release-publish.md
+++ b/docs/python-release-publish.md
@@ -89,6 +89,7 @@ jobs:
       contents: write
     with:
       artifact-name: python-dist
+      tooling-ref: "<sha>" # vX.Y.Z
       generate-release-notes: true
       egress-policy: block
       allowed-endpoints: >

--- a/docs/python-release-publish.md
+++ b/docs/python-release-publish.md
@@ -103,11 +103,14 @@ jobs:
 
 Use the same `artifact-name` for `reusable-publish-pypi-release.yml` and
 `reusable-github-release.yml` so the release job downloads the wheel/sdist
-uploaded by the build job. The release workflow defaults to uploading all files
-from `{artifact-path}/*` as release assets. Only override the `files` input if
-you need custom globbing patterns or if you change the default `artifact-path`.
-Changing `files` without updating `artifact-path` points at the wrong uploaded
-assets.
+uploaded by the build job. When `inputs.files` is empty, the release workflow
+defaults asset globs to `{artifact-path}/*` (via `format('{0}/*',
+inputs.artifact-path)`; default `artifact-path` is `dist`) for both the verify
+step (`FILES`) and `softprops/action-gh-release` (`files`). If you override
+`inputs.files`, ensure those glob patterns match the files actually placed in
+the artifact download path — you do not need to change `inputs.artifact-path`
+just because you customized `files`. `ARTIFACT_PATH` is only used in verify
+error messages.
 
 ## TestPyPI (single job)
 

--- a/docs/python-release-publish.md
+++ b/docs/python-release-publish.md
@@ -1,0 +1,143 @@
+# Python release publishing
+
+Guide for composing lgtm-ci reusables in Python package release workflows (tag
+push or manual dispatch). Callers keep product-specific steps (Homebrew binary,
+Docker images, bootstrap actions) local and delegate the shared publish path to
+lgtm-ci.
+
+## Workflows
+
+| Workflow | Purpose |
+| --- | --- |
+| `reusable-publish-pypi.yml` | Single-job TestPyPI or simple tag publish |
+| `reusable-publish-pypi-release.yml` | Split build artifact + OIDC publish + attestation |
+| `reusable-github-release.yml` | Attach artifacts to a GitHub Release |
+
+There is **no orchestrator** workflow. Compose jobs in the caller repository,
+matching the pattern from #231 (`reusable-quality-lint.yml` +
+`reusable-quality-pr-comment.yml` invoked directly).
+
+## Production tag push (recommended layout)
+
+Typical caller jobs:
+
+1. **Quality** — `reusable-quality-lint.yml` (not the removed orchestrator)
+2. **SBOM** — `reusable-sbom.yml` with `security-events: write`
+3. **Build + publish** — `reusable-publish-pypi-release.yml`
+4. **GitHub Release** — `reusable-github-release.yml` (`needs: publish`)
+5. **Product-specific** — local workflows (Homebrew tap, Docker, etc.)
+
+```yaml
+permissions: {}
+
+jobs:
+  quality:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@<sha> # vX.Y.Z
+    permissions:
+      contents: read
+      packages: read
+    with:
+      tooling-ref: "<sha> # vX.Y.Z"
+      egress-policy: block
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        ghcr.io:443
+
+  sbom:
+    needs: quality
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@<sha> # vX.Y.Z
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      attestations: write
+    with:
+      tooling-ref: "<sha> # vX.Y.Z"
+      egress-policy: block
+
+  publish:
+    needs: [quality, sbom]
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@<sha> # vX.Y.Z
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    with:
+      python-version: "3.12"
+      tooling-ref: "<sha> # vX.Y.Z"
+      artifact-name: python-dist
+      egress-policy: block
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        pypi.org:443
+        upload.pypi.org:443
+        files.pythonhosted.org:443
+        astral.sh:443
+        releases.astral.sh:443
+        fulcio.sigstore.dev:443
+        rekor.sigstore.dev:443
+        tuf-repo-cdn.sigstore.dev:443
+
+  github-release:
+    needs: [publish]
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@<sha> # vX.Y.Z
+    permissions:
+      contents: write
+    with:
+      artifact-name: python-dist
+      generate-release-notes: true
+      egress-policy: block
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        uploads.github.com:443
+```
+
+Use the same `artifact-name` for `reusable-publish-pypi-release.yml` and
+`reusable-github-release.yml` so the release job downloads the wheel/sdist
+uploaded by the build job.
+
+## TestPyPI (single job)
+
+For staging/manual publishes, keep the existing single-job reusable:
+
+```yaml
+jobs:
+  publish:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi.yml@<sha> # vX.Y.Z
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    with:
+      test-pypi: true
+      update-homebrew: false
+      python-version: "3.12"
+      tooling-ref: "<sha> # vX.Y.Z"
+```
+
+## Caller permissions summary
+
+| Job | Required permissions |
+| --- | --- |
+| Quality lint | `contents: read`, `packages: read` |
+| SBOM | `contents: read`, `security-events: write`, `id-token: write`, `attestations: write` |
+| PyPI publish | `contents: read`, `id-token: write`, `attestations: write` |
+| GitHub Release | `contents: write` |
+
+Nested reusable workflows validate permissions at parse time. Grant only what
+each job needs; do not set top-level `permissions: write-all`.
+
+## Egress allowlists
+
+When `egress-policy: block`, pass `allowed-endpoints` from the caller or rely
+on audit mode during rollout. See [workflow-contract.md](workflow-contract.md)
+for shared endpoint patterns.
+
+## Related docs
+
+- [workflow-contract.md](workflow-contract.md) — standard inputs and permission matrix
+- [reusable-workflows.md](reusable-workflows.md) — full workflow catalog
+- [pages-publishing.md](pages-publishing.md) — test coverage Pages deploy (separate path)

--- a/docs/python-release-publish.md
+++ b/docs/python-release-publish.md
@@ -37,7 +37,7 @@ jobs:
       contents: read
       packages: read
     with:
-      tooling-ref: "<sha> # vX.Y.Z"
+      tooling-ref: "<sha>" # vX.Y.Z
       egress-policy: block
       allowed-endpoints: >
         github.com:443
@@ -53,7 +53,7 @@ jobs:
       id-token: write
       attestations: write
     with:
-      tooling-ref: "<sha> # vX.Y.Z"
+      tooling-ref: "<sha>" # vX.Y.Z
       egress-policy: block
 
   publish:
@@ -65,7 +65,7 @@ jobs:
       attestations: write
     with:
       python-version: "3.12"
-      tooling-ref: "<sha> # vX.Y.Z"
+      tooling-ref: "<sha>" # vX.Y.Z
       artifact-name: python-dist
       egress-policy: block
       allowed-endpoints: >
@@ -97,7 +97,9 @@ jobs:
 
 Use the same `artifact-name` for `reusable-publish-pypi-release.yml` and
 `reusable-github-release.yml` so the release job downloads the wheel/sdist
-uploaded by the build job.
+uploaded by the build job. `reusable-github-release.yml` defaults release asset
+globs to `{artifact-path}/*`; override `files` only when you also change
+`artifact-path`.
 
 ## TestPyPI (single job)
 
@@ -115,7 +117,7 @@ jobs:
       test-pypi: true
       update-homebrew: false
       python-version: "3.12"
-      tooling-ref: "<sha> # vX.Y.Z"
+      tooling-ref: "<sha>" # vX.Y.Z
 ```
 
 ## Caller permissions summary

--- a/docs/python-release-publish.md
+++ b/docs/python-release-publish.md
@@ -14,8 +14,9 @@ lgtm-ci.
 | `reusable-github-release.yml` | Attach artifacts to a GitHub Release |
 
 There is **no orchestrator** workflow. Compose jobs in the caller repository,
-matching the pattern from #231 (`reusable-quality-lint.yml` +
-`reusable-quality-pr-comment.yml` invoked directly).
+matching the pattern from the split quality workflows PR
+([#231](https://github.com/lgtm-hq/lgtm-ci/pull/231): `reusable-quality-lint.yml`
+and `reusable-quality-pr-comment.yml` invoked directly).
 
 ## Production tag push (recommended layout)
 
@@ -101,9 +102,11 @@ jobs:
 
 Use the same `artifact-name` for `reusable-publish-pypi-release.yml` and
 `reusable-github-release.yml` so the release job downloads the wheel/sdist
-uploaded by the build job. `reusable-github-release.yml` defaults release asset
-globs to `{artifact-path}/*`; override `files` only when you also change
-`artifact-path`.
+uploaded by the build job. The release workflow defaults to uploading all files
+from `{artifact-path}/*` as release assets. Only override the `files` input if
+you need custom globbing patterns or if you change the default `artifact-path`.
+Changing `files` without updating `artifact-path` points at the wrong uploaded
+assets.
 
 ## TestPyPI (single job)
 

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -208,6 +208,21 @@ jobs:
       id-token: write
       attestations: write
 
+  pypi-release:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@<sha>
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+
+  github-release:
+    needs: pypi-release
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@<sha>
+    permissions:
+      contents: write
+    with:
+      artifact-name: python-dist
+
   gem:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-gem.yml@<sha>
     permissions:
@@ -229,6 +244,9 @@ jobs:
       build-command: bun run build
       package-manager: bun
 ```
+
+See [python-release-publish.md](python-release-publish.md) for a full production
+tag-push layout (quality, SBOM, split publish, release assets).
 
 ## Build, Coverage, And Supply Chain
 

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -214,6 +214,8 @@ jobs:
       contents: read
       id-token: write
       attestations: write
+    with:
+      tooling-ref: "<sha>" # vX.Y.Z
 
   github-release:
     needs: pypi-release

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -224,6 +224,7 @@ jobs:
       contents: write
     with:
       artifact-name: python-dist
+      tooling-ref: "<sha>" # vX.Y.Z
 
   gem:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-gem.yml@<sha>

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -50,6 +50,8 @@ would worsen check-name readability) and to access matrix-specific artifacts.
 | Publish to Pages | `contents: read`, `pages: write`, `id-token: write` | Separate publish job |
 | Release version | `contents: write`, `pull-requests: write` | `reusable-release-version-pr.yml` |
 | Package publish | `contents: read`, `id-token: write`, `attestations: write` | Publish reusables |
+| Split PyPI publish | Same as Package publish | `reusable-publish-pypi-release.yml` |
+| GitHub Release assets | `contents: write` | `reusable-github-release.yml` |
 
 `reusable-test-node.yml` no longer includes a publish job. Use
 `reusable-test-node-publish.yml` in a separate caller job when publishing is
@@ -144,6 +146,40 @@ allowed-endpoints: >
   codeload.github.com:443
   objects.githubusercontent.com:443
   release-assets.githubusercontent.com:443
+```
+
+### PyPI publish (OIDC + attestation)
+
+```yaml
+egress-policy: block
+allowed-endpoints: >
+  github.com:443
+  api.github.com:443
+  codeload.github.com:443
+  pypi.org:443
+  upload.pypi.org:443
+  files.pythonhosted.org:443
+  test.pypi.org:443
+  upload.test.pypi.org:443
+  astral.sh:443
+  releases.astral.sh:443
+  fulcio.sigstore.dev:443
+  rekor.sigstore.dev:443
+  tuf-repo-cdn.sigstore.dev:443
+  oauth2.sigstore.dev:443
+```
+
+### GitHub Release (artifact upload)
+
+```yaml
+egress-policy: block
+allowed-endpoints: >
+  github.com:443
+  api.github.com:443
+  uploads.github.com:443
+  codeload.github.com:443
+  release-assets.githubusercontent.com:443
+  objects.githubusercontent.com:443
 ```
 
 ## Action pinning policy

--- a/scripts/ci/actions/publish-pypi.sh
+++ b/scripts/ci/actions/publish-pypi.sh
@@ -3,7 +3,7 @@
 # Purpose: Build and publish Python packages to PyPI
 #
 # Environment variables:
-#   STEP: preflight | validate | build | validate-dist | summary
+#   STEP: preflight | validate | build | validate-dist | set-published | summary
 #   WORKING_DIRECTORY: Directory containing the package (default: .)
 #   VERIFY_TAG_VERSION: Verify git tag matches pyproject.toml version
 #   ENSURE_TAG_ON_DEFAULT_BRANCH: Verify tagged commit is on the default branch
@@ -136,11 +136,20 @@ validate-dist)
 		die "dist/ directory not found"
 	fi
 
+	if command -v uv >/dev/null 2>&1 && ! command -v twine >/dev/null 2>&1; then
+		log_info "Installing twine for validation..."
+		uv pip install --system twine
+	fi
+
 	if validate_pypi_package "dist"; then
 		log_success "Distribution validation passed"
 	else
 		die "Distribution validation failed"
 	fi
+	;;
+
+set-published)
+	set_github_output "published" "true"
 	;;
 
 summary)

--- a/scripts/ci/release/verify-release-assets.sh
+++ b/scripts/ci/release/verify-release-assets.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Verify release asset globs match at least one file before creating a release
+#
+# Required environment variables:
+#   FILES - Newline-separated asset glob patterns
+#
+# Optional environment variables:
+#   ARTIFACT_PATH - Artifact directory (for error messages only)
+
+set -euo pipefail
+
+: "${FILES:?FILES is required}"
+: "${ARTIFACT_PATH:=dist}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/log.sh
+source "$SCRIPT_DIR/../lib/log.sh"
+
+shopt -s nullglob
+count=0
+while IFS= read -r pattern || [[ -n "$pattern" ]]; do
+	[[ -z "${pattern// /}" ]] && continue
+	for file in $pattern; do
+		if [[ -f "$file" ]]; then
+			count=$((count + 1))
+		fi
+	done
+done <<<"$FILES"
+
+if ((count == 0)); then
+	log_error "No release assets matched FILES patterns (artifact-path=${ARTIFACT_PATH})"
+	exit 1
+fi
+
+log_success "Found ${count} release asset(s)"

--- a/tests/bats/integration/test_reusable_python_release_publish.bats
+++ b/tests/bats/integration/test_reusable_python_release_publish.bats
@@ -53,7 +53,7 @@ _tooling_sparse_cone_ok() {
 	run awk '
 		/^  publish:/ { in_publish = 1 }
 		in_publish && /STEP: validate-dist/ { validate = 1 }
-		in_publish && /uv pip install twine/ { twine = 1 }
+		in_publish && /uv pip install --system twine/ { twine = 1 }
 		in_publish && /gh-action-pypi-publish@/ { pypi = 1 }
 		in_publish && /attest-build-provenance@/ { attest = 1 }
 		END { exit !(validate && twine && pypi && attest) }
@@ -133,7 +133,7 @@ _tooling_sparse_cone_ok() {
 		END { exit !(download && verify && release) }
 	' "$workflow"
 	assert_success
-	run grep -Fq "format('{0}/*', inputs.artifact-path)" "$workflow"
+	run grep -Eq "format\\(['\"]\\{0\\}/\\*['\"],\\s*inputs\\.artifact-path\\)" "$workflow"
 	assert_success
 }
 

--- a/tests/bats/integration/test_reusable_python_release_publish.bats
+++ b/tests/bats/integration/test_reusable_python_release_publish.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for Python release publish reusables (#232)
+
+load "../../helpers/common"
+
+_checkout_order_ok() {
+	local workflow="$1"
+	local job_pattern="$2"
+	awk -v job="$job_pattern" '
+		$0 ~ "^  " job ":" { in_job = 1 }
+		in_job && /^  [a-zA-Z0-9_-]+:/ && $0 !~ "^  " job ":" { in_job = 0 }
+		in_job && /^    steps:/ { in_steps = 1 }
+		in_job && in_steps && /^      - name: Harden runner/ { harden = NR }
+		in_job && in_steps && /^      - name: Checkout repository/ { repo = NR }
+		in_job && in_steps && /^      - name: Checkout lgtm-ci tooling/ { tooling = NR }
+		END {
+			ok = (harden > 0 && repo > 0 && tooling > 0 && harden < repo && repo < tooling)
+			exit !ok
+		}
+	' "$workflow"
+}
+
+_tooling_sparse_cone_ok() {
+	local workflow="$1"
+	run awk '
+		/sparse-checkout-cone-mode: true/ { found = 1; exit }
+		END { exit !found }
+	' "$workflow"
+}
+
+@test "reusable-publish-pypi-release: build job checkout order" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-publish-pypi-release.yml"
+	run _checkout_order_ok "$workflow" "build-artifacts"
+	assert_success
+}
+
+@test "reusable-publish-pypi-release: build uses publish-pypi dry-run and uploads artifact" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-publish-pypi-release.yml"
+	run awk '
+		/^  build-artifacts:/ { in_build = 1 }
+		/^  publish:/ { in_build = 0 }
+		in_build && /dry-run: true/ { dry_run = 1 }
+		in_build && /actions\/upload-artifact@/ { upload = 1 }
+		in_build && /publish-pypi/ { action = 1 }
+		END { exit !(dry_run && upload && action) }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-publish-pypi-release: publish job validates dist and attests" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-publish-pypi-release.yml"
+	run awk '
+		/^  publish:/ { in_publish = 1 }
+		in_publish && /STEP: validate-dist/ { validate = 1 }
+		in_publish && /gh-action-pypi-publish@/ { pypi = 1 }
+		in_publish && /attest-build-provenance@/ { attest = 1 }
+		END { exit !(validate && pypi && attest) }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-publish-pypi-release: publish job permissions" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-publish-pypi-release.yml"
+	run awk '
+		/^  publish:/ { in_publish = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  publish:/ { in_publish = 0 }
+		in_publish && /contents: read/ { contents = 1 }
+		in_publish && /id-token: write/ { id_token = 1 }
+		in_publish && /attestations: write/ { attestations = 1 }
+		in_publish && /contents: write/ { bad = 1 }
+		END { exit !(contents && id_token && attestations && !bad) }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-publish-pypi-release: exposes publish outputs" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-publish-pypi-release.yml"
+	run grep -q 'jobs.publish.outputs.published' "$workflow"
+	assert_success
+	run grep -q 'jobs.publish.outputs.version' "$workflow"
+	assert_success
+	run grep -q 'jobs.publish.outputs.package-name' "$workflow"
+	assert_success
+}
+
+@test "reusable-publish-pypi: wires python-version via setup-python" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-publish-pypi.yml"
+	run awk '
+		/setup-python/ { setup = 1 }
+		/python-version: \$\{\{ inputs.python-version \}\}/ { version = 1 }
+		/install-dependencies: "false"/ { no_deps = 1 }
+		END { exit !(setup && version && no_deps) }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-publish-pypi: tooling sparse checkout uses cone mode" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-publish-pypi.yml"
+	run _tooling_sparse_cone_ok "$workflow"
+	assert_success
+}
+
+@test "reusable-github-release: downloads artifact and uses softprops action" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-github-release.yml"
+	run awk '
+		/actions\/download-artifact@/ { download = 1 }
+		/softprops\/action-gh-release@/ { release = 1 }
+		END { exit !(download && release) }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-github-release: requires contents write only" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-github-release.yml"
+	run awk '
+		/^  release:/ { in_release = 1 }
+		in_release && /contents: write/ { contents_write = 1 }
+		in_release && /id-token: write/ { bad = 1 }
+		END { exit !(contents_write && !bad) }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-github-release: exposes release outputs" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-github-release.yml"
+	run grep -q 'jobs.release.outputs.release-url' "$workflow"
+	assert_success
+	run grep -q 'steps.gh-release.outputs.url' "$workflow"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_python_release_publish.bats
+++ b/tests/bats/integration/test_reusable_python_release_publish.bats
@@ -51,6 +51,7 @@ _tooling_sparse_cone_ok() {
 @test "reusable-publish-pypi-release: publish job validates dist and attests" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-publish-pypi-release.yml"
 	run awk '
+		/^  [a-zA-Z0-9_-]+:/ { in_publish = 0 }
 		/^  publish:/ { in_publish = 1 }
 		in_publish && /STEP: validate-dist/ { validate = 1 }
 		in_publish && /scripts\/ci\/actions\/publish-pypi\.sh/ { validate_script = 1 }
@@ -65,6 +66,7 @@ _tooling_sparse_cone_ok() {
 @test "reusable-publish-pypi-release: publish job installs Python before validate" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-publish-pypi-release.yml"
 	run awk '
+		/^  [a-zA-Z0-9_-]+:/ { in_publish = 0 }
 		/^  publish:/ { in_publish = 1 }
 		in_publish && /setup-python/ { setup = NR }
 		in_publish && /STEP: validate-dist/ { validate = NR }
@@ -76,6 +78,7 @@ _tooling_sparse_cone_ok() {
 @test "reusable-publish-pypi-release: sets published output after attestation" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-publish-pypi-release.yml"
 	run awk '
+		/^  [a-zA-Z0-9_-]+:/ { in_publish = 0 }
 		/^  publish:/ { in_publish = 1 }
 		in_publish && /attest-build-provenance@/ { attest = NR }
 		in_publish && /id: set-published/ { published = NR }
@@ -147,9 +150,9 @@ _tooling_sparse_cone_ok() {
 		/^  [a-zA-Z0-9_-]+:/ && !/^  release:/ { in_release = 0 }
 		in_release && /^    permissions:/ { in_permissions = 1 }
 		in_permissions && /^    [a-zA-Z0-9_-]+:/ && !/^    permissions:/ { in_permissions = 0 }
-		in_permissions && /^      [a-zA-Z0-9_-]+: write/ {
+		in_permissions && /^      [a-zA-Z0-9_-]+: / {
 			total_permissions++
-			if ($1 == "contents:") {
+			if ($1 == "contents:" && $2 == "write") {
 				contents_count++
 			}
 		}

--- a/tests/bats/integration/test_reusable_python_release_publish.bats
+++ b/tests/bats/integration/test_reusable_python_release_publish.bats
@@ -23,7 +23,7 @@ _checkout_order_ok() {
 
 _tooling_sparse_cone_ok() {
 	local workflow="$1"
-	run awk '
+	awk '
 		/sparse-checkout-cone-mode: true/ { found = 1; exit }
 		END { exit !found }
 	' "$workflow"
@@ -56,6 +56,17 @@ _tooling_sparse_cone_ok() {
 		in_publish && /gh-action-pypi-publish@/ { pypi = 1 }
 		in_publish && /attest-build-provenance@/ { attest = 1 }
 		END { exit !(validate && pypi && attest) }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-publish-pypi-release: sets published output after attestation" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-publish-pypi-release.yml"
+	run awk '
+		/^  publish:/ { in_publish = 1 }
+		in_publish && /attest-build-provenance@/ { attest = NR }
+		in_publish && /id: set-published/ { published = NR }
+		END { exit !(attest > 0 && published > 0 && attest < published) }
 	' "$workflow"
 	assert_success
 }
@@ -108,6 +119,8 @@ _tooling_sparse_cone_ok() {
 		/softprops\/action-gh-release@/ { release = 1 }
 		END { exit !(download && release) }
 	' "$workflow"
+	assert_success
+	run grep -Fq "format('{0}/*', inputs.artifact-path)" "$workflow"
 	assert_success
 }
 

--- a/tests/bats/integration/test_reusable_python_release_publish.bats
+++ b/tests/bats/integration/test_reusable_python_release_publish.bats
@@ -53,10 +53,11 @@ _tooling_sparse_cone_ok() {
 	run awk '
 		/^  publish:/ { in_publish = 1 }
 		in_publish && /STEP: validate-dist/ { validate = 1 }
-		in_publish && /uv pip install --system twine/ { twine = 1 }
+		in_publish && /scripts\/ci\/actions\/publish-pypi\.sh/ { validate_script = 1 }
+		in_publish && /run: \|/ { inline_shell = 1 }
 		in_publish && /gh-action-pypi-publish@/ { pypi = 1 }
 		in_publish && /attest-build-provenance@/ { attest = 1 }
-		END { exit !(validate && twine && pypi && attest) }
+		END { exit !(validate && validate_script && pypi && attest && !inline_shell) }
 	' "$workflow"
 	assert_success
 }
@@ -129,8 +130,10 @@ _tooling_sparse_cone_ok() {
 	run awk '
 		/actions\/download-artifact@/ { download = 1 }
 		/Verify release assets exist/ { verify = 1 }
+		/verify-release-assets\.sh/ { verify_script = 1 }
+		/run: \|/ { inline_shell = 1 }
 		/softprops\/action-gh-release@/ { release = 1 }
-		END { exit !(download && verify && release) }
+		END { exit !(download && verify && verify_script && release && !inline_shell) }
 	' "$workflow"
 	assert_success
 	run grep -Eq "format\\(['\"]\\{0\\}/\\*['\"],\\s*inputs\\.artifact-path\\)" "$workflow"

--- a/tests/bats/integration/test_reusable_python_release_publish.bats
+++ b/tests/bats/integration/test_reusable_python_release_publish.bats
@@ -53,9 +53,21 @@ _tooling_sparse_cone_ok() {
 	run awk '
 		/^  publish:/ { in_publish = 1 }
 		in_publish && /STEP: validate-dist/ { validate = 1 }
+		in_publish && /uv pip install twine/ { twine = 1 }
 		in_publish && /gh-action-pypi-publish@/ { pypi = 1 }
 		in_publish && /attest-build-provenance@/ { attest = 1 }
-		END { exit !(validate && pypi && attest) }
+		END { exit !(validate && twine && pypi && attest) }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-publish-pypi-release: publish job installs Python before validate" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-publish-pypi-release.yml"
+	run awk '
+		/^  publish:/ { in_publish = 1 }
+		in_publish && /setup-python/ { setup = NR }
+		in_publish && /STEP: validate-dist/ { validate = NR }
+		END { exit !(setup > 0 && validate > 0 && setup < validate) }
 	' "$workflow"
 	assert_success
 }
@@ -116,8 +128,9 @@ _tooling_sparse_cone_ok() {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-github-release.yml"
 	run awk '
 		/actions\/download-artifact@/ { download = 1 }
+		/Verify release assets exist/ { verify = 1 }
 		/softprops\/action-gh-release@/ { release = 1 }
-		END { exit !(download && release) }
+		END { exit !(download && verify && release) }
 	' "$workflow"
 	assert_success
 	run grep -Fq "format('{0}/*', inputs.artifact-path)" "$workflow"
@@ -128,9 +141,16 @@ _tooling_sparse_cone_ok() {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-github-release.yml"
 	run awk '
 		/^  release:/ { in_release = 1 }
-		in_release && /contents: write/ { contents_write = 1 }
-		in_release && /id-token: write/ { bad = 1 }
-		END { exit !(contents_write && !bad) }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  release:/ { in_release = 0 }
+		in_release && /^    permissions:/ { in_permissions = 1 }
+		in_permissions && /^    [a-zA-Z0-9_-]+:/ && !/^    permissions:/ { in_permissions = 0 }
+		in_permissions && /^      [a-zA-Z0-9_-]+: write/ {
+			total_permissions++
+			if ($1 == "contents:") {
+				contents_count++
+			}
+		}
+		END { exit !(contents_count == 1 && total_permissions == 1) }
 	' "$workflow"
 	assert_success
 }

--- a/tests/bats/unit/release/test_verify_release_assets.bats
+++ b/tests/bats/unit/release/test_verify_release_assets.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/release/verify-release-assets.sh
+
+load "../../../helpers/common"
+
+setup() {
+	setup_temp_dir
+	cd "${BATS_TEST_TMPDIR}" || exit 1
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "verify-release-assets: passes when files match glob" {
+	mkdir -p dist
+	echo "wheel" >dist/example-1.0.0-py3-none-any.whl
+
+	run env FILES="dist/*" ARTIFACT_PATH=dist \
+		bash "${PROJECT_ROOT}/scripts/ci/release/verify-release-assets.sh"
+
+	assert_success
+	assert_output --partial "Found 1 release asset(s)"
+}
+
+@test "verify-release-assets: fails when no files match glob" {
+	mkdir -p dist
+
+	run env FILES="dist/*" ARTIFACT_PATH=dist \
+		bash "${PROJECT_ROOT}/scripts/ci/release/verify-release-assets.sh"
+
+	assert_failure
+	assert_output --partial "No release assets matched FILES patterns"
+}
+
+@test "verify-release-assets: skips blank pattern lines" {
+	mkdir -p release
+	echo "sdist" >release/example-1.0.0.tar.gz
+
+	run env $'FILES=release/*\n\n' ARTIFACT_PATH=release \
+		bash "${PROJECT_ROOT}/scripts/ci/release/verify-release-assets.sh"
+
+	assert_success
+	assert_output --partial "Found 1 release asset(s)"
+}


### PR DESCRIPTION
## Summary

Add split Python release publish reusables so lgtm-hq Python repos can compose
production tag workflows without duplicating build, OIDC publish, attestation,
and GitHub Release glue. Callers keep product-specific steps (Homebrew binary,
Docker, bootstrap actions) local.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. Existing `reusable-publish-pypi.yml` callers gain `setup-python` before
build; behavior is unchanged aside from a more reliable Python/uv toolchain.

## Closes

- Closes #232

### Changes

- Add `reusable-publish-pypi-release.yml` (build artifact + OIDC publish + attestation jobs)
- Add `reusable-github-release.yml` (artifact download + `softprops/action-gh-release`)
- Wire `setup-python` into `reusable-publish-pypi.yml`
- Add `docs/python-release-publish.md` with caller composition example
- Update workflow contract, catalog docs, README, and CHANGELOG
- Add BATS contract tests in `test_reusable_python_release_publish.bats`

### Testing

- [x] `uv run lintro fmt` and `uv run lintro chk`
- [x] `bats tests/bats/integration/test_reusable_python_release_publish.bats`
- [x] `bats tests/bats/unit/actions/test_publish_pypi.bats`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add reusable split build/publish workflows for Python PyPI and GitHub releases
> - Adds [`reusable-publish-pypi-release.yml`](.github/workflows/reusable-publish-pypi-release.yml) which separates the Python distribution build (dry-run, artifact upload) from OIDC publishing to PyPI/TestPyPI, attestation, and a `published` output flag.
> - Adds [`reusable-github-release.yml`](.github/workflows/reusable-github-release.yml) which downloads a named workflow artifact, verifies at least one asset matches the configured file patterns via [`verify-release-assets.sh`](scripts/ci/release/verify-release-assets.sh), then calls `softprops/action-gh-release` and exposes `release-url` and `release-id` outputs.
> - Updates [`reusable-publish-pypi.yml`](.github/workflows/reusable-publish-pypi.yml) to install Python via the `setup-python` composite action (with `sparse-checkout-cone-mode: true`) before invoking the publish step.
> - Extends [`publish-pypi.sh`](scripts/ci/actions/publish-pypi.sh) with a `set-published` step and auto-bootstraps `twine` via `uv` when validating distributions.
> - Adds docs, CHANGELOG entries, and Bats integration/unit tests covering the new workflows and scripts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a66190.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two reusable workflows for split Python build/publish and GitHub Release attachments, plus a release-asset verification script for CI.

* **Documentation**
  * New Python release publishing guide and updates to workflow docs, README, and CHANGELOG describing publishing patterns, permissions, and egress examples.

* **Tests**
  * Added integration tests for reusable workflows and unit tests for the asset verification script.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces two new reusable workflows — `reusable-publish-pypi-release.yml` (split build + OIDC publish + attestation) and `reusable-github-release.yml` (artifact download + GitHub Release creation) — plus a supporting asset-verification script, BATS contract tests, and a `setup-python` injection into the existing `reusable-publish-pypi.yml`. Previous review findings around `setup-python` missing from the `publish` job and the ordering of `set-published` relative to attestation have both been addressed in this revision.

- `reusable-publish-pypi-release.yml` runs a two-job workflow that builds a Python distribution in one job, uploads it as an artifact, then downloads and publishes it with OIDC trusted publishing and `actions/attest-build-provenance` in a separate job.
- `reusable-github-release.yml` downloads the shared artifact, verifies at least one file is present via `verify-release-assets.sh`, and creates a GitHub Release using `softprops/action-gh-release`.
- Three issues flagged in earlier review rounds remain unresolved in the current HEAD: the `upload-artifact@v7` / `download-artifact@v8` major-version mismatch, the silent zero-asset-release risk when `artifact-path` is overridden without a matching `files` override, and the `_tooling_sparse_cone_ok` BATS helper that always returns success regardless of file contents.
</details>

<h3>Confidence Score: 3/5</h3>

Safe to merge only after the open artifact-version mismatch and silent-release issues are resolved; the core workflow logic is sound but two failure modes can cause real release runs to fail or silently produce incomplete releases.

Three findings from earlier review rounds remain open in the current HEAD. The upload-artifact@v7 / download-artifact@v8 mismatch means every actual release run through the split workflow will fail at the download step with an artifact-not-found error. The artifact-path / files default coupling means a caller who changes artifact-path without updating files will create a GitHub Release with zero attached assets and no warning. These are both defects in the changed code paths that would surface on the first real production run.

.github/workflows/reusable-publish-pypi-release.yml (artifact action version mismatch) and .github/workflows/reusable-github-release.yml (artifact-path/files coupling, same version mismatch) need the most attention before merging.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-publish-pypi-release.yml | New two-job build+publish workflow; correctly adds setup-python and moves set-published after attestation, but still uses upload-artifact@v7 vs download-artifact@v8 (previous thread open) |
| .github/workflows/reusable-github-release.yml | New GitHub Release workflow; artifact-path/files default coupling still unresolved (previous thread open), download-artifact@v8 against upload-artifact@v7 |
| scripts/ci/release/verify-release-assets.sh | New asset verification script; logic is sound but unquoted $pattern in glob loop could miscount assets with spaces in filenames |
| scripts/ci/actions/publish-pypi.sh | Adds set-published step and lazy twine install via uv; both additions are straightforward and correctly integrate with the new workflow's publish job |
| .github/workflows/reusable-publish-pypi.yml | Adds setup-python step and cone-mode to existing workflow; backward-compatible change that makes Python/uv toolchain explicit before build |
| tests/bats/integration/test_reusable_python_release_publish.bats | New contract tests for the reusable workflows; includes good structural checks but the _tooling_sparse_cone_ok helper is a no-op (previous thread open) |
| tests/bats/unit/release/test_verify_release_assets.bats | Unit tests for verify-release-assets.sh; covers the main pass/fail/blank-line cases adequately |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Caller Workflow
    participant Build as build-artifacts job
    participant Publish as publish job
    participant Release as release job
    participant PyPI as PyPI (OIDC)
    participant GH as GitHub Releases

    Caller->>Build: trigger (tag push)
    Build->>Build: checkout repo + tooling
    Build->>Build: setup-python
    Build->>Build: "publish-pypi action (dry-run=true)"
    Build->>Build: "upload-artifact@v7 → python-dist"
    Build-->>Publish: version, package-name outputs

    Publish->>Publish: checkout tooling
    Publish->>Publish: setup-python
    Publish->>Publish: "download-artifact@v8 ← python-dist"
    Publish->>Publish: validate-dist (twine check)
    Publish->>PyPI: pypa/gh-action-pypi-publish (OIDC)
    Publish->>Publish: attest-build-provenance
    Publish->>Publish: "set-published=true"
    Publish-->>Caller: published, version, package-name

    Caller->>Release: trigger (needs: publish)
    Release->>Release: checkout tooling
    Release->>Release: "download-artifact@v8 ← python-dist"
    Release->>Release: verify-release-assets.sh
    Release->>GH: softprops/action-gh-release
    Release-->>Caller: release-url, release-id
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Frelease%2Fverify-release-assets.sh%3A24-28%0A**Unquoted%20glob%20expansion%20may%20count%20directory%20entries%20as%20files**%0A%0A%60for%20file%20in%20%24pattern%60%20performs%20word-splitting%20on%20%60%24pattern%60%20before%20globbing.%20With%20%60shopt%20-s%20nullglob%60%20this%20correctly%20handles%20the%20zero-match%20case%2C%20but%20a%20pattern%20like%20%60dist%2Fmy%20package-1.0.0.whl%60%20%28space%20in%20filename%29%20would%20be%20word-split%20into%20two%20non-matching%20words%20before%20globbing%2C%20so%20a%20legitimately%20matching%20file%20would%20not%20be%20counted%20and%20the%20verify%20step%20would%20exit%201%20even%20though%20the%20asset%20is%20present.%20Quoting%20%60%22%24pattern%22%60%20prevents%20word-splitting%20while%20still%20allowing%20%60nullglob%60%20to%20collapse%20unmatched%20patterns%20to%20zero%20words%20in%20%60for%60%20loop%20expansion.%0A%0A&pr=239&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Frelease%2Fverify-release-assets.sh%3A24-28%0A**Unquoted%20glob%20expansion%20may%20count%20directory%20entries%20as%20files**%0A%0A%60for%20file%20in%20%24pattern%60%20performs%20word-splitting%20on%20%60%24pattern%60%20before%20globbing.%20With%20%60shopt%20-s%20nullglob%60%20this%20correctly%20handles%20the%20zero-match%20case%2C%20but%20a%20pattern%20like%20%60dist%2Fmy%20package-1.0.0.whl%60%20%28space%20in%20filename%29%20would%20be%20word-split%20into%20two%20non-matching%20words%20before%20globbing%2C%20so%20a%20legitimately%20matching%20file%20would%20not%20be%20counted%20and%20the%20verify%20step%20would%20exit%201%20even%20though%20the%20asset%20is%20present.%20Quoting%20%60%22%24pattern%22%60%20prevents%20word-splitting%20while%20still%20allowing%20%60nullglob%60%20to%20collapse%20unmatched%20patterns%20to%20zero%20words%20in%20%60for%60%20loop%20expansion.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=239&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F232-consolidate-python-release-publish-reusables%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F232-consolidate-python-release-publish-reusables%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Frelease%2Fverify-release-assets.sh%3A24-28%0A**Unquoted%20glob%20expansion%20may%20count%20directory%20entries%20as%20files**%0A%0A%60for%20file%20in%20%24pattern%60%20performs%20word-splitting%20on%20%60%24pattern%60%20before%20globbing.%20With%20%60shopt%20-s%20nullglob%60%20this%20correctly%20handles%20the%20zero-match%20case%2C%20but%20a%20pattern%20like%20%60dist%2Fmy%20package-1.0.0.whl%60%20%28space%20in%20filename%29%20would%20be%20word-split%20into%20two%20non-matching%20words%20before%20globbing%2C%20so%20a%20legitimately%20matching%20file%20would%20not%20be%20counted%20and%20the%20verify%20step%20would%20exit%201%20even%20though%20the%20asset%20is%20present.%20Quoting%20%60%22%24pattern%22%60%20prevents%20word-splitting%20while%20still%20allowing%20%60nullglob%60%20to%20collapse%20unmatched%20patterns%20to%20zero%20words%20in%20%60for%60%20loop%20expansion.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["docs(tests): clarify release asset globs..."](https://github.com/lgtm-hq/lgtm-ci/commit/7a661903c9439fddb532f038dd50087d6154edb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34208589)</sub>

<!-- /greptile_comment -->