### PR TITLE
fix(ci): checkout tooling for setup-python in upload-pypi-oidc

### DIFF
--- a/.github/actions/build-python-package/action.yml
+++ b/.github/actions/build-python-package/action.yml
@@ -4,7 +4,6 @@ description: >-
   Preflight tag checks, validate metadata, build sdist/wheel, and twine-check dist.
   Does not upload to PyPI.
 author: "lgtm-hq"
-
 inputs:
   validate:
     description: "Run twine check on built distributions"

--- a/.github/actions/resolve-tooling-ref/action.yml
+++ b/.github/actions/resolve-tooling-ref/action.yml
@@ -4,7 +4,6 @@ description: >-
   Resolve the Git ref for lgtm-ci tooling checkout. Returns the caller-provided
   tooling-ref if set, otherwise falls back to github.workflow_sha.
 author: "lgtm-hq"
-
 inputs:
   tooling-ref:
     description: "Caller-provided Git ref override (empty to use workflow SHA)"

--- a/.github/actions/upload-pypi-oidc/action.yml
+++ b/.github/actions/upload-pypi-oidc/action.yml
@@ -7,7 +7,6 @@ description: >-
   repository workflow (not from a cross-repo reusable workflow) with
   environment and id-token: write set on that job.
 author: "lgtm-hq"
-
 inputs:
   artifact-name:
     description: "Workflow artifact containing dist/"

--- a/.github/actions/upload-pypi-oidc/action.yml
+++ b/.github/actions/upload-pypi-oidc/action.yml
@@ -43,11 +43,21 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Checkout lgtm-ci tooling
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        repository: lgtm-hq/lgtm-ci
+        path: .lgtm-ci-tooling
+        ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.action_ref }}
+        sparse-checkout: |
+          .github/actions/
+          scripts/ci/
+        sparse-checkout-cone-mode: true
+        persist-credentials: false
+
     - name: Resolve scripts directory
       shell: bash
-      run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+      run: echo "SCRIPTS_DIR=${GITHUB_WORKSPACE}/.lgtm-ci-tooling/scripts" >> "$GITHUB_ENV"
 
     - name: Download Python distribution
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -56,10 +66,7 @@ runs:
         path: ${{ inputs.working-directory }}/dist
 
     - name: Setup Python
-      # yamllint disable-line rule:line-length
-      uses: >-
-        lgtm-hq/lgtm-ci/.github/actions/setup-python@${{
-        inputs.tooling-ref != '' && inputs.tooling-ref || github.action_ref }}
+      uses: ./.lgtm-ci-tooling/.github/actions/setup-python
       with:
         python-version: ${{ inputs.python-version }}
         working-directory: ${{ inputs.working-directory }}

--- a/.github/actions/validate-action-pinning/action.yml
+++ b/.github/actions/validate-action-pinning/action.yml
@@ -3,7 +3,6 @@ name: "Validate Action Pinning"
 description: >-
   Ensure GitHub Actions references use SHA pins with Renovate version comments
 author: "lgtm-hq"
-
 inputs:
   enforce:
     description: "Fail if pinning policy violations are found"

--- a/.github/workflows/reusable-test-python.yml
+++ b/.github/workflows/reusable-test-python.yml
@@ -389,7 +389,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
-      actions: write  # upload-artifact/merge re-uploads merged python-coverage (artifact write)
+      actions: write # upload-artifact/merge re-uploads merged python-coverage (artifact write)
       contents: read
     outputs:
       tests-passed: ${{ steps.aggregate.outputs.tests-passed }}

--- a/docs/pages-publishing.md
+++ b/docs/pages-publishing.md
@@ -7,10 +7,15 @@ lgtm-ci uses a single deployment model: **GitHub Actions OIDC** via
 
 ## Model A vs Model B
 
-| Model | Use when | Entry point |
-| ----- | -------- | ----------- |
-| **A — report subtree** | Single-report repos (py-lintro) | `publish-test-results` |
-| **B — bundled site** | Docs site + CI HTML on one origin | `reusable-deploy-site-with-reports` |
+<!-- Wide table kept to compare the two Pages deployment models side by side. -->
+<!-- markdownlint-disable MD013 -->
+
+| Model                  | Use when                          | Entry point                         |
+| ---------------------- | --------------------------------- | ----------------------------------- |
+| **A — report subtree** | Single-report repos (py-lintro)   | `publish-test-results`              |
+| **B — bundled site**   | Docs site + CI HTML on one origin | `reusable-deploy-site-with-reports` |
+
+<!-- markdownlint-enable MD013 -->
 
 **Model A** uploads one subtree (`python/`, `vitest/`, …) per job. Each deploy
 replaces the **entire** published site.
@@ -28,11 +33,16 @@ instead.
 
 ## Entry points
 
-| Workflow / action | Content | `target-dir` / `site-root` |
-| ----------------- | ------- | -------------------------- |
-| `publish-test-results` | Coverage, badges, test HTML | configurable (`target-dir`) |
-| `deploy-pages` + `reusable-deploy-pages` | Built static sites | `dist` (site root) |
-| `reusable-deploy-site-with-reports` | Site + CI HTML bundles | `site-root` |
+<!-- Wide table kept to compare page-publishing entry points and output paths. -->
+<!-- markdownlint-disable MD013 -->
+
+| Workflow / action                        | Content                     | `target-dir` / `site-root`  |
+| ---------------------------------------- | --------------------------- | --------------------------- |
+| `publish-test-results`                   | Coverage, badges, test HTML | configurable (`target-dir`) |
+| `deploy-pages` + `reusable-deploy-pages` | Built static sites          | `dist` (site root)          |
+| `reusable-deploy-site-with-reports`      | Site + CI HTML bundles      | `site-root`                 |
+
+<!-- markdownlint-enable MD013 -->
 
 Typical `publish-test-results` directories include `python`, `vitest`,
 `coverage`, and `playwright`.
