### PR TITLE
fix(ci): validate PyPI dist with uv run twine

### DIFF
--- a/.github/workflows/reusable-publish-pypi-release.yml
+++ b/.github/workflows/reusable-publish-pypi-release.yml
@@ -1,4 +1,8 @@
 ---
+# Split build + OIDC publish for production tag releases.
+# Caller: set `environment` on the workflow_call job for PyPI trusted publishing.
+# Caller: pass full PyPI egress (incl. ghcr.io) when egress-policy is block —
+# see docs/python-release-publish.md and docs/workflow-contract.md.
 name: Reusable PyPI Release Publishing Workflow
 
 on:

--- a/.github/workflows/reusable-publish-pypi-release.yml
+++ b/.github/workflows/reusable-publish-pypi-release.yml
@@ -1,6 +1,6 @@
 ---
 # Split build + OIDC publish for production tag releases.
-# Caller: set `environment` on the workflow_call job for PyPI trusted publishing.
+# Caller: pass `github-environment` (e.g. pypi) for PyPI trusted publishing.
 # Caller: pass full PyPI egress (incl. ghcr.io) when egress-policy is block —
 # see docs/python-release-publish.md and docs/workflow-contract.md.
 name: Reusable PyPI Release Publishing Workflow
@@ -88,6 +88,13 @@ on:
         required: false
         type: number
         default: 15
+      github-environment:
+        description: >-
+          GitHub Environment for the publish job (PyPI OIDC trusted publishing).
+          Leave empty to omit the environment.
+        required: false
+        type: string
+        default: ""
 
     outputs:
       published:
@@ -168,6 +175,7 @@ jobs:
     needs: build-artifacts
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    environment: ${{ inputs.github-environment }}
     permissions:
       contents: read
       id-token: write # OIDC token for PyPI Trusted Publishing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **docs**: document full PyPI publish egress (ghcr.io, setup-python hosts) and
