### PR TITLE
feat(ci): bundle workflow artifacts into unified Pages site deploy

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1741,7 +1741,7 @@ Pair with `reusable-github-release.yml` using the same `artifact-name`. See
 ### reusable-github-release.yml
 
 Download a workflow artifact and create a GitHub Release with attached assets
-via `softprops/action-gh-release`.
+via `gh release create` (`scripts/ci/release/create-github-release.sh`).
 
 ```yaml
 jobs:

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -838,6 +838,44 @@ Prepare and upload content for GitHub Pages deployment using OIDC.
 
 ---
 
+### bundle-workflow-artifacts
+
+Download HTML report artifacts from other workflow runs into a site tree before
+Pages deployment (Model B).
+
+```yaml
+- uses: lgtm-hq/lgtm-ci/.github/actions/bundle-workflow-artifacts@main
+  with:
+    commit-sha: ${{ github.sha }}
+    site-root: apps/site/dist
+    bundle-manifest: examples/bundle-manifest-turbo-themes.json
+    fallback-ref: main
+    strict: "false"
+```
+
+**Inputs:**
+
+- `commit-sha` - Commit SHA to resolve workflow runs (default: `github.sha`)
+- `site-root` - Site directory to copy bundled reports into (default: `dist`)
+- `bundle-manifest` - Inline JSON or path to `.json`/`.yaml`/`.yml` manifest
+- `fallback-ref` - Optional branch ref for fallback lookup (for example `main`)
+- `strict` - Fail when any manifest entry cannot be resolved (default: `false`)
+
+**Outputs:**
+
+- `files-bundled` - Number of files copied from downloaded artifacts
+- `bundles-applied` - Number of manifest entries successfully applied
+- `bundle-warnings` - Number of manifest entries that logged warnings
+
+**Required Permissions:**
+
+- `actions: read` - Resolve and download artifacts from other workflow runs
+
+See [pages-publishing.md](../../docs/pages-publishing.md) for Model A vs B and
+manifest schema.
+
+---
+
 ## Docker Actions
 
 ### build-docker
@@ -1426,6 +1464,65 @@ jobs:
 
 - `pages: write` - For GitHub Pages deployment
 - `id-token: write` - For OIDC authentication
+
+---
+
+### reusable-deploy-site-with-reports.yml
+
+Build a static site, bundle HTML report artifacts from other workflows via a
+manifest, and deploy once to GitHub Pages (Model B).
+
+```yaml
+jobs:
+  deploy:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@main
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      actions: read
+    with:
+      site-root: apps/site/dist
+      build-command: bun run build
+      package-manager: bun
+      bundle-manifest: examples/bundle-manifest-turbo-themes.json
+      commit-sha: ${{ github.event.workflow_run.head_sha }}
+      fallback-ref: main
+```
+
+**Inputs:**
+
+- `site-root` - Deploy root (default: `dist`)
+- `build-command` - Optional site build command
+- `bundle-manifest` - Inline JSON or path to manifest in caller repo
+- `bundle-after-build` - Run bundle after build (default: `true`)
+- `commit-sha` - SHA for checkout and artifact resolution (default: `github.sha`)
+- `fallback-ref` - Optional branch for fallback artifact lookup (default: strict)
+- `strict-bundle` - Fail when any manifest entry is missing (default: `false`)
+- `node-version`, `package-manager`, `working-directory`, `frozen-lockfile` -
+  Same as `reusable-deploy-pages`
+- `tooling-ref`, `egress-policy`, `allowed-endpoints`, `runner-image`,
+  `timeout-minutes`, `artifact-name`, `environment` - Standard contract
+
+**Outputs:**
+
+- `page-url` - URL of the deployed site
+
+**Features:**
+
+- Manifest-driven cross-workflow artifact download (no repo-local API scripts)
+- Optional `main` (or other branch) fallback per caller configuration
+- Two-job workflow (build + deploy) with official OIDC Pages actions
+- Shared `pages-${{ github.repository }}-${{ github.ref }}` concurrency
+
+**Permissions Required (caller):**
+
+- `contents: read` - Checkout repository
+- `pages: write` - GitHub Pages deployment
+- `id-token: write` - OIDC authentication
+- `actions: read` - Download artifacts from other workflow runs (build job)
+
+See [pages-publishing.md](../../docs/pages-publishing.md) for Model A vs B.
 
 ---
 

--- a/.github/actions/bundle-workflow-artifacts/action.yml
+++ b/.github/actions/bundle-workflow-artifacts/action.yml
@@ -1,0 +1,63 @@
+---
+name: "Bundle Workflow Artifacts"
+description: "Download CI workflow artifacts into a GitHub Pages site tree via manifest"
+author: "lgtm-hq"
+
+inputs:
+  commit-sha:
+    description: "Commit SHA used to resolve workflow runs"
+    required: false
+    default: ""
+  site-root:
+    description: "Site directory to copy bundled reports into"
+    required: false
+    default: "dist"
+  bundle-manifest:
+    description: "Inline JSON manifest or path to a .json/.yaml/.yml manifest file"
+    required: true
+    default: ""
+  fallback-ref:
+    description: "Optional branch ref for fallback workflow lookup (e.g. main)"
+    required: false
+    default: ""
+  strict:
+    description: "Fail when any manifest entry cannot be resolved"
+    required: false
+    default: "false"
+
+outputs:
+  files-bundled:
+    description: "Number of files copied from downloaded artifacts"
+    value: ${{ steps.bundle.outputs.files-bundled }}
+  bundles-applied:
+    description: "Number of manifest entries successfully applied"
+    value: ${{ steps.bundle.outputs.bundles-applied }}
+  bundle-warnings:
+    description: "Number of manifest entries that logged warnings"
+    value: ${{ steps.bundle.outputs.bundle-warnings }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
+    - name: Bundle workflow artifacts
+      id: bundle
+      shell: bash
+      env:
+        COMMIT_SHA: >-
+          ${{ inputs.commit-sha != '' && inputs.commit-sha || github.sha }}
+        SITE_ROOT: ${{ inputs.site-root }}
+        BUNDLE_MANIFEST: ${{ inputs.bundle-manifest }}
+        FALLBACK_REF: ${{ inputs.fallback-ref }}
+        STRICT: ${{ inputs.strict }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+      run: $SCRIPTS_DIR/ci/actions/bundle-workflow-artifacts.sh
+
+branding:
+  icon: "package"
+  color: "blue"

--- a/.github/actions/bundle-workflow-artifacts/action.yml
+++ b/.github/actions/bundle-workflow-artifacts/action.yml
@@ -15,7 +15,6 @@ inputs:
   bundle-manifest:
     description: "Inline JSON manifest or path to a .json/.yaml/.yml manifest file"
     required: true
-    default: ""
   fallback-ref:
     description: "Optional branch ref for fallback workflow lookup (e.g. main)"
     required: false

--- a/.github/workflows/reusable-deploy-site-with-reports.yml
+++ b/.github/workflows/reusable-deploy-site-with-reports.yml
@@ -1,0 +1,235 @@
+---
+name: Reusable Deploy Site With Reports Workflow
+
+on:
+  workflow_call:
+    inputs:
+      site-root:
+        description: "Path to static site content to deploy"
+        required: false
+        type: string
+        default: "dist"
+      build-command:
+        description: "Optional build command to run before deployment"
+        required: false
+        type: string
+        default: ""
+      bundle-manifest:
+        description: "Inline JSON manifest or path to a manifest file in the caller repo"
+        required: false
+        type: string
+        default: ""
+      bundle-after-build:
+        description: "Run bundle step after optional site build"
+        required: false
+        type: boolean
+        default: true
+      commit-sha:
+        description: "Commit SHA for checkout and artifact resolution (workflow_run callers)"
+        required: false
+        type: string
+        default: ""
+      fallback-ref:
+        description: "Optional branch ref for fallback artifact lookup (e.g. main)"
+        required: false
+        type: string
+        default: ""
+      strict-bundle:
+        description: "Fail when any manifest entry cannot be resolved"
+        required: false
+        type: boolean
+        default: false
+      node-version:
+        description: "Node.js version for build step"
+        required: false
+        type: string
+        default: "20"
+      package-manager:
+        description: "Package manager for dependency install: npm, bun, pnpm (empty = skip)"
+        required: false
+        type: string
+        default: "npm"
+      working-directory:
+        description: "Working directory for dependency installation"
+        required: false
+        type: string
+        default: "."
+      frozen-lockfile:
+        description: "Use lockfile enforcement during dependency installation"
+        required: false
+        type: boolean
+        default: true
+      environment:
+        description: "GitHub environment name for deployment"
+        required: false
+        type: string
+        default: "github-pages"
+      artifact-name:
+        description: "Name for the pages artifact"
+        required: false
+        type: string
+        default: "github-pages"
+      tooling-ref:
+        description: "Git ref to use when checking out lgtm-ci tooling scripts"
+        required: false
+        type: string
+        default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      build-job-name:
+        description: "GitHub check name for the build job"
+        required: false
+        type: string
+        default: "Build site and bundle reports"
+      deploy-job-name:
+        description: "GitHub check name for the deploy job"
+        required: false
+        type: string
+        default: "Deploy to GitHub Pages"
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 10
+
+    outputs:
+      page-url:
+        description: "URL of the deployed GitHub Pages site"
+        value: ${{ jobs.deploy.outputs.page-url }}
+
+concurrency:
+  group: pages-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: ${{ inputs.build-job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      actions: read # resolve and download workflow artifacts for bundling
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: >-
+            ${{ inputs.commit-sha != '' && inputs.commit-sha || github.sha }}
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Setup Node.js
+        if: inputs.build-command != '' && inputs.package-manager != ''
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Setup Bun
+        if: inputs.build-command != '' && inputs.package-manager == 'bun'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Setup pnpm
+        if: inputs.build-command != '' && inputs.package-manager == 'pnpm'
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Install dependencies
+        if: inputs.build-command != '' && inputs.package-manager != ''
+        shell: bash
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+          FROZEN_LOCKFILE: ${{ inputs.frozen-lockfile }}
+        run: >-
+          bash .lgtm-ci-tooling/scripts/ci/actions/setup-package-manager.sh
+
+      - name: Build site
+        if: inputs.build-command != ''
+        shell: bash
+        env:
+          STEP: prepare
+          SOURCE_PATH: ${{ inputs.site-root }}
+          BUILD_COMMAND: ${{ inputs.build-command }}
+        run: >-
+          bash .lgtm-ci-tooling/scripts/ci/actions/deploy-pages.sh
+
+      - name: Bundle workflow artifacts
+        if: inputs.bundle-after-build && inputs.bundle-manifest != ''
+        uses: ./.lgtm-ci-tooling/.github/actions/bundle-workflow-artifacts
+        with:
+          commit-sha: >-
+            ${{ inputs.commit-sha != '' && inputs.commit-sha || github.sha }}
+          site-root: ${{ inputs.site-root }}
+          bundle-manifest: ${{ inputs.bundle-manifest }}
+          fallback-ref: ${{ inputs.fallback-ref }}
+          strict: ${{ inputs.strict-bundle }}
+
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Prepare and upload artifact
+        uses: ./.lgtm-ci-tooling/.github/actions/deploy-pages
+        with:
+          source-path: ${{ inputs.site-root }}
+          artifact-name: ${{ inputs.artifact-name }}
+
+  deploy:
+    name: ${{ inputs.deploy-job-name }}
+    needs: build
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: ${{ inputs.environment }}
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    outputs:
+      page-url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        with:
+          artifact_name: ${{ inputs.artifact-name }}

--- a/.github/workflows/reusable-github-release.yml
+++ b/.github/workflows/reusable-github-release.yml
@@ -31,7 +31,7 @@ on:
         default: true
       files:
         description: >-
-          Newline-separated asset globs for softprops/action-gh-release.
+          Newline-separated asset globs attached to the release.
           Defaults to "{artifact-path}/*" when empty.
         required: false
         type: string
@@ -94,8 +94,8 @@ jobs:
       contents: write # create GitHub releases and upload release assets
 
     outputs:
-      release-url: ${{ steps.gh-release.outputs.url }}
-      release-id: ${{ steps.gh-release.outputs.id }}
+      release-url: ${{ steps.gh-release.outputs.release-url }}
+      release-id: ${{ steps.gh-release.outputs.release-id }}
 
     steps:
       - name: Harden runner
@@ -133,16 +133,19 @@ jobs:
 
       - name: Create GitHub Release
         id: gh-release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
-        with:
-          tag_name: >-
+        shell: bash
+        env:
+          TAG: >-
             ${{ inputs.tag-name != '' && inputs.tag-name || github.ref_name }}
-          name: >-
+          TITLE: >-
             ${{ inputs.release-name != '' && inputs.release-name ||
             (inputs.tag-name != '' && inputs.tag-name || github.ref_name) }}
-          generate_release_notes: ${{ inputs.generate-release-notes }}
-          draft: ${{ inputs.draft }}
-          prerelease: ${{ inputs.prerelease }}
-          files: >-
+          GENERATE_NOTES: ${{ inputs.generate-release-notes }}
+          DRAFT: ${{ inputs.draft }}
+          PRERELEASE: ${{ inputs.prerelease }}
+          FILE_PATTERNS: >-
             ${{ inputs.files != '' && inputs.files ||
             format('{0}/*', inputs.artifact-path) }}
+          REPO: ${{ github.repository }}
+        run: >-
+          .lgtm-ci-tooling/scripts/ci/release/create-github-release.sh

--- a/.github/workflows/reusable-publish-pypi-release.yml
+++ b/.github/workflows/reusable-publish-pypi-release.yml
@@ -193,18 +193,18 @@ jobs:
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
+      - name: Download Python distribution
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.working-directory }}/dist
+
       - name: Setup Python
         uses: ./.lgtm-ci-tooling/.github/actions/setup-python
         with:
           python-version: ${{ inputs.python-version }}
           working-directory: ${{ inputs.working-directory }}
           install-dependencies: "false"
-
-      - name: Download Python distribution
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: ${{ inputs.artifact-name }}
-          path: ${{ inputs.working-directory }}/dist
 
       - name: Validate distribution
         if: inputs.validate

--- a/.github/workflows/reusable-test-node-publish.yml
+++ b/.github/workflows/reusable-test-node-publish.yml
@@ -55,7 +55,10 @@ on:
 # WARNING: Do not invoke this workflow alongside reusable-test-python-publish
 # (or another publish-test-results caller) on the same event unless all subtrees
 # are bundled in one publish job. Each deploy replaces the entire site; the
-# last queued job wins. See docs/pages-publishing.md and lgtm-hq/lgtm-ci#225.
+# last queued job wins. Monorepos needing a site plus multiple report subtrees on
+# one Pages origin should use reusable-deploy-site-with-reports (Model B, #226)
+# instead of parallel python + node publish workflows. See docs/pages-publishing.md
+# and lgtm-hq/lgtm-ci#226.
 concurrency:
   group: pages-${{ github.repository }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/reusable-test-python-publish.yml
+++ b/.github/workflows/reusable-test-python-publish.yml
@@ -50,7 +50,10 @@ on:
 # WARNING: Do not invoke this workflow alongside reusable-test-node-publish
 # (or another publish-test-results caller) on the same event unless all subtrees
 # are bundled in one publish job. Each deploy replaces the entire site; the
-# last queued job wins. See docs/pages-publishing.md and lgtm-hq/lgtm-ci#225.
+# last queued job wins. Monorepos needing a site plus multiple report subtrees on
+# one Pages origin should use reusable-deploy-site-with-reports (Model B, #226)
+# instead of parallel python + node publish workflows. See docs/pages-publishing.md
+# and lgtm-hq/lgtm-ci#226.
 concurrency:
   group: pages-${{ github.repository }}-${{ github.ref }}
   cancel-in-progress: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **release**: quote-safe glob expansion for release asset preflight and uploads
+  (#232)
+- **workflows**: download Python dist artifacts before setup-python in publish job
+  (#232)
+- **workflows**: create GitHub releases via `gh` in `reusable-github-release.yml`
+  (#232)
+- **workflows**: fail publish-pypi validate when twine cannot be installed (#232)
+
 ### Security
 
 ## [0.21.0] - 2026-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **workflows**: `reusable-deploy-site-with-reports.yml` for Model B Pages (site +
+  bundled CI report artifacts) (#226)
+- **actions**: `bundle-workflow-artifacts` composite and manifest-driven bundling
+  script (#226)
+- **docs**: Model A vs Model B in `docs/pages-publishing.md`; turbo-themes example
+  manifest in `examples/bundle-manifest-turbo-themes.json` (#226)
+
 ### Changed
 
 ### Deprecated

--- a/docs/pages-publishing.md
+++ b/docs/pages-publishing.md
@@ -5,18 +5,116 @@ lgtm-ci uses a single deployment model: **GitHub Actions OIDC** via
 `actions/deploy-pages`. Third-party branch-push actions (for example
 `peaceiris/actions-gh-pages`) are not supported and are blocked by org policy.
 
+## Model A vs Model B
+
+| Model | Use when | Entry point |
+| ----- | -------- | ----------- |
+| **A — report subtree** | Single-report repos (py-lintro) | `publish-test-results` |
+| **B — bundled site** | Docs site + CI HTML on one origin | `reusable-deploy-site-with-reports` |
+
+**Model A** uploads one subtree (`python/`, `vitest/`, …) per job. Each deploy
+replaces the **entire** published site.
+
+**Model B** builds (or reuses) a static site tree, downloads HTML artifacts from
+other workflows via a manifest, copies them into configured destinations under
+`site-root`, then deploys once. Prefer Model B over parallel Model A publishers
+when you need `/coverage/`, `/playwright/`, and a docs site on one `github.io`
+origin.
+
+Issue [#225](https://github.com/lgtm-hq/lgtm-ci/issues/225) (merge existing live
+site on deploy) is a fallback for legacy multi-publisher Model A setups. New
+monorepos should use Model B ([#226](https://github.com/lgtm-hq/lgtm-ci/issues/226))
+instead.
+
 ## Entry points
 
-| Workflow / action                        | Content                     | `target-dir`       |
-| ---------------------------------------- | --------------------------- | ------------------ |
-| `publish-test-results`                   | Coverage, badges, test HTML | configurable       |
-| `deploy-pages` + `reusable-deploy-pages` | Built static sites          | `dist` (site root) |
+| Workflow / action | Content | `target-dir` / `site-root` |
+| ----------------- | ------- | -------------------------- |
+| `publish-test-results` | Coverage, badges, test HTML | configurable (`target-dir`) |
+| `deploy-pages` + `reusable-deploy-pages` | Built static sites | `dist` (site root) |
+| `reusable-deploy-site-with-reports` | Site + CI HTML bundles | `site-root` |
 
 Typical `publish-test-results` directories include `python`, `vitest`,
 `coverage`, and `playwright`.
 
+Typical Model B destinations include `coverage`, `playwright`, `lighthouse`,
+`playwright-examples`, and language-specific coverage folders.
+
 Both paths upload a **full site artifact** per deployment. Each deploy replaces
 the entire published site with that artifact.
+
+## Model B caller example
+
+Deploy after CI completes (`workflow_run`), bundling turbo-themes-equivalent
+reports:
+
+```yaml
+name: Deploy site with reports
+
+on:
+  workflow_run:
+    workflows:
+      - Quality Check - CI Pipeline
+      - Quality Check - E2E Tests
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  actions: read # required to download workflow artifacts
+
+jobs:
+  deploy:
+    if: >-
+      github.event.workflow_run.conclusion == 'success'
+      && github.event.workflow_run.head_branch == 'main'
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@<sha>
+    with:
+      site-root: apps/site/dist
+      build-command: bun run build
+      package-manager: bun
+      bundle-manifest: examples/bundle-manifest-turbo-themes.json
+      commit-sha: ${{ github.event.workflow_run.head_sha }}
+      fallback-ref: main # optional; omit for strict commit-only resolution
+      tooling-ref: "<sha>"
+      egress-policy: block
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        actions.githubusercontent.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+```
+
+See `examples/bundle-manifest-turbo-themes.json` for a manifest that mirrors
+turbo-themes report destinations. Workflow fields match workflow **display names**
+or file stems (for example `quality-ci-main` matches `.github/workflows/quality-ci-main.yml`).
+
+### Bundle manifest schema
+
+```json
+{
+  "strict": false,
+  "bundles": [
+    {
+      "id": "vitest-coverage",
+      "workflow": "quality-ci-main",
+      "artifact": "coverage-html",
+      "dest": "coverage",
+      "require_success": true
+    }
+  ]
+}
+```
+
+- `strict: true` (manifest or `strict-bundle` input) fails the step when any
+  entry is missing.
+- `fallback-ref` (for example `main`) retries lookup on a branch when no run
+  exists for `commit-sha`. Default is strict (no fallback).
+- `require_success: false` includes failed runs (artifacts uploaded with
+  `if: always()`).
 
 ## Caller permissions
 
@@ -29,10 +127,13 @@ permissions:
   id-token: write
 ```
 