@@ -172,11 +182,16 @@ The old `peaceiris/actions-gh-pages` model pushed to one branch with
 `keep_files: true`, so `python/` and `vitest/` could coexist. The official
 artifact model cannot do that without an explicit merge step.
 
-| Mitigation | When |
-| ---------- | ---- |
-| One publish job per event | One `publish-test-results` with combined subtrees |
-| Model B site bundle | Monorepos — `reusable-deploy-site-with-reports` [226] |
-| Optional live-site merge | Legacy Model A multi-publisher fallback [225] — set `merge-existing-site: true` on `publish-test-results` (and optionally `base-site-path` to skip HTTP mirror) |
+<!-- Wide table kept to compare mitigation choices and selection criteria. -->
+<!-- markdownlint-disable MD013 -->
+
+| Mitigation                | When                                                                                                                                                            |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| One publish job per event | One `publish-test-results` with combined subtrees                                                                                                               |
+| Model B site bundle       | Monorepos — `reusable-deploy-site-with-reports` [226]                                                                                                           |
+| Optional live-site merge  | Legacy Model A multi-publisher fallback [225] — set `merge-existing-site: true` on `publish-test-results` (and optionally `base-site-path` to skip HTTP mirror) |
+
+<!-- markdownlint-enable MD013 -->
 
 [225]: https://github.com/lgtm-hq/lgtm-ci/issues/225
 [226]: https://github.com/lgtm-hq/lgtm-ci/issues/226

--- a/docs/python-release-publish.md
+++ b/docs/python-release-publish.md
@@ -6,12 +6,12 @@ workflows (tag push or manual dispatch). Callers keep product-specific steps
 
 ## Components
 
-| Component | Purpose |
-| --- | --- |
-| `reusable-build-python-dist.yml` | Build sdist/wheel and upload workflow artifact |
-| `upload-pypi-oidc` action | OIDC upload + best-effort attestation (caller job only) |
-| `build-python-package` action | Build/validate (used inside build reusable) |
-| `reusable-github-release.yml` | Attach artifacts to a GitHub Release |
+| Component                        | Purpose                                                 |
+| -------------------------------- | ------------------------------------------------------- |
+| `reusable-build-python-dist.yml` | Build sdist/wheel and upload workflow artifact          |
+| `upload-pypi-oidc` action        | OIDC upload + best-effort attestation (caller job only) |
+| `build-python-package` action    | Build/validate (used inside build reusable)             |
+| `reusable-github-release.yml`    | Attach artifacts to a GitHub Release                    |
 
 There is **no orchestrator** workflow. Compose jobs in the caller repository.
 
@@ -101,6 +101,10 @@ jobs:
 Use the same `artifact-name` for `reusable-build-python-dist.yml` and
 `reusable-github-release.yml`.
 
+`upload-pypi-oidc` checks out lgtm-ci tooling and calls sibling actions by local
+path. See [workflow-contract.md](workflow-contract.md) for the composite action
+local-path contract.
+
 ## TestPyPI
 
 Same split: build reusable + caller upload job with `test-pypi: true` on
@@ -108,11 +112,11 @@ Same split: build reusable + caller upload job with `test-pypi: true` on
 
 ## Caller permissions summary
 
-| Job | Required permissions |
-| --- | --- |
-| PyPI build (reusable) | `contents: read` |
-| PyPI upload (local) | `contents: read`, `id-token: write`, `attestations: write` |
-| GitHub Release | `contents: write` |
+| Job                   | Required permissions                                       |
+| --------------------- | ---------------------------------------------------------- |
+| PyPI build (reusable) | `contents: read`                                           |
+| PyPI upload (local)   | `contents: read`, `id-token: write`, `attestations: write` |
+| GitHub Release        | `contents: write`                                          |
 
 ## PyPI trusted publishing
 
@@ -150,12 +154,12 @@ depend on a published GitHub Release.
 
 ## Migration from v0.23.x
 
