### PR TITLE
feat(ci): merge existing Pages site when multiple publishers deploy

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -778,6 +778,8 @@ actions.
     coverage-path: "coverage/" # optional
     badge-path: "coverage/badge.svg" # optional
     target-dir: "." # optional
+    merge-existing-site: "false" # optional Model A multi-publisher merge
+    base-site-path: "" # optional local site tree instead of HTTP mirror
 ```
 
 **Outputs:**
@@ -787,6 +789,8 @@ actions.
 **Features:**
 
 - Stages coverage, badges, and test HTML under `target-dir`
+- Optional `merge-existing-site` preserves sibling subtrees when multiple Model A
+  publishers deploy to the same Pages site (see `docs/pages-publishing.md`)
 - Deploys with `actions/configure-pages`, `upload-pages-artifact`, `deploy-pages`
 - Generates index.html for coverage reports when missing
 

--- a/.github/actions/publish-test-results/action.yml
+++ b/.github/actions/publish-test-results/action.yml
@@ -20,6 +20,18 @@ inputs:
     description: "Subdirectory under the Pages site root"
     required: false
     default: "."
+  merge-existing-site:
+    description: >-
+      When true, merge existing live site content (or base-site-path) before
+      uploading so parallel Model A publishers retain sibling target-dir trees
+    required: false
+    default: "false"
+  base-site-path:
+    description: >-
+      Optional local directory tree to use as the existing site instead of
+      mirroring the public GitHub Pages URL
+    required: false
+    default: ""
   working-directory:
     description: "Working directory"
     required: false
@@ -43,6 +55,8 @@ runs:
         COVERAGE_PATH: ${{ inputs.coverage-path }}
         BADGE_PATH: ${{ inputs.badge-path }}
         TARGET_DIR: ${{ inputs.target-dir }}
+        MERGE_EXISTING_SITE: ${{ inputs.merge-existing-site }}
+        BASE_SITE_PATH: ${{ inputs.base-site-path }}
       run: bash "$GITHUB_ACTION_PATH/../../../scripts/ci/actions/publish-test-results.sh"
 
     - name: Configure GitHub Pages

--- a/.github/workflows/reusable-test-node-publish.yml
+++ b/.github/workflows/reusable-test-node-publish.yml
@@ -53,12 +53,12 @@ on:
 
 # Shared Pages concurrency serializes deploys per repository/ref.
 # WARNING: Do not invoke this workflow alongside reusable-test-python-publish
-# (or another publish-test-results caller) on the same event unless all subtrees
-# are bundled in one publish job. Each deploy replaces the entire site; the
-# last queued job wins. Monorepos needing a site plus multiple report subtrees on
-# one Pages origin should use reusable-deploy-site-with-reports (Model B, #226)
-# instead of parallel python + node publish workflows. See docs/pages-publishing.md
-# and lgtm-hq/lgtm-ci#226.
+# on the same event unless subtrees are combined in one publish job or each job
+# uses publish-test-results merge-existing-site: true (Model A fallback, #225).
+# Without merge, each deploy replaces the entire site and the last queued job
+# wins. Monorepos needing a site plus multiple report subtrees on one Pages
+# origin should prefer reusable-deploy-site-with-reports (Model B, #226).
+# See docs/pages-publishing.md.
 concurrency:
   group: pages-${{ github.repository }}-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/reusable-test-python-publish.yml
+++ b/.github/workflows/reusable-test-python-publish.yml
@@ -48,12 +48,12 @@ on:
 
 # Shared Pages concurrency serializes deploys per repository/ref.
 # WARNING: Do not invoke this workflow alongside reusable-test-node-publish
-# (or another publish-test-results caller) on the same event unless all subtrees
-# are bundled in one publish job. Each deploy replaces the entire site; the
-# last queued job wins. Monorepos needing a site plus multiple report subtrees on
-# one Pages origin should use reusable-deploy-site-with-reports (Model B, #226)
-# instead of parallel python + node publish workflows. See docs/pages-publishing.md
-# and lgtm-hq/lgtm-ci#226.
+# on the same event unless subtrees are combined in one publish job or each job
+# uses publish-test-results merge-existing-site: true (Model A fallback, #225).
+# Without merge, each deploy replaces the entire site and the last queued job
+# wins. Monorepos needing a site plus multiple report subtrees on one Pages
+# origin should prefer reusable-deploy-site-with-reports (Model B, #226).
+# See docs/pages-publishing.md.
 concurrency:
   group: pages-${{ github.repository }}-${{ github.ref }}
   cancel-in-progress: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **actions**: optional `merge-existing-site` and `base-site-path` inputs on
+  `publish-test-results` to merge existing Pages content before deploy (#225)
+
 ### Changed
 
 ### Deprecated

--- a/docs/pages-publishing.md
+++ b/docs/pages-publishing.md
@@ -176,10 +176,30 @@ artifact model cannot do that without an explicit merge step.
 | ---------- | ---- |
 | One publish job per event | One `publish-test-results` with combined subtrees |
 | Model B site bundle | Monorepos — `reusable-deploy-site-with-reports` [226] |
-| Optional live-site merge | Legacy Model A multi-publisher fallback [225] |
+| Optional live-site merge | Legacy Model A multi-publisher fallback [225] — set `merge-existing-site: true` on `publish-test-results` (and optionally `base-site-path` to skip HTTP mirror) |
 
 [225]: https://github.com/lgtm-hq/lgtm-ci/issues/225
 [226]: https://github.com/lgtm-hq/lgtm-ci/issues/226
+
+### Optional Model A merge (`merge-existing-site`)
+
+When a repository must keep **separate** Model A publish jobs (for example python
+then node on the same ref), enable merge on each job after the first:
+
+```yaml
+- uses: lgtm-hq/lgtm-ci/.github/actions/publish-test-results@v0.22.0
+  with:
+    target-dir: vitest
+    coverage-path: coverage/
+    merge-existing-site: "true"
+    # Optional: copy a local tree instead of mirroring the public Pages URL
+    # base-site-path: /path/to/previous/site
+```
+
+By default the prepare step mirrors `https://<owner>.github.io/<repo>/` with
+`wget`. That mirror can be **stale** (CDN/cache) and is unsuitable for private
+Pages without supplying `base-site-path`. Prefer **Model B**
+(`reusable-deploy-site-with-reports`) for monorepos that own the full site tree.
 
 **Current org usage:** py-lintro calls only `reusable-test-python-publish`—not
 affected.