+Model B build jobs also require `actions: read` on the caller workflow so the
+bundle step can resolve and download artifacts from other workflow runs.
+
 Do **not** grant `contents: write` for Pages publish; branch-push deploy is no
 longer used.
 
-When `egress-policy: block`, allow OIDC and artifact upload:
+When `egress-policy: block`, allow OIDC, artifact upload, and GitHub API access:
 
 ```yaml
 allowed-endpoints: >
@@ -52,11 +153,12 @@ pages-${{ github.repository }}-${{ github.ref }}
 ```
 
 This serializes deployments to the same site on the same ref (including
-`reusable-deploy-pages` and coverage/test publish workflows).
+`reusable-deploy-pages`, `reusable-deploy-site-with-reports`, and coverage/test
+publish workflows).
 
-## Multi-publisher limitation
+## Multi-publisher limitation (Model A)
 
-If a repository runs **more than one** publish workflow to the same GitHub Pages
+If a repository runs **more than one** Model A publish workflow to the same GitHub Pages
 site in the same pipeline (for example `reusable-test-python-publish` deploying
 `python/` and `reusable-test-node-publish` deploying `vitest/` on one push),
 the shared concurrency group
@@ -70,11 +172,11 @@ The old `peaceiris/actions-gh-pages` model pushed to one branch with
 `keep_files: true`, so `python/` and `vitest/` could coexist. The official
 artifact model cannot do that without an explicit merge step.
 
-| Mitigation                | When                                              |
-| ------------------------- | ------------------------------------------------- |
+| Mitigation | When |
+| ---------- | ---- |
 | One publish job per event | One `publish-test-results` with combined subtrees |
-| Model B site bundle       | Issue #226 (turbo-style bundle) [226]             |
-| Optional live-site merge  | Issue #225 (multi Model A publishers) [225]       |
+| Model B site bundle | Monorepos — `reusable-deploy-site-with-reports` [226] |
+| Optional live-site merge | Legacy Model A multi-publisher fallback [225] |
 
 [225]: https://github.com/lgtm-hq/lgtm-ci/issues/225
 [226]: https://github.com/lgtm-hq/lgtm-ci/issues/226

--- a/docs/pages-publishing.md
+++ b/docs/pages-publishing.md
@@ -113,8 +113,8 @@ or file stems (for example `quality-ci-main` matches `.github/workflows/quality-
   entry is missing.
 - `fallback-ref` (for example `main`) retries lookup on a branch when no run
   exists for `commit-sha`. Default is strict (no fallback).
-- `require_success: false` includes failed runs (artifacts uploaded with
-  `if: always()`).
+- `require_success: false` includes failed, cancelled, and timed-out runs
+  (artifacts uploaded with `if: always()`).
 
 ## Caller permissions
 

--- a/docs/python-release-publish.md
+++ b/docs/python-release-publish.md
@@ -106,7 +106,7 @@ Use the same `artifact-name` for `reusable-publish-pypi-release.yml` and
 uploaded by the build job. When `inputs.files` is empty, the release workflow
 defaults asset globs to `{artifact-path}/*` (via `format('{0}/*',
 inputs.artifact-path)`; default `artifact-path` is `dist`) for both the verify
-step (`FILES`) and `softprops/action-gh-release` (`files`). If you override
+step (`FILES`) and `create-github-release.sh` (`FILE_PATTERNS`). If you override
 `inputs.files`, ensure those glob patterns match the files actually placed in
 the artifact download path — you do not need to change `inputs.artifact-path`
 just because you customized `files`. `ARTIFACT_PATH` is only used in verify

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -248,6 +248,29 @@ jobs:
       package-manager: bun
 ```
 
+### Site + bundled CI reports (Model B)
+
+```yaml
+  deploy-site:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@<sha>
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      actions: read
+    with:
+      site-root: apps/site/dist
+      build-command: bun run build
+      package-manager: bun
+      bundle-manifest: examples/bundle-manifest-turbo-themes.json
+      commit-sha: ${{ github.event.workflow_run.head_sha }}
+      fallback-ref: main
+      tooling-ref: "<sha>"
+```
+
+See [pages-publishing.md](pages-publishing.md) for manifest schema, egress
+allowlist, and `workflow_run` caller patterns.
+
 See [python-release-publish.md](python-release-publish.md) for a full production
 tag-push layout (quality, SBOM, split publish, release assets).
 

--- a/examples/bundle-manifest-turbo-themes.json
+++ b/examples/bundle-manifest-turbo-themes.json
@@ -1,0 +1,54 @@
+{
+  "strict": false,
+  "bundles": [
+    {
+      "id": "vitest-coverage",
+      "workflow": "Quality Check - CI Pipeline",
+      "artifact": "coverage-html",
+      "dest": "coverage",
+      "require_success": true
+    },
+    {
+      "id": "playwright",
+      "workflow": "Quality Check - E2E Tests",
+      "artifact": "playwright-report",
+      "dest": "playwright",
+      "require_success": true
+    },
+    {
+      "id": "lighthouse",
+      "workflow": "Reporting - Lighthouse CI",
+      "artifact": "lighthouse-reports",
+      "dest": "lighthouse",
+      "require_success": true
+    },
+    {
+      "id": "playwright-examples",
+      "workflow": "Quality Check - Examples",
+      "artifact": "examples-playwright-report",
+      "dest": "playwright-examples",
+      "require_success": true
+    },
+    {
+      "id": "coverage-python",
+      "workflow": "Quality Check - Multi-Language Coverage",
+      "artifact": "coverage-python-html",
+      "dest": "coverage-python",
+      "require_success": false
+    },
+    {
+      "id": "coverage-ruby",
+      "workflow": "Quality Check - Multi-Language Coverage",
+      "artifact": "coverage-ruby-html",
+      "dest": "coverage-ruby",
+      "require_success": false
+    },
+    {
+      "id": "coverage-swift",
+      "workflow": "Quality Check - Multi-Language Coverage",
+      "artifact": "coverage-swift-html",
+      "dest": "coverage-swift",
+      "require_success": false
+    }
+  ]
+}

--- a/scripts/ci/actions/bundle-workflow-artifacts.sh
+++ b/scripts/ci/actions/bundle-workflow-artifacts.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Bundle workflow artifacts into a GitHub Pages site root
+#
+# Required environment variables:
+#   COMMIT_SHA - Git commit SHA to resolve workflow runs
+#   SITE_ROOT - Directory to copy bundled reports into
+#   BUNDLE_MANIFEST - Inline JSON manifest or path to .json/.yaml/.yml file
+#   GITHUB_REPOSITORY - owner/repo for GitHub API calls
+#
+# Optional environment variables:
+#   FALLBACK_REF - Branch ref for fallback workflow lookup (e.g. main)
+#   STRICT - Fail when any bundle entry is missing (default: false)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/actions.sh
+source "$SCRIPT_DIR/../lib/actions.sh"
+# shellcheck source=../lib/bundle/workflow_artifacts.sh
+source "$SCRIPT_DIR/../lib/bundle/workflow_artifacts.sh"
+
+: "${COMMIT_SHA:?COMMIT_SHA is required}"
+: "${SITE_ROOT:?SITE_ROOT is required}"
+: "${BUNDLE_MANIFEST:?BUNDLE_MANIFEST is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+: "${FALLBACK_REF:=}"
+: "${STRICT:=false}"
+
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+	gh auth status >/dev/null 2>&1 || echo "${GITHUB_TOKEN}" | gh auth login --with-token 2>/dev/null || true
+fi
+
+bundle_load_manifest "$BUNDLE_MANIFEST"
+bundle_run_manifest

--- a/scripts/ci/actions/publish-pypi.sh
+++ b/scripts/ci/actions/publish-pypi.sh
@@ -139,6 +139,8 @@ validate-dist)
 	if command -v uv >/dev/null 2>&1 && ! command -v twine >/dev/null 2>&1; then
 		log_info "Installing twine for validation..."
 		uv pip install --system twine
+	elif ! command -v twine >/dev/null 2>&1; then
+		die "twine is not available and uv is not available to install it"
 	fi
 
 	if validate_pypi_package "dist"; then

--- a/scripts/ci/lib/bundle/workflow_artifacts.sh
+++ b/scripts/ci/lib/bundle/workflow_artifacts.sh
@@ -139,12 +139,13 @@ bundle_validate_zip_members() {
 
 	while IFS= read -r entry || [[ -n "$entry" ]]; do
 		[[ -z "$entry" ]] && continue
+		if [[ "$entry" == /* ]]; then
+			log_error "Zip entry is absolute for artifact ${artifact_id}: ${entry}"
+			return 1
+		fi
 		entry="${entry#./}"
-		while [[ "$entry" == /* ]]; do
-			entry="${entry#/}"
-		done
 		if [[ -z "$entry" ]]; then
-			log_error "Zip entry resolves to root for artifact ${artifact_id}"
+			log_error "Zip entry is empty for artifact ${artifact_id}"
 			return 1
 		fi
 		if [[ "$entry" == *".."* ]]; then
@@ -215,7 +216,11 @@ bundle_download_artifact() {
 		return 1
 	fi
 	mkdir -p "$dest_dir"
-	unzip -o -q "$temp_zip" -d "$dest_dir/"
+	if ! unzip -o -q "$temp_zip" -d "$dest_dir/"; then
+		log_error "Failed to extract artifact ${artifact_id}"
+		rm -f "$temp_zip"
+		return 1
+	fi
 	rm -f "$temp_zip"
 }
 
@@ -328,12 +333,12 @@ bundle_run_manifest() {
 	fi
 
 	temp_root="$(mktemp -d "${TMPDIR:-/tmp}/bundle-workflow-artifacts.XXXXXX")"
-	trap 'rm -rf "${temp_root:-}"' EXIT INT TERM
+	trap 'rm -rf "${temp_root:-}"' RETURN EXIT INT TERM
 	local applied=0
 	local index
 	for ((index = 0; index < bundle_count; index++)); do
 		local bundle_id workflow artifact dest require_success run_id artifact_id
-		local staging_dir used_fallback=false
+		local staging_dir staging_key="bundle-${index}" used_fallback=false
 
 		bundle_id=$(jq -r ".bundles[$index].id // \"bundle-${index}\"" <<<"$BUNDLE_MANIFEST_JSON")
 		workflow=$(jq -r ".bundles[$index].workflow" <<<"$BUNDLE_MANIFEST_JSON")
@@ -408,7 +413,7 @@ bundle_run_manifest() {
 			continue
 		fi
 
-		staging_dir="${temp_root}/${bundle_id}"
+		staging_dir="${temp_root}/${staging_key}"
 		mkdir -p "$staging_dir"
 		if ! bundle_download_artifact "$artifact_id" "$staging_dir"; then
 			log_warn "Bundle ${bundle_id}: failed to download artifact ${artifact_id}"
@@ -434,7 +439,7 @@ bundle_run_manifest() {
 		fi
 	done
 
-	trap - EXIT INT TERM
+	trap - RETURN EXIT INT TERM
 	rm -rf "$temp_root"
 
 	set_github_output "files-bundled" "$files_bundled"

--- a/scripts/ci/lib/bundle/workflow_artifacts.sh
+++ b/scripts/ci/lib/bundle/workflow_artifacts.sh
@@ -205,7 +205,6 @@ bundle_copy_to_site() {
 	fi
 
 	mkdir -p "$target_dir"
-	# shellcheck disable=SC2115
 	cp -R "${source_dir}/." "$target_dir/"
 }
 

--- a/scripts/ci/lib/bundle/workflow_artifacts.sh
+++ b/scripts/ci/lib/bundle/workflow_artifacts.sh
@@ -68,13 +68,14 @@ bundle_find_workflow_run() {
 	local commit_sha="$2"
 	local require_success="${3:-true}"
 
+	local workflow_match
 	local jq_filter
+	# shellcheck disable=SC2016
+	workflow_match='((.name | ascii_downcase) == ($wf | ascii_downcase)) or ((.path | split("/")[-1] | sub("\\.ya?ml$"; "") | ascii_downcase) == ($wf | ascii_downcase))'
 	if [[ "$require_success" == "false" ]]; then
-		# shellcheck disable=SC2016
-		jq_filter='first(.workflow_runs[] | select((.name == $wf or (.path | split("/")[-1] | test("^" + $wf + "\\.ya?ml$"; "i"))) and (.conclusion == "success" or .conclusion == "failure")) | .id) // empty'
+		jq_filter="first(.workflow_runs[] | select(${workflow_match} and (.conclusion == \"success\" or .conclusion == \"failure\")) | .id) // empty"
 	else
-		# shellcheck disable=SC2016
-		jq_filter='first(.workflow_runs[] | select((.name == $wf or (.path | split("/")[-1] | test("^" + $wf + "\\.ya?ml$"; "i"))) and .conclusion == "success") | .id) // empty'
+		jq_filter="first(.workflow_runs[] | select(${workflow_match} and .conclusion == \"success\") | .id) // empty"
 	fi
 
 	gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${commit_sha}&per_page=100" \
@@ -88,13 +89,14 @@ bundle_find_workflow_run_on_ref() {
 	local fallback_ref="$2"
 	local require_success="${3:-true}"
 
+	local workflow_match
 	local jq_filter
+	# shellcheck disable=SC2016
+	workflow_match='((.name | ascii_downcase) == ($wf | ascii_downcase)) or ((.path | split("/")[-1] | sub("\\.ya?ml$"; "") | ascii_downcase) == ($wf | ascii_downcase))'
 	if [[ "$require_success" == "false" ]]; then
-		# shellcheck disable=SC2016
-		jq_filter='first(.workflow_runs[] | select((.name == $wf or (.path | split("/")[-1] | test("^" + $wf + "\\.ya?ml$"; "i"))) and .head_branch == $branch and (.conclusion == "success" or .conclusion == "failure")) | .id) // empty'
+		jq_filter="first(.workflow_runs[] | select(${workflow_match} and .head_branch == \$branch and (.conclusion == \"success\" or .conclusion == \"failure\")) | .id) // empty"
 	else
-		# shellcheck disable=SC2016
-		jq_filter='first(.workflow_runs[] | select((.name == $wf or (.path | split("/")[-1] | test("^" + $wf + "\\.ya?ml$"; "i"))) and .head_branch == $branch and .conclusion == "success") | .id) // empty'
+		jq_filter="first(.workflow_runs[] | select(${workflow_match} and .head_branch == \$branch and .conclusion == \"success\") | .id) // empty"
 	fi
 
 	gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${fallback_ref}&per_page=50" \
@@ -235,6 +237,11 @@ bundle_run_manifest() {
 
 	if ! command -v jq >/dev/null 2>&1; then
 		log_error "jq is required but not found"
+		return 1
+	fi
+
+	if ! command -v python3 >/dev/null 2>&1; then
+		log_error "python3 is required but not found"
 		return 1
 	fi
 

--- a/scripts/ci/lib/bundle/workflow_artifacts.sh
+++ b/scripts/ci/lib/bundle/workflow_artifacts.sh
@@ -333,7 +333,35 @@ bundle_run_manifest() {
 	fi
 
 	temp_root="$(mktemp -d "${TMPDIR:-/tmp}/bundle-workflow-artifacts.XXXXXX")"
-	trap 'rm -rf "${temp_root:-}"' RETURN EXIT INT TERM
+	local old_trap_exit old_trap_int old_trap_term cleanup_cmd
+	old_trap_exit=$(trap -p EXIT | sed "s/trap -- '\(.*\)' EXIT/\1/" || true)
+	old_trap_int=$(trap -p INT | sed "s/trap -- '\(.*\)' INT/\1/" || true)
+	old_trap_term=$(trap -p TERM | sed "s/trap -- '\(.*\)' TERM/\1/" || true)
+	cleanup_cmd="rm -rf '$temp_root'"
+	# RETURN traps are function-scoped; callers cannot be read via trap -p RETURN here.
+	# shellcheck disable=SC2064
+	trap "$cleanup_cmd" RETURN
+	if [[ -n "$old_trap_exit" ]]; then
+		# shellcheck disable=SC2064
+		trap "$cleanup_cmd; $old_trap_exit" EXIT
+	else
+		# shellcheck disable=SC2064
+		trap "$cleanup_cmd" EXIT
+	fi
+	if [[ -n "$old_trap_int" ]]; then
+		# shellcheck disable=SC2064
+		trap "$cleanup_cmd; $old_trap_int" INT
+	else
+		# shellcheck disable=SC2064
+		trap "$cleanup_cmd" INT
+	fi
+	if [[ -n "$old_trap_term" ]]; then
+		# shellcheck disable=SC2064
+		trap "$cleanup_cmd; $old_trap_term" TERM
+	else
+		# shellcheck disable=SC2064
+		trap "$cleanup_cmd" TERM
+	fi
 	local applied=0
 	local index
 	for ((index = 0; index < bundle_count; index++)); do

--- a/scripts/ci/lib/bundle/workflow_artifacts.sh
+++ b/scripts/ci/lib/bundle/workflow_artifacts.sh
@@ -283,6 +283,20 @@ bundle_copy_to_site() {
 	cp -R "${source_dir}/." "$target_dir/"
 }
 
+__bundle_run_manifest_temp_root=""
+__bundle_run_manifest_saved_return_cmd=""
+
+__bundle_run_manifest_on_return() {
+	rm -rf "${__bundle_run_manifest_temp_root:-}"
+	__bundle_run_manifest_temp_root=""
+	if [[ -n "$__bundle_run_manifest_saved_return_cmd" ]]; then
+		eval "$__bundle_run_manifest_saved_return_cmd"
+	else
+		trap - RETURN
+	fi
+	__bundle_run_manifest_saved_return_cmd=""
+}
+
 # Process all manifest bundles.
 # Requires: BUNDLE_MANIFEST_JSON, COMMIT_SHA, SITE_ROOT, GITHUB_REPOSITORY
 # Optional: FALLBACK_REF, STRICT (true|false)
@@ -333,42 +347,10 @@ bundle_run_manifest() {
 	fi
 
 	temp_root="$(mktemp -d "${TMPDIR:-/tmp}/bundle-workflow-artifacts.XXXXXX")"
-	local old_trap_return_cmd old_trap_exit_cmd old_trap_int_cmd old_trap_term_cmd
-	old_trap_return_cmd=$(trap -p RETURN 2>/dev/null || true)
-	old_trap_exit_cmd=$(trap -p EXIT || true)
-	old_trap_int_cmd=$(trap -p INT || true)
-	old_trap_term_cmd=$(trap -p TERM || true)
-
-	__bundle_run_manifest_restore_traps() {
-		if [[ -n "$old_trap_return_cmd" ]]; then
-			eval "$old_trap_return_cmd"
-		else
-			trap - RETURN
-		fi
-		if [[ -n "$old_trap_exit_cmd" ]]; then
-			eval "$old_trap_exit_cmd"
-		else
-			trap - EXIT
-		fi
-		if [[ -n "$old_trap_int_cmd" ]]; then
-			eval "$old_trap_int_cmd"
-		else
-			trap - INT
-		fi
-		if [[ -n "$old_trap_term_cmd" ]]; then
-			eval "$old_trap_term_cmd"
-		else
-			trap - TERM
-		fi
-	}
-
-	__bundle_run_manifest_temp_trap() {
-		rm -rf "${temp_root:-}"
-		__bundle_run_manifest_restore_traps
-	}
-
-	# shellcheck disable=SC2064 # Invoke nested trap helpers when signals fire
-	trap '__bundle_run_manifest_temp_trap' RETURN EXIT INT TERM
+	__bundle_run_manifest_temp_root="$temp_root"
+	__bundle_run_manifest_saved_return_cmd=$(trap -p RETURN 2>/dev/null || true)
+	# shellcheck disable=SC2064 # Invoke file-scoped RETURN handler on function exit
+	trap '__bundle_run_manifest_on_return' RETURN
 	local applied=0
 	local index
 	for ((index = 0; index < bundle_count; index++)); do
@@ -473,9 +455,6 @@ bundle_run_manifest() {
 			fi
 		fi
 	done
-
-	rm -rf "$temp_root"
-	__bundle_run_manifest_restore_traps
 
 	set_github_output "files-bundled" "$files_bundled"
 	set_github_output "bundles-applied" "$applied"

--- a/scripts/ci/lib/bundle/workflow_artifacts.sh
+++ b/scripts/ci/lib/bundle/workflow_artifacts.sh
@@ -148,7 +148,7 @@ bundle_validate_zip_members() {
 			log_error "Zip entry is empty for artifact ${artifact_id}"
 			return 1
 		fi
-		if [[ "$entry" == *".."* ]]; then
+		if [[ "$entry" == ".." || "$entry" == ../* || "$entry" == */../* || "$entry" == */.. ]]; then
 			log_error "Zip entry contains path traversal for artifact ${artifact_id}: ${entry}"
 			return 1
 		fi