-| Removed | Replacement |
-| --- | --- |
-| `reusable-publish-pypi-release.yml` | `reusable-build-python-dist.yml` + `upload-pypi-oidc` |
-| `reusable-publish-pypi.yml` | Same pattern; set `test-pypi: true` on upload action |
-| `publish-pypi` action | `build-python-package` + `upload-pypi-oidc` |
-| `github-environment` on reusable `with:` | `environment:` on caller upload **job** |
+| Removed                                  | Replacement                                           |
+| ---------------------------------------- | ----------------------------------------------------- |
+| `reusable-publish-pypi-release.yml`      | `reusable-build-python-dist.yml` + `upload-pypi-oidc` |
+| `reusable-publish-pypi.yml`              | Same pattern; set `test-pypi: true` on upload action  |
+| `publish-pypi` action                    | `build-python-package` + `upload-pypi-oidc`           |
+| `github-environment` on reusable `with:` | `environment:` on caller upload **job**               |
 
 ## Related docs
 

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -257,21 +257,21 @@ jobs:
 ### Site + bundled CI reports (Model B)
 
 ```yaml
-  deploy-site:
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@<sha>
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-      actions: read
-    with:
-      site-root: apps/site/dist
-      build-command: bun run build
-      package-manager: bun
-      bundle-manifest: examples/bundle-manifest-turbo-themes.json
-      commit-sha: ${{ github.event.workflow_run.head_sha }}
-      fallback-ref: main
-      tooling-ref: "<sha>"
+deploy-site:
+  uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-site-with-reports.yml@<sha>
+  permissions:
+    contents: read
+    pages: write
+    id-token: write
+    actions: read
+  with:
+    site-root: apps/site/dist
+    build-command: bun run build
+    package-manager: bun
+    bundle-manifest: examples/bundle-manifest-turbo-themes.json
+    commit-sha: ${{ github.event.workflow_run.head_sha }}
+    fallback-ref: main
+    tooling-ref: "<sha>"
 ```
 
 See [pages-publishing.md](pages-publishing.md) for manifest schema, egress
@@ -370,15 +370,15 @@ jobs:
 
 ### Docker workflow inputs
 
-| Input | Default | Description |
-| ----- | ------- | ----------- |
-| `validate-on-pr` | `false` | Use native split builds on PRs without pushing staging images |
-| `scan-exit-code` | `"0"` | Trivy exit code; set `"1"` to block PRs on CRITICAL/HIGH CVEs |
-| `cache-registry-ref` | `""` | Registry cache fallback (e.g. `ghcr.io/org/repo:cache`) |
-| `cosign-sign` | `false` | Keyless Cosign signature on pushed manifests |
-| `no-cache` | `false` | Disable GHA/registry cache for clean release builds |
-| `provenance` | `true` | Generate provenance attestation (only when `push: true`) |
-| `sbom` | `true` | Generate SBOM attestation (only when `push: true`) |
+| Input                | Default | Description                                                   |
+| -------------------- | ------- | ------------------------------------------------------------- |
+| `validate-on-pr`     | `false` | Use native split builds on PRs without pushing staging images |
+| `scan-exit-code`     | `"0"`   | Trivy exit code; set `"1"` to block PRs on CRITICAL/HIGH CVEs |
+| `cache-registry-ref` | `""`    | Registry cache fallback (e.g. `ghcr.io/org/repo:cache`)       |
+| `cosign-sign`        | `false` | Keyless Cosign signature on pushed manifests                  |
+| `no-cache`           | `false` | Disable GHA/registry cache for clean release builds           |
+| `provenance`         | `true`  | Generate provenance attestation (only when `push: true`)      |
+| `sbom`               | `true`  | Generate SBOM attestation (only when `push: true`)            |
 
 `sbom` and `provenance` only apply when `push: true`. PR validation
 (`validate-on-pr` with `scan`) loads images locally via `--load`; buildx cannot

--- a/docs/rust-testing.md
+++ b/docs/rust-testing.md
@@ -3,13 +3,13 @@
 Rust CI follows the same model as Python and Node: **one language reusable per
 stack**, composed in the consumer caller workflow.
 
-| Language | Reusable |
-| --- | --- |
-| Python | `reusable-test-python.yml` |
-| Node / TypeScript | `reusable-test-node.yml` |
-| Rust (build) | `reusable-rust-build.yml` |
-| Rust (coverage) | `reusable-rust-coverage.yml` |
-| Rust (legacy) | `reusable-test-rust.yml` |
+| Language          | Reusable                     |
+| ----------------- | ---------------------------- |
+| Python            | `reusable-test-python.yml`   |
+| Node / TypeScript | `reusable-test-node.yml`     |
+| Rust (build)      | `reusable-rust-build.yml`    |
+| Rust (coverage)   | `reusable-rust-coverage.yml` |
+| Rust (legacy)     | `reusable-test-rust.yml`     |
 
 ## Rust-only repository
 

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -6,6 +6,9 @@ All `lgtm-ci` reusable workflows share a common consumer contract.
 
 Where applicable, workflows accept:
 
+<!-- Wide table kept for quick input-to-purpose scanning across reusable workflows. -->
+<!-- markdownlint-disable MD013 -->
+
 | Input                              | Purpose                                                       |
 | ---------------------------------- | ------------------------------------------------------------- |
 | `tooling-ref`                      | Pin lgtm-ci scripts/actions (defaults to caller workflow SHA) |
@@ -17,6 +20,8 @@ Where applicable, workflows accept:
 | `post-pr-comment`                  | Enable PR summary comments                                    |
 | `comment-marker` / `comment-title` | PR comment identity                                           |
 | `draft-pr-skip`                    | Skip PR jobs on draft pull requests                           |
+
+<!-- markdownlint-enable MD013 -->
 
 ## Permissions by mode
 
@@ -41,6 +46,9 @@ Actions maps matrix values to reusable workflow inputs. `reusable-test-node.yml`
 `coverage-pr-comment` uses inline steps to avoid an extra nesting level (which
 would worsen check-name readability) and to access matrix-specific artifacts.
 
+<!-- Wide table kept to compare permissions, modes, and workflow entry points. -->
+<!-- markdownlint-disable MD013 -->
+
 | Mode                  | Caller permissions                                   | Workflow                                |
 | --------------------- | ---------------------------------------------------- | --------------------------------------- |
 | Quality / lint only   | `contents: read`, `packages: read`                   | `reusable-quality-lint.yml`             |