+  caller `environment` for trusted publishing (#246)
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- **ci**: validate PyPI dist via `uv run twine check` instead of
+  `uv pip install --system twine` (PEP 668 on Ubuntu 24.04 runners) (#246)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **docs**: document full PyPI publish egress (ghcr.io, setup-python hosts) and
-  caller `environment` for trusted publishing (#246)
+  `github-environment` input for trusted publishing (#246)
+- **workflows**: `reusable-publish-pypi-release.yml` adds `github-environment`
+  input for publish-job OIDC environments (#246)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **ci**: validate PyPI dist via `uv run --with twine twine check` instead of
-  `uv pip install --system twine` (PEP 668 on Ubuntu 24.04 runners) (#246)
+- **ci**: validate PyPI dist with twine when available, or `uv run --with twine
+  twine check` when only uv is present; `validate_pypi_package` warns and skips
+  validation when neither tool is available (replaces PEP 668-breaking
+  `uv pip install --system twine`) (#246)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **ci**: validate PyPI dist via `uv run twine check` instead of
+- **ci**: validate PyPI dist via `uv run --with twine twine check` instead of
   `uv pip install --system twine` (PEP 668 on Ubuntu 24.04 runners) (#246)
 
 ### Security

--- a/docs/python-release-publish.md
+++ b/docs/python-release-publish.md
@@ -180,7 +180,8 @@ in [workflow-contract.md](workflow-contract.md) (§ PyPI publish).
 | --- | --- |
 | `ghcr.io:443` | `pypa/gh-action-pypi-publish` Docker image pull |
 | `pkg-containers.githubusercontent.com:443` | Container registry routing |
-| `github-releases.githubusercontent.com:443`, `raw.githubusercontent.com:443` | `setup-python` / uv Python install |
+| `github-releases.githubusercontent.com:443` | `setup-python` / uv Python install |
+| `raw.githubusercontent.com:443` | `setup-python` / uv Python install |
 | `astral.sh:443`, `releases.astral.sh:443` | uv |
 | `upload.pypi.org:443`, `pypi.org:443`, `files.pythonhosted.org:443` | PyPI upload |
 | Sigstore hosts | OIDC publish + `attest-build-provenance` |

--- a/docs/python-release-publish.md
+++ b/docs/python-release-publish.md
@@ -59,8 +59,6 @@ jobs:
 
   publish:
     needs: [quality, sbom]
-    # Trusted publishing: match the Environment name configured on PyPI (if any).
-    environment: pypi
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@<sha> # vX.Y.Z
     permissions:
       contents: read
@@ -70,6 +68,7 @@ jobs:
       python-version: "3.12"
       tooling-ref: "<sha>" # vX.Y.Z
       artifact-name: python-dist
+      github-environment: pypi
       egress-policy: block
       # Full list: workflow-contract.md § PyPI publish (build + publish jobs).
       allowed-endpoints: >
@@ -156,14 +155,16 @@ each job needs; do not set top-level `permissions: write-all`.
 
 ## PyPI trusted publishing
 
-`reusable-publish-pypi-release.yml` does not define a GitHub Environment
-internally. Set it on the **caller** job that invokes the reusable workflow:
+Pass `github-environment` on the reusable workflow `with:` block. The publish
+job inside `reusable-publish-pypi-release.yml` sets `environment` from that
+input (caller jobs that use `uses:` cannot set `environment` themselves).
 
 ```yaml
 jobs:
   publish:
-    environment: pypi
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@<sha>
+    with:
+      github-environment: pypi
 ```
 
 Ensure the PyPI project trusted publisher matches this repository, workflow

--- a/docs/python-release-publish.md
+++ b/docs/python-release-publish.md
@@ -59,6 +59,8 @@ jobs:
 
   publish:
     needs: [quality, sbom]
+    # Trusted publishing: match the Environment name configured on PyPI (if any).
+    environment: pypi
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@<sha> # vX.Y.Z
     permissions:
       contents: read
@@ -69,9 +71,18 @@ jobs:
       tooling-ref: "<sha>" # vX.Y.Z
       artifact-name: python-dist
       egress-policy: block
+      # Full list: workflow-contract.md § PyPI publish (build + publish jobs).
       allowed-endpoints: >
         github.com:443
         api.github.com:443
+        codeload.github.com:443
+        release-assets.githubusercontent.com:443
+        objects.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        uploads.github.com:443
+        ghcr.io:443
+        pkg-containers.githubusercontent.com:443
         pypi.org:443
         upload.pypi.org:443
         files.pythonhosted.org:443
@@ -143,11 +154,43 @@ jobs:
 Nested reusable workflows validate permissions at parse time. Grant only what
 each job needs; do not set top-level `permissions: write-all`.
 
+## PyPI trusted publishing
+
+`reusable-publish-pypi-release.yml` does not define a GitHub Environment
+internally. Set it on the **caller** job that invokes the reusable workflow:
+
+```yaml
+jobs:
+  publish:
+    environment: pypi
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@<sha>
+```
+
+Ensure the PyPI project trusted publisher matches this repository, workflow
+file name, and environment (if used).
+
 ## Egress allowlists
 
-When `egress-policy: block`, pass `allowed-endpoints` from the caller or rely
-on audit mode during rollout. See [workflow-contract.md](workflow-contract.md)
-for shared endpoint patterns.
+When `egress-policy: block`, pass `allowed-endpoints` from the caller for
+**both** nested jobs (`build-artifacts` and `publish`). Use the canonical list
+in [workflow-contract.md](workflow-contract.md) (§ PyPI publish).
+
+| Endpoint | Why |
+| --- | --- |
+| `ghcr.io:443` | `pypa/gh-action-pypi-publish` Docker image pull |
+| `pkg-containers.githubusercontent.com:443` | Container registry routing |
+| `github-releases.githubusercontent.com:443`, `raw.githubusercontent.com:443` | `setup-python` / uv Python install |
+| `astral.sh:443`, `releases.astral.sh:443` | uv |
+| `upload.pypi.org:443`, `pypi.org:443`, `files.pythonhosted.org:443` | PyPI upload |
+| Sigstore hosts | OIDC publish + `attest-build-provenance` |
+
+Run an end-to-end tag publish (or TestPyPI) in `audit` mode first, then copy
+any additional hosts from the Harden Runner report into the allowlist.
+
+## Product-specific jobs
+
+Run Homebrew tap or other release-asset consumers **`needs: [publish,
+github-release]`** when they expect GitHub Release assets to exist.
 
 ## Related docs
 

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -209,6 +209,7 @@ jobs:
       attestations: write
 
   pypi-release:
+    environment: pypi
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@<sha>
     permissions:
       contents: read
@@ -216,6 +217,8 @@ jobs:
       attestations: write
     with:
       tooling-ref: "<sha>" # vX.Y.Z
+      egress-policy: block
+      # See workflow-contract.md § PyPI publish for allowed-endpoints.
 
   github-release:
     needs: pypi-release

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -209,7 +209,6 @@ jobs:
       attestations: write
 
   pypi-release:
-    environment: pypi
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-pypi-release.yml@<sha>
     permissions:
       contents: read
@@ -217,6 +216,7 @@ jobs:
       attestations: write
     with:
       tooling-ref: "<sha>" # vX.Y.Z
+      github-environment: pypi
       egress-policy: block
       # See workflow-contract.md § PyPI publish for allowed-endpoints.
 

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -185,8 +185,8 @@ allowed-endpoints: >
   oauth2.sigstore.dev:443
 ```
 
-Set `environment: <name>` on the **caller** job that invokes the reusable
-workflow when PyPI trusted publishing is bound to a GitHub Environment (see
+Pass `github-environment: <name>` in the reusable workflow `with:` block when
+PyPI trusted publishing is bound to a GitHub Environment (see
 [python-release-publish.md](python-release-publish.md)).
 
 ### GitHub Release (artifact upload)

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -150,12 +150,28 @@ allowed-endpoints: >
 
 ### PyPI publish (OIDC + attestation)
 
+Used by `reusable-publish-pypi.yml` and `reusable-publish-pypi-release.yml`
+(build and publish jobs share the caller's `allowed-endpoints`).
+
+`pypa/gh-action-pypi-publish` runs as a **Docker** action and pulls
+`ghcr.io/pypa/gh-action-pypi-publish` — include `ghcr.io:443` and
+`pkg-containers.githubusercontent.com:443`.
+
+`setup-python` (uv-managed interpreters) needs GitHub release asset hosts.
+
 ```yaml
 egress-policy: block
 allowed-endpoints: >
   github.com:443
   api.github.com:443
   codeload.github.com:443
+  release-assets.githubusercontent.com:443
+  objects.githubusercontent.com:443
+  github-releases.githubusercontent.com:443
+  raw.githubusercontent.com:443
+  uploads.github.com:443
+  ghcr.io:443
+  pkg-containers.githubusercontent.com:443
   pypi.org:443
   upload.pypi.org:443
   files.pythonhosted.org:443
@@ -168,6 +184,10 @@ allowed-endpoints: >
   tuf-repo-cdn.sigstore.dev:443
   oauth2.sigstore.dev:443
 ```
+
+Set `environment: <name>` on the **caller** job that invokes the reusable
+workflow when PyPI trusted publishing is bound to a GitHub Environment (see
+[python-release-publish.md](python-release-publish.md)).
 
 ### GitHub Release (artifact upload)
 

--- a/scripts/ci/actions/publish-pypi.sh
+++ b/scripts/ci/actions/publish-pypi.sh
@@ -136,8 +136,8 @@ validate-dist)
 		die "dist/ directory not found"
 	fi
 
-	# validate_pypi_package runs twine when available, or `uv run twine check`
-	# (no `uv pip install --system` — PEP 668 blocks that on Ubuntu runners).
+	# validate_pypi_package runs twine when available, or provisions it via
+	# `uv run --with twine twine check` (no `uv pip install --system` — PEP 668).
 	if validate_pypi_package "dist"; then
 		log_success "Distribution validation passed"
 	else

--- a/scripts/ci/actions/publish-pypi.sh
+++ b/scripts/ci/actions/publish-pypi.sh
@@ -136,13 +136,8 @@ validate-dist)
 		die "dist/ directory not found"
 	fi
 
-	if command -v uv >/dev/null 2>&1 && ! command -v twine >/dev/null 2>&1; then
-		log_info "Installing twine for validation..."
-		uv pip install --system twine
-	elif ! command -v twine >/dev/null 2>&1; then
-		die "twine is not available and uv is not available to install it"
-	fi
-
+	# validate_pypi_package runs twine when available, or `uv run twine check`
+	# (no `uv pip install --system` — PEP 668 blocks that on Ubuntu runners).
 	if validate_pypi_package "dist"; then
 		log_success "Distribution validation passed"
 	else

--- a/scripts/ci/lib/publish/validate.sh
+++ b/scripts/ci/lib/publish/validate.sh
@@ -43,7 +43,7 @@ validate_pypi_package() {
 		log_success "twine check passed"
 	elif command -v uv >/dev/null 2>&1; then
 		log_info "Running twine check via uv..."
-		if ! uv run twine check "$dist_dir"/*; then
+		if ! uv run --with twine twine check "$dist_dir"/*; then
 			log_error "twine check failed"
 			return 1
 		fi

--- a/tests/bats/integration/test_reusable_python_release_publish.bats
+++ b/tests/bats/integration/test_reusable_python_release_publish.bats
@@ -48,6 +48,18 @@ _tooling_sparse_cone_ok() {
 	assert_success
 }
 
+@test "reusable-publish-pypi-release: publish job uses github-environment input" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-publish-pypi-release.yml"
+	run awk '
+		/github-environment:/ { input = 1 }
+		/^  publish:/ { in_publish = 1 }
+		in_publish && /^  [a-zA-Z0-9_-]+:/ && $0 !~ /^  publish:/ { in_publish = 0 }
+		in_publish && /environment: \$\{\{ inputs\.github-environment \}\}/ { env = 1 }
+		END { exit !(input && env) }
+	' "$workflow"
+	assert_success
+}
+
 @test "reusable-publish-pypi-release: publish job validates dist and attests" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-publish-pypi-release.yml"
 	run awk '

--- a/tests/bats/integration/test_reusable_python_release_publish.bats
+++ b/tests/bats/integration/test_reusable_python_release_publish.bats
@@ -51,10 +51,10 @@ _tooling_sparse_cone_ok() {
 @test "reusable-publish-pypi-release: publish job uses github-environment input" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-publish-pypi-release.yml"
 	run awk '
-		/github-environment:/ { input = 1 }
-		/^  publish:/ { in_publish = 1 }
-		in_publish && /^  [a-zA-Z0-9_-]+:/ && $0 !~ /^  publish:/ { in_publish = 0 }
-		in_publish && /environment: \$\{\{ inputs\.github-environment \}\}/ { env = 1 }
+		/^      github-environment:/ { input = 1 }
+		/^  publish:$/ { in_publish = 1 }
+		in_publish && /^  [a-zA-Z0-9_-]+:/ && $0 !~ /^  publish:$/ { in_publish = 0 }
+		in_publish && /^    environment: \$\{\{ inputs\.github-environment \}\}$/ { env = 1 }
 		END { exit !(input && env) }
 	' "$workflow"
 	assert_success

--- a/tests/bats/unit/lib/publish/test_validate.bats
+++ b/tests/bats/unit/lib/publish/test_validate.bats
@@ -109,6 +109,25 @@ teardown() {
 	assert_output --partial "twine check failed"
 }
 
+@test "validate_pypi_package: provisions twine via uv when twine not on PATH" {
+	local dist_dir="${BATS_TEST_TMPDIR}/dist"
+	mkdir -p "$dist_dir"
+	touch "$dist_dir/package-1.0.0.tar.gz"
+	mock_command_record "uv" "Checking dist/package-1.0.0.tar.gz: PASSED"
+
+	run bash -c "
+		source \"\$LIB_DIR/log.sh\"
+		source \"\$LIB_DIR/publish/validate.sh\"
+		validate_pypi_package \"$dist_dir\" 2>&1
+	"
+	assert_success
+	assert_output --partial "twine check via uv"
+	assert_output --partial "twine check passed"
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_uv"
+	assert_output --partial "--with twine"
+	assert_output --partial "twine check"
+}
+
 # =============================================================================
 # validate_npm_package tests
 # =============================================================================


### PR DESCRIPTION
## Summary

- **Fix:** `validate-dist` uses `validate_pypi_package` only (via `uv run twine check`), not `uv pip install --system twine` (PEP 668 on Ubuntu 24.04).
- **Docs:** Canonical PyPI publish egress in `workflow-contract.md` (ghcr.io, pkg-containers, setup-python hosts, PyPI, Sigstore).
- **Docs:** `python-release-publish.md` — full publish example, `environment: pypi` on caller job, egress table, Homebrew `needs` guidance.
- **Docs:** `reusable-workflows.md` — `environment` + egress pointer on `pypi-release` example.
- **Workflow comment:** `reusable-publish-pypi-release.yml` header notes caller `environment` and egress.

## Why

py-lintro v0.64.3 tag publish failed in layers: PEP 668 validate-dist, missing `ghcr.io` for `pypa/gh-action-pypi-publish`, dropped `environment: pypi`. Callers adopting v0.23.0 followed a minimal doc example that omitted these.

## Test plan

- [ ] Shell tests / CI green
- [ ] After release: py-lintro repins `tooling-ref` to release SHA and can drop branch pin
- [ ] py-lintro #960 adds matching egress on caller (until this ships)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now delegates PyPI distribution validation to a shared helper and surfaces an environment input for publish jobs.
* **Documentation**
  * Updated publishing docs and workflow guidance: added PyPI trusted-publishing examples, clarified environment usage, and expanded egress/allowlist guidance for production releases.
* **Tests**
  * Added an integration contract test asserting the publish job consumes the provided environment input.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix PyPI dist validation to provision twine via `uv run --with twine`
> - Changes [`validate_pypi_package`](https://github.com/lgtm-hq/lgtm-ci/pull/246/files#diff-ac2e201ac8e6d9c8de4438a5246c11b6697cf137434101c4a28f960270122b41) to invoke `uv run --with twine twine check` instead of `uv run twine check`, so twine is provisioned on-the-fly without requiring a prior system install.
> - Removes the `uv pip install --system twine` step from [`publish-pypi.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/246/files#diff-dc203e73ceaaf4d6016ca5e4deede62f8cf0e8440d8645a8ef30397cb05731ff); validation now warns and skips when neither twine nor uv is available instead of failing.
> - Adds a `github-environment` input to the reusable publish workflow so the publish job can run under a named GitHub Environment for trusted publishing (OIDC).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97a4352.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a PEP 668 breakage in the `validate-dist` step by replacing `uv pip install --system twine` with `uv run --with twine twine check` (ephemeral, no system-install), and adds a `github-environment` input to `reusable-publish-pypi-release.yml` so callers can bind the publish job to a GitHub Environment for OIDC trusted publishing.

- **Core fix** (`validate.sh`): `uv run --with twine twine check` now provisions twine on-demand rather than relying on it being a project dependency or installed globally; new bats test verifies `--with twine` is passed.
- **New input** (`reusable-publish-pypi-release.yml`): `github-environment` (default `\"\"`) is wired to `environment:` on the publish job; integration contract test validates the binding.
- **Docs** (`workflow-contract.md`, `python-release-publish.md`, `reusable-workflows.md`): expanded PyPI egress allowlists to include `ghcr.io`/`pkg-containers` for the Docker-based `pypa/gh-action-pypi-publish`, and added a trusted-publishing section with a complete caller example.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge for the primary fix; one behavioral regression remains where publish proceeds unvalidated on runners missing both twine and uv.

The `uv run --with twine` fix is correct and well-tested. However, the explicit `die` guard in `publish-pypi.sh` that previously caught "neither twine nor uv available" was removed, and the fallback in `validate_pypi_package` returns 0 with only a warning — so a minimal self-hosted runner without uv silently ships an unvalidated dist instead of failing the build.

scripts/ci/actions/publish-pypi.sh — the removed `die` guard leaves a silent-pass path for the no-uv no-twine case.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/ci/lib/publish/validate.sh | Core fix: replaces `uv run twine check` (requires project venv twine) with `uv run --with twine twine check` (ephemeral provision). Validation is skipped with a warning when neither tool is present. |
| scripts/ci/actions/publish-pypi.sh | Removes the explicit `die` guard for "neither twine nor uv available", delegating fully to `validate_pypi_package`; the silent-skip path now reaches the caller without a loud failure. |
| .github/workflows/reusable-publish-pypi-release.yml | Adds `github-environment` input (default `""`) and wires it to `environment: ${{ inputs.github-environment }}` on the publish job, enabling OIDC trusted publishing via GitHub Environments. Empty-string default correctly results in no environment binding. |
| tests/bats/unit/lib/publish/test_validate.bats | New test exercises the `uv run --with twine twine check` path via `mock_command_record "uv"` and asserts the recorded args include `--with twine` and `twine check`. |
| tests/bats/integration/test_reusable_python_release_publish.bats | Contract test added: awk verifies `github-environment` input is declared and the publish job's `environment:` is bound to `${{ inputs.github-environment }}`. |
| docs/workflow-contract.md | Expands PyPI publish egress allowlist with container registry hosts (`ghcr.io`, `pkg-containers`) and GitHub release asset hosts required by `pypa/gh-action-pypi-publish`. |
| docs/python-release-publish.md | New sections for PyPI trusted publishing, egress table, and Homebrew `needs` guidance; updated allowlist example matches workflow-contract.md additions. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validate-dist step] --> B{dist/ exists?}
    B -- No --> C[die: dist/ directory not found]
    B -- Yes --> D[validate_pypi_package dist/]
    D --> E{twine on PATH?}
    E -- Yes --> F[twine check dist/*]
    E -- No --> G{uv on PATH?}
    G -- Yes --> H["uv run --with twine twine check dist/*"]
    G -- No --> I["log_warn 'twine not available' / return 0 - Silent pass"]
    F -- fail --> J[return 1 - die: validation failed]
    H -- fail --> J
    F -- pass --> K[return 0]
    H -- pass --> K
    K --> L[log_success: Distribution validation passed]
    I --> L
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/ci/actions/publish-pypi.sh`, line 136-145 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/97a4352c32e6e4fcc14933a06947cf68f677b06b/scripts/ci/actions/publish-pypi.sh#L136-L145)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`validate-dist` now silently succeeds when neither `twine` nor `uv` is available**

   Before this PR, `publish-pypi.sh` had an explicit guard: `die "twine is not available and uv is not available to install it"`. That guard is now removed, so on a runner that has neither tool, `validate_pypi_package` falls through to `log_warn "twine not available, skipping package validation"` and returns 0 — causing `validate-dist` to succeed silently, and publish to proceed with an unvalidated dist. On GitHub-hosted `ubuntu-latest` this is unlikely because `uv` ships pre-installed, but any self-hosted or minimal runner without `uv` hits this path silently instead of failing loudly.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Factions%2Fpublish-pypi.sh%0ALine%3A%20136-145%0A%0AComment%3A%0A**%60validate-dist%60%20now%20silently%20succeeds%20when%20neither%20%60twine%60%20nor%20%60uv%60%20is%20available**%0A%0ABefore%20this%20PR%2C%20%60publish-pypi.sh%60%20had%20an%20explicit%20guard%3A%20%60die%20%22twine%20is%20not%20available%20and%20uv%20is%20not%20available%20to%20install%20it%22%60.%20That%20guard%20is%20now%20removed%2C%20so%20on%20a%20runner%20that%20has%20neither%20tool%2C%20%60validate_pypi_package%60%20falls%20through%20to%20%60log_warn%20%22twine%20not%20available%2C%20skipping%20package%20validation%22%60%20and%20returns%200%20%E2%80%94%20causing%20%60validate-dist%60%20to%20succeed%20silently%2C%20and%20publish%20to%20proceed%20with%20an%20unvalidated%20dist.%20On%20GitHub-hosted%20%60ubuntu-latest%60%20this%20is%20unlikely%20because%20%60uv%60%20ships%20pre-installed%2C%20but%20any%20self-hosted%20or%20minimal%20runner%20without%20%60uv%60%20hits%20this%20path%20silently%20instead%20of%20failing%20loudly.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=246&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Factions%2Fpublish-pypi.sh%0ALine%3A%20136-145%0A%0AComment%3A%0A**%60validate-dist%60%20now%20silently%20succeeds%20when%20neither%20%60twine%60%20nor%20%60uv%60%20is%20available**%0A%0ABefore%20this%20PR%2C%20%60publish-pypi.sh%60%20had%20an%20explicit%20guard%3A%20%60die%20%22twine%20is%20not%20available%20and%20uv%20is%20not%20available%20to%20install%20it%22%60.%20That%20guard%20is%20now%20removed%2C%20so%20on%20a%20runner%20that%20has%20neither%20tool%2C%20%60validate_pypi_package%60%20falls%20through%20to%20%60log_warn%20%22twine%20not%20available%2C%20skipping%20package%20validation%22%60%20and%20returns%200%20%E2%80%94%20causing%20%60validate-dist%60%20to%20succeed%20silently%2C%20and%20publish%20to%20proceed%20with%20an%20unvalidated%20dist.%20On%20GitHub-hosted%20%60ubuntu-latest%60%20this%20is%20unlikely%20because%20%60uv%60%20ships%20pre-installed%2C%20but%20any%20self-hosted%20or%20minimal%20runner%20without%20%60uv%60%20hits%20this%20path%20silently%20instead%20of%20failing%20loudly.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=246&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22fix%2Fpublish-validate-dist-uv-run-twine%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpublish-validate-dist-uv-run-twine%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Factions%2Fpublish-pypi.sh%0ALine%3A%20136-145%0A%0AComment%3A%0A**%60validate-dist%60%20now%20silently%20succeeds%20when%20neither%20%60twine%60%20nor%20%60uv%60%20is%20available**%0A%0ABefore%20this%20PR%2C%20%60publish-pypi.sh%60%20had%20an%20explicit%20guard%3A%20%60die%20%22twine%20is%20not%20available%20and%20uv%20is%20not%20available%20to%20install%20it%22%60.%20That%20guard%20is%20now%20removed%2C%20so%20on%20a%20runner%20that%20has%20neither%20tool%2C%20%60validate_pypi_package%60%20falls%20through%20to%20%60log_warn%20%22twine%20not%20available%2C%20skipping%20package%20validation%22%60%20and%20returns%200%20%E2%80%94%20causing%20%60validate-dist%60%20to%20succeed%20silently%2C%20and%20publish%20to%20proceed%20with%20an%20unvalidated%20dist.%20On%20GitHub-hosted%20%60ubuntu-latest%60%20this%20is%20unlikely%20because%20%60uv%60%20ships%20pre-installed%2C%20but%20any%20self-hosted%20or%20minimal%20runner%20without%20%60uv%60%20hits%20this%20path%20silently%20instead%20of%20failing%20loudly.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fpublish-pypi.sh%3A136-145%0A**%60validate-dist%60%20now%20silently%20succeeds%20when%20neither%20%60twine%60%20nor%20%60uv%60%20is%20available**%0A%0ABefore%20this%20PR%2C%20%60publish-pypi.sh%60%20had%20an%20explicit%20guard%3A%20%60die%20%22twine%20is%20not%20available%20and%20uv%20is%20not%20available%20to%20install%20it%22%60.%20That%20guard%20is%20now%20removed%2C%20so%20on%20a%20runner%20that%20has%20neither%20tool%2C%20%60validate_pypi_package%60%20falls%20through%20to%20%60log_warn%20%22twine%20not%20available%2C%20skipping%20package%20validation%22%60%20and%20returns%200%20%E2%80%94%20causing%20%60validate-dist%60%20to%20succeed%20silently%2C%20and%20publish%20to%20proceed%20with%20an%20unvalidated%20dist.%20On%20GitHub-hosted%20%60ubuntu-latest%60%20this%20is%20unlikely%20because%20%60uv%60%20ships%20pre-installed%2C%20but%20any%20self-hosted%20or%20minimal%20runner%20without%20%60uv%60%20hits%20this%20path%20silently%20instead%20of%20failing%20loudly.%0A%0A&pr=246&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fpublish-pypi.sh%3A136-145%0A**%60validate-dist%60%20now%20silently%20succeeds%20when%20neither%20%60twine%60%20nor%20%60uv%60%20is%20available**%0A%0ABefore%20this%20PR%2C%20%60publish-pypi.sh%60%20had%20an%20explicit%20guard%3A%20%60die%20%22twine%20is%20not%20available%20and%20uv%20is%20not%20available%20to%20install%20it%22%60.%20That%20guard%20is%20now%20removed%2C%20so%20on%20a%20runner%20that%20has%20neither%20tool%2C%20%60validate_pypi_package%60%20falls%20through%20to%20%60log_warn%20%22twine%20not%20available%2C%20skipping%20package%20validation%22%60%20and%20returns%200%20%E2%80%94%20causing%20%60validate-dist%60%20to%20succeed%20silently%2C%20and%20publish%20to%20proceed%20with%20an%20unvalidated%20dist.%20On%20GitHub-hosted%20%60ubuntu-latest%60%20this%20is%20unlikely%20because%20%60uv%60%20ships%20pre-installed%2C%20but%20any%20self-hosted%20or%20minimal%20runner%20without%20%60uv%60%20hits%20this%20path%20silently%20instead%20of%20failing%20loudly.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=246&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22fix%2Fpublish-validate-dist-uv-run-twine%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpublish-validate-dist-uv-run-twine%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fpublish-pypi.sh%3A136-145%0A**%60validate-dist%60%20now%20silently%20succeeds%20when%20neither%20%60twine%60%20nor%20%60uv%60%20is%20available**%0A%0ABefore%20this%20PR%2C%20%60publish-pypi.sh%60%20had%20an%20explicit%20guard%3A%20%60die%20%22twine%20is%20not%20available%20and%20uv%20is%20not%20available%20to%20install%20it%22%60.%20That%20guard%20is%20now%20removed%2C%20so%20on%20a%20runner%20that%20has%20neither%20tool%2C%20%60validate_pypi_package%60%20falls%20through%20to%20%60log_warn%20%22twine%20not%20available%2C%20skipping%20package%20validation%22%60%20and%20returns%200%20%E2%80%94%20causing%20%60validate-dist%60%20to%20succeed%20silently%2C%20and%20publish%20to%20proceed%20with%20an%20unvalidated%20dist.%20On%20GitHub-hosted%20%60ubuntu-latest%60%20this%20is%20unlikely%20because%20%60uv%60%20ships%20pre-installed%2C%20but%20any%20self-hosted%20or%20minimal%20runner%20without%20%60uv%60%20hits%20this%20path%20silently%20instead%20of%20failing%20loudly.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["test(ci): anchor publish-job AWK checks;..."](https://github.com/lgtm-hq/lgtm-ci/commit/97a4352c32e6e4fcc14933a06947cf68f677b06b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34521866)</sub>

<!-- /greptile_comment -->