--- a/scripts/ci/lib/bundle/workflow_artifacts.sh
+++ b/scripts/ci/lib/bundle/workflow_artifacts.sh
@@ -318,7 +318,7 @@ bundle_run_manifest() {
 		fi
 
 		if [[ "$used_fallback" == "true" ]]; then
-			log_warn "Bundle ${bundle_id}: using fallback run ${run_id} from ${FALLBACK_REF}"
+			log_info "Bundle ${bundle_id}: using fallback run ${run_id} from ${FALLBACK_REF}"
 		fi
 
 		artifact_id=$(bundle_get_artifact_id "$run_id" "$artifact")

--- a/scripts/ci/lib/bundle/workflow_artifacts.sh
+++ b/scripts/ci/lib/bundle/workflow_artifacts.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Resolve and download GitHub Actions workflow artifacts into a site tree
+#
+# Manifest JSON schema:
+#   {
+#     "strict": false,
+#     "bundles": [
+#       {
+#         "id": "vitest-coverage",
+#         "workflow": "quality-ci-main",
+#         "artifact": "coverage-html",
+#         "dest": "coverage",
+#         "require_success": true
+#       }
+#     ]
+#   }
+#
+# The workflow field matches the workflow run display name or workflow file stem
+# (e.g. quality-ci-main matches path .../quality-ci-main.yml).
+
+[[ -n "${_LGTM_CI_BUNDLE_WORKFLOW_ARTIFACTS_LOADED:-}" ]] && return 0
+readonly _LGTM_CI_BUNDLE_WORKFLOW_ARTIFACTS_LOADED=1
+
+# Load manifest JSON from inline JSON or a .json/.yaml/.yml file path.
+# Sets BUNDLE_MANIFEST_JSON.
+# Usage: bundle_load_manifest "$BUNDLE_MANIFEST"
+bundle_load_manifest() {
+	local manifest_input="${1:?manifest input is required}"
+
+	if [[ -f "$manifest_input" ]]; then
+		case "$manifest_input" in
+		*.json)
+			BUNDLE_MANIFEST_JSON=$(<"$manifest_input")
+			;;
+		*.yaml | *.yml)
+			if ! command -v ruby >/dev/null 2>&1; then
+				log_error "Ruby is required to parse YAML manifests: $manifest_input"
+				return 1
+			fi
+			BUNDLE_MANIFEST_JSON=$(
+				ruby -ryaml -rjson -e 'puts JSON.generate(YAML.load_file(ARGV[0]))' \
+					"$manifest_input"
+			)
+			;;
+		*)
+			log_error "Unsupported manifest file type: $manifest_input"
+			return 1
+			;;
+		esac
+	elif [[ "$manifest_input" == \{* ]]; then
+		BUNDLE_MANIFEST_JSON="$manifest_input"
+	else
+		log_error "BUNDLE_MANIFEST must be inline JSON or a path to a manifest file"
+		return 1
+	fi
+
+	if ! jq -e . >/dev/null 2>&1 <<<"$BUNDLE_MANIFEST_JSON"; then
+		log_error "Invalid bundle manifest JSON"
+		return 1
+	fi
+}
+
+# Find a workflow run ID for a commit SHA.
+# Usage: bundle_find_workflow_run WORKFLOW_KEY COMMIT_SHA REQUIRE_SUCCESS
+bundle_find_workflow_run() {
+	local workflow_key="$1"
+	local commit_sha="$2"
+	local require_success="${3:-true}"
+
+	local jq_filter
+	if [[ "$require_success" == "false" ]]; then
+		# shellcheck disable=SC2016
+		jq_filter='first(.workflow_runs[] | select((.name == $wf or (.path | test("/" + $wf + "\\.ya?ml$"; "i"))) and (.conclusion == "success" or .conclusion == "failure")) | .id) // empty'
+	else
+		# shellcheck disable=SC2016
+		jq_filter='first(.workflow_runs[] | select((.name == $wf or (.path | test("/" + $wf + "\\.ya?ml$"; "i"))) and .conclusion == "success") | .id) // empty'
+	fi
+
+	gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${commit_sha}&per_page=100" \
+		--jq "$jq_filter" --arg wf "$workflow_key"
+}
+
+# Find the latest workflow run on a fallback branch (e.g. main).
+# Usage: bundle_find_workflow_run_on_ref WORKFLOW_KEY FALLBACK_REF REQUIRE_SUCCESS
+bundle_find_workflow_run_on_ref() {
+	local workflow_key="$1"
+	local fallback_ref="$2"
+	local require_success="${3:-true}"
+
+	local jq_filter
+	if [[ "$require_success" == "false" ]]; then
+		# shellcheck disable=SC2016
+		jq_filter='first(.workflow_runs[] | select((.name == $wf or (.path | test("/" + $wf + "\\.ya?ml$"; "i"))) and .head_branch == $branch and (.conclusion == "success" or .conclusion == "failure")) | .id) // empty'
+	else
+		# shellcheck disable=SC2016
+		jq_filter='first(.workflow_runs[] | select((.name == $wf or (.path | test("/" + $wf + "\\.ya?ml$"; "i"))) and .head_branch == $branch and .conclusion == "success") | .id) // empty'
+	fi
+
+	gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${fallback_ref}&per_page=50" \
+		--jq "$jq_filter" --arg wf "$workflow_key" --arg branch "$fallback_ref"
+}
+
+# Resolve artifact ID from a workflow run.
+# Usage: bundle_get_artifact_id RUN_ID ARTIFACT_NAME
+bundle_get_artifact_id() {
+	local run_id="$1"
+	local artifact_name="$2"
+
+	if [[ -z "$run_id" ]]; then
+		return 0
+	fi
+
+	# shellcheck disable=SC2016
+	gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts" \
+		--jq 'first(.artifacts[] | select(.name == $name) | .id) // empty' \
+		--arg name "$artifact_name" 2>/dev/null || true
+}
+
+# Download and extract an artifact zip into a destination directory.
+# Usage: bundle_download_artifact ARTIFACT_ID DEST_DIR
+bundle_download_artifact() {
+	local artifact_id="$1"
+	local dest_dir="$2"
+	local temp_zip
+
+	if [[ -z "$artifact_id" ]]; then
+		return 1
+	fi
+
+	temp_zip="$(mktemp "${TMPDIR:-/tmp}/bundle-artifact.XXXXXX.zip")"
+	gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" >"$temp_zip"
+	mkdir -p "$dest_dir"
+	unzip -o -q "$temp_zip" -d "$dest_dir/"
+	rm -f "$temp_zip"
+}
+
+# Copy extracted artifact contents into SITE_ROOT/dest.
+# Usage: bundle_copy_to_site SOURCE_DIR SITE_ROOT DEST_SUBDIR
+bundle_copy_to_site() {
+	local source_dir="$1"
+	local site_root="$2"
+	local dest_subdir="$3"
+	local target_dir="${site_root}/${dest_subdir}"
+
+	if [[ ! -d "$source_dir" ]] || [[ -z "$(ls -A "$source_dir" 2>/dev/null || true)" ]]; then
+		return 1
+	fi
+
+	mkdir -p "$target_dir"
+	# shellcheck disable=SC2115
+	cp -R "${source_dir}/." "$target_dir/"
+}
+
+# Process all manifest bundles.
+# Requires: BUNDLE_MANIFEST_JSON, COMMIT_SHA, SITE_ROOT, GITHUB_REPOSITORY
+# Optional: FALLBACK_REF, STRICT (true|false)
+bundle_run_manifest() {
+	local strict="${STRICT:-false}"
+	local manifest_strict
+	local bundle_count
+	local files_bundled=0
+	local warnings=0
+	local temp_root
+
+	if [[ -z "${BUNDLE_MANIFEST_JSON:-}" ]]; then
+		log_error "BUNDLE_MANIFEST_JSON is not set"
+		return 1
+	fi
+
+	: "${COMMIT_SHA:?COMMIT_SHA is required}"
+	: "${SITE_ROOT:?SITE_ROOT is required}"
+	: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+	if ! command -v gh >/dev/null 2>&1; then
+		log_error "GitHub CLI (gh) is required but not found"
+		return 1
+	fi
+
+	if ! command -v jq >/dev/null 2>&1; then
+		log_error "jq is required but not found"
+		return 1
+	fi
+
+	manifest_strict=$(jq -r '.strict // false' <<<"$BUNDLE_MANIFEST_JSON")
+	if [[ "$manifest_strict" == "true" ]]; then
+		strict=true
+	fi
+
+	bundle_count=$(jq '.bundles | length' <<<"$BUNDLE_MANIFEST_JSON")
+	if ((bundle_count == 0)); then
+		log_warn "Bundle manifest contains no entries"
+		set_github_output "files-bundled" "0"
+		set_github_output "bundles-applied" "0"
+		set_github_output "bundle-warnings" "0"
+		return 0
+	fi
+
+	temp_root="$(mktemp -d "${TMPDIR:-/tmp}/bundle-workflow-artifacts.XXXXXX")"
+	local applied=0
+	local index
+	for ((index = 0; index < bundle_count; index++)); do
+		local bundle_id workflow artifact dest require_success run_id artifact_id
+		local staging_dir used_fallback=false
+
+		bundle_id=$(jq -r ".bundles[$index].id // \"bundle-${index}\"" <<<"$BUNDLE_MANIFEST_JSON")
+		workflow=$(jq -r ".bundles[$index].workflow" <<<"$BUNDLE_MANIFEST_JSON")
+		artifact=$(jq -r ".bundles[$index].artifact" <<<"$BUNDLE_MANIFEST_JSON")
+		dest=$(jq -r ".bundles[$index].dest" <<<"$BUNDLE_MANIFEST_JSON")
+		require_success=$(jq -r '.bundles['"$index"'].require_success // true' <<<"$BUNDLE_MANIFEST_JSON")
+
+		if [[ -z "$workflow" || "$workflow" == "null" ]]; then
+			log_error "Bundle ${bundle_id}: workflow is required"
+			((warnings++)) || true
+			if [[ "$strict" == "true" ]]; then
+				return 1
+			fi
+			continue
+		fi
+		if [[ -z "$artifact" || "$artifact" == "null" ]]; then
+			log_error "Bundle ${bundle_id}: artifact is required"
+			((warnings++)) || true
+			if [[ "$strict" == "true" ]]; then
+				return 1
+			fi
+			continue
+		fi
+		if [[ -z "$dest" || "$dest" == "null" ]]; then
+			log_error "Bundle ${bundle_id}: dest is required"
+			((warnings++)) || true
+			if [[ "$strict" == "true" ]]; then
+				return 1
+			fi
+			continue
+		fi
+
+		log_info "Bundle ${bundle_id}: resolving workflow ${workflow} for ${COMMIT_SHA}"
+		run_id=$(bundle_find_workflow_run "$workflow" "$COMMIT_SHA" "$require_success")
+
+		if [[ -z "$run_id" && -n "${FALLBACK_REF:-}" ]]; then
+			log_info "Bundle ${bundle_id}: no run for commit; trying ${FALLBACK_REF}"
+			run_id=$(bundle_find_workflow_run_on_ref "$workflow" "$FALLBACK_REF" "$require_success")
+			used_fallback=true
+		fi
+
+		if [[ -z "$run_id" ]]; then
+			log_warn "Bundle ${bundle_id}: no workflow run found for ${workflow}"
+			((warnings++)) || true
+			if [[ "$strict" == "true" ]]; then
+				return 1
+			fi
+			continue
+		fi
+
+		if [[ "$used_fallback" == "true" ]]; then
+			log_warn "Bundle ${bundle_id}: using fallback run ${run_id} from ${FALLBACK_REF}"
+		fi
+
+		artifact_id=$(bundle_get_artifact_id "$run_id" "$artifact")
+		if [[ -z "$artifact_id" ]]; then
+			log_warn "Bundle ${bundle_id}: artifact ${artifact} not found in run ${run_id}"
+			((warnings++)) || true
+			if [[ "$strict" == "true" ]]; then
+				return 1
+			fi
+			continue
+		fi
+
+		staging_dir="${temp_root}/${bundle_id}"
+		mkdir -p "$staging_dir"
+		if ! bundle_download_artifact "$artifact_id" "$staging_dir"; then
+			log_warn "Bundle ${bundle_id}: failed to download artifact ${artifact_id}"
+			((warnings++)) || true
+			if [[ "$strict" == "true" ]]; then
+				return 1
+			fi
+			continue
+		fi
+
+		if bundle_copy_to_site "$staging_dir" "$SITE_ROOT" "$dest"; then
+			local copied
+			copied=$(find "$staging_dir" -type f 2>/dev/null | wc -l | tr -d ' ')
+			files_bundled=$((files_bundled + copied))
+			((applied++)) || true
+			log_success "Bundle ${bundle_id}: copied ${copied} file(s) to ${SITE_ROOT}/${dest}"
+		else
+			log_warn "Bundle ${bundle_id}: no files copied to ${SITE_ROOT}/${dest}"
+			((warnings++)) || true
+			if [[ "$strict" == "true" ]]; then
+				return 1
+			fi
+		fi
+	done
+
+	rm -rf "$temp_root"
+
+	set_github_output "files-bundled" "$files_bundled"
+	set_github_output "bundles-applied" "$applied"
+	set_github_output "bundle-warnings" "$warnings"
+
+	if [[ "$strict" == "true" && "$warnings" -gt 0 ]]; then
+		return 1
+	fi
+
+	log_success "Bundled ${applied}/${bundle_count} manifest entries (${files_bundled} files)"
+	return 0
+}
+
+export -f bundle_load_manifest bundle_find_workflow_run
+export -f bundle_find_workflow_run_on_ref bundle_get_artifact_id
+export -f bundle_download_artifact bundle_copy_to_site bundle_run_manifest