@@ -52,6 +60,8 @@ would worsen check-name readability) and to access matrix-specific artifacts.
 | PyPI upload (OIDC)    | `contents: read`; `id-token` + `attestations: write` | `upload-pypi-oidc`                      |
 | PyPI build            | `contents: read`                                     | `reusable-build-python-dist.yml`        |
 | GitHub Release assets | `contents: write`                                    | `reusable-github-release.yml`           |
+
+<!-- markdownlint-enable MD013 -->
 
 `reusable-test-node.yml` no longer includes a publish job. Use
 `reusable-test-node-publish.yml` in a separate caller job when publishing is

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -6,17 +6,17 @@ All `lgtm-ci` reusable workflows share a common consumer contract.
 
 Where applicable, workflows accept:
 
-| Input | Purpose |
-| --- | --- |
-| `tooling-ref` | Pin lgtm-ci scripts/actions (defaults to caller workflow SHA) |
-| `egress-policy` | `audit` or `block` for StepSecurity harden-runner |
-| `allowed-endpoints` | Allowlist when `egress-policy: block` |
-| `job-name` | Visible GitHub check name |
-| `runner-image` | Runner label for long-running jobs |
-| `timeout-minutes` | Job timeout |
-| `post-pr-comment` | Enable PR summary comments |
-| `comment-marker` / `comment-title` | PR comment identity |
-| `draft-pr-skip` | Skip PR jobs on draft pull requests |
+| Input                              | Purpose                                                       |
+| ---------------------------------- | ------------------------------------------------------------- |
+| `tooling-ref`                      | Pin lgtm-ci scripts/actions (defaults to caller workflow SHA) |
+| `egress-policy`                    | `audit` or `block` for StepSecurity harden-runner             |
+| `allowed-endpoints`                | Allowlist when `egress-policy: block`                         |
+| `job-name`                         | Visible GitHub check name                                     |
+| `runner-image`                     | Runner label for long-running jobs                            |
+| `timeout-minutes`                  | Job timeout                                                   |
+| `post-pr-comment`                  | Enable PR summary comments                                    |
+| `comment-marker` / `comment-title` | PR comment identity                                           |
+| `draft-pr-skip`                    | Skip PR jobs on draft pull requests                           |
 
 ## Permissions by mode
 
@@ -41,17 +41,17 @@ Actions maps matrix values to reusable workflow inputs. `reusable-test-node.yml`
 `coverage-pr-comment` uses inline steps to avoid an extra nesting level (which
 would worsen check-name readability) and to access matrix-specific artifacts.
 
-| Mode | Caller permissions | Workflow |
-| --- | --- | --- |
-| Quality / lint only | `contents: read`, `packages: read` | `reusable-quality-lint.yml` |
-| Quality comment | `contents: read`, `pull-requests: write` | `reusable-quality-pr-comment.yml` |
-| Test / coverage only | `contents: read` | Reusables with `post-pr-comment: false` |
-| PR comments | `contents: read`, `pull-requests: write` | `reusable-*-pr-comment.yml` |
-| Publish to Pages | `contents: read`, `pages: write`, `id-token: write` | Separate publish job |
-| Release version | `contents: write`, `pull-requests: write` | `reusable-release-version-pr.yml` |
-| PyPI upload (OIDC) | `contents: read`; `id-token` + `attestations: write` | `upload-pypi-oidc` |
-| PyPI build | `contents: read` | `reusable-build-python-dist.yml` |
-| GitHub Release assets | `contents: write` | `reusable-github-release.yml` |
+| Mode                  | Caller permissions                                   | Workflow                                |
+| --------------------- | ---------------------------------------------------- | --------------------------------------- |
+| Quality / lint only   | `contents: read`, `packages: read`                   | `reusable-quality-lint.yml`             |
+| Quality comment       | `contents: read`, `pull-requests: write`             | `reusable-quality-pr-comment.yml`       |
+| Test / coverage only  | `contents: read`                                     | Reusables with `post-pr-comment: false` |
+| PR comments           | `contents: read`, `pull-requests: write`             | `reusable-*-pr-comment.yml`             |
+| Publish to Pages      | `contents: read`, `pages: write`, `id-token: write`  | Separate publish job                    |
+| Release version       | `contents: write`, `pull-requests: write`            | `reusable-release-version-pr.yml`       |
+| PyPI upload (OIDC)    | `contents: read`; `id-token` + `attestations: write` | `upload-pypi-oidc`                      |
+| PyPI build            | `contents: read`                                     | `reusable-build-python-dist.yml`        |
+| GitHub Release assets | `contents: write`                                    | `reusable-github-release.yml`           |
 
 `reusable-test-node.yml` no longer includes a publish job. Use
 `reusable-test-node-publish.yml` in a separate caller job when publishing is
@@ -81,12 +81,12 @@ existing `.git`, `actions/checkout` wipes the workspace and deletes
 
 Prefer split workflows to avoid skipped checks in PR UI:
 