--- a/docs/pages-publishing.md
+++ b/docs/pages-publishing.md
@@ -187,7 +187,7 @@ When a repository must keep **separate** Model A publish jobs (for example pytho
 then node on the same ref), enable merge on each job after the first:
 
 ```yaml
-- uses: lgtm-hq/lgtm-ci/.github/actions/publish-test-results@v0.22.0
+- uses: lgtm-hq/lgtm-ci/.github/actions/publish-test-results@v0.23.0
   with:
     target-dir: vitest
     coverage-path: coverage/

--- a/scripts/ci/actions/publish-test-results.sh
+++ b/scripts/ci/actions/publish-test-results.sh
@@ -25,9 +25,22 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
 source "$SCRIPT_DIR/../lib/actions.sh"
 
 _publish_test_results_normalize_target_dir() {
-	local target_dir="${1#.}"
+	local raw_target_dir="$1"
+
+	if [[ "$raw_target_dir" == /* ]]; then
+		log_error "target-dir must be relative: ${raw_target_dir}"
+		exit 1
+	fi
+
+	if [[ "$raw_target_dir" == *".."* ]]; then
+		log_error "target-dir must not contain .. segments: ${raw_target_dir}"
+		exit 1
+	fi
+
+	local target_dir="${raw_target_dir#.}"
 	target_dir="${target_dir%/}"
 	target_dir="${target_dir#/}"
+
 	if [[ -z "$target_dir" ]]; then
 		echo "."
 	else

--- a/scripts/ci/actions/publish-test-results.sh
+++ b/scripts/ci/actions/publish-test-results.sh
@@ -10,6 +10,8 @@
 #   COVERAGE_PATH - Path to coverage report directory
 #   BADGE_PATH - Path to badge files
 #   TARGET_DIR - Subdirectory under the Pages site root (default: .)
+#   MERGE_EXISTING_SITE - When true, merge live or base-site content before upload
+#   BASE_SITE_PATH - Optional local tree to use instead of HTTP mirror
 #   BASE_PAGE_URL - Deployed site URL from actions/deploy-pages
 #   WORKING_DIRECTORY - Directory to run in
 
@@ -22,84 +24,73 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
 # shellcheck source=../lib/actions.sh
 source "$SCRIPT_DIR/../lib/actions.sh"
 
-case "$STEP" in
-prepare)
-	: "${RESULTS_PATH:=}"
-	: "${COVERAGE_PATH:=}"
-	: "${BADGE_PATH:=}"
-	: "${TARGET_DIR:=.}"
-	: "${WORKING_DIRECTORY:=.}"
-
-	if [[ -n "${TARGET_BRANCH:-}" || -n "${KEEP_HISTORY:-}" || -n "${RETENTION_DAYS:-}" ]]; then
-		log_error "target-branch, keep-history, and retention-days were removed; use official Pages deploy only (see docs/pages-publishing.md)"
-		exit 1
+_publish_test_results_normalize_target_dir() {
+	local target_dir="${1#.}"
+	target_dir="${target_dir%/}"
+	target_dir="${target_dir#/}"
+	if [[ -z "$target_dir" ]]; then
+		echo "."
+	else
+		echo "$target_dir"
 	fi
+}
 
-	cd "$WORKING_DIRECTORY"
+_publish_test_results_build_content() {
+	local content_root="$1"
+	local target_dir="$2"
 
-	# Create staging directory
-	staging_dir=$(mktemp -d)
-	log_info "Preparing files in staging directory: $staging_dir"
+	mkdir -p "$content_root/$target_dir"
 
-	# Create target directory structure
-	mkdir -p "$staging_dir/$TARGET_DIR"
-
-	# Copy test results if provided
-	if [[ -n "$RESULTS_PATH" ]]; then
+	if [[ -n "${RESULTS_PATH:-}" ]]; then
 		if [[ -d "$RESULTS_PATH" ]]; then
-			# Check if directory is non-empty before copying
 			if [[ -n "$(ls -A "$RESULTS_PATH" 2>/dev/null)" ]]; then
-				mkdir -p "$staging_dir/$TARGET_DIR/tests"
-				cp -r "$RESULTS_PATH"/* "$staging_dir/$TARGET_DIR/tests/"
+				mkdir -p "$content_root/$target_dir/tests"
+				cp -r "$RESULTS_PATH"/* "$content_root/$target_dir/tests/"
 				log_info "Copied test results from $RESULTS_PATH"
 			else
 				log_warn "Test results directory is empty: $RESULTS_PATH"
 			fi
 		elif [[ -f "$RESULTS_PATH" ]]; then
-			mkdir -p "$staging_dir/$TARGET_DIR/tests"
-			cp "$RESULTS_PATH" "$staging_dir/$TARGET_DIR/tests/"
+			mkdir -p "$content_root/$target_dir/tests"
+			cp "$RESULTS_PATH" "$content_root/$target_dir/tests/"
 			log_info "Copied test results file: $RESULTS_PATH"
 		fi
 	fi
 
-	# Copy coverage report if provided
-	if [[ -n "$COVERAGE_PATH" ]]; then
+	if [[ -n "${COVERAGE_PATH:-}" ]]; then
 		if [[ -d "$COVERAGE_PATH" ]]; then
-			# Check if directory is non-empty before copying
 			if [[ -n "$(ls -A "$COVERAGE_PATH" 2>/dev/null)" ]]; then
-				mkdir -p "$staging_dir/$TARGET_DIR/coverage"
-				cp -r "$COVERAGE_PATH"/* "$staging_dir/$TARGET_DIR/coverage/"
+				mkdir -p "$content_root/$target_dir/coverage"
+				cp -r "$COVERAGE_PATH"/* "$content_root/$target_dir/coverage/"
 				log_info "Copied coverage report from $COVERAGE_PATH"
 			else
 				log_warn "Coverage directory is empty: $COVERAGE_PATH"
 			fi
 		elif [[ -f "$COVERAGE_PATH" ]]; then
-			mkdir -p "$staging_dir/$TARGET_DIR/coverage"
-			cp "$COVERAGE_PATH" "$staging_dir/$TARGET_DIR/coverage/"
+			mkdir -p "$content_root/$target_dir/coverage"
+			cp "$COVERAGE_PATH" "$content_root/$target_dir/coverage/"
 			log_info "Copied coverage file: $COVERAGE_PATH"
 		fi
 	fi
 
-	# Copy badges if provided
-	if [[ -n "$BADGE_PATH" ]]; then
+	if [[ -n "${BADGE_PATH:-}" ]]; then
 		if [[ -d "$BADGE_PATH" ]]; then
-			mkdir -p "$staging_dir/$TARGET_DIR/coverage"
+			mkdir -p "$content_root/$target_dir/coverage"
 			# shellcheck disable=SC2086
 			for f in "$BADGE_PATH"/*.svg "$BADGE_PATH"/*.json; do
-				[[ -f "$f" ]] && cp "$f" "$staging_dir/$TARGET_DIR/coverage/"
+				[[ -f "$f" ]] && cp "$f" "$content_root/$target_dir/coverage/"
 			done
 			log_info "Copied badges from $BADGE_PATH"
 		elif [[ -f "$BADGE_PATH" ]]; then
-			mkdir -p "$staging_dir/$TARGET_DIR/coverage"
-			cp "$BADGE_PATH" "$staging_dir/$TARGET_DIR/coverage/"
+			mkdir -p "$content_root/$target_dir/coverage"
+			cp "$BADGE_PATH" "$content_root/$target_dir/coverage/"
 			log_info "Copied badge file: $BADGE_PATH"
 		fi
 	fi
 
-	# Create index.html if coverage report exists
-	if [[ -d "$staging_dir/$TARGET_DIR/coverage" ]]; then
-		if [[ ! -f "$staging_dir/$TARGET_DIR/coverage/index.html" ]]; then
-			cat >"$staging_dir/$TARGET_DIR/coverage/index.html" <<'EOF'
+	if [[ -d "$content_root/$target_dir/coverage" ]]; then
+		if [[ ! -f "$content_root/$target_dir/coverage/index.html" ]]; then
+			cat >"$content_root/$target_dir/coverage/index.html" <<'EOF'
 <!DOCTYPE html>
 <html>
 <head>
@@ -125,6 +116,109 @@ prepare)
 </html>
 EOF
 		fi
+	fi
+}
+
+_publish_test_results_copy_existing_site() {
+	local staging_dir="$1"
+
+	if [[ -n "${BASE_SITE_PATH:-}" ]]; then
+		if [[ ! -d "$BASE_SITE_PATH" ]]; then
+			log_error "base-site-path is not a directory: ${BASE_SITE_PATH}"
+			return 1
+		fi
+		log_info "Merging existing site from base-site-path: ${BASE_SITE_PATH}"
+		cp -a "${BASE_SITE_PATH}/." "$staging_dir/"
+		return 0
+	fi
+
+	local site_url=""
+	site_url=$(get_github_pages_url "") || site_url=""
+
+	if [[ -z "$site_url" ]]; then
+		log_error "merge-existing-site requires base-site-path or GITHUB_REPOSITORY for live site mirror"
+		return 1
+	fi
+
+	if ! command -v wget >/dev/null 2>&1; then
+		log_error "wget is required to mirror live GitHub Pages when base-site-path is unset"
+		return 1
+	fi
+
+	local cut_dirs=1
+	if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
+		local repo_name="${GITHUB_REPOSITORY##*/}"
+		local owner="${GITHUB_REPOSITORY%%/*}"
+		local owner_lower repo_lower
+		owner_lower=$(echo "$owner" | tr '[:upper:]' '[:lower:]')
+		repo_lower=$(echo "$repo_name" | tr '[:upper:]' '[:lower:]')
+		if [[ "$repo_lower" == "${owner_lower}.github.io" ]]; then
+			cut_dirs=0
+		fi
+	fi
+
+	log_warn "Mirroring live site from ${site_url} (CDN/cache may serve stale content)"
+	local wget_root="${staging_dir}/.lgtm-wget-root"
+	mkdir -p "$wget_root"
+	if ! wget -q -e robots=off -r -l 10 -np -nH --cut-dirs="$cut_dirs" -P "$wget_root" "$site_url"; then
+		log_warn "Live site mirror failed or site is empty; continuing with new content only"
+		rm -rf "$wget_root"
+		return 0
+	fi
+
+	if [[ -d "$wget_root" ]] && [[ -n "$(ls -A "$wget_root" 2>/dev/null)" ]]; then
+		cp -a "$wget_root"/. "$staging_dir/"
+	fi
+	rm -rf "$wget_root"
+}
+
+_publish_test_results_overlay_content() {
+	local staging_dir="$1"
+	local content_root="$2"
+	local target_dir="$3"
+
+	if [[ "$target_dir" == "." ]]; then
+		cp -a "$content_root"/. "$staging_dir/"
+		return 0
+	fi
+
+	mkdir -p "$staging_dir/$target_dir"
+	if [[ -d "$content_root/$target_dir" ]]; then
+		cp -a "$content_root/$target_dir"/. "$staging_dir/$target_dir/"
+	fi
+}
+
+case "$STEP" in
+prepare)
+	: "${RESULTS_PATH:=}"
+	: "${COVERAGE_PATH:=}"
+	: "${BADGE_PATH:=}"
+	: "${TARGET_DIR:=.}"
+	: "${WORKING_DIRECTORY:=.}"
+	: "${MERGE_EXISTING_SITE:=false}"
+	: "${BASE_SITE_PATH:=}"
+
+	if [[ -n "${TARGET_BRANCH:-}" || -n "${KEEP_HISTORY:-}" || -n "${RETENTION_DAYS:-}" ]]; then
+		log_error "target-branch, keep-history, and retention-days were removed; use official Pages deploy only (see docs/pages-publishing.md)"
+		exit 1
+	fi
+
+	cd "$WORKING_DIRECTORY"
+
+	normalized_target_dir=$(_publish_test_results_normalize_target_dir "$TARGET_DIR")
+
+	staging_dir=$(mktemp -d)
+	overlay_root=""
+	log_info "Preparing files in staging directory: $staging_dir"
+
+	if [[ "$MERGE_EXISTING_SITE" == "true" ]]; then
+		overlay_root=$(mktemp -d)
+		_publish_test_results_build_content "$overlay_root" "$normalized_target_dir"
+		_publish_test_results_copy_existing_site "$staging_dir"
+		_publish_test_results_overlay_content "$staging_dir" "$overlay_root" "$normalized_target_dir"
+		rm -rf "$overlay_root"
+	else
+		_publish_test_results_build_content "$staging_dir" "$normalized_target_dir"
 	fi
 
 	set_github_output "staging-dir" "$staging_dir"

--- a/scripts/ci/actions/publish-test-results.sh
+++ b/scripts/ci/actions/publish-test-results.sh
@@ -145,25 +145,20 @@ _publish_test_results_copy_existing_site() {
 		return 1
 	fi
 
-	local cut_dirs=1
-	if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
-		local repo_name="${GITHUB_REPOSITORY##*/}"
-		local owner="${GITHUB_REPOSITORY%%/*}"
-		local owner_lower repo_lower
-		owner_lower=$(echo "$owner" | tr '[:upper:]' '[:lower:]')
-		repo_lower=$(echo "$repo_name" | tr '[:upper:]' '[:lower:]')
-		if [[ "$repo_lower" == "${owner_lower}.github.io" ]]; then
-			cut_dirs=0
-		fi
-	fi
+	local cut_dirs=""
+	cut_dirs=$(get_github_pages_wget_cut_dirs "$site_url") || {
+		log_error "Could not derive wget cut-dirs from site URL: ${site_url}"
+		return 1
+	}
 
 	log_warn "Mirroring live site from ${site_url} (CDN/cache may serve stale content)"
 	local wget_root="${staging_dir}/.lgtm-wget-root"
 	mkdir -p "$wget_root"
 	if ! wget -q -e robots=off -r -l 10 -np -nH --cut-dirs="$cut_dirs" -P "$wget_root" "$site_url"; then
-		log_warn "Live site mirror failed or site is empty; continuing with new content only"
+		log_error "Live site mirror failed; merge-existing-site cannot preserve sibling trees"
+		echo "::warning::Live site mirror failed for ${site_url}; existing Pages content was not merged"
 		rm -rf "$wget_root"
-		return 0
+		return 1
 	fi
 
 	if [[ -d "$wget_root" ]] && [[ -n "$(ls -A "$wget_root" 2>/dev/null)" ]]; then
@@ -213,10 +208,12 @@ prepare)
 
 	if [[ "$MERGE_EXISTING_SITE" == "true" ]]; then
 		overlay_root=$(mktemp -d)
+		trap 'rm -rf "${overlay_root:-}"' EXIT
 		_publish_test_results_build_content "$overlay_root" "$normalized_target_dir"
 		_publish_test_results_copy_existing_site "$staging_dir"
 		_publish_test_results_overlay_content "$staging_dir" "$overlay_root" "$normalized_target_dir"
 		rm -rf "$overlay_root"
+		trap - EXIT
 	else
 		_publish_test_results_build_content "$staging_dir" "$normalized_target_dir"
 	fi

--- a/scripts/ci/lib/github/format.sh
+++ b/scripts/ci/lib/github/format.sh
@@ -56,6 +56,36 @@ get_github_pages_url() {
 	fi
 }
 
+# Derive wget --cut-dirs from a GitHub Pages site root URL
+# Usage: get_github_pages_wget_cut_dirs "https://owner.github.io/repo/"
+get_github_pages_wget_cut_dirs() {
+	local site_url="$1"
+
+	if [[ -z "$site_url" ]]; then
+		echo ""
+		return 1
+	fi
+
+	local without_scheme="${site_url#*://}"
+	if [[ "$without_scheme" == "$site_url" ]]; then
+		echo ""
+		return 1
+	fi
+
+	local path="${without_scheme#*/}"
+	path="${path#/}"
+	path="${path%/}"
+
+	if [[ -z "$path" ]]; then
+		echo 0
+		return 0
+	fi
+
+	local -a segments=()
+	IFS='/' read -r -a segments <<<"$path"
+	echo "${#segments[@]}"
+}
+
 # =============================================================================
 # Score formatting helpers for PR comments
 # =============================================================================
@@ -206,5 +236,5 @@ format_github_commit_line() {
 # =============================================================================
 # Export functions
 # =============================================================================
-export -f get_github_pages_url score_emoji format_score_with_color format_percentage_with_color
+export -f get_github_pages_url get_github_pages_wget_cut_dirs score_emoji format_score_with_color format_percentage_with_color
 export -f get_github_actions_run_url format_github_commit_line

--- a/tests/bats/integration/test_publish_test_results_merge.bats
+++ b/tests/bats/integration/test_publish_test_results_merge.bats
@@ -159,6 +159,28 @@ _run_prepare() {
 	assert_output --partial "merge-existing-site requires base-site-path or GITHUB_REPOSITORY"
 }
 
+@test "publish-test-results prepare: merge fails when live site mirror fails" {
+	local fake_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$fake_bin"
+	cat >"${fake_bin}/wget" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+	chmod +x "${fake_bin}/wget"
+
+	export PATH="${fake_bin}:${PATH}"
+	export MERGE_EXISTING_SITE=true
+	export BASE_SITE_PATH=""
+	export GITHUB_REPOSITORY="lgtm-hq/example"
+	export TARGET_DIR="vitest"
+	export COVERAGE_PATH=""
+
+	_run_prepare
+	assert_failure
+	assert_output --partial "Live site mirror failed"
+	assert_output --partial "::warning::Live site mirror failed for https://lgtm-hq.github.io/example/"
+}
+
 @test "publish-test-results action: exposes merge inputs" {
 	local action="${PROJECT_ROOT}/.github/actions/publish-test-results/action.yml"
 	run grep -q 'merge-existing-site:' "$action"

--- a/tests/bats/integration/test_publish_test_results_merge.bats
+++ b/tests/bats/integration/test_publish_test_results_merge.bats
@@ -1,0 +1,172 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Fixture-based tests for publish-test-results live-site merge
+
+load "../../helpers/common"
+load "../../helpers/github_env"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+_staging_dir_from_output() {
+	grep '^staging-dir=' "$GITHUB_OUTPUT" | cut -d= -f2-
+}
+
+_run_prepare() {
+	run env \
+		STEP=prepare \
+		RESULTS_PATH="${RESULTS_PATH:-}" \
+		COVERAGE_PATH="${COVERAGE_PATH:-}" \
+		BADGE_PATH="${BADGE_PATH:-}" \
+		TARGET_DIR="${TARGET_DIR:-.}" \
+		MERGE_EXISTING_SITE="${MERGE_EXISTING_SITE:-false}" \
+		BASE_SITE_PATH="${BASE_SITE_PATH:-}" \
+		GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-lgtm-hq/example}" \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/publish-test-results.sh"
+}
+
+@test "publish-test-results prepare: merge preserves sibling target-dir trees" {
+	local base_site="${BATS_TEST_TMPDIR}/base-site"
+	local coverage="${BATS_TEST_TMPDIR}/vitest-coverage"
+	mkdir -p "${base_site}/python/coverage"
+	echo "python-report" >"${base_site}/python/coverage/index.html"
+	mkdir -p "$coverage"
+	echo "vitest-report" >"${coverage}/index.html"
+
+	export BASE_SITE_PATH="$base_site"
+	export MERGE_EXISTING_SITE=true
+	export TARGET_DIR="vitest"
+	export COVERAGE_PATH="$coverage"
+
+	_run_prepare
+	assert_success
+
+	local staging_dir
+	staging_dir=$(_staging_dir_from_output)
+	run test -f "${staging_dir}/python/coverage/index.html"
+	assert_success
+	run grep -q "python-report" "${staging_dir}/python/coverage/index.html"
+	assert_success
+	run test -f "${staging_dir}/vitest/coverage/index.html"
+	assert_success
+	run grep -q "vitest-report" "${staging_dir}/vitest/coverage/index.html"
+	assert_success
+}
+
+@test "publish-test-results prepare: merge overlays matching target-dir content" {
+	local base_site="${BATS_TEST_TMPDIR}/base-site"
+	local results="${BATS_TEST_TMPDIR}/vitest-results"
+	mkdir -p "${base_site}/vitest/tests"
+	echo "stale" >"${base_site}/vitest/tests/output.json"
+	mkdir -p "$results"
+	echo "fresh" >"${results}/output.json"
+
+	export BASE_SITE_PATH="$base_site"
+	export MERGE_EXISTING_SITE=true
+	export TARGET_DIR="vitest"
+	export RESULTS_PATH="$results"
+
+	_run_prepare
+	assert_success
+
+	local staging_dir
+	staging_dir=$(_staging_dir_from_output)
+	run grep -q "fresh" "${staging_dir}/vitest/tests/output.json"
+	assert_success
+}
+
+@test "publish-test-results prepare: without merge only publishes target-dir" {
+	local base_site="${BATS_TEST_TMPDIR}/base-site"
+	local coverage="${BATS_TEST_TMPDIR}/vitest-coverage"
+	mkdir -p "${base_site}/python/coverage"
+	echo "python-report" >"${base_site}/python/coverage/index.html"
+	mkdir -p "$coverage"
+	echo "vitest-report" >"${coverage}/index.html"
+
+	export BASE_SITE_PATH="$base_site"
+	export MERGE_EXISTING_SITE=false
+	export TARGET_DIR="vitest"
+	export COVERAGE_PATH="$coverage"
+
+	_run_prepare
+	assert_success
+
+	local staging_dir
+	staging_dir=$(_staging_dir_from_output)
+	run test ! -e "${staging_dir}/python/coverage/index.html"
+	assert_success
+	run test -f "${staging_dir}/vitest/coverage/index.html"
+	assert_success
+}
+
+@test "publish-test-results prepare: merge with target-dir . overlays at root" {
+	local base_site="${BATS_TEST_TMPDIR}/base-site"
+	local coverage="${BATS_TEST_TMPDIR}/root-coverage"
+	mkdir -p "${base_site}/existing"
+	echo "keep-me" >"${base_site}/existing/report.html"
+	mkdir -p "$coverage"
+	echo "root-coverage" >"${coverage}/index.html"
+
+	export BASE_SITE_PATH="$base_site"
+	export MERGE_EXISTING_SITE=true
+	export TARGET_DIR="."
+	export COVERAGE_PATH="$coverage"
+
+	_run_prepare
+	assert_success
+
+	local staging_dir
+	staging_dir=$(_staging_dir_from_output)
+	run test -f "${staging_dir}/existing/report.html"
+	assert_success
+	run grep -q "keep-me" "${staging_dir}/existing/report.html"
+	assert_success
+	run test -f "${staging_dir}/coverage/index.html"
+	assert_success
+	run grep -q "root-coverage" "${staging_dir}/coverage/index.html"
+	assert_success
+}
+
+@test "publish-test-results prepare: rejects invalid base-site-path" {
+	export BASE_SITE_PATH="${BATS_TEST_TMPDIR}/missing-base"
+	export MERGE_EXISTING_SITE=true
+	export TARGET_DIR="vitest"
+
+	_run_prepare
+	assert_failure
+	assert_output --partial "base-site-path is not a directory"
+}
+
+@test "publish-test-results prepare: merge without base-site-path or GITHUB_REPOSITORY fails" {
+	run env \
+		STEP=prepare \
+		RESULTS_PATH="" \
+		COVERAGE_PATH="" \
+		BADGE_PATH="" \
+		TARGET_DIR="vitest" \
+		MERGE_EXISTING_SITE=true \
+		BASE_SITE_PATH="" \
+		GITHUB_REPOSITORY="" \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/publish-test-results.sh"
+	assert_failure
+	assert_output --partial "merge-existing-site requires base-site-path or GITHUB_REPOSITORY"
+}
+
+@test "publish-test-results action: exposes merge inputs" {
+	local action="${PROJECT_ROOT}/.github/actions/publish-test-results/action.yml"
+	run grep -q 'merge-existing-site:' "$action"
+	assert_success
+	run grep -q 'base-site-path:' "$action"
+	assert_success
+	run grep -q 'MERGE_EXISTING_SITE:' "$action"
+	assert_success
+	run grep -q 'BASE_SITE_PATH:' "$action"
+	assert_success
+}

--- a/tests/bats/integration/test_publish_test_results_merge.bats
+++ b/tests/bats/integration/test_publish_test_results_merge.bats
@@ -181,6 +181,24 @@ EOF
 	assert_output --partial "::warning::Live site mirror failed for https://lgtm-hq.github.io/example/"
 }
 
+@test "publish-test-results prepare: rejects absolute target-dir" {
+	export TARGET_DIR="/vitest"
+	export MERGE_EXISTING_SITE=false
+
+	_run_prepare
+	assert_failure
+	assert_output --partial "target-dir must be relative"
+}
+
+@test "publish-test-results prepare: rejects target-dir with .. segments" {
+	export TARGET_DIR="../vitest"
+	export MERGE_EXISTING_SITE=false
+
+	_run_prepare
+	assert_failure
+	assert_output --partial "target-dir must not contain .. segments"
+}
+
 @test "publish-test-results action: exposes merge inputs" {
 	local action="${PROJECT_ROOT}/.github/actions/publish-test-results/action.yml"
 	run grep -q 'merge-existing-site:' "$action"

--- a/tests/bats/unit/lib/github/test_format.bats
+++ b/tests/bats/unit/lib/github/test_format.bats
@@ -87,6 +87,55 @@ teardown() {
 }
 
 # =============================================================================
+# get_github_pages_wget_cut_dirs tests
+# =============================================================================
+
+@test "get_github_pages_wget_cut_dirs: returns 0 for user pages root URL" {
+	run bash -c '
+		source "$LIB_DIR/github/format.sh"
+		get_github_pages_wget_cut_dirs "https://alice.github.io/"
+	'
+	assert_success
+	assert_output "0"
+}
+
+@test "get_github_pages_wget_cut_dirs: returns 1 for project pages root URL" {
+	run bash -c '
+		source "$LIB_DIR/github/format.sh"
+		get_github_pages_wget_cut_dirs "https://my-org.github.io/my-repo/"
+	'
+	assert_success
+	assert_output "1"
+}
+
+@test "get_github_pages_wget_cut_dirs: matches get_github_pages_url site roots" {
+	run bash -c '
+		export GITHUB_REPOSITORY="alice/alice.github.io"
+		source "$LIB_DIR/github/format.sh"
+		get_github_pages_wget_cut_dirs "$(get_github_pages_url "")"
+	'
+	assert_success
+	assert_output "0"
+
+	run bash -c '
+		export GITHUB_REPOSITORY="my-org/my-repo"
+		source "$LIB_DIR/github/format.sh"
+		get_github_pages_wget_cut_dirs "$(get_github_pages_url "")"
+	'
+	assert_success
+	assert_output "1"
+}
+
+@test "get_github_pages_wget_cut_dirs: fails for invalid URL" {
+	run bash -c '
+		source "$LIB_DIR/github/format.sh"
+		get_github_pages_wget_cut_dirs "not-a-url"
+	'
+	assert_failure
+	assert_output ""
+}
+
+# =============================================================================
 # score_emoji tests
 # =============================================================================
 
@@ -285,6 +334,11 @@ teardown() {
 
 @test "github/format.sh: exports get_github_pages_url function" {
 	run bash -c 'source "$LIB_DIR/github/format.sh" && bash -c "type get_github_pages_url"'
+	assert_success
+}
+
+@test "github/format.sh: exports get_github_pages_wget_cut_dirs function" {
+	run bash -c 'source "$LIB_DIR/github/format.sh" && bash -c "type get_github_pages_wget_cut_dirs"'
 	assert_success
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Adds optional `merge-existing-site` and `base-site-path` inputs to `publish-test-results` so multiple Model A publish jobs on the same ref can retain sibling `target-dir` trees instead of each deploy replacing the entire GitHub Pages site.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. Merge is opt-in via `merge-existing-site: "true"`.

## Closes

- Closes #225

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Merge existing GitHub Pages site content when multiple publishers deploy
> - Adds `merge-existing-site` and `base-site-path` inputs to the [`publish-test-results` action](https://github.com/lgtm-hq/lgtm-ci/pull/244/files#diff-e2911e19ede7d0afc581ff0adcfc47516adf8f8136fe6615aae85b653f32ff59), allowing multiple CI jobs to publish to Pages without overwriting each other's content.
> - When `merge-existing-site: true`, the [prepare script](https://github.com/lgtm-hq/lgtm-ci/pull/244/files#diff-3be2b2c19972d0dea137a63ed3586237220e0b6a2b34fa3e63577cd7e9ca2d1d) pre-populates the staging directory with existing site content — either from a local `base-site-path` or by mirroring the live GitHub Pages URL via `wget`.
> - New content is overlaid on top of the merged base, preserving sibling directories from previous deploys.
> - Adds `get_github_pages_wget_cut_dirs` to [format.sh](https://github.com/lgtm-hq/lgtm-ci/pull/244/files#diff-941393bea621eee97b88735323d51d4d0aa73b4cd1102436f072a045de1f2fbb) to compute the correct `--cut-dirs` value for `wget` mirroring.
> - Risk: live-site mirroring via HTTP can be slow or fail if the site is large or unavailable; failures are surfaced as hard errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 369e715.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `merge-existing-site` input to preserve existing GitHub Pages content when publishing test results
  * Added optional `base-site-path` input to use local site content instead of the live site

* **Documentation**
  * Updated documentation with guidance on merging GitHub Pages content for multi-publisher scenarios
  * Updated changelog with new action inputs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds opt-in `merge-existing-site` and `base-site-path` inputs to the `publish-test-results` composite action, allowing parallel Model A publish jobs to preserve sibling `target-dir` subtrees instead of each deploy overwriting the full Pages site.

- Refactors the `prepare` step into focused helpers and introduces a merge flow: existing site content is mirrored via `wget` (or copied from a local `base-site-path`) into a staging dir, then new content is overlaid on top.
- Adds `get_github_pages_wget_cut_dirs` to `format.sh` to derive the correct `--cut-dirs` value for `wget` from the Pages root URL, and ships integration and unit tests covering merge/overlay semantics, all error paths, and action input wiring.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the merge/overlay logic is correct, the wget failure path now exits non-zero, and the overlay_root trap ensures temp-dir cleanup on failure.

The core merge flow is logically sound and well-tested. Previous review concerns (silent sibling-tree loss on wget failure, missing EXIT trap for overlay_root) have both been addressed. Remaining findings are style-level only.

No files require special attention; publish-test-results.sh carries the bulk of the new logic and the two observations are minor.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/actions/publish-test-results.sh | Refactored into helpers and added merge flow; logic is correct, minor style issue with exit inside a helper function |
| scripts/ci/lib/github/format.sh | Adds get_github_pages_wget_cut_dirs correctly counting path segments from URL |
| .github/actions/publish-test-results/action.yml | Adds merge-existing-site and base-site-path inputs with correct defaults and env var wiring |
| tests/bats/integration/test_publish_test_results_merge.bats | New integration tests cover merge/overlay semantics, root overlay, error paths, and action input wiring |
| tests/bats/unit/lib/github/test_format.bats | Adds unit tests for get_github_pages_wget_cut_dirs covering user/project pages and invalid URLs |
| docs/pages-publishing.md | Adds clear guidance on the new merge-existing-site option including CDN staleness caveat and Model B preference |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["prepare step starts"] --> B["normalize TARGET_DIR"]
    B --> C{"MERGE_EXISTING_SITE == 'true'?"}
    C -- "no" --> D["_build_content(staging_dir, target_dir)"]
    D --> Z["set_github_output staging-dir"]
    C -- "yes" --> E["mktemp overlay_root / register EXIT trap"]
    E --> F["_build_content(overlay_root, target_dir)"]
    F --> G["_copy_existing_site(staging_dir)"]
    G --> H{"BASE_SITE_PATH set?"}
    H -- "yes" --> I["cp -a BASE_SITE_PATH/. staging_dir/"]
    H -- "no" --> J{"GITHUB_REPOSITORY set?"}
    J -- "no" --> ERR1["error / exit"]
    J -- "yes" --> K["wget mirror → wget_root"]
    K -- "fails" --> ERR2["warning + error / exit"]
    K -- "ok" --> N["cp wget_root/. staging_dir/ / rm wget_root"]
    I --> O["_overlay_content"]
    N --> O
    O --> P{"target_dir == '.'?"}
    P -- "yes" --> Q["cp -a overlay_root/. staging_dir/"]
    P -- "no" --> R["cp -a overlay_root/target_dir/. staging_dir/target_dir/"]
    Q --> S["rm -rf overlay_root / trap - EXIT"]
    R --> S
    S --> Z
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Factions%2Fpublish-test-results.sh%3A30-38%0A%60_publish_test_results_normalize_target_dir%60%20uses%20%60exit%201%60%20rather%20than%20%60return%201%60%20to%20signal%20validation%20errors.%20Because%20the%20call%20site%20wraps%20it%20in%20a%20command%20substitution%20%28%60normalized_target_dir%3D%24%28...%29%60%29%20it%20works%20correctly%20today%20%E2%80%94%20the%20%60exit%60%20terminates%20the%20subshell%20and%20%60set%20-e%60%20fires%20in%20the%20parent.%20But%20if%20the%20function%20is%20ever%20called%20directly%20%28e.g.%2C%20in%20a%20unit%20test%2C%20a%20sourcing%20script%2C%20or%20after%20refactoring%29%2C%20%60exit%201%60%20will%20terminate%20the%20entire%20shell%20process%20rather%20than%20just%20returning%20an%20error%20to%20the%20caller.%20Using%20%60return%201%60%20is%20the%20conventional%20and%20safer%20approach%20for%20helper%20functions.%0A%0A%60%60%60suggestion%0A%09if%20%5B%5B%20%22%24raw_target_dir%22%20%3D%3D%20%2F*%20%5D%5D%3B%20then%0A%09%09log_error%20%22target-dir%20must%20be%20relative%3A%20%24%7Braw_target_dir%7D%22%0A%09%09return%201%0A%09fi%0A%0A%09if%20%5B%5B%20%22%24raw_target_dir%22%20%3D%3D%20*%22..%22*%20%5D%5D%3B%20then%0A%09%09log_error%20%22target-dir%20must%20not%20contain%20..%20segments%3A%20%24%7Braw_target_dir%7D%22%0A%09%09return%201%0A%09fi%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Factions%2Fpublish-test-results.sh%3A149%0AThe%20%60%7C%7C%20site_url%3D%22%22%60%20guard%20is%20redundant%3A%20%60get_github_pages_url%60%20already%20emits%20an%20empty%20string%20and%20returns%20non-zero%20whenever%20%60GITHUB_REPOSITORY%60%20is%20absent%20or%20malformed%2C%20so%20the%20%60%7C%7C%60%20branch%20can%20never%20set%20%60site_url%60%20to%20a%20value%20different%20from%20what%20the%20subshell%20already%20produced.%20Using%20%60%7C%7C%20true%60%20makes%20the%20intent%20%28suppress%20%60set%20-e%60%20for%20the%20assignment%29%20explicit.%0A%0A%60%60%60suggestion%0A%09site_url%3D%24%28get_github_pages_url%20%22%22%29%20%7C%7C%20true%0A%60%60%60%0A%0A&pr=244&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Factions%2Fpublish-test-results.sh%3A30-38%0A%60_publish_test_results_normalize_target_dir%60%20uses%20%60exit%201%60%20rather%20than%20%60return%201%60%20to%20signal%20validation%20errors.%20Because%20the%20call%20site%20wraps%20it%20in%20a%20command%20substitution%20%28%60normalized_target_dir%3D%24%28...%29%60%29%20it%20works%20correctly%20today%20%E2%80%94%20the%20%60exit%60%20terminates%20the%20subshell%20and%20%60set%20-e%60%20fires%20in%20the%20parent.%20But%20if%20the%20function%20is%20ever%20called%20directly%20%28e.g.%2C%20in%20a%20unit%20test%2C%20a%20sourcing%20script%2C%20or%20after%20refactoring%29%2C%20%60exit%201%60%20will%20terminate%20the%20entire%20shell%20process%20rather%20than%20just%20returning%20an%20error%20to%20the%20caller.%20Using%20%60return%201%60%20is%20the%20conventional%20and%20safer%20approach%20for%20helper%20functions.%0A%0A%60%60%60suggestion%0A%09if%20%5B%5B%20%22%24raw_target_dir%22%20%3D%3D%20%2F*%20%5D%5D%3B%20then%0A%09%09log_error%20%22target-dir%20must%20be%20relative%3A%20%24%7Braw_target_dir%7D%22%0A%09%09return%201%0A%09fi%0A%0A%09if%20%5B%5B%20%22%24raw_target_dir%22%20%3D%3D%20*%22..%22*%20%5D%5D%3B%20then%0A%09%09log_error%20%22target-dir%20must%20not%20contain%20..%20segments%3A%20%24%7Braw_target_dir%7D%22%0A%09%09return%201%0A%09fi%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Factions%2Fpublish-test-results.sh%3A149%0AThe%20%60%7C%7C%20site_url%3D%22%22%60%20guard%20is%20redundant%3A%20%60get_github_pages_url%60%20already%20emits%20an%20empty%20string%20and%20returns%20non-zero%20whenever%20%60GITHUB_REPOSITORY%60%20is%20absent%20or%20malformed%2C%20so%20the%20%60%7C%7C%60%20branch%20can%20never%20set%20%60site_url%60%20to%20a%20value%20different%20from%20what%20the%20subshell%20already%20produced.%20Using%20%60%7C%7C%20true%60%20makes%20the%20intent%20%28suppress%20%60set%20-e%60%20for%20the%20assignment%29%20explicit.%0A%0A%60%60%60suggestion%0A%09site_url%3D%24%28get_github_pages_url%20%22%22%29%20%7C%7C%20true%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=244&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F225-merge-existing-pages-site-when-multiple-publishers-deploy%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F225-merge-existing-pages-site-when-multiple-publishers-deploy%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Factions%2Fpublish-test-results.sh%3A30-38%0A%60_publish_test_results_normalize_target_dir%60%20uses%20%60exit%201%60%20rather%20than%20%60return%201%60%20to%20signal%20validation%20errors.%20Because%20the%20call%20site%20wraps%20it%20in%20a%20command%20substitution%20%28%60normalized_target_dir%3D%24%28...%29%60%29%20it%20works%20correctly%20today%20%E2%80%94%20the%20%60exit%60%20terminates%20the%20subshell%20and%20%60set%20-e%60%20fires%20in%20the%20parent.%20But%20if%20the%20function%20is%20ever%20called%20directly%20%28e.g.%2C%20in%20a%20unit%20test%2C%20a%20sourcing%20script%2C%20or%20after%20refactoring%29%2C%20%60exit%201%60%20will%20terminate%20the%20entire%20shell%20process%20rather%20than%20just%20returning%20an%20error%20to%20the%20caller.%20Using%20%60return%201%60%20is%20the%20conventional%20and%20safer%20approach%20for%20helper%20functions.%0A%0A%60%60%60suggestion%0A%09if%20%5B%5B%20%22%24raw_target_dir%22%20%3D%3D%20%2F*%20%5D%5D%3B%20then%0A%09%09log_error%20%22target-dir%20must%20be%20relative%3A%20%24%7Braw_target_dir%7D%22%0A%09%09return%201%0A%09fi%0A%0A%09if%20%5B%5B%20%22%24raw_target_dir%22%20%3D%3D%20*%22..%22*%20%5D%5D%3B%20then%0A%09%09log_error%20%22target-dir%20must%20not%20contain%20..%20segments%3A%20%24%7Braw_target_dir%7D%22%0A%09%09return%201%0A%09fi%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Factions%2Fpublish-test-results.sh%3A149%0AThe%20%60%7C%7C%20site_url%3D%22%22%60%20guard%20is%20redundant%3A%20%60get_github_pages_url%60%20already%20emits%20an%20empty%20string%20and%20returns%20non-zero%20whenever%20%60GITHUB_REPOSITORY%60%20is%20absent%20or%20malformed%2C%20so%20the%20%60%7C%7C%60%20branch%20can%20never%20set%20%60site_url%60%20to%20a%20value%20different%20from%20what%20the%20subshell%20already%20produced.%20Using%20%60%7C%7C%20true%60%20makes%20the%20intent%20%28suppress%20%60set%20-e%60%20for%20the%20assignment%29%20explicit.%0A%0A%60%60%60suggestion%0A%09site_url%3D%24%28get_github_pages_url%20%22%22%29%20%7C%7C%20true%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): validate target-dir paths and u..."](https://github.com/lgtm-hq/lgtm-ci/commit/369e715a96bd027377a879a8e98809a613e64945) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34340755)</sub>

<!-- /greptile_comment -->