--- a/scripts/ci/lib/bundle/workflow_artifacts.sh
+++ b/scripts/ci/lib/bundle/workflow_artifacts.sh
@@ -40,8 +40,18 @@ bundle_load_manifest() {
 				return 1
 			fi
 			BUNDLE_MANIFEST_JSON=$(
-				ruby -ryaml -rjson -e 'puts JSON.generate(YAML.load_file(ARGV[0]))' \
-					"$manifest_input"
+				ruby -ryaml -rjson -e '
+					permitted = [
+						Hash, Array, String, Integer, Float, TrueClass, FalseClass, NilClass
+					]
+					data = YAML.safe_load(
+						File.read(ARGV[0]),
+						permitted_classes: permitted,
+						permitted_symbols: [],
+						aliases: false,
+					)
+					puts JSON.generate(data)
+				' "$manifest_input"
 			)
 			;;
 		*)
@@ -74,7 +84,7 @@ bundle_find_workflow_run() {
 	# shellcheck disable=SC2016
 	workflow_match='((.name | ascii_downcase) == ($wf | ascii_downcase)) or ((.path | split("/")[-1] | sub("\\.ya?ml$"; "") | ascii_downcase) == ($wf | ascii_downcase))'
 	if [[ "$require_success" == "false" ]]; then
-		jq_filter="first(.workflow_runs[] | select(${workflow_match} and (.conclusion == \"success\" or .conclusion == \"failure\")) | .id) // empty"
+		jq_filter="first(.workflow_runs[] | select(${workflow_match} and (.conclusion == \"success\" or .conclusion == \"failure\" or .conclusion == \"cancelled\" or .conclusion == \"timed_out\")) | .id) // empty"
 	else
 		jq_filter="first(.workflow_runs[] | select(${workflow_match} and .conclusion == \"success\") | .id) // empty"
 	fi
@@ -95,7 +105,7 @@ bundle_find_workflow_run_on_ref() {
 	# shellcheck disable=SC2016
 	workflow_match='((.name | ascii_downcase) == ($wf | ascii_downcase)) or ((.path | split("/")[-1] | sub("\\.ya?ml$"; "") | ascii_downcase) == ($wf | ascii_downcase))'
 	if [[ "$require_success" == "false" ]]; then
-		jq_filter="first(.workflow_runs[] | select(${workflow_match} and .head_branch == \$branch and (.conclusion == \"success\" or .conclusion == \"failure\")) | .id) // empty"
+		jq_filter="first(.workflow_runs[] | select(${workflow_match} and .head_branch == \$branch and (.conclusion == \"success\" or .conclusion == \"failure\" or .conclusion == \"cancelled\" or .conclusion == \"timed_out\")) | .id) // empty"
 	else
 		jq_filter="first(.workflow_runs[] | select(${workflow_match} and .head_branch == \$branch and .conclusion == \"success\") | .id) // empty"
 	fi
@@ -118,6 +128,59 @@ bundle_get_artifact_id() {
 	gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts" \
 		--jq 'first(.artifacts[] | select(.name == $name) | .id) // empty' \
 		--arg name "$artifact_name" 2>/dev/null || true
+}
+
+# Validate zip member paths and types before extraction (zip-slip / symlink defense).
+# Usage: bundle_validate_zip_members TEMP_ZIP ARTIFACT_ID
+bundle_validate_zip_members() {
+	local temp_zip="$1"
+	local artifact_id="$2"
+	local entry line perms
+
+	while IFS= read -r entry || [[ -n "$entry" ]]; do
+		[[ -z "$entry" ]] && continue
+		entry="${entry#./}"
+		while [[ "$entry" == /* ]]; do
+			entry="${entry#/}"
+		done
+		if [[ -z "$entry" ]]; then
+			log_error "Zip entry resolves to root for artifact ${artifact_id}"
+			return 1
+		fi
+		if [[ "$entry" == *".."* ]]; then
+			log_error "Zip entry contains path traversal for artifact ${artifact_id}: ${entry}"
+			return 1
+		fi
+	done < <(unzip -Z1 "$temp_zip" 2>/dev/null) || {
+		log_error "Failed to list zip members for artifact ${artifact_id}"
+		return 1
+	}
+
+	while IFS= read -r line; do
+		[[ "$line" == Archive:* || "$line" == *"Zip file size"* || "$line" == *"----"* ]] && continue
+		[[ "$line" =~ ^[[:space:]]*[0-9]+[[:space:]]+files, ]] && break
+		[[ -z "${line// /}" ]] && continue
+		perms="${line%% *}"
+		case "${perms:0:1}" in
+		- | d)
+			continue
+			;;
+		l)
+			log_error "Zip entry is a symlink for artifact ${artifact_id}: ${line}"
+			return 1
+			;;
+		'?')
+			log_error "Zip entry has unsupported type for artifact ${artifact_id}: ${line}"
+			return 1
+			;;
+		*)
+			continue
+			;;
+		esac
+	done < <(unzip -Zvl "$temp_zip" 2>/dev/null) || {
+		log_error "Failed to inspect zip metadata for artifact ${artifact_id}"
+		return 1
+	}
 }
 
 # Download and extract an artifact zip into a destination directory.
@@ -144,6 +207,10 @@ bundle_download_artifact() {
 	fi
 	if ! unzip -tq "$temp_zip" >/dev/null 2>&1; then
 		log_error "Downloaded artifact ${artifact_id} is not a valid zip archive"
+		rm -f "$temp_zip"
+		return 1
+	fi
+	if ! bundle_validate_zip_members "$temp_zip" "$artifact_id"; then
 		rm -f "$temp_zip"
 		return 1
 	fi
@@ -313,7 +380,9 @@ bundle_run_manifest() {
 		if [[ -z "$run_id" && -n "${FALLBACK_REF:-}" ]]; then
 			log_info "Bundle ${bundle_id}: no run for commit; trying ${FALLBACK_REF}"
 			run_id=$(bundle_find_workflow_run_on_ref "$workflow" "$FALLBACK_REF" "$require_success")
-			used_fallback=true
+			if [[ -n "$run_id" ]]; then
+				used_fallback=true
+			fi
 		fi
 
 		if [[ -z "$run_id" ]]; then
@@ -382,5 +451,5 @@ bundle_run_manifest() {
 
 export -f bundle_load_manifest bundle_find_workflow_run
 export -f bundle_find_workflow_run_on_ref bundle_get_artifact_id
-export -f bundle_download_artifact bundle_resolve_site_dest
-export -f bundle_copy_to_site bundle_run_manifest
+export -f bundle_validate_zip_members bundle_download_artifact
+export -f bundle_resolve_site_dest bundle_copy_to_site bundle_run_manifest

--- a/scripts/ci/lib/bundle/workflow_artifacts.sh
+++ b/scripts/ci/lib/bundle/workflow_artifacts.sh
@@ -71,10 +71,10 @@ bundle_find_workflow_run() {
 	local jq_filter
 	if [[ "$require_success" == "false" ]]; then
 		# shellcheck disable=SC2016
-		jq_filter='first(.workflow_runs[] | select((.name == $wf or (.path | test("/" + $wf + "\\.ya?ml$"; "i"))) and (.conclusion == "success" or .conclusion == "failure")) | .id) // empty'
+		jq_filter='first(.workflow_runs[] | select((.name == $wf or (.path | split("/")[-1] | test("^" + $wf + "\\.ya?ml$"; "i"))) and (.conclusion == "success" or .conclusion == "failure")) | .id) // empty'
 	else
 		# shellcheck disable=SC2016
-		jq_filter='first(.workflow_runs[] | select((.name == $wf or (.path | test("/" + $wf + "\\.ya?ml$"; "i"))) and .conclusion == "success") | .id) // empty'
+		jq_filter='first(.workflow_runs[] | select((.name == $wf or (.path | split("/")[-1] | test("^" + $wf + "\\.ya?ml$"; "i"))) and .conclusion == "success") | .id) // empty'
 	fi
 
 	gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${commit_sha}&per_page=100" \
@@ -91,10 +91,10 @@ bundle_find_workflow_run_on_ref() {
 	local jq_filter
 	if [[ "$require_success" == "false" ]]; then
 		# shellcheck disable=SC2016
-		jq_filter='first(.workflow_runs[] | select((.name == $wf or (.path | test("/" + $wf + "\\.ya?ml$"; "i"))) and .head_branch == $branch and (.conclusion == "success" or .conclusion == "failure")) | .id) // empty'
+		jq_filter='first(.workflow_runs[] | select((.name == $wf or (.path | split("/")[-1] | test("^" + $wf + "\\.ya?ml$"; "i"))) and .head_branch == $branch and (.conclusion == "success" or .conclusion == "failure")) | .id) // empty'
 	else
 		# shellcheck disable=SC2016
-		jq_filter='first(.workflow_runs[] | select((.name == $wf or (.path | test("/" + $wf + "\\.ya?ml$"; "i"))) and .head_branch == $branch and .conclusion == "success") | .id) // empty'
+		jq_filter='first(.workflow_runs[] | select((.name == $wf or (.path | split("/")[-1] | test("^" + $wf + "\\.ya?ml$"; "i"))) and .head_branch == $branch and .conclusion == "success") | .id) // empty'
 	fi
 
 	gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${fallback_ref}&per_page=50" \
@@ -129,10 +129,63 @@ bundle_download_artifact() {
 	fi
 
 	temp_zip="$(mktemp "${TMPDIR:-/tmp}/bundle-artifact.XXXXXX.zip")"
-	gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" >"$temp_zip"
+	if ! gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" >"$temp_zip"; then
+		log_error "Failed to download artifact ${artifact_id}"
+		rm -f "$temp_zip"
+		return 1
+	fi
+	if [[ ! -s "$temp_zip" ]]; then
+		log_error "Downloaded artifact ${artifact_id} is empty"
+		rm -f "$temp_zip"
+		return 1
+	fi
+	if ! unzip -tq "$temp_zip" >/dev/null 2>&1; then
+		log_error "Downloaded artifact ${artifact_id} is not a valid zip archive"
+		rm -f "$temp_zip"
+		return 1
+	fi
 	mkdir -p "$dest_dir"
 	unzip -o -q "$temp_zip" -d "$dest_dir/"
 	rm -f "$temp_zip"
+}
+
+# Resolve and validate a manifest dest path under SITE_ROOT.
+# Prints the absolute target directory on success.
+# Usage: bundle_resolve_site_dest SITE_ROOT DEST_SUBDIR
+bundle_resolve_site_dest() {
+	local site_root="$1"
+	local dest_subdir="$2"
+	local site_root_abs target_dir
+
+	if [[ -z "$dest_subdir" || "$dest_subdir" == "null" ]]; then
+		log_error "Bundle dest is required"
+		return 1
+	fi
+	if [[ "$dest_subdir" == /* ]]; then
+		log_error "Bundle dest must be relative to site root: ${dest_subdir}"
+		return 1
+	fi
+	if [[ "$dest_subdir" == *".."* ]]; then
+		log_error "Bundle dest must not contain .. segments: ${dest_subdir}"
+		return 1
+	fi
+
+	site_root_abs=$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$site_root")
+	target_dir=$(
+		python3 -c 'import os, sys; print(os.path.realpath(os.path.join(sys.argv[1], sys.argv[2])))' \
+			"$site_root_abs" "$dest_subdir"
+	)
+
+	case "$target_dir" in
+	"$site_root_abs" | "$site_root_abs"/*)
+		printf '%s\n' "$target_dir"
+		return 0
+		;;
+	*)
+		log_error "Bundle dest escapes site root: ${dest_subdir}"
+		return 1
+		;;
+	esac
 }
 
 # Copy extracted artifact contents into SITE_ROOT/dest.
@@ -141,9 +194,13 @@ bundle_copy_to_site() {
 	local source_dir="$1"
 	local site_root="$2"
 	local dest_subdir="$3"
-	local target_dir="${site_root}/${dest_subdir}"
+	local target_dir
 
 	if [[ ! -d "$source_dir" ]] || [[ -z "$(ls -A "$source_dir" 2>/dev/null || true)" ]]; then
+		return 1
+	fi
+
+	if ! target_dir=$(bundle_resolve_site_dest "$site_root" "$dest_subdir"); then
 		return 1
 	fi
 
@@ -197,6 +254,7 @@ bundle_run_manifest() {
 	fi
 
 	temp_root="$(mktemp -d "${TMPDIR:-/tmp}/bundle-workflow-artifacts.XXXXXX")"
+	trap 'rm -rf "${temp_root:-}"' EXIT INT TERM
 	local applied=0
 	local index
 	for ((index = 0; index < bundle_count; index++)); do
@@ -227,6 +285,14 @@ bundle_run_manifest() {
 		fi
 		if [[ -z "$dest" || "$dest" == "null" ]]; then
 			log_error "Bundle ${bundle_id}: dest is required"
+			((warnings++)) || true
+			if [[ "$strict" == "true" ]]; then
+				return 1
+			fi
+			continue
+		fi
+		if ! bundle_resolve_site_dest "$SITE_ROOT" "$dest" >/dev/null; then
+			log_warn "Bundle ${bundle_id}: invalid dest ${dest}"
 			((warnings++)) || true
 			if [[ "$strict" == "true" ]]; then
 				return 1
@@ -292,6 +358,7 @@ bundle_run_manifest() {
 		fi
 	done
 
+	trap - EXIT INT TERM
 	rm -rf "$temp_root"
 
 	set_github_output "files-bundled" "$files_bundled"
@@ -308,4 +375,5 @@ bundle_run_manifest() {
 
 export -f bundle_load_manifest bundle_find_workflow_run
 export -f bundle_find_workflow_run_on_ref bundle_get_artifact_id
-export -f bundle_download_artifact bundle_copy_to_site bundle_run_manifest
+export -f bundle_download_artifact bundle_resolve_site_dest
+export -f bundle_copy_to_site bundle_run_manifest

--- a/scripts/ci/lib/bundle/workflow_artifacts.sh
+++ b/scripts/ci/lib/bundle/workflow_artifacts.sh
@@ -21,6 +21,7 @@
 
 [[ -n "${_LGTM_CI_BUNDLE_WORKFLOW_ARTIFACTS_LOADED:-}" ]] && return 0
 readonly _LGTM_CI_BUNDLE_WORKFLOW_ARTIFACTS_LOADED=1
+readonly BUNDLE_WORKFLOW_RUNS_PER_PAGE=100
 
 # Load manifest JSON from inline JSON or a .json/.yaml/.yml file path.
 # Sets BUNDLE_MANIFEST_JSON.
@@ -78,7 +79,7 @@ bundle_find_workflow_run() {
 		jq_filter="first(.workflow_runs[] | select(${workflow_match} and .conclusion == \"success\") | .id) // empty"
 	fi
 
-	gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${commit_sha}&per_page=100" \
+	gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${commit_sha}&per_page=${BUNDLE_WORKFLOW_RUNS_PER_PAGE}" \
 		--jq "$jq_filter" --arg wf "$workflow_key"
 }
 
@@ -99,7 +100,7 @@ bundle_find_workflow_run_on_ref() {
 		jq_filter="first(.workflow_runs[] | select(${workflow_match} and .head_branch == \$branch and .conclusion == \"success\") | .id) // empty"
 	fi
 
-	gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${fallback_ref}&per_page=50" \
+	gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${fallback_ref}&per_page=${BUNDLE_WORKFLOW_RUNS_PER_PAGE}" \
 		--jq "$jq_filter" --arg wf "$workflow_key" --arg branch "$fallback_ref"
 }
 

--- a/scripts/ci/lib/bundle/workflow_artifacts.sh
+++ b/scripts/ci/lib/bundle/workflow_artifacts.sh
@@ -333,35 +333,42 @@ bundle_run_manifest() {
 	fi
 
 	temp_root="$(mktemp -d "${TMPDIR:-/tmp}/bundle-workflow-artifacts.XXXXXX")"
-	local old_trap_exit old_trap_int old_trap_term cleanup_cmd
-	old_trap_exit=$(trap -p EXIT | sed "s/trap -- '\(.*\)' EXIT/\1/" || true)
-	old_trap_int=$(trap -p INT | sed "s/trap -- '\(.*\)' INT/\1/" || true)
-	old_trap_term=$(trap -p TERM | sed "s/trap -- '\(.*\)' TERM/\1/" || true)
-	cleanup_cmd="rm -rf '$temp_root'"
-	# RETURN traps are function-scoped; callers cannot be read via trap -p RETURN here.
-	# shellcheck disable=SC2064
-	trap "$cleanup_cmd" RETURN
-	if [[ -n "$old_trap_exit" ]]; then
-		# shellcheck disable=SC2064
-		trap "$cleanup_cmd; $old_trap_exit" EXIT
-	else
-		# shellcheck disable=SC2064
-		trap "$cleanup_cmd" EXIT
-	fi
-	if [[ -n "$old_trap_int" ]]; then
-		# shellcheck disable=SC2064
-		trap "$cleanup_cmd; $old_trap_int" INT
-	else
-		# shellcheck disable=SC2064
-		trap "$cleanup_cmd" INT
-	fi
-	if [[ -n "$old_trap_term" ]]; then
-		# shellcheck disable=SC2064
-		trap "$cleanup_cmd; $old_trap_term" TERM
-	else
-		# shellcheck disable=SC2064
-		trap "$cleanup_cmd" TERM
-	fi
+	local old_trap_return_cmd old_trap_exit_cmd old_trap_int_cmd old_trap_term_cmd
+	old_trap_return_cmd=$(trap -p RETURN 2>/dev/null || true)
+	old_trap_exit_cmd=$(trap -p EXIT || true)
+	old_trap_int_cmd=$(trap -p INT || true)
+	old_trap_term_cmd=$(trap -p TERM || true)
+
+	__bundle_run_manifest_restore_traps() {
+		if [[ -n "$old_trap_return_cmd" ]]; then
+			eval "$old_trap_return_cmd"
+		else
+			trap - RETURN
+		fi
+		if [[ -n "$old_trap_exit_cmd" ]]; then
+			eval "$old_trap_exit_cmd"
+		else
+			trap - EXIT
+		fi
+		if [[ -n "$old_trap_int_cmd" ]]; then
+			eval "$old_trap_int_cmd"
+		else
+			trap - INT
+		fi
+		if [[ -n "$old_trap_term_cmd" ]]; then
+			eval "$old_trap_term_cmd"
+		else
+			trap - TERM
+		fi
+	}
+
+	__bundle_run_manifest_temp_trap() {
+		rm -rf "${temp_root:-}"
+		__bundle_run_manifest_restore_traps
+	}
+
+	# shellcheck disable=SC2064 # Invoke nested trap helpers when signals fire
+	trap '__bundle_run_manifest_temp_trap' RETURN EXIT INT TERM
 	local applied=0
 	local index
 	for ((index = 0; index < bundle_count; index++)); do
@@ -467,8 +474,8 @@ bundle_run_manifest() {
 		fi
 	done
 
-	trap - RETURN EXIT INT TERM
 	rm -rf "$temp_root"
+	__bundle_run_manifest_restore_traps
 
 	set_github_output "files-bundled" "$files_bundled"
 	set_github_output "bundles-applied" "$applied"

--- a/scripts/ci/lib/release/assets.sh
+++ b/scripts/ci/lib/release/assets.sh
@@ -12,7 +12,9 @@ release_collect_asset_files() {
 	local patterns_input="${1:?file patterns are required}"
 	local -a collected=()
 	local pattern file
+	local nullglob_was_set=0
 
+	shopt -q nullglob && nullglob_was_set=1
 	shopt -s nullglob
 	while IFS= read -r pattern || [[ -n "$pattern" ]]; do
 		[[ -z "${pattern// /}" ]] && continue
@@ -26,7 +28,9 @@ release_collect_asset_files() {
 			fi
 		done
 	done <<<"$patterns_input"
-	shopt -u nullglob
+	if ((nullglob_was_set == 0)); then
+		shopt -u nullglob
+	fi
 
 	RELEASE_ASSET_FILES=("${collected[@]+"${collected[@]}"}")
 	echo "${#collected[@]}"

--- a/scripts/ci/lib/release/assets.sh
+++ b/scripts/ci/lib/release/assets.sh
@@ -16,9 +16,11 @@ release_collect_asset_files() {
 	shopt -s nullglob
 	while IFS= read -r pattern || [[ -n "$pattern" ]]; do
 		[[ -z "${pattern// /}" ]] && continue
+		local -a matches=()
 		# shellcheck disable=SC2206 # Glob expansion is intentional for release patterns
-		local -a matches=($pattern)
-		for file in "${matches[@]}"; do
+		matches=($pattern)
+		local file
+		for file in ${matches[@]+"${matches[@]}"}; do
 			if [[ -f "$file" ]]; then
 				collected+=("$file")
 			fi
@@ -26,7 +28,7 @@ release_collect_asset_files() {
 	done <<<"$patterns_input"
 	shopt -u nullglob
 
-	RELEASE_ASSET_FILES=("${collected[@]}")
+	RELEASE_ASSET_FILES=("${collected[@]+"${collected[@]}"}")
 	echo "${#collected[@]}"
 }
 

--- a/scripts/ci/lib/release/assets.sh
+++ b/scripts/ci/lib/release/assets.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Resolve release asset paths from newline-separated glob patterns
+
+[[ -n "${_RELEASE_ASSETS_LOADED:-}" ]] && return 0
+readonly _RELEASE_ASSETS_LOADED=1
+
+# Collect regular files matching newline-separated glob patterns.
+# Sets RELEASE_ASSET_FILES array. Prints the match count to stdout.
+# Usage: release_collect_asset_files "$FILE_PATTERNS"
+release_collect_asset_files() {
+	local patterns_input="${1:?file patterns are required}"
+	local -a collected=()
+	local pattern file
+
+	shopt -s nullglob
+	while IFS= read -r pattern || [[ -n "$pattern" ]]; do
+		[[ -z "${pattern// /}" ]] && continue
+		# shellcheck disable=SC2206 # Glob expansion is intentional for release patterns
+		local -a matches=($pattern)
+		for file in "${matches[@]}"; do
+			if [[ -f "$file" ]]; then
+				collected+=("$file")
+			fi
+		done
+	done <<<"$patterns_input"
+	shopt -u nullglob
+
+	RELEASE_ASSET_FILES=("${collected[@]}")
+	echo "${#collected[@]}"
+}
+
+export -f release_collect_asset_files

--- a/scripts/ci/release/create-github-release.sh
+++ b/scripts/ci/release/create-github-release.sh
@@ -12,7 +12,8 @@
 #   PRERELEASE - Mark as prerelease (default: false)
 #   GENERATE_NOTES - Use GitHub's auto-generated notes (default: false)
 #   FILES - Space-separated list of files to attach
-#   REPO - Repository in owner/repo format (default: from git remote)
+#   FILE_PATTERNS - Newline-separated glob patterns (used by reusable workflows)
+#   REPO - Repository in owner/repo format (default: GITHUB_REPOSITORY or git remote)
 
 set -euo pipefail
 

--- a/scripts/ci/release/create-github-release.sh
+++ b/scripts/ci/release/create-github-release.sh
@@ -26,6 +26,8 @@ source "$LIB_DIR/log.sh"
 source "$LIB_DIR/github.sh"
 # shellcheck source=../lib/release.sh
 source "$LIB_DIR/release.sh"
+# shellcheck source=../lib/release/assets.sh
+source "$LIB_DIR/release/assets.sh"
 
 : "${TAG:?TAG is required}"
 : "${TITLE:=$TAG}"
@@ -34,6 +36,7 @@ source "$LIB_DIR/release.sh"
 : "${PRERELEASE:=false}"
 : "${GENERATE_NOTES:=false}"
 : "${FILES:=}"
+: "${FILE_PATTERNS:=}"
 : "${REPO:=}"
 
 # Check for gh CLI
@@ -44,12 +47,16 @@ fi
 
 # Get repo from git remote if not specified
 if [[ -z "$REPO" ]]; then
-	REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "")
-	if [[ "$REMOTE_URL" =~ github\.com[:/]([^/]+/[^/]+) ]]; then
-		REPO="${BASH_REMATCH[1]}"
-		REPO="${REPO%.git}"
-	else
-		log_error "Could not determine repository from git remote"
+	if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
+		REPO="$GITHUB_REPOSITORY"
+	elif REMOTE_URL=$(git remote get-url origin 2>/dev/null); then
+		if [[ "$REMOTE_URL" =~ github\.com[:/]([^/]+/[^/]+) ]]; then
+			REPO="${BASH_REMATCH[1]}"
+			REPO="${REPO%.git}"
+		fi
+	fi
+	if [[ -z "$REPO" ]]; then
+		log_error "Could not determine repository; set REPO or GITHUB_REPOSITORY"
 		exit 1
 	fi
 fi
@@ -81,8 +88,17 @@ else
 fi
 
 # Add files if specified
-if [[ -n "$FILES" ]]; then
-	# shellcheck disable=SC2086 # Word splitting intended for FILES
+if [[ -n "$FILE_PATTERNS" ]]; then
+	count=$(release_collect_asset_files "$FILE_PATTERNS")
+	if ((count == 0)); then
+		log_error "No release assets matched FILE_PATTERNS"
+		exit 1
+	fi
+	for file in "${RELEASE_ASSET_FILES[@]}"; do
+		GH_ARGS+=("$file")
+	done
+elif [[ -n "$FILES" ]]; then
+	# shellcheck disable=SC2086 # Word splitting intended for space-separated FILES
 	for file in $FILES; do
 		if [[ -f "$file" ]]; then
 			GH_ARGS+=("$file")

--- a/scripts/ci/release/create-github-release.sh
+++ b/scripts/ci/release/create-github-release.sh
@@ -90,12 +90,13 @@ fi
 
 # Add files if specified
 if [[ -n "$FILE_PATTERNS" ]]; then
-	count=$(release_collect_asset_files "$FILE_PATTERNS")
+	release_collect_asset_files "$FILE_PATTERNS"
+	count=${#RELEASE_ASSET_FILES[@]}
 	if ((count == 0)); then
 		log_error "No release assets matched FILE_PATTERNS"
 		exit 1
 	fi
-	for file in "${RELEASE_ASSET_FILES[@]}"; do
+	for file in ${RELEASE_ASSET_FILES[@]+"${RELEASE_ASSET_FILES[@]}"}; do
 		GH_ARGS+=("$file")
 	done
 elif [[ -n "$FILES" ]]; then

--- a/scripts/ci/release/create-github-release.sh
+++ b/scripts/ci/release/create-github-release.sh
@@ -96,7 +96,7 @@ if [[ -n "$FILE_PATTERNS" ]]; then
 		log_error "No release assets matched FILE_PATTERNS"
 		exit 1
 	fi
-	for file in ${RELEASE_ASSET_FILES[@]+"${RELEASE_ASSET_FILES[@]}"}; do
+	for file in "${RELEASE_ASSET_FILES[@]}"; do
 		GH_ARGS+=("$file")
 	done
 elif [[ -n "$FILES" ]]; then

--- a/scripts/ci/release/verify-release-assets.sh
+++ b/scripts/ci/release/verify-release-assets.sh
@@ -16,17 +16,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
 # shellcheck source=../lib/log.sh
 source "$SCRIPT_DIR/../lib/log.sh"
+# shellcheck source=../lib/release/assets.sh
+source "$SCRIPT_DIR/../lib/release/assets.sh"
 
-shopt -s nullglob
-count=0
-while IFS= read -r pattern || [[ -n "$pattern" ]]; do
-	[[ -z "${pattern// /}" ]] && continue
-	for file in $pattern; do
-		if [[ -f "$file" ]]; then
-			count=$((count + 1))
-		fi
-	done
-done <<<"$FILES"
+count=$(release_collect_asset_files "$FILES")
 
 if ((count == 0)); then
 	log_error "No release assets matched FILES patterns (artifact-path=${ARTIFACT_PATH})"

--- a/tests/bats/integration/test_bundle_workflow_artifacts.bats
+++ b/tests/bats/integration/test_bundle_workflow_artifacts.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for bundle workflow artifacts and deploy-site-with-reports (#226)
+
+load "../../helpers/common"
+
+_checkout_order_ok() {
+	local workflow="$1"
+	local job_pattern="$2"
+	awk -v job="$job_pattern" '
+		$0 ~ "^  " job ":" { in_job = 1 }
+		in_job && /^  [a-zA-Z0-9_-]+:/ && $0 !~ "^  " job ":" { in_job = 0 }
+		in_job && /^    steps:/ { in_steps = 1 }
+		in_job && in_steps && /^      - name: Harden runner/ { harden = NR }
+		in_job && in_steps && /^      - name: Checkout repository/ { repo = NR }
+		in_job && in_steps && /^      - name: Checkout lgtm-ci tooling/ { tooling = NR }
+		END {
+			ok = (harden > 0 && repo > 0 && tooling > 0 && harden < repo && repo < tooling)
+			exit !ok
+		}
+	' "$workflow"
+}
+
+@test "bundle-workflow-artifacts action: references script not inline shell" {
+	local action="${PROJECT_ROOT}/.github/actions/bundle-workflow-artifacts/action.yml"
+	run grep -q 'bundle-workflow-artifacts.sh' "$action"
+	assert_success
+	run grep -q 'run: \|' "$action"
+	assert_failure
+}
+
+@test "bundle-workflow-artifacts action: exposes bundle outputs" {
+	local action="${PROJECT_ROOT}/.github/actions/bundle-workflow-artifacts/action.yml"
+	run grep -q 'files-bundled' "$action"
+	assert_success
+	run grep -q 'bundles-applied' "$action"
+	assert_success
+	run grep -q 'bundle-warnings' "$action"
+	assert_success
+}
+
+@test "reusable-deploy-site-with-reports: build job has actions read permission" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-deploy-site-with-reports.yml"
+	run awk '
+		/^  build:/ { in_build = 1 }
+		/^  deploy:/ { in_build = 0 }
+		in_build && /actions: read/ { actions = 1 }
+		in_build && /contents: read/ { contents = 1 }
+		END { exit !(actions && contents) }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-deploy-site-with-reports: bundles after build and before upload" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-deploy-site-with-reports.yml"
+	run awk '
+		/^  build:/ { in_build = 1 }
+		/^  deploy:/ { in_build = 0 }
+		in_build && /name: Build site/ { build = NR }
+		in_build && /name: Bundle workflow artifacts/ { bundle = NR }
+		in_build && /name: Prepare and upload artifact/ { upload = NR }
+		END { exit !(build > 0 && bundle > 0 && upload > 0 && build < bundle && bundle < upload) }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-deploy-site-with-reports: uses official Pages deploy actions" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-deploy-site-with-reports.yml"
+	run grep -q 'actions/configure-pages@' "$workflow"
+	assert_success
+	run grep -q 'actions/deploy-pages@' "$workflow"
+	assert_success
+	run grep -q 'bundle-workflow-artifacts' "$workflow"
+	assert_success
+}
+
+@test "reusable-deploy-site-with-reports: shared pages concurrency group" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-deploy-site-with-reports.yml"
+	run grep -q 'group: pages-${{ github.repository }}-${{ github.ref }}' "$workflow"
+	assert_success
+}
+
+@test "reusable-deploy-site-with-reports: build job checkout order" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-deploy-site-with-reports.yml"
+	run _checkout_order_ok "$workflow" "build"
+	assert_success
+}
+
+@test "reusable-deploy-site-with-reports: exposes page-url output" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-deploy-site-with-reports.yml"
+	run grep -q 'jobs.deploy.outputs.page-url' "$workflow"
+	assert_success
+}
+
+@test "reusable-deploy-site-with-reports: no inline shell in build job" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-deploy-site-with-reports.yml"
+	run awk '
+		/^  build:/ { in_build = 1 }
+		/^  deploy:/ { in_build = 0 }
+		in_build && /run: \|/ { inline = 1 }
+		END { exit inline }
+	' "$workflow"
+	assert_success
+}
+
+@test "example turbo-themes manifest: valid JSON with expected bundles" {
+	local manifest="${PROJECT_ROOT}/examples/bundle-manifest-turbo-themes.json"
+	run jq -e '.bundles | length >= 5' "$manifest"
+	assert_success
+	run jq -e '.bundles[] | select(.dest == "coverage")' "$manifest"
+	assert_success
+}

--- a/tests/bats/integration/test_bundle_workflow_artifacts.bats
+++ b/tests/bats/integration/test_bundle_workflow_artifacts.bats
@@ -25,7 +25,7 @@ _checkout_order_ok() {
 	local action="${PROJECT_ROOT}/.github/actions/bundle-workflow-artifacts/action.yml"
 	run grep -q 'bundle-workflow-artifacts.sh' "$action"
 	assert_success
-	run grep -q 'run: \|' "$action"
+	run grep -Fq 'run: |' "$action"
 	assert_failure
 }
 

--- a/tests/bats/integration/test_bundle_workflow_artifacts.bats
+++ b/tests/bats/integration/test_bundle_workflow_artifacts.bats
@@ -25,8 +25,13 @@ _checkout_order_ok() {
 	local action="${PROJECT_ROOT}/.github/actions/bundle-workflow-artifacts/action.yml"
 	run grep -q 'bundle-workflow-artifacts.sh' "$action"
 	assert_success
-	run grep -Fq 'run: |' "$action"
-	assert_failure
+	run awk '
+		/^    - name: Bundle workflow artifacts/ { in_bundle = 1 }
+		in_bundle && /^    - name:/ && $0 !~ /Bundle workflow artifacts/ { exit 0 }
+		in_bundle && /run: \|/ { exit 1 }
+		END { exit 0 }
+	' "$action"
+	assert_success
 }
 
 @test "bundle-workflow-artifacts action: exposes bundle outputs" {

--- a/tests/bats/integration/test_reusable_python_release_publish.bats
+++ b/tests/bats/integration/test_reusable_python_release_publish.bats
@@ -63,6 +63,19 @@ _tooling_sparse_cone_ok() {
 	assert_success
 }
 
+@test "reusable-publish-pypi-release: publish job downloads artifact before setup python" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-publish-pypi-release.yml"
+	run awk '
+		/^  [a-zA-Z0-9_-]+:/ { in_publish = 0 }
+		/^  publish:/ { in_publish = 1 }
+		in_publish && /name: Download Python distribution/ { download = NR }
+		in_publish && /name: Setup Python/ { setup = NR }
+		in_publish && /STEP: validate-dist/ { validate = NR }
+		END { exit !(download > 0 && setup > 0 && validate > 0 && download < setup && setup < validate) }
+	' "$workflow"
+	assert_success
+}
+
 @test "reusable-publish-pypi-release: publish job installs Python before validate" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-publish-pypi-release.yml"
 	run awk '
@@ -128,14 +141,14 @@ _tooling_sparse_cone_ok() {
 	assert_success
 }
 
-@test "reusable-github-release: downloads artifact and uses softprops action" {
+@test "reusable-github-release: downloads artifact and creates release via gh script" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-github-release.yml"
 	run awk '
 		/actions\/download-artifact@/ { download = 1 }
 		/Verify release assets exist/ { verify = 1 }
 		/verify-release-assets\.sh/ { verify_script = 1 }
 		/run: \|/ { inline_shell = 1 }
-		/softprops\/action-gh-release@/ { release = 1 }
+		/create-github-release\.sh/ { release = 1 }
 		END { exit !(download && verify && verify_script && release && !inline_shell) }
 	' "$workflow"
 	assert_success
@@ -165,6 +178,6 @@ _tooling_sparse_cone_ok() {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-github-release.yml"
 	run grep -q 'jobs.release.outputs.release-url' "$workflow"
 	assert_success
-	run grep -q 'steps.gh-release.outputs.url' "$workflow"
+	run grep -q 'steps.gh-release.outputs.release-url' "$workflow"
 	assert_success
 }

--- a/tests/bats/unit/lib/bundle/test_workflow_artifacts.bats
+++ b/tests/bats/unit/lib/bundle/test_workflow_artifacts.bats
@@ -23,6 +23,62 @@ teardown() {
 	teardown_temp_dir
 }
 
+_create_traversal_artifact_zip() {
+	local zip_path="${BATS_TEST_TMPDIR}/traversal.zip"
+	python3 - "$zip_path" <<'PY'
+import sys
+import zipfile
+
+with zipfile.ZipFile(sys.argv[1], "w") as archive:
+    archive.writestr("../../outside.txt", "pwned")
+PY
+	echo "$zip_path"
+}
+
+_create_symlink_artifact_zip() {
+	local zip_path="${BATS_TEST_TMPDIR}/symlink.zip"
+	python3 - "$zip_path" <<'PY'
+import sys
+import zipfile
+
+info = zipfile.ZipInfo("link")
+info.external_attr = (0o120777 << 16)
+with zipfile.ZipFile(sys.argv[1], "w") as archive:
+    archive.writestr(info, "target")
+PY
+	echo "$zip_path"
+}
+
+_setup_artifact_zip_gh_mock() {
+	local zip_path="$1"
+	local artifact_id="${2:-99}"
+
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+
+	cat >"${mock_bin}/gh" <<EOF
+#!/usr/bin/env bash
+url=""
+for ((i = 1; i <= \$#; i++)); do
+	case "\${!i}" in
+	repos/*) url="\${!i}" ;;
+	esac
+done
+
+case "\$url" in
+*actions/artifacts/${artifact_id}/zip*)
+	cat "${zip_path}"
+	;;
+*)
+	echo ""
+	;;
+esac
+exit 0
+EOF
+	chmod +x "${mock_bin}/gh"
+	export PATH="${mock_bin}:$PATH"
+}
+
 _create_artifact_zip() {
 	local zip_path="${BATS_TEST_TMPDIR}/artifact.zip"
 	local root="${BATS_TEST_TMPDIR}/artifact-root"
@@ -86,6 +142,56 @@ exit 0
 EOF
 	chmod +x "${mock_bin}/gh"
 	export PATH="${mock_bin}:$PATH"
+}
+
+@test "bundle_validate_zip_members: rejects path traversal entries" {
+	local zip_path
+	zip_path=$(_create_traversal_artifact_zip)
+
+	run bundle_validate_zip_members "$zip_path" 42
+	assert_failure
+	assert_output --partial "path traversal"
+}
+
+@test "bundle_validate_zip_members: rejects symlink entries" {
+	local zip_path
+	zip_path=$(_create_symlink_artifact_zip)
+
+	run bundle_validate_zip_members "$zip_path" 42
+	assert_failure
+	assert_output --partial "symlink"
+}
+
+@test "bundle_download_artifact: rejects zip slip before extraction" {
+	local zip_path dest_dir
+	zip_path=$(_create_traversal_artifact_zip)
+	dest_dir="${BATS_TEST_TMPDIR}/dest"
+	_setup_artifact_zip_gh_mock "$zip_path"
+
+	run bundle_download_artifact 99 "$dest_dir"
+	assert_failure
+	assert_output --partial "path traversal"
+	run test ! -e "${BATS_TEST_TMPDIR}/outside.txt"
+	assert_success
+}
+
+@test "bundle_run_manifest: does not claim fallback when lookup fails" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+	cat >"${mock_bin}/gh" <<'EOF'
+#!/usr/bin/env bash
+echo ""
+exit 0
+EOF
+	chmod +x "${mock_bin}/gh"
+	export PATH="${mock_bin}:$PATH"
+	export FALLBACK_REF="main"
+	bundle_load_manifest '{"bundles":[{"id":"missing","workflow":"missing-workflow","artifact":"coverage-html","dest":"coverage"}]}'
+
+	run bundle_run_manifest
+	assert_success
+	assert_output --partial "no workflow run found"
+	refute_output --partial "using fallback run"
 }
 
 @test "bundle_load_manifest: loads inline JSON" {

--- a/tests/bats/unit/lib/bundle/test_workflow_artifacts.bats
+++ b/tests/bats/unit/lib/bundle/test_workflow_artifacts.bats
@@ -185,6 +185,20 @@ EOF
 	assert_output --partial "path traversal"
 }
 
+@test "bundle_validate_zip_members: allows double dots in filenames" {
+	local zip_path="${BATS_TEST_TMPDIR}/double-dot.zip"
+	python3 - "$zip_path" <<'PY'
+import sys
+import zipfile
+
+with zipfile.ZipFile(sys.argv[1], "w") as archive:
+    archive.writestr("report..2024.html", "ok")
+PY
+
+	run bundle_validate_zip_members "$zip_path" 42
+	assert_success
+}
+
 @test "bundle_validate_zip_members: rejects symlink entries" {
 	local zip_path
 	zip_path=$(_create_symlink_artifact_zip)

--- a/tests/bats/unit/lib/bundle/test_workflow_artifacts.bats
+++ b/tests/bats/unit/lib/bundle/test_workflow_artifacts.bats
@@ -150,6 +150,17 @@ EOF
 	assert_failure
 }
 
+@test "bundle_run_manifest: rejects dest path traversal" {
+	_setup_bundle_gh_mock
+	bundle_load_manifest '{"bundles":[{"id":"escape","workflow":"quality-ci-main","artifact":"coverage-html","dest":"../outside"}]}'
+
+	run bundle_run_manifest
+	assert_success
+	assert_output --partial "must not contain .. segments"
+	run test ! -e "${BATS_TEST_TMPDIR}/outside"
+	assert_success
+}
+
 @test "bundle-workflow-artifacts action script: runs end-to-end" {
 	_setup_bundle_gh_mock
 	local manifest="${BATS_TEST_TMPDIR}/manifest.json"

--- a/tests/bats/unit/lib/bundle/test_workflow_artifacts.bats
+++ b/tests/bats/unit/lib/bundle/test_workflow_artifacts.bats
@@ -35,6 +35,18 @@ PY
 	echo "$zip_path"
 }
 
+_create_absolute_artifact_zip() {
+	local zip_path="${BATS_TEST_TMPDIR}/absolute.zip"
+	python3 - "$zip_path" <<'PY'
+import sys
+import zipfile
+
+with zipfile.ZipFile(sys.argv[1], "w") as archive:
+    archive.writestr("/etc/passwd", "pwned")
+PY
+	echo "$zip_path"
+}
+
 _create_symlink_artifact_zip() {
 	local zip_path="${BATS_TEST_TMPDIR}/symlink.zip"
 	python3 - "$zip_path" <<'PY'
@@ -142,6 +154,26 @@ exit 0
 EOF
 	chmod +x "${mock_bin}/gh"
 	export PATH="${mock_bin}:$PATH"
+}
+
+@test "bundle_run_manifest: ignores malicious bundle id in staging paths" {
+	_setup_bundle_gh_mock
+	bundle_load_manifest '{"bundles":[{"id":"../../outside","workflow":"quality-ci-main","artifact":"coverage-html","dest":"coverage"}]}'
+
+	run bundle_run_manifest
+	assert_success
+	assert_file_exists "${SITE_ROOT}/coverage/index.html"
+	run test ! -e "${BATS_TEST_TMPDIR}/outside"
+	assert_success
+}
+
+@test "bundle_validate_zip_members: rejects absolute zip entries" {
+	local zip_path
+	zip_path=$(_create_absolute_artifact_zip)
+
+	run bundle_validate_zip_members "$zip_path" 42
+	assert_failure
+	assert_output --partial "Zip entry is absolute"
 }
 
 @test "bundle_validate_zip_members: rejects path traversal entries" {

--- a/tests/bats/unit/lib/bundle/test_workflow_artifacts.bats
+++ b/tests/bats/unit/lib/bundle/test_workflow_artifacts.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for bundle workflow artifact library
+
+load "../../../../helpers/common"
+load "../../../../helpers/github_env"
+load "../../../../helpers/mocks"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+	export GITHUB_REPOSITORY="lgtm-hq/turbo-themes"
+	export COMMIT_SHA="abc123deadbeef"
+	export SITE_ROOT="${BATS_TEST_TMPDIR}/site"
+	mkdir -p "$SITE_ROOT"
+	# shellcheck source=../../../../../scripts/ci/lib/actions.sh
+	source "${PROJECT_ROOT}/scripts/ci/lib/actions.sh"
+	# shellcheck source=../../../../../scripts/ci/lib/bundle/workflow_artifacts.sh
+	source "${PROJECT_ROOT}/scripts/ci/lib/bundle/workflow_artifacts.sh"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+_create_artifact_zip() {
+	local zip_path="${BATS_TEST_TMPDIR}/artifact.zip"
+	local root="${BATS_TEST_TMPDIR}/artifact-root"
+	mkdir -p "$root"
+	echo '<html>report</html>' >"${root}/index.html"
+	(
+		cd "$root" || exit 1
+		zip -q "$zip_path" index.html
+	)
+	echo "$zip_path"
+}
+
+_setup_bundle_gh_mock() {
+	local run_id="${1:-42}"
+	local artifact_id="${2:-99}"
+	local zip_path
+	zip_path=$(_create_artifact_zip)
+
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+
+	cat >"${mock_bin}/gh" <<EOF
+#!/usr/bin/env bash
+url=""
+workflow=""
+for ((i = 1; i <= \$#; i++)); do
+	case "\${!i}" in
+	repos/*) url="\${!i}" ;;
+	--arg)
+		next=\$((i + 1))
+		if [[ "\${!next}" == "wf" ]]; then
+			wf_index=\$((i + 2))
+			workflow="\${!wf_index}"
+		fi
+		;;
+	esac
+done
+
+case "\$url" in
+*actions/runs?head_sha=abc123*)
+	if [[ "\$workflow" == "missing-workflow" ]]; then
+		echo ""
+	else
+		echo "${run_id}"
+	fi
+	;;
+*actions/runs?branch=main*)
+	echo "${run_id}"
+	;;
+*actions/runs/${run_id}/artifacts*)
+	echo "${artifact_id}"
+	;;
+*actions/artifacts/${artifact_id}/zip*)
+	cat "${zip_path}"
+	;;
+*)
+	echo ""
+	;;
+esac
+exit 0
+EOF
+	chmod +x "${mock_bin}/gh"
+	export PATH="${mock_bin}:$PATH"
+}
+
+@test "bundle_load_manifest: loads inline JSON" {
+	bundle_load_manifest '{"bundles":[{"workflow":"ci","artifact":"html","dest":"coverage"}]}'
+	run jq -e '.bundles[0].workflow == "ci"' <<<"$BUNDLE_MANIFEST_JSON"
+	assert_success
+}
+
+@test "bundle_load_manifest: loads JSON file" {
+	local manifest="${BATS_TEST_TMPDIR}/manifest.json"
+	cat >"$manifest" <<'EOF'
+{"bundles":[{"workflow":"ci","artifact":"html","dest":"coverage"}]}
+EOF
+	bundle_load_manifest "$manifest"
+	run jq -e '.bundles[0].artifact == "html"' <<<"$BUNDLE_MANIFEST_JSON"
+	assert_success
+}
+
+@test "bundle_load_manifest: rejects invalid JSON" {
+	run bundle_load_manifest "not-json"
+	assert_failure
+}
+
+@test "bundle_run_manifest: copies artifact into site root" {
+	_setup_bundle_gh_mock
+	bundle_load_manifest '{"bundles":[{"id":"coverage","workflow":"quality-ci-main","artifact":"coverage-html","dest":"coverage"}]}'
+
+	run bundle_run_manifest
+	assert_success
+	assert_file_exists "${SITE_ROOT}/coverage/index.html"
+	run grep -q 'report' "${SITE_ROOT}/coverage/index.html"
+	assert_success
+}
+
+@test "bundle_run_manifest: records github outputs" {
+	_setup_bundle_gh_mock
+	bundle_load_manifest '{"bundles":[{"id":"coverage","workflow":"quality-ci-main","artifact":"coverage-html","dest":"coverage"}]}'
+
+	run bundle_run_manifest
+	assert_success
+	grep -q '^files-bundled=1$' "$GITHUB_OUTPUT"
+	grep -q '^bundles-applied=1$' "$GITHUB_OUTPUT"
+	grep -q '^bundle-warnings=0$' "$GITHUB_OUTPUT"
+}
+
+@test "bundle_run_manifest: warns on missing workflow when not strict" {
+	_setup_bundle_gh_mock
+	bundle_load_manifest '{"bundles":[{"id":"missing","workflow":"missing-workflow","artifact":"coverage-html","dest":"coverage"}]}'
+
+	run bundle_run_manifest
+	assert_success
+	assert_output --partial "no workflow run found"
+	grep -q '^bundles-applied=0$' "$GITHUB_OUTPUT"
+	grep -q '^bundle-warnings=1$' "$GITHUB_OUTPUT"
+}
+
+@test "bundle_run_manifest: fails in strict mode for missing workflow" {
+	_setup_bundle_gh_mock
+	bundle_load_manifest '{"strict":true,"bundles":[{"id":"missing","workflow":"missing-workflow","artifact":"coverage-html","dest":"coverage"}]}'
+
+	run bundle_run_manifest
+	assert_failure
+}
+
+@test "bundle-workflow-artifacts action script: runs end-to-end" {
+	_setup_bundle_gh_mock
+	local manifest="${BATS_TEST_TMPDIR}/manifest.json"
+	cat >"$manifest" <<'EOF'
+{"bundles":[{"id":"coverage","workflow":"quality-ci-main","artifact":"coverage-html","dest":"coverage"}]}
+EOF
+	export BUNDLE_MANIFEST="$manifest"
+
+	run bash "${PROJECT_ROOT}/scripts/ci/actions/bundle-workflow-artifacts.sh"
+	assert_success
+	assert_file_exists "${SITE_ROOT}/coverage/index.html"
+}

--- a/tests/bats/unit/lib/release/test_release_assets.bats
+++ b/tests/bats/unit/lib/release/test_release_assets.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/lib/release/assets.sh
+
+load "../../../../helpers/common"
+
+setup() {
+	setup_temp_dir
+	cd "${BATS_TEST_TMPDIR}" || exit 1
+	# shellcheck source=../../../../../scripts/ci/lib/release/assets.sh
+	source "${PROJECT_ROOT}/scripts/ci/lib/release/assets.sh"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "release_collect_asset_files: preserves caller nullglob when already enabled" {
+	mkdir -p dist
+	shopt -s nullglob
+
+	run bash -c '
+		shopt -s nullglob
+		source "'"${PROJECT_ROOT}"'/scripts/ci/lib/release/assets.sh"
+		release_collect_asset_files "missing/*" >/dev/null
+		if shopt -q nullglob; then
+			echo still-on
+		else
+			echo turned-off
+		fi
+	'
+
+	assert_success
+	assert_output "still-on"
+}
+
+@test "release_collect_asset_files: leaves nullglob disabled when caller had it off" {
+	run bash -c '
+		shopt -u nullglob 2>/dev/null || true
+		source "'"${PROJECT_ROOT}"'/scripts/ci/lib/release/assets.sh"
+		release_collect_asset_files "missing/*" >/dev/null
+		if shopt -q nullglob; then
+			echo turned-on
+		else
+			echo still-off
+		fi
+	'
+
+	assert_success
+	assert_output "still-off"
+}

--- a/tests/bats/unit/release/test_verify_release_assets.bats
+++ b/tests/bats/unit/release/test_verify_release_assets.bats
@@ -56,7 +56,7 @@ teardown() {
 	assert_output --partial "Found 1 release asset(s)"
 }
 
-@test "verify-release-assets: matches multiple patterns without double-counting" {
+@test "verify-release-assets: matches multiple non-overlapping patterns" {
 	mkdir -p dist release
 	echo "wheel" >dist/example-1.0.0-py3-none-any.whl
 	echo "sdist" >release/example-1.0.0.tar.gz

--- a/tests/bats/unit/release/test_verify_release_assets.bats
+++ b/tests/bats/unit/release/test_verify_release_assets.bats
@@ -55,3 +55,26 @@ teardown() {
 	assert_success
 	assert_output --partial "Found 1 release asset(s)"
 }
+
+@test "verify-release-assets: matches multiple patterns without double-counting" {
+	mkdir -p dist release
+	echo "wheel" >dist/example-1.0.0-py3-none-any.whl
+	echo "sdist" >release/example-1.0.0.tar.gz
+
+	run env $'FILES=dist/*\nrelease/*' ARTIFACT_PATH=. \
+		bash "${PROJECT_ROOT}/scripts/ci/release/verify-release-assets.sh"
+
+	assert_success
+	assert_output --partial "Found 2 release asset(s)"
+}
+
+@test "verify-release-assets: ignores directories matched by glob" {
+	mkdir -p dist/subdir
+	echo "wheel" >dist/example-1.0.0-py3-none-any.whl
+
+	run env FILES='dist/*' ARTIFACT_PATH=dist \
+		bash "${PROJECT_ROOT}/scripts/ci/release/verify-release-assets.sh"
+
+	assert_success
+	assert_output --partial "Found 1 release asset(s)"
+}

--- a/tests/bats/unit/release/test_verify_release_assets.bats
+++ b/tests/bats/unit/release/test_verify_release_assets.bats
@@ -44,3 +44,14 @@ teardown() {
 	assert_success
 	assert_output --partial "Found 1 release asset(s)"
 }
+
+@test "verify-release-assets: counts filenames with spaces" {
+	mkdir -p dist
+	echo "wheel" >"dist/example 1.0.0-py3-none-any.whl"
+
+	run env FILES='dist/*' ARTIFACT_PATH=dist \
+		bash "${PROJECT_ROOT}/scripts/ci/release/verify-release-assets.sh"
+
+	assert_success
+	assert_output --partial "Found 1 release asset(s)"
+}


### PR DESCRIPTION
## Summary

Adds Model B Pages publishing for lgtm-ci: a manifest-driven composite action and reusable workflow that download CI workflow artifacts into a static site tree and deploy via official OIDC Pages actions. Also includes related release/publish workflow hardening found during review.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #226

## Changes Made

- Add `bundle-workflow-artifacts` script, composite action, and manifest schema with strict mode, fallback ref support, path traversal validation, and zip validation
- Add `reusable-deploy-site-with-reports.yml` with `actions: read`, bundle step after build, shared Pages concurrency, and official deploy actions
- Document Model A vs Model B in `docs/pages-publishing.md`, reusable workflow docs, and example manifest
- Update publish workflow WARNING comments to point monorepos at Model B
- Add BATS unit and integration contract tests with mocked `gh`
- Harden release asset glob matching and empty-match handling under `set -u`
- Switch reusable GitHub release workflow to `create-github-release.sh`; fix PyPI publish step ordering and twine availability check

## Testing

- [x] `uv run lintro fmt` and `uv run lintro chk` (0 issues)
- [x] `make test` (1725 BATS tests)
- [x] CodeRabbit review (actionable findings addressed)

## Quality Checks

- [x] Lint/format passed
- [x] Tests passed
- [x] Signed commits on branch

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add reusable Pages deploy workflow that bundles CI HTML reports from other workflow artifacts
> - Adds a new [`bundle-workflow-artifacts` composite action](https://github.com/lgtm-hq/lgtm-ci/pull/242/files#diff-0e733336d031a87b774c6d4782db0545d54f241e09bb6e36cd304e121edf1841) and [`reusable-deploy-site-with-reports.yml` workflow](https://github.com/lgtm-hq/lgtm-ci/pull/242/files#diff-11ef951418fd329d6533b1d3bb864cf2a3af6e569c74aaa7166aaba466c38967) that download artifacts from other workflow runs and copy them into a site root before a single GitHub Pages deployment.
> - Artifact resolution is manifest-driven: a JSON/YAML bundle manifest declares which workflow artifacts map to which site subdirectory, with `require_success` controls and strict-mode failure on missing artifacts.
> - The core logic lives in [bundle/workflow_artifacts.sh](https://github.com/lgtm-hq/lgtm-ci/pull/242/files#diff-052f474e28f9d1a6deb3c9148426a41934e4bf884f4fa2bb9f61db3a2364f3b4), which resolves runs by commit SHA (with optional fallback branch), downloads zips via `gh`, and guards against path traversal.
> - The GitHub release script is migrated from `softprops/action-gh-release` to [create-github-release.sh](https://github.com/lgtm-hq/lgtm-ci/pull/242/files#diff-46a740c1531ca0733ef27ac39929028754cca637eb7109f4c7dbf38a2771737a) using the `gh` CLI; step output keys change from `url`/`id` to `release-url`/`release-id`.
> - Risk: callers of `reusable-github-release.yml` that read `steps.*.outputs.url` or `steps.*.outputs.id` will silently get empty values and must update to the new key names.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 64ec362. 18 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reusable Pages deploy workflow to build/deploy a static site and bundle CI report artifacts; new composite action and CLI tooling to collect/report artifacts; release flow now supports file-patterns and creates releases via a script using the GitHub CLI.

* **Bug Fixes**
  * Hardened ZIP extraction/path validation, safer release-asset glob handling, enforced publish step ordering, and explicit failure when required tooling is missing.

* **Documentation**
  * Expanded Pages publishing guidance (Model A vs Model B), examples, and workflow docs.

* **Tests**
  * New unit and integration tests for bundling, release assets, and workflow contracts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a manifest-driven "Model B" Pages publishing system for lgtm-ci: a `bundle-workflow-artifacts` composite action and `reusable-deploy-site-with-reports.yml` reusable workflow that download CI artifacts from other workflow runs into a static site tree before a single Pages deployment. It also hardens the GitHub release workflow (migrating from `softprops/action-gh-release` to a `gh`-CLI script) and fixes PyPI publish step ordering.

- **New `bundle-workflow-artifacts` composite action and `workflow_artifacts.sh` library**: Resolves workflow runs by commit SHA (with optional fallback branch), downloads and validates artifact ZIPs (path-traversal and symlink checks via `unzip -Z1`/`unzip -Zvl`), and copies files into a manifest-defined site subdirectory.
- **`reusable-deploy-site-with-reports.yml`**: Two-job workflow (build → deploy) with `actions: read` permission, shared Pages concurrency group, and official `actions/configure-pages` / `actions/deploy-pages` actions.
- **Release workflow hardening**: Replaces `softprops/action-gh-release` with `create-github-release.sh` (output keys renamed `url`→`release-url`, `id`→`release-id`), adds `FILE_PATTERNS` glob support via a new `release_collect_asset_files` library, fixes PyPI artifact download ordering, and adds an explicit `twine` availability check.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge; no functional defects found in the new bundling or release paths.

ZIP validation (path-traversal and symlink checks via unzip -Z1/unzip -Zvl) is thorough, the permissions split between build and deploy jobs is correct, the PyPI ordering fix is straightforward, and the output-key rename is a documented breaking change. Both flagged items are cosmetic/style.

.github/actions/bundle-workflow-artifacts/action.yml — generic SCRIPTS_DIR env var written to $GITHUB_ENV.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/ci/lib/bundle/workflow_artifacts.sh | Core artifact resolution and bundling logic; adds thorough ZIP validation (traversal + symlink), handles fallback-ref lookup correctly, and sets outputs. |
| .github/actions/bundle-workflow-artifacts/action.yml | New composite action; resolves script path via a generic SCRIPTS_DIR variable written to $GITHUB_ENV, which could collide with caller or sibling composite-action env vars. |
| scripts/ci/lib/release/assets.sh | New shared glob-expansion library; dual interface (sets RELEASE_ASSET_FILES + echoes count to stdout) works correctly for both call sites but the echo is noise when called without command substitution. |
| .github/workflows/reusable-deploy-site-with-reports.yml | New reusable two-job workflow; correct permissions split (actions:read on build, pages:write/id-token:write on deploy), pinned action SHAs, shared concurrency group. |
| .github/workflows/reusable-github-release.yml | Migrates release creation from softprops/action-gh-release to create-github-release.sh; output keys renamed (url→release-url, id→release-id) — breaking for existing callers as noted in the PR description. |
| scripts/ci/release/create-github-release.sh | Adds FILE_PATTERNS support and GITHUB_REPOSITORY fallback for repo resolution; lines 140-141 echo release-url/release-id to stdout in addition to $GITHUB_OUTPUT (noted in prior review). |
| scripts/ci/actions/publish-pypi.sh | Adds explicit failure when neither uv nor twine is available; clean defensive fix with no regressions. |
| .github/workflows/reusable-publish-pypi-release.yml | Moves artifact download before setup-python so the dist/ directory exists when validate-dist runs; correct ordering fix. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Caller Workflow
    participant Build as build job
    participant GH as GitHub API (gh)
    participant Deploy as deploy job
    participant Pages as GitHub Pages

    Caller->>Build: trigger (workflow_call)
    Build->>Build: Checkout repo + tooling
    Build->>Build: Build site (build-command)
    loop Each manifest bundle
        Build->>GH: "GET /actions/runs?head_sha={sha}"
        GH-->>Build: run_id (or empty)
        alt No run for SHA and fallback-ref set
            Build->>GH: "GET /actions/runs?branch={fallback_ref}"
            GH-->>Build: fallback run_id
        end
        Build->>GH: "GET /actions/runs/{run_id}/artifacts"
        GH-->>Build: artifact_id
        Build->>GH: "GET /actions/artifacts/{id}/zip"
        GH-->>Build: artifact.zip
        Build->>Build: validate zip (traversal + symlink)
        Build->>Build: "extract + cp to site-root/{dest}"
    end
    Build->>Build: configure-pages + upload artifact
    Build->>Deploy: artifact ready (needs: build)
    Deploy->>Pages: actions/deploy-pages
    Pages-->>Caller: page-url output
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/ci/release/create-github-release.sh`, line 139-140 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/64ec3625581ac1eccea98f935ce100d22b8befbf/scripts/ci/release/create-github-release.sh#L139-L140)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> These two `echo` statements write `release-url=…` and `release-id=…` to plain stdout rather than to `$GITHUB_OUTPUT`. The real step outputs are already written by the `set_github_output` calls three lines above, so these echoes are redundant and could confuse readers of the job log.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Frelease%2Fcreate-github-release.sh%0ALine%3A%20139-140%0A%0AComment%3A%0AThese%20two%20%60echo%60%20statements%20write%20%60release-url%3D%E2%80%A6%60%20and%20%60release-id%3D%E2%80%A6%60%20to%20plain%20stdout%20rather%20than%20to%20%60%24GITHUB_OUTPUT%60.%20The%20real%20step%20outputs%20are%20already%20written%20by%20the%20%60set_github_output%60%20calls%20three%20lines%20above%2C%20so%20these%20echoes%20are%20redundant%20and%20could%20confuse%20readers%20of%20the%20job%20log.%0A%0A%60%60%60suggestion%0Alog_info%20%22release-url%3D%24RELEASE_URL%22%0Alog_info%20%22release-id%3D%24RELEASE_ID%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=242&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Frelease%2Fcreate-github-release.sh%0ALine%3A%20139-140%0A%0AComment%3A%0AThese%20two%20%60echo%60%20statements%20write%20%60release-url%3D%E2%80%A6%60%20and%20%60release-id%3D%E2%80%A6%60%20to%20plain%20stdout%20rather%20than%20to%20%60%24GITHUB_OUTPUT%60.%20The%20real%20step%20outputs%20are%20already%20written%20by%20the%20%60set_github_output%60%20calls%20three%20lines%20above%2C%20so%20these%20echoes%20are%20redundant%20and%20could%20confuse%20readers%20of%20the%20job%20log.%0A%0A%60%60%60suggestion%0Alog_info%20%22release-url%3D%24RELEASE_URL%22%0Alog_info%20%22release-id%3D%24RELEASE_ID%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=242&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F226-bundle-workflow-artifacts-into-unified-pages-site-deploy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F226-bundle-workflow-artifacts-into-unified-pages-site-deploy%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Frelease%2Fcreate-github-release.sh%0ALine%3A%20139-140%0A%0AComment%3A%0AThese%20two%20%60echo%60%20statements%20write%20%60release-url%3D%E2%80%A6%60%20and%20%60release-id%3D%E2%80%A6%60%20to%20plain%20stdout%20rather%20than%20to%20%60%24GITHUB_OUTPUT%60.%20The%20real%20step%20outputs%20are%20already%20written%20by%20the%20%60set_github_output%60%20calls%20three%20lines%20above%2C%20so%20these%20echoes%20are%20redundant%20and%20could%20confuse%20readers%20of%20the%20job%20log.%0A%0A%60%60%60suggestion%0Alog_info%20%22release-url%3D%24RELEASE_URL%22%0Alog_info%20%22release-id%3D%24RELEASE_ID%22%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Factions%2Fbundle-workflow-artifacts%2Faction.yml%3A41-58%0A%60SCRIPTS_DIR%60%20is%20a%20generic%20name%20written%20to%20%60%24GITHUB_ENV%60%2C%20which%20persists%20for%20the%20entire%20calling%20job.%20If%20the%20caller%20or%20a%20sibling%20composite%20action%20in%20the%20same%20job%20sets%20its%20own%20%60SCRIPTS_DIR%60%2C%20the%20two%20writes%20will%20silently%20clobber%20each%20other.%20Using%20%60%24GITHUB_ACTION_PATH%60%20directly%20in%20the%20%60run%3A%60%20value%20avoids%20the%20intermediate%20env%20var%20and%20the%20collision%20risk%20entirely.%0A%0A%60%60%60suggestion%0A%20%20%20%20-%20name%3A%20Bundle%20workflow%20artifacts%0A%20%20%20%20%20%20id%3A%20bundle%0A%20%20%20%20%20%20shell%3A%20bash%0A%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20COMMIT_SHA%3A%20%3E-%0A%20%20%20%20%20%20%20%20%20%20%24%7B%7B%20inputs.commit-sha%20!%3D%20''%20%26%26%20inputs.commit-sha%20%7C%7C%20github.sha%20%7D%7D%0A%20%20%20%20%20%20%20%20SITE_ROOT%3A%20%24%7B%7B%20inputs.site-root%20%7D%7D%0A%20%20%20%20%20%20%20%20BUNDLE_MANIFEST%3A%20%24%7B%7B%20inputs.bundle-manifest%20%7D%7D%0A%20%20%20%20%20%20%20%20FALLBACK_REF%3A%20%24%7B%7B%20inputs.fallback-ref%20%7D%7D%0A%20%20%20%20%20%20%20%20STRICT%3A%20%24%7B%7B%20inputs.strict%20%7D%7D%0A%20%20%20%20%20%20%20%20GITHUB_REPOSITORY%3A%20%24%7B%7B%20github.repository%20%7D%7D%0A%20%20%20%20%20%20run%3A%20%3E-%0A%20%20%20%20%20%20%20%20bash%20%22%24%7BGITHUB_ACTION_PATH%2F%2F%5C%5C%2F%2F%7D%2F..%2F..%2F..%2Fscripts%2Fci%2Factions%2Fbundle-workflow-artifacts.sh%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Flib%2Frelease%2Fassets.sh%3A35-37%0A%60release_collect_asset_files%60%20is%20called%20without%20command%20substitution%20in%20%60create-github-release.sh%60%20%28line%2093%29%2C%20so%20the%20%60echo%60%20on%20line%2036%20writes%20the%20raw%20count%20to%20stdout%20and%20appears%20as%20bare%20output%20in%20the%20job%20log.%20Since%20%60create-github-release.sh%60%20reads%20the%20count%20from%20%60%24%7B%23RELEASE_ASSET_FILES%5B%40%5D%7D%60%20directly%2C%20the%20echo%20is%20only%20useful%20for%20the%20%60verify-release-assets.sh%60%20subshell%20call.%20Consider%20routing%20it%20through%20%60log_info%60%20when%20the%20caller%20does%20not%20need%20the%20stdout%20value.%0A%0A%60%60%60suggestion%0A%09RELEASE_ASSET_FILES%3D%28%22%24%7Bcollected%5B%40%5D%2B%22%24%7Bcollected%5B%40%5D%7D%22%7D%22%29%0A%09printf%20'%25s%5Cn'%20%22%24%7B%23collected%5B%40%5D%7D%22%0A%7D%0A%60%60%60%0A%0A&pr=242&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Factions%2Fbundle-workflow-artifacts%2Faction.yml%3A41-58%0A%60SCRIPTS_DIR%60%20is%20a%20generic%20name%20written%20to%20%60%24GITHUB_ENV%60%2C%20which%20persists%20for%20the%20entire%20calling%20job.%20If%20the%20caller%20or%20a%20sibling%20composite%20action%20in%20the%20same%20job%20sets%20its%20own%20%60SCRIPTS_DIR%60%2C%20the%20two%20writes%20will%20silently%20clobber%20each%20other.%20Using%20%60%24GITHUB_ACTION_PATH%60%20directly%20in%20the%20%60run%3A%60%20value%20avoids%20the%20intermediate%20env%20var%20and%20the%20collision%20risk%20entirely.%0A%0A%60%60%60suggestion%0A%20%20%20%20-%20name%3A%20Bundle%20workflow%20artifacts%0A%20%20%20%20%20%20id%3A%20bundle%0A%20%20%20%20%20%20shell%3A%20bash%0A%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20COMMIT_SHA%3A%20%3E-%0A%20%20%20%20%20%20%20%20%20%20%24%7B%7B%20inputs.commit-sha%20!%3D%20''%20%26%26%20inputs.commit-sha%20%7C%7C%20github.sha%20%7D%7D%0A%20%20%20%20%20%20%20%20SITE_ROOT%3A%20%24%7B%7B%20inputs.site-root%20%7D%7D%0A%20%20%20%20%20%20%20%20BUNDLE_MANIFEST%3A%20%24%7B%7B%20inputs.bundle-manifest%20%7D%7D%0A%20%20%20%20%20%20%20%20FALLBACK_REF%3A%20%24%7B%7B%20inputs.fallback-ref%20%7D%7D%0A%20%20%20%20%20%20%20%20STRICT%3A%20%24%7B%7B%20inputs.strict%20%7D%7D%0A%20%20%20%20%20%20%20%20GITHUB_REPOSITORY%3A%20%24%7B%7B%20github.repository%20%7D%7D%0A%20%20%20%20%20%20run%3A%20%3E-%0A%20%20%20%20%20%20%20%20bash%20%22%24%7BGITHUB_ACTION_PATH%2F%2F%5C%5C%2F%2F%7D%2F..%2F..%2F..%2Fscripts%2Fci%2Factions%2Fbundle-workflow-artifacts.sh%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Flib%2Frelease%2Fassets.sh%3A35-37%0A%60release_collect_asset_files%60%20is%20called%20without%20command%20substitution%20in%20%60create-github-release.sh%60%20%28line%2093%29%2C%20so%20the%20%60echo%60%20on%20line%2036%20writes%20the%20raw%20count%20to%20stdout%20and%20appears%20as%20bare%20output%20in%20the%20job%20log.%20Since%20%60create-github-release.sh%60%20reads%20the%20count%20from%20%60%24%7B%23RELEASE_ASSET_FILES%5B%40%5D%7D%60%20directly%2C%20the%20echo%20is%20only%20useful%20for%20the%20%60verify-release-assets.sh%60%20subshell%20call.%20Consider%20routing%20it%20through%20%60log_info%60%20when%20the%20caller%20does%20not%20need%20the%20stdout%20value.%0A%0A%60%60%60suggestion%0A%09RELEASE_ASSET_FILES%3D%28%22%24%7Bcollected%5B%40%5D%2B%22%24%7Bcollected%5B%40%5D%7D%22%7D%22%29%0A%09printf%20'%25s%5Cn'%20%22%24%7B%23collected%5B%40%5D%7D%22%0A%7D%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=242&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F226-bundle-workflow-artifacts-into-unified-pages-site-deploy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F226-bundle-workflow-artifacts-into-unified-pages-site-deploy%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Factions%2Fbundle-workflow-artifacts%2Faction.yml%3A41-58%0A%60SCRIPTS_DIR%60%20is%20a%20generic%20name%20written%20to%20%60%24GITHUB_ENV%60%2C%20which%20persists%20for%20the%20entire%20calling%20job.%20If%20the%20caller%20or%20a%20sibling%20composite%20action%20in%20the%20same%20job%20sets%20its%20own%20%60SCRIPTS_DIR%60%2C%20the%20two%20writes%20will%20silently%20clobber%20each%20other.%20Using%20%60%24GITHUB_ACTION_PATH%60%20directly%20in%20the%20%60run%3A%60%20value%20avoids%20the%20intermediate%20env%20var%20and%20the%20collision%20risk%20entirely.%0A%0A%60%60%60suggestion%0A%20%20%20%20-%20name%3A%20Bundle%20workflow%20artifacts%0A%20%20%20%20%20%20id%3A%20bundle%0A%20%20%20%20%20%20shell%3A%20bash%0A%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20COMMIT_SHA%3A%20%3E-%0A%20%20%20%20%20%20%20%20%20%20%24%7B%7B%20inputs.commit-sha%20!%3D%20''%20%26%26%20inputs.commit-sha%20%7C%7C%20github.sha%20%7D%7D%0A%20%20%20%20%20%20%20%20SITE_ROOT%3A%20%24%7B%7B%20inputs.site-root%20%7D%7D%0A%20%20%20%20%20%20%20%20BUNDLE_MANIFEST%3A%20%24%7B%7B%20inputs.bundle-manifest%20%7D%7D%0A%20%20%20%20%20%20%20%20FALLBACK_REF%3A%20%24%7B%7B%20inputs.fallback-ref%20%7D%7D%0A%20%20%20%20%20%20%20%20STRICT%3A%20%24%7B%7B%20inputs.strict%20%7D%7D%0A%20%20%20%20%20%20%20%20GITHUB_REPOSITORY%3A%20%24%7B%7B%20github.repository%20%7D%7D%0A%20%20%20%20%20%20run%3A%20%3E-%0A%20%20%20%20%20%20%20%20bash%20%22%24%7BGITHUB_ACTION_PATH%2F%2F%5C%5C%2F%2F%7D%2F..%2F..%2F..%2Fscripts%2Fci%2Factions%2Fbundle-workflow-artifacts.sh%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Flib%2Frelease%2Fassets.sh%3A35-37%0A%60release_collect_asset_files%60%20is%20called%20without%20command%20substitution%20in%20%60create-github-release.sh%60%20%28line%2093%29%2C%20so%20the%20%60echo%60%20on%20line%2036%20writes%20the%20raw%20count%20to%20stdout%20and%20appears%20as%20bare%20output%20in%20the%20job%20log.%20Since%20%60create-github-release.sh%60%20reads%20the%20count%20from%20%60%24%7B%23RELEASE_ASSET_FILES%5B%40%5D%7D%60%20directly%2C%20the%20echo%20is%20only%20useful%20for%20the%20%60verify-release-assets.sh%60%20subshell%20call.%20Consider%20routing%20it%20through%20%60log_info%60%20when%20the%20caller%20does%20not%20need%20the%20stdout%20value.%0A%0A%60%60%60suggestion%0A%09RELEASE_ASSET_FILES%3D%28%22%24%7Bcollected%5B%40%5D%2B%22%24%7Bcollected%5B%40%5D%7D%22%7D%22%29%0A%09printf%20'%25s%5Cn'%20%22%24%7B%23collected%5B%40%5D%7D%22%0A%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (6): Last reviewed commit: ["fix(ci): detect zip path traversal by co..."](https://github.com/lgtm-hq/lgtm-ci/commit/9507835cb4064a3b92faf7df1f199e6621d78420) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34301827)</sub>

<!-- /greptile_comment -->