-| Use case | Workflow |
-| --- | --- |
-| Rust build only | `reusable-rust-build.yml` or `reusable-test-rust-build.yml` |
-| Rust coverage only | `reusable-rust-coverage.yml` or `reusable-test-rust-coverage.yml` |
-| Node Vitest tests | `reusable-test-node.yml` with `test-command` empty |
-| Node custom command | `reusable-test-node.yml` with `test-command` set |
+| Use case            | Workflow                                                          |
+| ------------------- | ----------------------------------------------------------------- |
+| Rust build only     | `reusable-rust-build.yml` or `reusable-test-rust-build.yml`       |
+| Rust coverage only  | `reusable-rust-coverage.yml` or `reusable-test-rust-coverage.yml` |
+| Node Vitest tests   | `reusable-test-node.yml` with `test-command` empty                |
+| Node custom command | `reusable-test-node.yml` with `test-command` set                  |
 
 `reusable-test-rust.yml` remains for backward compatibility but may show
 skipped jobs when only build or only coverage is enabled.
@@ -215,13 +215,13 @@ Renovate version comment on the same line. Tag refs (for example `@v4`) fail
 `reusable-validate-action-pinning.yml` unless the action is listed in the narrow
 `allow-tag-exceptions` input.
 
-| Pin | Result |
-| --- | --- |
-| `uses: org/action@sha` | Fail — missing `# vX.Y.Z` |
-| `uses: org/action@v1.2.3` | Fail — tag pin |
-| `uses: org/action@sha # v1.2.3` | Pass |
-| `tooling-ref: 'sha'` | Fail — missing `# vX.Y.Z` |
-| `tooling-ref: 'sha' # v0.18.4` | Pass |
+| Pin                                                       | Result                     |
+| --------------------------------------------------------- | -------------------------- |
+| `uses: org/action@sha`                                    | Fail — missing `# vX.Y.Z`  |
+| `uses: org/action@v1.2.3`                                 | Fail — tag pin             |
+| `uses: org/action@sha # v1.2.3`                           | Pass                       |
+| `tooling-ref: 'sha'`                                      | Fail — missing `# vX.Y.Z`  |
+| `tooling-ref: 'sha' # v0.18.4`                            | Pass                       |
 | `ref: 'sha'` under `repository: lgtm-hq/lgtm-ci` checkout | Same rule as `tooling-ref` |
 
 Use the **release commit SHA** for `tooling-ref` and lgtm-ci checkout `ref` pins, not the
@@ -232,12 +232,57 @@ Canonical examples:
 
 ```yaml
 uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
-tooling-ref: 'd3736367191ddaf56c41804d2dd5174732ed2d2b' # v0.18.4
+tooling-ref: "d3736367191ddaf56c41804d2dd5174732ed2d2b" # v0.18.4
 ```
 
 Template expressions (for example `${{ inputs.tooling-ref }}`) are ignored.
 Bare SHA pins without version comments are invisible to Renovate and are blocked
 by design.
+
+### Composite actions calling sibling lgtm-ci actions
+
+Composite `action.yml` files must not call sibling lgtm-ci actions with a remote
+template ref:
+
+```yaml
+uses: lgtm-hq/lgtm-ci/.github/actions/setup-python@${{ inputs.tooling-ref }}
+```
+
+GitHub validates nested composite `uses:` values before composite inputs are
+available, so this pattern fails during workflow template validation. Workflows
+and reusable workflows may still pass `${{ inputs.tooling-ref }}` to checkout
+`ref:` values or reusable workflow inputs; this restriction is only for
+composite action `uses:` fields.
+
+Composite actions that need sibling lgtm-ci actions should checkout lgtm-ci
+tooling into `.lgtm-ci-tooling` and call those actions by local path:
+
+```yaml
+- name: Checkout lgtm-ci tooling
+  uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  with:
+    repository: lgtm-hq/lgtm-ci
+    path: .lgtm-ci-tooling
+    ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.action_ref }}
+    sparse-checkout: |
+      .github/actions/
+      scripts/ci/
+    sparse-checkout-cone-mode: true
+    persist-credentials: false
+
+- name: Resolve scripts directory
+  shell: bash
+  run: echo "SCRIPTS_DIR=${GITHUB_WORKSPACE}/.lgtm-ci-tooling/scripts" >> "$GITHUB_ENV"
+
+- name: Setup Python
+  uses: ./.lgtm-ci-tooling/.github/actions/setup-python
+```
+
+`tests/bats/integration/test_composite_action_refs.bats` guards this contract
+and fails if any `.github/actions/**/action.yml` uses
+`lgtm-hq/lgtm-ci/...@${{ ... }}`. Hardened caller jobs that run composites with
+tooling checkout need egress for `codeload.github.com`, `astral.sh`, and
+`releases.astral.sh`; see the PyPI egress examples above.
 
 ## Dependency review
 
@@ -250,12 +295,12 @@ being skipped.
 Callers using GitHub merge queue can add `merge_group:` triggers to thin
 caller workflows alongside `pull_request:`.
 
-| Workflow | `merge_group` behavior |
-| --- | --- |
-| `reusable-codeql.yml` | Safe to run — no PR context required |
-| `reusable-validate-action-pinning.yml` | Safe to run — no PR context required |
-| `reusable-dependency-review.yml` | Runs on `merge_group` (same as PR) |
-| `reusable-semantic-pr-title.yml` | Skips on `merge_group` — title validated on PR |
+| Workflow                               | `merge_group` behavior                         |
+| -------------------------------------- | ---------------------------------------------- |
+| `reusable-codeql.yml`                  | Safe to run — no PR context required           |
+| `reusable-validate-action-pinning.yml` | Safe to run — no PR context required           |
+| `reusable-dependency-review.yml`       | Runs on `merge_group` (same as PR)             |
+| `reusable-semantic-pr-title.yml`       | Skips on `merge_group` — title validated on PR |
 
 Semantic title validation is intentionally skipped in the merge queue because
 `amannn/action-semantic-pull-request` requires pull request context.

--- a/tests/bats/integration/test_composite_action_refs.bats
+++ b/tests/bats/integration/test_composite_action_refs.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for composite action references (#253)
+
+load "../../helpers/common"
+
+_forbidden_dynamic_lgtm_ci_uses() {
+	local scan_path="$1"
+
+	while IFS= read -r -d '' action; do
+		awk -v file="$action" '
+			function indent_of(line, prefix) {
+				prefix = line
+				sub(/[^ \t].*$/, "", prefix)
+				return length(prefix)
+			}
+			function check(line, clean) {
+				clean = line
+				sub(/[[:space:]]+#.*/, "", clean)
+				if (clean ~ /lgtm-hq\/lgtm-ci\/.*@\$\{\{/) {
+					printf("%s:%d:%s\n", file, NR, line)
+					found = 1
+				}
+			}
+			/^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*/ {
+				in_uses = 1
+				uses_indent = indent_of($0)
+				check($0)
+				next
+			}
+			in_uses {
+				if ($0 ~ /^[[:space:]]*$/) {
+					next
+				}
+				current_indent = indent_of($0)
+				if (current_indent <= uses_indent && $0 ~ /^[[:space:]]*[A-Za-z0-9_-]+:/) {
+					in_uses = 0
+				} else {
+					check($0)
+				}
+			}
+			END {
+				exit found
+			}
+		' "$action"
+	done < <(find "$scan_path" -path "*/action.yml" -type f -print0)
+}
+
+@test "composite actions: forbid dynamic lgtm-ci remote uses refs" {
+	run _forbidden_dynamic_lgtm_ci_uses "${PROJECT_ROOT}/.github/actions"
+	assert_success
+	refute_output --partial "lgtm-hq/lgtm-ci/"
+}
+
+@test "composite actions: guard catches folded dynamic lgtm-ci uses refs" {
+	local fixture_dir="${BATS_TEST_TMPDIR}/.github/actions/broken"
+	mkdir -p "$fixture_dir"
+	cat >"${fixture_dir}/action.yml" <<'YAML'
+---
+name: Broken composite
+runs:
+  using: composite
+  steps:
+    - name: Setup Python
+      uses: >-
+        lgtm-hq/lgtm-ci/.github/actions/setup-python@${{
+        inputs.tooling-ref != '' && inputs.tooling-ref || github.action_ref }}
+YAML
+
+	run _forbidden_dynamic_lgtm_ci_uses "${BATS_TEST_TMPDIR}/.github/actions"
+	assert_failure
+	assert_output --partial "lgtm-hq/lgtm-ci/.github/actions/setup-python@\${{"
+}
+
+@test "upload-pypi-oidc: checks out lgtm-ci tooling before local setup-python" {
+	local action="${PROJECT_ROOT}/.github/actions/upload-pypi-oidc/action.yml"
+	run awk '
+		/Checkout lgtm-ci tooling/ { checkout = NR }
+		/path: .lgtm-ci-tooling/ { path = NR }
+		/sparse-checkout-cone-mode: true/ { cone = NR }
+		/SCRIPTS_DIR=\$\{GITHUB_WORKSPACE\}\/.lgtm-ci-tooling\/scripts/ { scripts = NR }
+		/uses: \.\/.lgtm-ci-tooling\/.github\/actions\/setup-python/ { setup = NR }
+		END {
+			exit !(checkout > 0 && path > checkout && cone > path &&
+				scripts > cone && setup > scripts)
+		}
+	' "$action"
+	assert_success
+}


### PR DESCRIPTION
## Summary

- Fixes the `upload-pypi-oidc` template validation failure by checking out lgtm-ci tooling into `.lgtm-ci-tooling` and invoking `setup-python` via local path.
- Adds a BATS regression guard that rejects dynamic `lgtm-hq/lgtm-ci/...@${{ ... }}` refs in composite action `uses:` fields.
- Documents the composite local tooling checkout contract and links the Python release guide to it.

## Test plan

- [x] `uv run lintro chk docs/workflow-contract.md docs/python-release-publish.md tests/bats/integration/test_composite_action_refs.bats`
- [x] `bats tests/bats/integration/test_composite_action_refs.bats`
- [x] `bash scripts/ci/actions/run-bats-tests.sh`
- [ ] Merge and tag v0.24.1
- [ ] py-lintro repins `upload-pypi-oidc` from temporary PR SHA to v0.24.1 release SHA and retags v0.64.3

## Closes

- Closes #253

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `upload-pypi-oidc` to checkout lgtm-ci tooling and invoke `setup-python` via local path
> - Adds a checkout step to [action.yml](https://github.com/lgtm-hq/lgtm-ci/pull/252/files#diff-b0018696dada5c9cdad85cf885b088acda3b5bd4758f412066e6e05640edc9f5) that sparse-clones the lgtm-ci repo into `.lgtm-ci-tooling`, resolving the ref from `inputs.tooling-ref` or `github.action_ref`.
> - Changes the `setup-python` step to reference the locally checked-out action (`./.lgtm-ci-tooling/.github/actions/setup-python`) instead of a dynamic remote `lgtm-hq/lgtm-ci` ref in `uses:`.
> - Sets `SCRIPTS_DIR` to the checked-out tooling path instead of computing it from `GITHUB_ACTION_PATH`.
> - Adds a [bats integration test](https://github.com/lgtm-hq/lgtm-ci/pull/252/files#diff-9d3a01c5c5d8d664399c19ad1b7ef353f8c956a3caf770970f25f00f650d2d1b) that fails if any composite action uses a dynamic remote ref for sibling lgtm-ci actions, and asserts the correct checkout-then-local-path order in `upload-pypi-oidc`.
> - Documents the required checkout pattern for composite actions in [workflow-contract.md](https://github.com/lgtm-hq/lgtm-ci/pull/252/files#diff-516a439fe86a0212ef098570637d887a6ef2bb796c179416edee44bc92be0a5f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e620385.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the PyPI OIDC publish action to checkout and invoke local tooling instead of using dynamic remote refs.
  * Added integration tests to enforce composite-action reference rules and local-tooling usage.

* **Documentation**
  * Expanded the workflow contract with standard inputs, permission-mode mappings, and action-pinning guidance.
  * Clarified Python release publishing guidance and improved table formatting across docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a GitHub Actions validation failure in `upload-pypi-oidc` where a dynamic template expression in a composite action `uses:` field was being evaluated at parse time before inputs were available. The fix adds an explicit sparse-checkout of `lgtm-hq/lgtm-ci` into `.lgtm-ci-tooling` and switches `setup-python` to a local path reference.

- **`upload-pypi-oidc/action.yml`**: Adds a `actions/checkout` step sparse-cloning `lgtm-hq/lgtm-ci` into `.lgtm-ci-tooling` (using `inputs.tooling-ref` or `github.action_ref` as the ref), then references `setup-python` via `./.lgtm-ci-tooling/.github/actions/setup-python`; `SCRIPTS_DIR` is updated accordingly.
- **`test_composite_action_refs.bats`**: New BATS integration tests guard the contract — one scan test rejects dynamic `lgtm-hq/lgtm-ci/...@${{ ... }}` refs across all composite actions, a fixture test verifies folded YAML detection, and a structural test validates the checkout-then-local-path ordering in `upload-pypi-oidc`.
- **`docs/workflow-contract.md`**: Documents the new composite-action local-tooling-checkout pattern as the required approach, with a canonical YAML example and a pointer to the BATS guard.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the composite action fix is structurally correct and the BATS regression guard, while having a minor exit-code aggregation quirk, is functionally defended by its refute_output assertion.

The root cause (dynamic template expression in composite uses:) is correctly addressed; the checkout ref fallback chain, sparse-checkout paths, local-path uses:, and SCRIPTS_DIR update all align. The new BATS tests cover the forbidden pattern, folded YAML detection, and step ordering. The only finding is a helper function that returns only the last awk exit code instead of aggregating across all files — the test still passes correctly today, and refute_output would catch any future regression.

No files require special attention; all changes are self-consistent.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/upload-pypi-oidc/action.yml | Core fix: replaces forbidden dynamic remote uses: ref with a tooling checkout step and local-path setup-python reference; SCRIPTS_DIR updated accordingly. |
| tests/bats/integration/test_composite_action_refs.bats | New regression guard with three tests; while-loop exit-code aggregation is technically incorrect for multi-file scans, though refute_output compensates in practice. |
| docs/workflow-contract.md | Documents the new composite-action local-tooling-checkout contract with full YAML example; wide tables wrapped in markdownlint disable/enable blocks. |
| docs/python-release-publish.md | Adds a prose note linking upload-pypi-oidc local-path contract to workflow-contract.md; table formatting normalized. |
| .github/actions/build-python-package/action.yml | Cosmetic only — removes a stray blank line after author:. |
| .github/actions/resolve-tooling-ref/action.yml | Cosmetic only — removes a stray blank line after author:. |
| .github/actions/validate-action-pinning/action.yml | Cosmetic only — removes a stray blank line after author:. |
| .github/workflows/reusable-test-python.yml | Single-character whitespace fix in a comment. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Caller Job
    participant CO as actions/checkout (tooling)
    participant FS as .lgtm-ci-tooling/
    participant SP as setup-python (local)
    participant DA as download-artifact
    participant PyPI as pypa/gh-action-pypi-publish

    Caller->>CO: "sparse-clone lgtm-hq/lgtm-ci ref=tooling-ref OR github.action_ref"
    CO->>FS: writes .github/actions/ + scripts/ci/
    Caller->>FS: "SCRIPTS_DIR = GITHUB_WORKSPACE/.lgtm-ci-tooling/scripts"
    Caller->>DA: download artifact to dist/
    Caller->>SP: uses ./.lgtm-ci-tooling/.github/actions/setup-python
    SP-->>Caller: Python env ready
    Caller->>Caller: validate-dist via SCRIPTS_DIR
    Caller->>PyPI: upload dist/
    Caller->>Caller: attest + set-published
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fbats%2Fintegration%2Ftest_composite_action_refs.bats%3A7-46%0A**Exit-code%20not%20aggregated%20across%20multiple%20files**%0A%0A%60_forbidden_dynamic_lgtm_ci_uses%60%20runs%20a%20separate%20%60awk%60%20process%20per%20file%20but%20the%20function's%20exit%20code%20is%20only%20the%20exit%20code%20of%20the%20_last_%20%60awk%60%20invocation.%20If%20a%20forbidden%20pattern%20is%20found%20in%20any%20file%20that%20is%20not%20the%20final%20one%20visited%20by%20%60find%20-print0%60%2C%20the%20loop%20continues%20to%20the%20next%20%28clean%29%20file%20and%20the%20function%20ultimately%20returns%200.%20The%20first%20test%20%28%60assert_success%60%29%20would%20then%20silently%20pass%20even%20though%20a%20violation%20was%20printed%20to%20stdout.%0A%0AThe%20test%20remains%20functionally%20correct%20today%20because%20%60refute_output%20--partial%20%22lgtm-hq%2Flgtm-ci%2F%22%60%20also%20guards%20the%20assertion%2C%20but%20the%20exit-code%20semantics%20of%20the%20helper%20are%20misleading%20%E2%80%94%20any%20future%20callers%20that%20rely%20on%20the%20exit%20code%20alone%20%28e.g.%20%60if%20!%20_forbidden_dynamic_lgtm_ci_uses%20%E2%80%A6%3B%20then%60%29%20would%20be%20incorrect.%20A%20simple%20fix%20is%20to%20track%20a%20%60local%20rc%3D0%60%20and%20%60%7C%7C%20rc%3D1%60%20inside%20the%20loop%2C%20then%20%60return%20%22%24rc%22%60%20at%20the%20end.%0A%0A&pr=252&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fbats%2Fintegration%2Ftest_composite_action_refs.bats%3A7-46%0A**Exit-code%20not%20aggregated%20across%20multiple%20files**%0A%0A%60_forbidden_dynamic_lgtm_ci_uses%60%20runs%20a%20separate%20%60awk%60%20process%20per%20file%20but%20the%20function's%20exit%20code%20is%20only%20the%20exit%20code%20of%20the%20_last_%20%60awk%60%20invocation.%20If%20a%20forbidden%20pattern%20is%20found%20in%20any%20file%20that%20is%20not%20the%20final%20one%20visited%20by%20%60find%20-print0%60%2C%20the%20loop%20continues%20to%20the%20next%20%28clean%29%20file%20and%20the%20function%20ultimately%20returns%200.%20The%20first%20test%20%28%60assert_success%60%29%20would%20then%20silently%20pass%20even%20though%20a%20violation%20was%20printed%20to%20stdout.%0A%0AThe%20test%20remains%20functionally%20correct%20today%20because%20%60refute_output%20--partial%20%22lgtm-hq%2Flgtm-ci%2F%22%60%20also%20guards%20the%20assertion%2C%20but%20the%20exit-code%20semantics%20of%20the%20helper%20are%20misleading%20%E2%80%94%20any%20future%20callers%20that%20rely%20on%20the%20exit%20code%20alone%20%28e.g.%20%60if%20!%20_forbidden_dynamic_lgtm_ci_uses%20%E2%80%A6%3B%20then%60%29%20would%20be%20incorrect.%20A%20simple%20fix%20is%20to%20track%20a%20%60local%20rc%3D0%60%20and%20%60%7C%7C%20rc%3D1%60%20inside%20the%20loop%2C%20then%20%60return%20%22%24rc%22%60%20at%20the%20end.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=252&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22fix%2Fupload-pypi-oidc-setup-python-local%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fupload-pypi-oidc-setup-python-local%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fbats%2Fintegration%2Ftest_composite_action_refs.bats%3A7-46%0A**Exit-code%20not%20aggregated%20across%20multiple%20files**%0A%0A%60_forbidden_dynamic_lgtm_ci_uses%60%20runs%20a%20separate%20%60awk%60%20process%20per%20file%20but%20the%20function's%20exit%20code%20is%20only%20the%20exit%20code%20of%20the%20_last_%20%60awk%60%20invocation.%20If%20a%20forbidden%20pattern%20is%20found%20in%20any%20file%20that%20is%20not%20the%20final%20one%20visited%20by%20%60find%20-print0%60%2C%20the%20loop%20continues%20to%20the%20next%20%28clean%29%20file%20and%20the%20function%20ultimately%20returns%200.%20The%20first%20test%20%28%60assert_success%60%29%20would%20then%20silently%20pass%20even%20though%20a%20violation%20was%20printed%20to%20stdout.%0A%0AThe%20test%20remains%20functionally%20correct%20today%20because%20%60refute_output%20--partial%20%22lgtm-hq%2Flgtm-ci%2F%22%60%20also%20guards%20the%20assertion%2C%20but%20the%20exit-code%20semantics%20of%20the%20helper%20are%20misleading%20%E2%80%94%20any%20future%20callers%20that%20rely%20on%20the%20exit%20code%20alone%20%28e.g.%20%60if%20!%20_forbidden_dynamic_lgtm_ci_uses%20%E2%80%A6%3B%20then%60%29%20would%20be%20incorrect.%20A%20simple%20fix%20is%20to%20track%20a%20%60local%20rc%3D0%60%20and%20%60%7C%7C%20rc%3D1%60%20inside%20the%20loop%2C%20then%20%60return%20%22%24rc%22%60%20at%20the%20end.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): satisfy markdown lint"](https://github.com/lgtm-hq/lgtm-ci/commit/e62038516d3eee974840aae11f7f97b8909cbdd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34616974)</sub>

<!-- /greptile_comment -->