### PR TITLE
feat(ci): Pages Model B coverage HTML artifacts for Rust and Node reusables

### DIFF
--- a/.github/actions/build-python-package/action.yml
+++ b/.github/actions/build-python-package/action.yml
@@ -40,8 +40,10 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        action_dir="${GITHUB_ACTION_PATH//\\//}"
+        repo_root="$(cd "$action_dir" && git rev-parse --show-toplevel 2>/dev/null \
+          || echo "${action_dir%/.github/actions/*}")"
+        echo "SCRIPTS_DIR=${repo_root}/scripts" >> "$GITHUB_ENV"
 
     - name: Preflight tag validation
       if: >-

--- a/.github/actions/upload-pypi-oidc/action.yml
+++ b/.github/actions/upload-pypi-oidc/action.yml
@@ -101,11 +101,21 @@ runs:
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
       run: "$SCRIPTS_DIR/ci/actions/python-dist.sh"
 
+    - name: Extract package metadata
+      id: extract-metadata
+      shell: bash
+      env:
+        STEP: extract-dist-metadata
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
+      run: "$SCRIPTS_DIR/ci/actions/python-dist.sh"
+
     - name: Generate upload summary
       shell: bash
       env:
         STEP: summary
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        PACKAGE_NAME: ${{ steps.extract-metadata.outputs.name }}
+        PACKAGE_VERSION: ${{ steps.extract-metadata.outputs.version }}
         PUBLISHED: "true"
         TEST_PYPI: ${{ inputs.test-pypi }}
       run: "$SCRIPTS_DIR/ci/actions/python-dist.sh"

--- a/.github/actions/upload-pypi-oidc/action.yml
+++ b/.github/actions/upload-pypi-oidc/action.yml
@@ -80,7 +80,7 @@ runs:
       run: "$SCRIPTS_DIR/ci/actions/python-dist.sh"
 
     - name: Upload to PyPI
-      uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
       with:
         repository-url: >-
           ${{ inputs.test-pypi == 'true' && 'https://test.pypi.org/legacy/' ||

--- a/.github/actions/upload-pypi-oidc/action.yml
+++ b/.github/actions/upload-pypi-oidc/action.yml
@@ -80,7 +80,7 @@ runs:
       run: "$SCRIPTS_DIR/ci/actions/python-dist.sh"
 
     - name: Upload to PyPI
-      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+      uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
       with:
         repository-url: >-
           ${{ inputs.test-pypi == 'true' && 'https://test.pypi.org/legacy/' ||
@@ -99,6 +99,15 @@ runs:
       env:
         STEP: set-published
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
+      run: "$SCRIPTS_DIR/ci/actions/python-dist.sh"
+
+    - name: Generate upload summary
+      shell: bash
+      env:
+        STEP: summary
+        WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        PUBLISHED: "true"
+        TEST_PYPI: ${{ inputs.test-pypi }}
       run: "$SCRIPTS_DIR/ci/actions/python-dist.sh"
 
 branding:

--- a/.github/workflows/reusable-rust-coverage.yml
+++ b/.github/workflows/reusable-rust-coverage.yml
@@ -20,6 +20,21 @@ on:
         required: false
         type: string
         default: ""
+      upload-pages-coverage-html:
+        description: "Upload flat HTML coverage artifact for Model B Pages bundling"
+        required: false
+        type: boolean
+        default: false
+      pages-coverage-artifact-name:
+        description: "Artifact name for flat Rust HTML coverage upload"
+        required: false
+        type: string
+        default: "rust-coverage-html"
+      pages-coverage-upload-on:
+        description: "When to upload flat Rust HTML coverage (v1: push-main only)"
+        required: false
+        type: string
+        default: "push-main"
       post-pr-comment:
         description: "Post coverage summary comment on pull requests"
         required: false
@@ -73,6 +88,12 @@ on:
       passed:
         description: "Whether coverage succeeded"
         value: ${{ jobs.coverage.outputs.passed }}
+      pages-coverage-artifact-name:
+        description: "Resolved flat HTML coverage artifact name"
+        value: ${{ jobs.coverage.outputs.pages-coverage-artifact-name }}
+      pages-coverage-uploaded:
+        description: "Whether flat HTML coverage artifact was uploaded this run"
+        value: ${{ jobs.coverage.outputs.pages-coverage-uploaded }}
 
 jobs:
   coverage:
@@ -81,6 +102,9 @@ jobs:
       job-name: ${{ inputs.job-name }}
       setup-script: ${{ inputs.setup-script }}
       coverage-script: ${{ inputs.coverage-script }}
+      upload-pages-coverage-html: ${{ inputs.upload-pages-coverage-html }}
+      pages-coverage-artifact-name: ${{ inputs.pages-coverage-artifact-name }}
+      pages-coverage-upload-on: ${{ inputs.pages-coverage-upload-on }}
       post-pr-comment: ${{ inputs.post-pr-comment }}
       comment-marker: ${{ inputs.comment-marker }}
       comment-title: ${{ inputs.comment-title }}

--- a/.github/workflows/reusable-test-node.yml
+++ b/.github/workflows/reusable-test-node.yml
@@ -738,6 +738,8 @@ jobs:
       && inputs.upload-pages-coverage-html
       && inputs.coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       pages-coverage-uploaded: ${{ steps.record.outputs.uploaded }}
     steps:

--- a/.github/workflows/reusable-test-node.yml
+++ b/.github/workflows/reusable-test-node.yml
@@ -269,6 +269,7 @@ jobs:
       tests-total: ${{ steps.parse.outputs.tests-total }}
       coverage-percent: ${{ steps.parse.outputs.coverage-percent }}
       passed: ${{ steps.run.outputs.exit-code == '0' }}
+      pages-upload-outcome: ${{ steps.record-pages-upload-outcome.outputs.outcome }}
 
     steps:
       - name: Harden runner
@@ -499,6 +500,7 @@ jobs:
         run: bash .lgtm-ci-tooling/scripts/ci/actions/pages-coverage-upload-gate.sh
 
       - name: Stage pages coverage HTML
+        id: stage-pages-coverage
         if: >-
           always()
           && inputs.upload-pages-coverage-html
@@ -519,12 +521,21 @@ jobs:
           && inputs.coverage
           && matrix.node-version == needs.prepare.outputs.pages-coverage-node-version
           && steps.pages-upload-gate.outputs.should-upload == 'true'
+          && steps.stage-pages-coverage.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.pages-coverage-artifact-name }}
           path: ${{ inputs.pages-coverage-artifact-name }}/
           retention-days: 7
           if-no-files-found: error
+
+      - name: Record pages upload outcome
+        if: >-
+          always()
+          && matrix.node-version == needs.prepare.outputs.pages-coverage-node-version
+        id: record-pages-upload-outcome
+        shell: bash
+        run: echo "outcome=${{ steps.pages-upload.outcome }}" >>"$GITHUB_OUTPUT"
 
       - name: Fail on vitest errors
         if: >-
@@ -554,6 +565,7 @@ jobs:
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     outputs:
       passed: ${{ steps.record.outputs.passed }}
+      pages-upload-outcome: ${{ steps.record-pages-upload-outcome.outputs.outcome }}
 
     steps:
       - name: Harden runner
@@ -685,6 +697,7 @@ jobs:
         run: bash .lgtm-ci-tooling/scripts/ci/actions/pages-coverage-upload-gate.sh
 
       - name: Stage pages coverage HTML
+        id: stage-pages-coverage
         if: >-
           always()
           && inputs.upload-pages-coverage-html
@@ -705,12 +718,21 @@ jobs:
           && inputs.coverage
           && matrix.node-version == needs.prepare.outputs.pages-coverage-node-version
           && steps.pages-upload-gate.outputs.should-upload == 'true'
+          && steps.stage-pages-coverage.outcome == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.pages-coverage-artifact-name }}
           path: ${{ inputs.pages-coverage-artifact-name }}/
           retention-days: 7
           if-no-files-found: error
+
+      - name: Record pages upload outcome
+        if: >-
+          always()
+          && matrix.node-version == needs.prepare.outputs.pages-coverage-node-version
+        id: record-pages-upload-outcome
+        shell: bash
+        run: echo "outcome=${{ steps.pages-upload.outcome }}" >>"$GITHUB_OUTPUT"
 
       - name: Fail on custom test command errors
         if: steps.custom-run.outcome == 'failure'
@@ -765,10 +787,9 @@ jobs:
         env:
           UPLOAD_PAGES_COVERAGE_HTML: ${{ inputs.upload-pages-coverage-html }}
           COVERAGE: ${{ inputs.coverage }}
-          TEST_COMMAND: ${{ inputs.test-command }}
-          TEST_VITEST_RESULT: ${{ needs.test-vitest.result }}
-          TEST_CUSTOM_RESULT: ${{ needs.test-custom.result }}
-          PAGES_COVERAGE_UPLOAD_ON: ${{ inputs.pages-coverage-upload-on }}
+          PAGES_UPLOAD_OUTCOME: >-
+            ${{ inputs.test-command == '' && needs.test-vitest.outputs.pages-upload-outcome ||
+            needs.test-custom.outputs.pages-upload-outcome }}
         run: >-
           bash .lgtm-ci-tooling/scripts/ci/actions/record-pages-coverage-upload-status.sh
 

--- a/.github/workflows/reusable-test-node.yml
+++ b/.github/workflows/reusable-test-node.yml
@@ -203,9 +203,7 @@ on:
         value: ${{ inputs.pages-coverage-artifact-name }}
       pages-coverage-uploaded:
         description: "Whether flat HTML coverage artifact was uploaded this run"
-        value: >-
-          ${{ inputs.test-command == '' && jobs.test-vitest.outputs.pages-coverage-uploaded ||
-          (inputs.test-command != '' && jobs.test-custom.outputs.pages-coverage-uploaded) }}
+        value: ${{ jobs.pages-coverage-status.outputs.pages-coverage-uploaded || 'false' }}
 
 jobs:
   prepare:
@@ -271,7 +269,6 @@ jobs:
       tests-total: ${{ steps.parse.outputs.tests-total }}
       coverage-percent: ${{ steps.parse.outputs.coverage-percent }}
       passed: ${{ steps.run.outputs.exit-code == '0' }}
-      pages-coverage-uploaded: ${{ steps.record-pages-upload.outputs.uploaded }}
 
     steps:
       - name: Harden runner
@@ -529,17 +526,6 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
-      - name: Record pages coverage upload result
-        if: always()
-        id: record-pages-upload
-        shell: bash
-        run: |
-          if [[ "${{ steps.pages-upload.outcome }}" == "success" ]]; then
-            echo "uploaded=true" >>"$GITHUB_OUTPUT"
-          else
-            echo "uploaded=false" >>"$GITHUB_OUTPUT"
-          fi
-
       - name: Fail on vitest errors
         if: >-
           steps.run.outputs.exit-code != ''
@@ -568,7 +554,6 @@ jobs:
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     outputs:
       passed: ${{ steps.record.outputs.passed }}
-      pages-coverage-uploaded: ${{ steps.record-pages-upload.outputs.uploaded }}
 
     steps:
       - name: Harden runner
@@ -727,17 +712,6 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
-      - name: Record pages coverage upload result
-        if: always()
-        id: record-pages-upload
-        shell: bash
-        run: |
-          if [[ "${{ steps.pages-upload.outcome }}" == "success" ]]; then
-            echo "uploaded=true" >>"$GITHUB_OUTPUT"
-          else
-            echo "uploaded=false" >>"$GITHUB_OUTPUT"
-          fi
-
       - name: Fail on custom test command errors
         if: steps.custom-run.outcome == 'failure'
         run: exit 1
@@ -752,6 +726,49 @@ jobs:
           else
             echo "passed=false" >>"$GITHUB_OUTPUT"
           fi
+
+  pages-coverage-status:
+    name: Pages coverage upload status
+    needs:
+      - prepare
+      - test-vitest
+      - test-custom
+    if: >-
+      always()
+      && inputs.upload-pages-coverage-html
+      && inputs.coverage
+    runs-on: ubuntu-latest
+    outputs:
+      pages-coverage-uploaded: ${{ steps.record.outputs.uploaded }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Record pages coverage upload status
+        id: record
+        shell: bash
+        env:
+          UPLOAD_PAGES_COVERAGE_HTML: ${{ inputs.upload-pages-coverage-html }}
+          COVERAGE: ${{ inputs.coverage }}
+          TEST_COMMAND: ${{ inputs.test-command }}
+          TEST_VITEST_RESULT: ${{ needs.test-vitest.result }}
+          TEST_CUSTOM_RESULT: ${{ needs.test-custom.result }}
+          PAGES_COVERAGE_UPLOAD_ON: ${{ inputs.pages-coverage-upload-on }}
+        run: >-
+          bash .lgtm-ci-tooling/scripts/ci/actions/record-pages-coverage-upload-status.sh
 
   aggregate-tests:
     name: Aggregate Node.js Results

--- a/.github/workflows/reusable-test-node.yml
+++ b/.github/workflows/reusable-test-node.yml
@@ -39,6 +39,28 @@ on:
         required: false
         type: boolean
         default: false
+      upload-pages-coverage-html:
+        description: "Upload flat HTML coverage artifact for Model B Pages bundling"
+        required: false
+        type: boolean
+        default: false
+      pages-coverage-artifact-name:
+        description: "Artifact name for flat Node HTML coverage upload"
+        required: false
+        type: string
+        default: "coverage-html"
+      pages-coverage-upload-on:
+        description: "When to upload flat Node HTML coverage (v1: push-main only)"
+        required: false
+        type: string
+        default: "push-main"
+      pages-coverage-source-subpath:
+        description: >-
+          Coverage HTML directory relative to working-directory for flat Pages
+          artifact staging
+        required: false
+        type: string
+        default: "coverage"
       publish-results:
         description: >-
           Deprecated: use reusable-test-node-publish.yml in a separate caller job.
@@ -176,6 +198,14 @@ on:
         value: >-
           ${{ inputs.test-command == '' && jobs.aggregate-tests.outputs.passed ||
           (inputs.test-command != '' && jobs.test-custom.outputs.passed == 'true') }}
+      pages-coverage-artifact-name:
+        description: "Resolved flat HTML coverage artifact name"
+        value: ${{ inputs.pages-coverage-artifact-name }}
+      pages-coverage-uploaded:
+        description: "Whether flat HTML coverage artifact was uploaded this run"
+        value: >-
+          ${{ inputs.test-command == '' && jobs.test-vitest.outputs.pages-coverage-uploaded ||
+          (inputs.test-command != '' && jobs.test-custom.outputs.pages-coverage-uploaded) }}
 
 jobs:
   prepare:
@@ -189,6 +219,7 @@ jobs:
       contents: read
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+      pages-coverage-node-version: ${{ steps.matrix.outputs.pages-coverage-node-version }}
 
     steps:
       - name: Harden runner
@@ -217,11 +248,7 @@ jobs:
         run: bash .lgtm-ci-tooling/scripts/ci/actions/generate-node-matrix.sh
 
   test-vitest:
-    name: >-
-      ${{
-        inputs.node-versions == '' && inputs.job-name ||
-        format('{0} ({1})', inputs.job-name, matrix.node-version)
-      }}
+    name: Node.js tests (Vitest)
     needs: prepare
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
@@ -244,6 +271,7 @@ jobs:
       tests-total: ${{ steps.parse.outputs.tests-total }}
       coverage-percent: ${{ steps.parse.outputs.coverage-percent }}
       passed: ${{ steps.run.outputs.exit-code == '0' }}
+      pages-coverage-uploaded: ${{ steps.record-pages-upload.outputs.uploaded }}
 
     steps:
       - name: Harden runner
@@ -465,6 +493,53 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+      - name: Evaluate pages coverage upload gate
+        id: pages-upload-gate
+        if: inputs.upload-pages-coverage-html && inputs.coverage
+        shell: bash
+        env:
+          PAGES_COVERAGE_UPLOAD_ON: ${{ inputs.pages-coverage-upload-on }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/pages-coverage-upload-gate.sh
+
+      - name: Stage pages coverage HTML
+        if: >-
+          always()
+          && inputs.upload-pages-coverage-html
+          && inputs.coverage
+          && matrix.node-version == needs.prepare.outputs.pages-coverage-node-version
+        shell: bash
+        env:
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+          PAGES_COVERAGE_SOURCE_SUBPATH: ${{ inputs.pages-coverage-source-subpath }}
+          PAGES_COVERAGE_STAGING_DIR: ${{ inputs.pages-coverage-artifact-name }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/stage-node-pages-coverage.sh
+
+      - name: Upload pages coverage HTML artifact
+        id: pages-upload
+        if: >-
+          always()
+          && inputs.upload-pages-coverage-html
+          && inputs.coverage
+          && matrix.node-version == needs.prepare.outputs.pages-coverage-node-version
+          && steps.pages-upload-gate.outputs.should-upload == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.pages-coverage-artifact-name }}
+          path: ${{ inputs.pages-coverage-artifact-name }}/
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Record pages coverage upload result
+        if: always()
+        id: record-pages-upload
+        shell: bash
+        run: |
+          if [[ "${{ steps.pages-upload.outcome }}" == "success" ]]; then
+            echo "uploaded=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "uploaded=false" >>"$GITHUB_OUTPUT"
+          fi
+
       - name: Fail on vitest errors
         if: >-
           steps.run.outputs.exit-code != ''
@@ -475,11 +550,7 @@ jobs:
         run: bash .lgtm-ci-tooling/scripts/ci/actions/fail-with-exit-code.sh
 
   test-custom:
-    name: >-
-      ${{
-        inputs.node-versions == '' && inputs.job-name ||
-        format('{0} ({1})', inputs.job-name, matrix.node-version)
-      }}
+    name: Node.js tests (custom command)
     needs: prepare
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
@@ -497,6 +568,7 @@ jobs:
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
     outputs:
       passed: ${{ steps.record.outputs.passed }}
+      pages-coverage-uploaded: ${{ steps.record-pages-upload.outputs.uploaded }}
 
     steps:
       - name: Harden runner
@@ -618,6 +690,53 @@ jobs:
         with:
           name: node-coverage-pr-comment-${{ matrix.node-version }}
           path: node-coverage-pr-comment.txt
+
+      - name: Evaluate pages coverage upload gate
+        id: pages-upload-gate
+        if: inputs.upload-pages-coverage-html && inputs.coverage
+        shell: bash
+        env:
+          PAGES_COVERAGE_UPLOAD_ON: ${{ inputs.pages-coverage-upload-on }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/pages-coverage-upload-gate.sh
+
+      - name: Stage pages coverage HTML
+        if: >-
+          always()
+          && inputs.upload-pages-coverage-html
+          && inputs.coverage
+          && matrix.node-version == needs.prepare.outputs.pages-coverage-node-version
+        shell: bash
+        env:
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+          PAGES_COVERAGE_SOURCE_SUBPATH: ${{ inputs.pages-coverage-source-subpath }}
+          PAGES_COVERAGE_STAGING_DIR: ${{ inputs.pages-coverage-artifact-name }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/stage-node-pages-coverage.sh
+
+      - name: Upload pages coverage HTML artifact
+        id: pages-upload
+        if: >-
+          always()
+          && inputs.upload-pages-coverage-html
+          && inputs.coverage
+          && matrix.node-version == needs.prepare.outputs.pages-coverage-node-version
+          && steps.pages-upload-gate.outputs.should-upload == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.pages-coverage-artifact-name }}
+          path: ${{ inputs.pages-coverage-artifact-name }}/
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Record pages coverage upload result
+        if: always()
+        id: record-pages-upload
+        shell: bash
+        run: |
+          if [[ "${{ steps.pages-upload.outcome }}" == "success" ]]; then
+            echo "uploaded=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "uploaded=false" >>"$GITHUB_OUTPUT"
+          fi
 
       - name: Fail on custom test command errors
         if: steps.custom-run.outcome == 'failure'

--- a/.github/workflows/reusable-test-node.yml
+++ b/.github/workflows/reusable-test-node.yml
@@ -493,7 +493,7 @@ jobs:
 
       - name: Evaluate pages coverage upload gate
         id: pages-upload-gate
-        if: inputs.upload-pages-coverage-html && inputs.coverage
+        if: always() && inputs.upload-pages-coverage-html && inputs.coverage
         shell: bash
         env:
           PAGES_COVERAGE_UPLOAD_ON: ${{ inputs.pages-coverage-upload-on }}
@@ -535,7 +535,9 @@ jobs:
           && matrix.node-version == needs.prepare.outputs.pages-coverage-node-version
         id: record-pages-upload-outcome
         shell: bash
-        run: echo "outcome=${{ steps.pages-upload.outcome }}" >>"$GITHUB_OUTPUT"
+        env:
+          PAGES_UPLOAD_OUTCOME: ${{ steps.pages-upload.outcome }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/record-pages-upload-outcome.sh
 
       - name: Fail on vitest errors
         if: >-
@@ -690,7 +692,7 @@ jobs:
 
       - name: Evaluate pages coverage upload gate
         id: pages-upload-gate
-        if: inputs.upload-pages-coverage-html && inputs.coverage
+        if: always() && inputs.upload-pages-coverage-html && inputs.coverage
         shell: bash
         env:
           PAGES_COVERAGE_UPLOAD_ON: ${{ inputs.pages-coverage-upload-on }}
@@ -732,7 +734,9 @@ jobs:
           && matrix.node-version == needs.prepare.outputs.pages-coverage-node-version
         id: record-pages-upload-outcome
         shell: bash
-        run: echo "outcome=${{ steps.pages-upload.outcome }}" >>"$GITHUB_OUTPUT"
+        env:
+          PAGES_UPLOAD_OUTCOME: ${{ steps.pages-upload.outcome }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/record-pages-upload-outcome.sh
 
       - name: Fail on custom test command errors
         if: steps.custom-run.outcome == 'failure'

--- a/.github/workflows/reusable-test-rust-coverage.yml
+++ b/.github/workflows/reusable-test-rust-coverage.yml
@@ -20,6 +20,21 @@ on:
         required: false
         type: string
         default: ""
+      upload-pages-coverage-html:
+        description: "Upload flat HTML coverage artifact for Model B Pages bundling"
+        required: false
+        type: boolean
+        default: false
+      pages-coverage-artifact-name:
+        description: "Artifact name for flat Rust HTML coverage upload"
+        required: false
+        type: string
+        default: "rust-coverage-html"
+      pages-coverage-upload-on:
+        description: "When to upload flat Rust HTML coverage (v1: push-main only)"
+        required: false
+        type: string
+        default: "push-main"
       post-pr-comment:
         description: "Post coverage summary comment on pull requests"
         required: false
@@ -73,6 +88,12 @@ on:
       passed:
         description: "Whether coverage succeeded"
         value: ${{ jobs.coverage.outputs.passed == 'true' }}
+      pages-coverage-artifact-name:
+        description: "Resolved flat HTML coverage artifact name"
+        value: ${{ jobs.coverage.outputs.pages-coverage-artifact-name }}
+      pages-coverage-uploaded:
+        description: "Whether flat HTML coverage artifact was uploaded this run"
+        value: ${{ jobs.coverage.outputs.pages-coverage-uploaded }}
 
 jobs:
   coverage:
@@ -91,11 +112,24 @@ jobs:
         ${{ steps.generate-comment.outcome == 'success' }}
       coverage-percent: >-
         ${{ steps.generate-comment.outputs.lines-coverage || '' }}
+      pages-coverage-artifact-name: ${{ inputs.pages-coverage-artifact-name }}
+      pages-coverage-uploaded: ${{ steps.record-pages-upload.outputs.uploaded }}
     concurrency:
       group: rust-coverage-${{ github.ref }}
       cancel-in-progress: true
 
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -106,17 +140,6 @@ jobs:
             .github/actions/
             scripts/ci/
           sparse-checkout-cone-mode: true
-          persist-credentials: false
-
-      - name: Harden runner
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
-
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
           persist-credentials: false
 
       - name: Setup Rust coverage toolchain
@@ -134,6 +157,36 @@ jobs:
           DEFAULT_SCRIPT_PATH: .lgtm-ci-tooling/scripts/ci/testing/rust/run-rust-coverage.sh
         run: bash .lgtm-ci-tooling/scripts/ci/actions/run-caller-script.sh
         continue-on-error: true
+
+      - name: Generate Rust coverage HTML
+        if: >-
+          inputs.upload-pages-coverage-html
+          && steps.rust-coverage.outcome == 'success'
+        shell: bash
+        env:
+          RUST_COVERAGE_HTML_DIR: ${{ inputs.pages-coverage-artifact-name }}
+        run: >-
+          bash .lgtm-ci-tooling/scripts/ci/testing/rust/run-rust-coverage-html.sh
+
+      - name: Evaluate pages coverage upload gate
+        id: pages-upload-gate
+        if: inputs.upload-pages-coverage-html
+        shell: bash
+        env:
+          PAGES_COVERAGE_UPLOAD_ON: ${{ inputs.pages-coverage-upload-on }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/pages-coverage-upload-gate.sh
+
+      - name: Upload pages coverage HTML artifact
+        id: pages-upload
+        if: >-
+          inputs.upload-pages-coverage-html
+          && steps.rust-coverage.outcome == 'success'
+          && steps.pages-upload-gate.outputs.should-upload == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.pages-coverage-artifact-name }}
+          path: ${{ inputs.pages-coverage-artifact-name }}/
+          if-no-files-found: error
 
       - name: Generate coverage PR comment
         id: generate-comment
@@ -172,6 +225,17 @@ jobs:
           COVERAGE_NAME: Rust
         run: >-
           bash .lgtm-ci-tooling/scripts/ci/testing/rust/fail-on-coverage.sh
+
+      - name: Record pages coverage upload result
+        if: always()
+        id: record-pages-upload
+        shell: bash
+        run: |
+          if [[ "${{ steps.pages-upload.outcome }}" == "success" ]]; then
+            echo "uploaded=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "uploaded=false" >>"$GITHUB_OUTPUT"
+          fi
 
       - name: Record coverage result
         if: always()

--- a/.github/workflows/reusable-test-rust-coverage.yml
+++ b/.github/workflows/reusable-test-rust-coverage.yml
@@ -186,6 +186,7 @@ jobs:
         with:
           name: ${{ inputs.pages-coverage-artifact-name }}
           path: ${{ inputs.pages-coverage-artifact-name }}/
+          retention-days: 7
           if-no-files-found: error
 
       - name: Generate coverage PR comment

--- a/.github/workflows/reusable-test-rust-coverage.yml
+++ b/.github/workflows/reusable-test-rust-coverage.yml
@@ -231,8 +231,10 @@ jobs:
         if: always()
         id: record-pages-upload
         shell: bash
+        env:
+          PAGES_UPLOAD_OUTCOME: ${{ steps.pages-upload.outcome }}
         run: |
-          if [[ "${{ steps.pages-upload.outcome }}" == "success" ]]; then
+          if [[ "${PAGES_UPLOAD_OUTCOME}" == "success" ]]; then
             echo "uploaded=true" >>"$GITHUB_OUTPUT"
           else
             echo "uploaded=false" >>"$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,10 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.24.0] - 2026-05-29
 
-### Breaking Changes
-
-- **ci**: split PyPI build/upload for OIDC (#248) (#249) (435f9a2)
-
 ### Previously Unreleased
 
 Target release: **v0.24.0** (breaking; `feat(ci)!`).
@@ -45,6 +41,8 @@ Target release: **v0.24.0** (breaking; `feat(ci)!`).
 - **actions**: `publish-pypi` (#248)
 
 ### Breaking changes
+
+- **ci**: split PyPI build/upload for OIDC (#248) (#249) (435f9a2)
 
 | Removed                                  | Use instead                                           |
 | ---------------------------------------- | ----------------------------------------------------- |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
 ### Changed
+
+- **workflows**: `reusable-test-node` matrix job display names are now static
+  (`Node.js tests (Vitest)` / `Node.js tests (custom command)`). Update branch
+  protection required checks that matched the previous `inputs.job-name`-based
+  names when upgrading.
+
+### Added
 
 ### Deprecated
 

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -144,19 +144,33 @@ Quality lint-only checks use `reusable-quality-lint.yml`; PR lint summaries use
 | ----- | ---- | -------- | ------- | ------- |
 | `upload-pages-coverage-html` | boolean | no | `false` | Upload flat HTML for Model B bundling |
 | `pages-coverage-artifact-name` | string | no | `coverage-html` | Flat HTML artifact name |
-| `pages-coverage-upload-on` | string | no | `push-main` | Upload only on push to `main` (v1) |
+| `pages-coverage-upload-on` | string | no | `push-main` | Upload gate selector (v1) |
 | `pages-coverage-source-subpath` | string | no | `coverage` | HTML dir under `working-directory` |
 
 Outputs: `pages-coverage-artifact-name`, `pages-coverage-uploaded` (`true`/`false`).
+
+**`pages-coverage-upload-on` (v1):** The `(v1)` suffix marks the first supported
+upload-gating behavior. Additional values may be added in later releases without
+breaking existing callers. Use the literal string values below — they are not
+Git ref aliases.
+
+| Value | Meaning |
+| ----- | ------- |
+| `push-main` | Upload only when `github.event_name == push` and `github.ref == refs/heads/main` |
 
 When `node-versions` is a matrix, only the **first** listed version uploads the
 flat artifact (avoids `upload-artifact` name collisions). Matrix debug artifacts
 (`node-coverage-<version>/…`) are unchanged when `upload-coverage: true`.
 
-**Skipped jobs:** `test-vitest` and `test-custom` use static job names so PR
-checks do not show unevaluated `${{ … }}` for the path that is skipped by design.
-When `test-command` is set, Vitest is skipped and the custom-command job runs;
-when `test-command` is empty, the opposite applies.
+**Job display names:** `test-vitest` and `test-custom` use static names
+(`Node.js tests (Vitest)` / `Node.js tests (custom command)`) so skipped matrix
+jobs do not show unevaluated `${{ … }}` in the PR checks UI. This replaces the
+previous dynamic names derived from `inputs.job-name` and matrix versions.
+Update branch protection required-status checks that matched the old names when
+upgrading to this tooling version.
+
+**Skipped jobs:** When `test-command` is set, Vitest is skipped and the
+custom-command job runs; when `test-command` is empty, the opposite applies.
 
 **PR comments:** `coverage-pr-comment: true` builds the comment artifact inside
 the test job, but the separate `Node coverage PR comment` job also requires
@@ -199,9 +213,14 @@ jobs:
 | ----- | ---- | -------- | ------- | ------- |
 | `upload-pages-coverage-html` | boolean | no | `false` | Upload flat HTML for Model B sites |
 | `pages-coverage-artifact-name` | string | no | `rust-coverage-html` | Rust HTML artifact name |
-| `pages-coverage-upload-on` | string | no | `push-main` | Upload only on push to `main` (v1) |
+| `pages-coverage-upload-on` | string | no | `push-main` | Upload gate selector (v1) |
 
 Outputs: `pages-coverage-artifact-name`, `pages-coverage-uploaded` (`true`/`false`).
+
+**`pages-coverage-upload-on` (v1):** Same gating semantics as the Node reusable
+(see table above). `push-main` is a literal selector meaning push events to
+`refs/heads/main`; it is not a Git ref alias. The `(v1)` suffix denotes the
+current upload-gating API; new non-breaking values may appear in later releases.
 
 HTML is generated in the same job as the LCOV run via `cargo llvm-cov report --html`
 (no second test run). The script flattens cargo-llvm-cov's `<output-dir>/html/`

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -138,6 +138,31 @@ the language-specific test workflows. Coverage and artifact-based comments use
 Quality lint-only checks use `reusable-quality-lint.yml`; PR lint summaries use
 `reusable-quality-pr-comment.yml` (called directly by the caller workflow).
 
+### Pages coverage HTML inputs (`reusable-test-node`)
+
+| Input | Type | Required | Default | Purpose |
+| ----- | ---- | -------- | ------- | ------- |
+| `upload-pages-coverage-html` | boolean | no | `false` | Upload flat HTML for Model B bundling |
+| `pages-coverage-artifact-name` | string | no | `coverage-html` | Flat HTML artifact name |
+| `pages-coverage-upload-on` | string | no | `push-main` | Upload only on push to `main` (v1) |
+| `pages-coverage-source-subpath` | string | no | `coverage` | HTML dir under `working-directory` |
+
+Outputs: `pages-coverage-artifact-name`, `pages-coverage-uploaded` (`true`/`false`).
+
+When `node-versions` is a matrix, only the **first** listed version uploads the
+flat artifact (avoids `upload-artifact` name collisions). Matrix debug artifacts
+(`node-coverage-<version>/…`) are unchanged when `upload-coverage: true`.
+
+**Skipped jobs:** `test-vitest` and `test-custom` use static job names so PR
+checks do not show unevaluated `${{ … }}` for the path that is skipped by design.
+When `test-command` is set, Vitest is skipped and the custom-command job runs;
+when `test-command` is empty, the opposite applies.
+
+**PR comments:** `coverage-pr-comment: true` builds the comment artifact inside
+the test job, but the separate `Node coverage PR comment` job also requires
+`post-pr-comment: true`. Setting only `coverage-pr-comment: true` skips the
+poster job by design.
+
 ### Rust
 
 Prefer `reusable-rust-build.yml` and `reusable-rust-coverage.yml` for separate
@@ -164,7 +189,23 @@ jobs:
       tooling-ref: "<sha>"
       job-name: "Rust Coverage"
       egress-policy: block
+      upload-pages-coverage-html: true
+      pages-coverage-artifact-name: rust-coverage-html
 ```
+
+### Pages coverage HTML inputs (`reusable-rust-coverage` / `reusable-test-rust-coverage`)
+
+| Input | Type | Required | Default | Purpose |
+| ----- | ---- | -------- | ------- | ------- |
+| `upload-pages-coverage-html` | boolean | no | `false` | Upload flat HTML for Model B sites |
+| `pages-coverage-artifact-name` | string | no | `rust-coverage-html` | Rust HTML artifact name |
+| `pages-coverage-upload-on` | string | no | `push-main` | Upload only on push to `main` (v1) |
+
+Outputs: `pages-coverage-artifact-name`, `pages-coverage-uploaded` (`true`/`false`).
+
+HTML is generated in the same job as the LCOV run via `cargo llvm-cov report --html`
+(no second test run). The script flattens cargo-llvm-cov's `<output-dir>/html/`
+layout so the artifact root is browsable HTML.
 
 ## Release
 

--- a/examples/bundle-manifest-turbo-themes.json
+++ b/examples/bundle-manifest-turbo-themes.json
@@ -9,6 +9,13 @@
       "require_success": true
     },
     {
+      "id": "rust-coverage",
+      "workflow": "Coverage Reports",
+      "artifact": "rust-coverage-html",
+      "dest": "coverage-rust",
+      "require_success": true
+    },
+    {
       "id": "playwright",
       "workflow": "Quality Check - E2E Tests",
       "artifact": "playwright-report",

--- a/examples/bundle-manifest-turbo-themes.json
+++ b/examples/bundle-manifest-turbo-themes.json
@@ -10,7 +10,7 @@
     },
     {
       "id": "rust-coverage",
-      "workflow": "Coverage Reports",
+      "workflow": "Quality Check - Rust Coverage",
       "artifact": "rust-coverage-html",
       "dest": "coverage-rust",
       "require_success": true

--- a/scripts/ci/actions/generate-node-matrix.sh
+++ b/scripts/ci/actions/generate-node-matrix.sh
@@ -33,6 +33,8 @@ matrix = {"include": [{"node-version": version} for version in versions]}
 
 with open(github_output, "a", encoding="utf-8") as output:
     output.write(f"matrix={json.dumps(matrix, separators=(',', ':'))}\n")
+    output.write(f"pages-coverage-node-version={versions[0]}\n")
 
 print(f"Node.js matrix: {', '.join(versions)}")
+print(f"Pages coverage node version: {versions[0]}")
 PY

--- a/scripts/ci/actions/pages-coverage-upload-gate.sh
+++ b/scripts/ci/actions/pages-coverage-upload-gate.sh
@@ -4,23 +4,15 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/pages_coverage.sh
+source "$SCRIPT_DIR/../lib/pages_coverage.sh"
+
 UPLOAD_ON="${PAGES_COVERAGE_UPLOAD_ON:-push-main}"
 EVENT="${GITHUB_EVENT_NAME:-}"
 REF="${GITHUB_REF:-}"
 
-should_upload=false
-
-case "$UPLOAD_ON" in
-push-main)
-	if [[ "$EVENT" == "push" && "$REF" == "refs/heads/main" ]]; then
-		should_upload=true
-	fi
-	;;
-*)
-	echo "Unsupported pages-coverage-upload-on value: ${UPLOAD_ON}" >&2
-	exit 1
-	;;
-esac
+should_upload=$(resolve_pages_coverage_should_upload "$UPLOAD_ON" "$EVENT" "$REF")
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
 	echo "should-upload=${should_upload}" >>"$GITHUB_OUTPUT"

--- a/scripts/ci/actions/pages-coverage-upload-gate.sh
+++ b/scripts/ci/actions/pages-coverage-upload-gate.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Decide whether flat Pages coverage HTML artifacts should upload this run.
+
+set -euo pipefail
+
+UPLOAD_ON="${PAGES_COVERAGE_UPLOAD_ON:-push-main}"
+EVENT="${GITHUB_EVENT_NAME:-}"
+REF="${GITHUB_REF:-}"
+
+should_upload=false
+
+case "$UPLOAD_ON" in
+push-main)
+	if [[ "$EVENT" == "push" && "$REF" == "refs/heads/main" ]]; then
+		should_upload=true
+	fi
+	;;
+*)
+	echo "Unsupported pages-coverage-upload-on value: ${UPLOAD_ON}" >&2
+	exit 1
+	;;
+esac
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	echo "should-upload=${should_upload}" >>"$GITHUB_OUTPUT"
+fi

--- a/scripts/ci/actions/python-dist.sh
+++ b/scripts/ci/actions/python-dist.sh
@@ -3,7 +3,8 @@
 # Purpose: Build and upload Python packages to PyPI (STEP dispatch)
 #
 # Environment variables:
-#   STEP: preflight | validate | build | validate-dist | set-published | summary
+#   STEP: preflight | validate | build | validate-dist | extract-dist-metadata |
+#         set-published | summary
 #   WORKING_DIRECTORY: Directory containing the package (default: .)
 #   VERIFY_TAG_VERSION: Verify git tag matches pyproject.toml version
 #   ENSURE_TAG_ON_DEFAULT_BRANCH: Verify tagged commit is on the default branch
@@ -190,6 +191,43 @@ validate-dist)
 
 set-published)
 	set_github_output "published" "true"
+	;;
+
+extract-dist-metadata)
+	name=""
+	version=""
+
+	if [[ -f "pyproject.toml" ]]; then
+		version=$(extract_pypi_version ".") || true
+		name=$(extract_pypi_name ".") || true
+	fi
+
+	if [[ (-z "$name" || -z "$version") && -d "dist" ]]; then
+		wheel_file=$(find dist -name "*.whl" -print -quit 2>/dev/null || true)
+		if [[ -n "$wheel_file" ]]; then
+			wheel_basename=$(basename "$wheel_file")
+			wheel_name="${wheel_basename%%-*}"
+			wheel_remainder="${wheel_basename#*-}"
+			wheel_version="${wheel_remainder%%-*}"
+			name="${name:-${wheel_name//_/-}}"
+			version="${version:-$wheel_version}"
+		else
+			sdist_file=$(find dist \( -name "*.tar.gz" -o -name "*.zip" \) -print -quit 2>/dev/null || true)
+			if [[ -n "$sdist_file" ]]; then
+				sdist_basename=$(basename "$sdist_file")
+				sdist_basename="${sdist_basename%.tar.gz}"
+				sdist_basename="${sdist_basename%.zip}"
+				sdist_name="${sdist_basename%%-*}"
+				sdist_remainder="${sdist_basename#*-}"
+				sdist_version="${sdist_remainder%%-*}"
+				name="${name:-${sdist_name//_/-}}"
+				version="${version:-$sdist_version}"
+			fi
+		fi
+	fi
+
+	set_github_output "name" "${name:-unknown}"
+	set_github_output "version" "${version:-unknown}"
 	;;
 
 summary)

--- a/scripts/ci/actions/python-dist.sh
+++ b/scripts/ci/actions/python-dist.sh
@@ -22,13 +22,23 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
 source "$SCRIPT_DIR/../lib/actions.sh"
 source "$SCRIPT_DIR/../lib/publish.sh"
 
-if [[ "$STEP" == "build" ]]; then
-	if [[ -z "$WORKING_DIRECTORY" || "$WORKING_DIRECTORY" == "/" || "$WORKING_DIRECTORY" == "~" || "$WORKING_DIRECTORY" == ~/* || "$WORKING_DIRECTORY" =~ ^~(/|$) ]]; then
-		die "Refusing to build with unsafe WORKING_DIRECTORY: ${WORKING_DIRECTORY:-<empty>}"
-	fi
-fi
+_validate_working_directory() {
+	local dir="${1:-.}"
 
-# Change to working directory
+	if [[ -z "$dir" || "$dir" == "/" || "$dir" == "~" || "$dir" == ~/* || "$dir" =~ ^~(/|$) ]]; then
+		die "Refusing to use unsafe WORKING_DIRECTORY: ${dir:-<empty>}"
+	fi
+
+	if [[ -n "${HOME:-}" && ("$dir" == "$HOME" || "$dir" == "${HOME}/"*) ]]; then
+		die "Refusing to use unsafe WORKING_DIRECTORY: ${dir}"
+	fi
+
+	if [[ ! -d "$dir" ]]; then
+		die "WORKING_DIRECTORY does not exist: ${dir}"
+	fi
+}
+
+_validate_working_directory "$WORKING_DIRECTORY"
 cd "$WORKING_DIRECTORY"
 
 case "$STEP" in
@@ -124,7 +134,10 @@ build)
 
 	# Extract version and name
 	version=$(extract_pypi_version ".") || die "Could not extract version"
-	name=$(extract_pypi_name ".") || true
+	name=$(extract_pypi_name ".") || die "Could not extract package name from pyproject.toml"
+	if [[ -z "$name" ]]; then
+		die "Could not extract package name from pyproject.toml"
+	fi
 
 	# Build using uv or python -m build
 	if command -v uv >/dev/null 2>&1; then

--- a/scripts/ci/actions/python-dist.sh
+++ b/scripts/ci/actions/python-dist.sh
@@ -217,9 +217,8 @@ extract-dist-metadata)
 				sdist_basename=$(basename "$sdist_file")
 				sdist_basename="${sdist_basename%.tar.gz}"
 				sdist_basename="${sdist_basename%.zip}"
-				sdist_name="${sdist_basename%%-*}"
-				sdist_remainder="${sdist_basename#*-}"
-				sdist_version="${sdist_remainder%%-*}"
+				sdist_version="${sdist_basename##*-}"
+				sdist_name="${sdist_basename%-*}"
 				name="${name:-${sdist_name//_/-}}"
 				version="${version:-$sdist_version}"
 			fi

--- a/scripts/ci/actions/record-pages-coverage-upload-status.sh
+++ b/scripts/ci/actions/record-pages-coverage-upload-status.sh
@@ -4,13 +4,15 @@
 
 set -euo pipefail
 
+output="${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
 if [[ "${UPLOAD_PAGES_COVERAGE_HTML:-false}" != "true" || "${COVERAGE:-false}" != "true" ]]; then
-	echo "uploaded=false" >>"${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+	echo "uploaded=false" >>"$output"
 	exit 0
 fi
 
 if [[ "${PAGES_UPLOAD_OUTCOME:-}" == "success" ]]; then
-	echo "uploaded=true" >>"$GITHUB_OUTPUT"
+	echo "uploaded=true" >>"$output"
 else
-	echo "uploaded=false" >>"$GITHUB_OUTPUT"
+	echo "uploaded=false" >>"$output"
 fi

--- a/scripts/ci/actions/record-pages-coverage-upload-status.sh
+++ b/scripts/ci/actions/record-pages-coverage-upload-status.sh
@@ -4,28 +4,13 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
-# shellcheck source=../lib/pages_coverage.sh
-source "$SCRIPT_DIR/../lib/pages_coverage.sh"
-
 if [[ "${UPLOAD_PAGES_COVERAGE_HTML:-false}" != "true" || "${COVERAGE:-false}" != "true" ]]; then
 	echo "uploaded=false" >>"${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
 	exit 0
 fi
 
-active_result="${TEST_VITEST_RESULT:-skipped}"
-if [[ -n "${TEST_COMMAND:-}" ]]; then
-	active_result="${TEST_CUSTOM_RESULT:-skipped}"
-fi
-
-if [[ "$active_result" != "success" ]]; then
+if [[ "${PAGES_UPLOAD_OUTCOME:-}" == "success" ]]; then
+	echo "uploaded=true" >>"$GITHUB_OUTPUT"
+else
 	echo "uploaded=false" >>"$GITHUB_OUTPUT"
-	exit 0
 fi
-
-should_upload=$(resolve_pages_coverage_should_upload \
-	"${PAGES_COVERAGE_UPLOAD_ON:-push-main}" \
-	"${GITHUB_EVENT_NAME:-}" \
-	"${GITHUB_REF:-}")
-
-echo "uploaded=${should_upload}" >>"$GITHUB_OUTPUT"

--- a/scripts/ci/actions/record-pages-coverage-upload-status.sh
+++ b/scripts/ci/actions/record-pages-coverage-upload-status.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Report whether flat pages coverage HTML was uploaded this workflow run.
+
+set -euo pipefail
+
+if [[ "${UPLOAD_PAGES_COVERAGE_HTML:-false}" != "true" || "${COVERAGE:-false}" != "true" ]]; then
+	echo "uploaded=false" >>"${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+	exit 0
+fi
+
+active_result="${TEST_VITEST_RESULT:-skipped}"
+if [[ -n "${TEST_COMMAND:-}" ]]; then
+	active_result="${TEST_CUSTOM_RESULT:-skipped}"
+fi
+
+if [[ "$active_result" != "success" ]]; then
+	echo "uploaded=false" >>"$GITHUB_OUTPUT"
+	exit 0
+fi
+
+PAGES_COVERAGE_UPLOAD_ON="${PAGES_COVERAGE_UPLOAD_ON:-push-main}"
+EVENT="${GITHUB_EVENT_NAME:-}"
+REF="${GITHUB_REF:-}"
+
+should_upload=false
+case "$PAGES_COVERAGE_UPLOAD_ON" in
+push-main)
+	if [[ "$EVENT" == "push" && "$REF" == "refs/heads/main" ]]; then
+		should_upload=true
+	fi
+	;;
+*)
+	echo "Unsupported pages-coverage-upload-on value: ${PAGES_COVERAGE_UPLOAD_ON}" >&2
+	exit 1
+	;;
+esac
+
+echo "uploaded=${should_upload}" >>"$GITHUB_OUTPUT"

--- a/scripts/ci/actions/record-pages-coverage-upload-status.sh
+++ b/scripts/ci/actions/record-pages-coverage-upload-status.sh
@@ -4,6 +4,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/pages_coverage.sh
+source "$SCRIPT_DIR/../lib/pages_coverage.sh"
+
 if [[ "${UPLOAD_PAGES_COVERAGE_HTML:-false}" != "true" || "${COVERAGE:-false}" != "true" ]]; then
 	echo "uploaded=false" >>"${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
 	exit 0
@@ -19,21 +23,9 @@ if [[ "$active_result" != "success" ]]; then
 	exit 0
 fi
 
-PAGES_COVERAGE_UPLOAD_ON="${PAGES_COVERAGE_UPLOAD_ON:-push-main}"
-EVENT="${GITHUB_EVENT_NAME:-}"
-REF="${GITHUB_REF:-}"
-
-should_upload=false
-case "$PAGES_COVERAGE_UPLOAD_ON" in
-push-main)
-	if [[ "$EVENT" == "push" && "$REF" == "refs/heads/main" ]]; then
-		should_upload=true
-	fi
-	;;
-*)
-	echo "Unsupported pages-coverage-upload-on value: ${PAGES_COVERAGE_UPLOAD_ON}" >&2
-	exit 1
-	;;
-esac
+should_upload=$(resolve_pages_coverage_should_upload \
+	"${PAGES_COVERAGE_UPLOAD_ON:-push-main}" \
+	"${GITHUB_EVENT_NAME:-}" \
+	"${GITHUB_REF:-}")
 
 echo "uploaded=${should_upload}" >>"$GITHUB_OUTPUT"

--- a/scripts/ci/actions/record-pages-upload-outcome.sh
+++ b/scripts/ci/actions/record-pages-upload-outcome.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Expose steps.pages-upload.outcome as a job output for downstream jobs.
+
+set -euo pipefail
+
+echo "outcome=${PAGES_UPLOAD_OUTCOME:-}" >>"${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"

--- a/scripts/ci/actions/stage-node-pages-coverage.sh
+++ b/scripts/ci/actions/stage-node-pages-coverage.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Stage flat Node.js coverage HTML for Model B Pages bundling.
+
+set -euo pipefail
+
+: "${WORKING_DIRECTORY:=.}"
+: "${PAGES_COVERAGE_SOURCE_SUBPATH:=coverage}"
+: "${PAGES_COVERAGE_STAGING_DIR:=pages-coverage-html}"
+
+source_dir="${WORKING_DIRECTORY}/${PAGES_COVERAGE_SOURCE_SUBPATH}"
+
+if [[ ! -d "$source_dir" ]]; then
+	echo "Pages coverage source directory missing: ${source_dir}" >&2
+	exit 1
+fi
+
+if [[ ! -f "${source_dir}/index.html" ]]; then
+	echo "Pages coverage HTML missing index.html under ${source_dir}" >&2
+	exit 1
+fi
+
+rm -rf "${PAGES_COVERAGE_STAGING_DIR}"
+mkdir -p "${PAGES_COVERAGE_STAGING_DIR}"
+cp -a "${source_dir}/." "${PAGES_COVERAGE_STAGING_DIR}/"
+echo "Staged ${source_dir} -> ${PAGES_COVERAGE_STAGING_DIR}/"

--- a/scripts/ci/lib/pages_coverage.sh
+++ b/scripts/ci/lib/pages_coverage.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Shared helpers for Model B pages coverage upload gating.
+
+[[ -n "${_PAGES_COVERAGE_LOADED:-}" ]] && return 0
+readonly _PAGES_COVERAGE_LOADED=1
+
+# Echo true/false for whether flat pages coverage HTML should upload.
+# Exits 1 when upload-on is unsupported.
+resolve_pages_coverage_should_upload() {
+	local upload_on="${1:-push-main}"
+	local event="${2:-${GITHUB_EVENT_NAME:-}}"
+	local ref="${3:-${GITHUB_REF:-}}"
+
+	case "$upload_on" in
+	push-main)
+		if [[ "$event" == "push" && "$ref" == "refs/heads/main" ]]; then
+			echo "true"
+		else
+			echo "false"
+		fi
+		;;
+	*)
+		echo "Unsupported pages-coverage-upload-on value: ${upload_on}" >&2
+		return 1
+		;;
+	esac
+}

--- a/scripts/ci/release/update-changelog.sh
+++ b/scripts/ci/release/update-changelog.sh
@@ -112,6 +112,7 @@ EXISTING_ENTRIES=$(
 # Prose lines (e.g. "Target release: …") outside Keep-a-Changelog sub-sections.
 EXISTING_PROSE=$(
 	echo "$EXISTING_UNRELEASED" | awk '
+		/^### [Bb]reaking changes/ { exit }
 		/^### / { next }
 		/^\[/ { next }
 		/^$/ { next }

--- a/scripts/ci/testing/rust/run-rust-coverage-html.sh
+++ b/scripts/ci/testing/rust/run-rust-coverage-html.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Generate a flat HTML coverage tree from in-job cargo llvm-cov profiling data.
+
+set -euo pipefail
+
+OUTPUT_DIR="${RUST_COVERAGE_HTML_DIR:-rust-coverage-html}"
+TEMP_DIR="${OUTPUT_DIR}.tmp"
+
+if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
+	echo "cargo-llvm-cov is required; run setup-rust-coverage.sh and run-rust-coverage.sh first." >&2
+	exit 1
+fi
+
+rm -rf "${OUTPUT_DIR}" "${TEMP_DIR}"
+cargo llvm-cov report --html --output-dir "${TEMP_DIR}"
+
+# cargo-llvm-cov 0.8.x writes browsable HTML under <output-dir>/html/.
+if [[ ! -d "${TEMP_DIR}/html" ]]; then
+	echo "Expected ${TEMP_DIR}/html after cargo llvm-cov report --html" >&2
+	exit 1
+fi
+
+if [[ ! -f "${TEMP_DIR}/html/index.html" ]]; then
+	echo "Expected ${TEMP_DIR}/html/index.html after cargo llvm-cov report --html" >&2
+	exit 1
+fi
+
+mv "${TEMP_DIR}/html" "${OUTPUT_DIR}"
+rm -rf "${TEMP_DIR}"
+
+echo "Rust coverage HTML written to ${OUTPUT_DIR}/"

--- a/scripts/ci/testing/rust/run-rust-coverage-html.sh
+++ b/scripts/ci/testing/rust/run-rust-coverage-html.sh
@@ -7,6 +7,57 @@ set -euo pipefail
 OUTPUT_DIR="${RUST_COVERAGE_HTML_DIR:-rust-coverage-html}"
 TEMP_DIR="${OUTPUT_DIR}.tmp"
 
+_validate_rust_coverage_html_dir() {
+	local dir="$1"
+
+	if [[ -z "$dir" || "$dir" == "." || "$dir" == ".." || "$dir" == "/" ]]; then
+		echo "Unsafe RUST_COVERAGE_HTML_DIR: ${dir:-<empty>}" >&2
+		return 1
+	fi
+
+	if [[ "$dir" == /* ]]; then
+		echo "RUST_COVERAGE_HTML_DIR must be repo-relative: ${dir}" >&2
+		return 1
+	fi
+
+	if [[ "$dir" == *".."* ]]; then
+		echo "RUST_COVERAGE_HTML_DIR must not contain .. segments: ${dir}" >&2
+		return 1
+	fi
+
+	local repo_root="${GITHUB_WORKSPACE:-}"
+	if [[ -z "$repo_root" ]] && git rev-parse --show-toplevel >/dev/null 2>&1; then
+		repo_root="$(git rev-parse --show-toplevel)"
+	fi
+	if [[ -z "$repo_root" ]]; then
+		repo_root="$(pwd -P)"
+	fi
+
+	local resolved_dir
+	if ! resolved_dir="$(
+		python3 - "$repo_root" "$dir" <<'PY'
+import os
+import sys
+
+root = os.path.realpath(sys.argv[1])
+target = os.path.realpath(os.path.join(root, sys.argv[2]))
+if target == root or target.startswith(root + os.sep):
+    print(target)
+    sys.exit(0)
+sys.exit(1)
+PY
+	)"; then
+		echo "RUST_COVERAGE_HTML_DIR must stay within repository root: ${dir}" >&2
+		return 1
+	fi
+
+	return 0
+}
+
+if ! _validate_rust_coverage_html_dir "$OUTPUT_DIR"; then
+	exit 1
+fi
+
 if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
 	echo "cargo-llvm-cov is required; run setup-rust-coverage.sh and run-rust-coverage.sh first." >&2
 	exit 1

--- a/scripts/ci/testing/rust/run-rust-coverage-html.sh
+++ b/scripts/ci/testing/rust/run-rust-coverage-html.sh
@@ -54,12 +54,12 @@ PY
 	return 0
 }
 
-if ! _validate_rust_coverage_html_dir "$OUTPUT_DIR"; then
+if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
+	echo "cargo-llvm-cov is required; run setup-rust-coverage.sh and run-rust-coverage.sh first." >&2
 	exit 1
 fi
 
-if ! command -v cargo-llvm-cov >/dev/null 2>&1; then
-	echo "cargo-llvm-cov is required; run setup-rust-coverage.sh and run-rust-coverage.sh first." >&2
+if ! _validate_rust_coverage_html_dir "$OUTPUT_DIR"; then
 	exit 1
 fi
 

--- a/tests/bats/integration/test_composite_action_refs.bats
+++ b/tests/bats/integration/test_composite_action_refs.bats
@@ -6,6 +6,7 @@ load "../../helpers/common"
 
 _forbidden_dynamic_lgtm_ci_uses() {
 	local scan_path="$1"
+	local rc=0
 
 	while IFS= read -r -d '' action; do
 		awk -v file="$action" '
@@ -42,8 +43,10 @@ _forbidden_dynamic_lgtm_ci_uses() {
 			END {
 				exit found
 			}
-		' "$action"
+		' "$action" || rc=1
 	done < <(find "$scan_path" -path "*/action.yml" -type f -print0)
+
+	return "$rc"
 }
 
 @test "composite actions: forbid dynamic lgtm-ci remote uses refs" {

--- a/tests/bats/integration/test_reusable_build_python_dist.bats
+++ b/tests/bats/integration/test_reusable_build_python_dist.bats
@@ -39,6 +39,7 @@ _tooling_sparse_cone_ok() {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-build-python-dist.yml"
 	run awk '
 		/^  build:/ { in_build = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  build:/ { in_build = 0 }
 		in_build && /build-python-package/ { action = 1 }
 		in_build && /actions\/upload-artifact@/ { upload = 1 }
 		in_build && /publish-pypi/ { bad = 1 }
@@ -71,7 +72,14 @@ _tooling_sparse_cone_ok() {
 		/gh-action-pypi-publish@/ { pypi = NR }
 		/attest-build-provenance@/ { attest = NR }
 		/STEP: validate-dist/ { validate = NR }
-		END { exit !(download > 0 && validate > 0 && pypi > 0 && attest > 0 && download < validate && validate < pypi && pypi < attest) }
+		/Generate upload summary/ { summary = NR }
+		/id: set-published/ { published = NR }
+		END {
+			exit !(download > 0 && validate > 0 && pypi > 0 && attest > 0 &&
+				published > 0 && summary > 0 && download < validate &&
+				validate < pypi && pypi < attest && attest < published &&
+				published < summary)
+		}
 	' "$action"
 	assert_success
 }
@@ -79,7 +87,8 @@ _tooling_sparse_cone_ok() {
 @test "upload-pypi-oidc: attestation is best-effort before set-published" {
 	local action="${PROJECT_ROOT}/.github/actions/upload-pypi-oidc/action.yml"
 	run awk '
-		/Attest build provenance/ { in_attest_step = 1 }
+		/Attest build provenance/ { in_attest_step = 1; next }
+		/^      - name:/ { in_attest_step = 0 }
 		in_attest_step && /continue-on-error: true/ { coe = NR }
 		in_attest_step && /attest-build-provenance@/ { attest = NR }
 		/id: set-published/ { published = NR }
@@ -103,14 +112,11 @@ _tooling_sparse_cone_ok() {
 		/actions\/download-artifact@/ { download = 1 }
 		/Verify release assets exist/ { verify = 1 }
 		/verify-release-assets\.sh/ { verify_script = 1 }
-		/create-github-release\.sh/ { release = 1; in_release_step = 1 }
-		/^      - name:/ {
-			if (in_release_step) {
-				in_release_step = 0
-			}
-		}
+		/Create GitHub Release/ { in_release_step = 1; release = 1; next }
+		in_release_step && /create-github-release\.sh/ { release_script = 1 }
+		in_release_step && /^      - name:/ { in_release_step = 0 }
 		in_release_step && /run: \|/ { inline_shell = 1 }
-		END { exit !(download && verify && verify_script && release && !inline_shell) }
+		END { exit !(download && verify && verify_script && release && release_script && !inline_shell) }
 	' "$workflow"
 	assert_success
 	run grep -Eq 'format\(\s*['\''"]\{0\}/\*\s*['\''"],\s*inputs\.artifact-path\s*\)' "$workflow"

--- a/tests/bats/integration/test_reusable_build_python_dist.bats
+++ b/tests/bats/integration/test_reusable_build_python_dist.bats
@@ -72,13 +72,14 @@ _tooling_sparse_cone_ok() {
 		/gh-action-pypi-publish@/ { pypi = NR }
 		/attest-build-provenance@/ { attest = NR }
 		/STEP: validate-dist/ { validate = NR }
+		/id: extract-metadata/ { extract = NR }
 		/Generate upload summary/ { summary = NR }
 		/id: set-published/ { published = NR }
 		END {
 			exit !(download > 0 && validate > 0 && pypi > 0 && attest > 0 &&
-				published > 0 && summary > 0 && download < validate &&
+				published > 0 && extract > 0 && summary > 0 && download < validate &&
 				validate < pypi && pypi < attest && attest < published &&
-				published < summary)
+				published < extract && extract < summary)
 		}
 	' "$action"
 	assert_success
@@ -103,6 +104,19 @@ _tooling_sparse_cone_ok() {
 @test "upload-pypi-oidc: exposes published output" {
 	local action="${PROJECT_ROOT}/.github/actions/upload-pypi-oidc/action.yml"
 	run grep -q 'steps.set-published.outputs.published' "$action"
+	assert_success
+}
+
+@test "upload-pypi-oidc: summary wires package metadata from extract-metadata step" {
+	local action="${PROJECT_ROOT}/.github/actions/upload-pypi-oidc/action.yml"
+	run awk '
+		/Generate upload summary/ { in_summary = 1; next }
+		in_summary && /STEP: summary/ { step = 1 }
+		in_summary && /PACKAGE_NAME: \$\{\{ steps\.extract-metadata\.outputs\.name \}\}/ { name = 1 }
+		in_summary && /PACKAGE_VERSION: \$\{\{ steps\.extract-metadata\.outputs\.version \}\}/ { version = 1 }
+		in_summary && /^    - name:/ { in_summary = 0 }
+		END { exit !(step && name && version) }
+	' "$action"
 	assert_success
 }
 

--- a/tests/bats/integration/test_reusable_test_node.bats
+++ b/tests/bats/integration/test_reusable_test_node.bats
@@ -35,3 +35,24 @@ _test_custom_checkout_order_ok() {
 	' "$WORKFLOW"
 	assert_success
 }
+
+@test "reusable-test-node: skipped jobs use static names without expressions" {
+	run awk '
+		/^  test-vitest:/ { vitest = 1; custom = 0 }
+		/^  test-custom:/ { custom = 1; vitest = 0 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  test-vitest:/ && !/^  test-custom:/ { vitest = 0; custom = 0 }
+		vitest && /^    name:/ { if ($0 ~ /\$\{\{/) bad_vitest = 1 }
+		custom && /^    name:/ { if ($0 ~ /\$\{\{/) bad_custom = 1 }
+		END { exit (bad_vitest || bad_custom) }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-test-node: exposes pages coverage HTML inputs and staging script" {
+	run grep -q 'upload-pages-coverage-html' "$WORKFLOW"
+	assert_success
+	run grep -q 'stage-node-pages-coverage.sh' "$WORKFLOW"
+	assert_success
+	run grep -q 'pages-coverage-node-version' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_test_node.bats
+++ b/tests/bats/integration/test_reusable_test_node.bats
@@ -55,4 +55,8 @@ _test_custom_checkout_order_ok() {
 	assert_success
 	run grep -q 'pages-coverage-node-version' "$WORKFLOW"
 	assert_success
+	run grep -q 'pages-coverage-status:' "$WORKFLOW"
+	assert_success
+	run grep -q 'record-pages-coverage-upload-status.sh' "$WORKFLOW"
+	assert_success
 }

--- a/tests/bats/integration/test_reusable_test_node.bats
+++ b/tests/bats/integration/test_reusable_test_node.bats
@@ -59,4 +59,13 @@ _test_custom_checkout_order_ok() {
 	assert_success
 	run grep -q 'record-pages-coverage-upload-status.sh' "$WORKFLOW"
 	assert_success
+	run grep -q 'pages-upload-outcome:' "$WORKFLOW"
+	assert_success
+	run grep -q 'PAGES_UPLOAD_OUTCOME:' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-test-node: gates pages upload on successful staging" {
+	run grep -Fq "steps.stage-pages-coverage.outcome == 'success'" "$WORKFLOW"
+	assert_success
 }

--- a/tests/bats/integration/test_reusable_test_rust_coverage.bats
+++ b/tests/bats/integration/test_reusable_test_rust_coverage.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-test-rust-coverage workflow
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-rust-coverage.yml"
+
+_coverage_checkout_order_ok() {
+	awk '
+		/^  coverage:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  coverage:/ { in_job = 0 }
+		in_job && /^    steps:/ { in_steps = 1 }
+		in_job && in_steps && /^      - name: Harden runner/ { harden = NR }
+		in_job && in_steps && /^      - name: Checkout repository/ { repo = NR }
+		in_job && in_steps && /^      - name: Checkout lgtm-ci tooling/ { tooling = NR }
+		END {
+			ok = (harden > 0 && repo > 0 && tooling > 0 && harden < repo && repo < tooling)
+			exit !ok
+		}
+	' "$WORKFLOW"
+}
+
+@test "reusable-test-rust-coverage: coverage job checkout order preserves tooling" {
+	run _coverage_checkout_order_ok
+	assert_success
+}
+
+@test "reusable-test-rust-coverage: exposes pages coverage inputs and outputs" {
+	run grep -q 'upload-pages-coverage-html' "$WORKFLOW"
+	assert_success
+	run grep -q 'pages-coverage-artifact-name' "$WORKFLOW"
+	assert_success
+	run grep -q 'run-rust-coverage-html.sh' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_update_changelog.bats
+++ b/tests/bats/integration/test_update_changelog.bats
@@ -771,10 +771,21 @@ See [docs/example.md](docs/example.md).
 	local changelog
 	changelog=$(cat "${MOCK_GIT_REPO}/CHANGELOG.md")
 
-	echo "$changelog" | grep -q 'Target release: \*\*v0.25.0\*\*' || fail "prose line missing"
-	echo "$changelog" | grep -q 'new composite' || fail "bullet missing"
-	echo "$changelog" | grep -q '| Removed | Use instead |' || fail "table missing"
-	echo "$changelog" | grep -q '### Breaking changes' || fail "breaking changes heading missing"
+	run bash -c 'grep -c "Target release: \*\*v0.25.0\*\*" "$1"' _ "$changelog"
+	assert_success
+	[ "$output" -eq 1 ] || fail "expected exactly one Target release line, found ${output}"
+
+	run bash -c 'grep -c "new composite" "$1"' _ "$changelog"
+	assert_success
+	[ "$output" -eq 1 ] || fail "expected exactly one new composite line, found ${output}"
+
+	run bash -c 'grep -c "| Removed | Use instead |" "$1"' _ "$changelog"
+	assert_success
+	[ "$output" -eq 1 ] || fail "expected exactly one migration table header, found ${output}"
+
+	run bash -c 'grep -c "### Breaking changes" "$1"' _ "$changelog"
+	assert_success
+	[ "$output" -eq 1 ] || fail "expected exactly one breaking changes heading, found ${output}"
 
 	# MD032: blank line between list and table (no bullet line immediately before |)
 	run bash -c "
@@ -792,7 +803,7 @@ See [docs/example.md](docs/example.md).
 	# MD032: blank line between prose and first bullet
 	run bash -c "
 		awk '
-			/^Target release:/ { prose = 1; next }
+			/^Target release:/ { prose = 1; prev = \$0; next }
 			prose && /^-/ {
 				if (prev !~ /^$/) {
 					print \"prose immediately before bullet\" > \"/dev/stderr\"

--- a/tests/bats/integration/test_update_changelog.bats
+++ b/tests/bats/integration/test_update_changelog.bats
@@ -771,19 +771,19 @@ See [docs/example.md](docs/example.md).
 	local changelog
 	changelog=$(cat "${MOCK_GIT_REPO}/CHANGELOG.md")
 
-	run bash -c 'grep -c "Target release: \*\*v0.25.0\*\*" "$1"' _ "$changelog"
+	run bash -c 'grep -c "Target release: \*\*v0.25.0\*\*" <<<"$1"' _ "$changelog"
 	assert_success
 	[ "$output" -eq 1 ] || fail "expected exactly one Target release line, found ${output}"
 
-	run bash -c 'grep -c "new composite" "$1"' _ "$changelog"
+	run bash -c 'grep -c "new composite" <<<"$1"' _ "$changelog"
 	assert_success
 	[ "$output" -eq 1 ] || fail "expected exactly one new composite line, found ${output}"
 
-	run bash -c 'grep -c "| Removed | Use instead |" "$1"' _ "$changelog"
+	run bash -c 'grep -c "| Removed | Use instead |" <<<"$1"' _ "$changelog"
 	assert_success
 	[ "$output" -eq 1 ] || fail "expected exactly one migration table header, found ${output}"
 
-	run bash -c 'grep -c "### Breaking changes" "$1"' _ "$changelog"
+	run bash -c 'grep -c "### Breaking changes" <<<"$1"' _ "$changelog"
 	assert_success
 	[ "$output" -eq 1 ] || fail "expected exactly one breaking changes heading, found ${output}"
 

--- a/tests/bats/unit/actions/test_generate_node_matrix.bats
+++ b/tests/bats/unit/actions/test_generate_node_matrix.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for generate-node-matrix.sh pages coverage output
+
+load "../../../helpers/common"
+load "../../../helpers/github_env"
+
+setup() {
+	setup_github_env
+	export SCRIPT="$PROJECT_ROOT/scripts/ci/actions/generate-node-matrix.sh"
+}
+
+@test "generate-node-matrix: emits pages-coverage-node-version for first matrix leg" {
+	NODE_VERSIONS=20,22 NODE_VERSION=20 run bash "$SCRIPT"
+	assert_success
+	grep -q '^pages-coverage-node-version=20$' "$GITHUB_OUTPUT"
+	assert_output --partial "Pages coverage node version: 20"
+}
+
+@test "generate-node-matrix: uses sole node-version when matrix is disabled" {
+	NODE_VERSION=22 NODE_VERSIONS= run bash "$SCRIPT"
+	assert_success
+	grep -q '^pages-coverage-node-version=22$' "$GITHUB_OUTPUT"
+}

--- a/tests/bats/unit/actions/test_generate_node_matrix.bats
+++ b/tests/bats/unit/actions/test_generate_node_matrix.bats
@@ -13,12 +13,15 @@ setup() {
 @test "generate-node-matrix: emits pages-coverage-node-version for first matrix leg" {
 	NODE_VERSIONS=20,22 NODE_VERSION=20 run bash "$SCRIPT"
 	assert_success
-	grep -q '^pages-coverage-node-version=20$' "$GITHUB_OUTPUT"
 	assert_output --partial "Pages coverage node version: 20"
+	run grep -q '^pages-coverage-node-version=20$' "$GITHUB_OUTPUT"
+	assert_success
 }
 
 @test "generate-node-matrix: uses sole node-version when matrix is disabled" {
 	NODE_VERSION=22 NODE_VERSIONS= run bash "$SCRIPT"
 	assert_success
-	grep -q '^pages-coverage-node-version=22$' "$GITHUB_OUTPUT"
+	assert_output --partial "Pages coverage node version: 22"
+	run grep -q '^pages-coverage-node-version=22$' "$GITHUB_OUTPUT"
+	assert_success
 }

--- a/tests/bats/unit/actions/test_pages_coverage_upload_gate.bats
+++ b/tests/bats/unit/actions/test_pages_coverage_upload_gate.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for pages-coverage-upload-gate.sh
+
+load "../../../helpers/common"
+load "../../../helpers/github_env"
+
+setup() {
+	setup_github_env
+	export SCRIPT="$PROJECT_ROOT/scripts/ci/actions/pages-coverage-upload-gate.sh"
+}
+
+@test "pages-coverage-upload-gate: push-main allows push to main" {
+	GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/main PAGES_COVERAGE_UPLOAD_ON=push-main \
+		run bash "$SCRIPT"
+	assert_success
+	grep -q '^should-upload=true$' "$GITHUB_OUTPUT"
+}
+
+@test "pages-coverage-upload-gate: push-main blocks pull requests" {
+	GITHUB_EVENT_NAME=pull_request GITHUB_REF=refs/pull/1/merge PAGES_COVERAGE_UPLOAD_ON=push-main \
+		run bash "$SCRIPT"
+	assert_success
+	grep -q '^should-upload=false$' "$GITHUB_OUTPUT"
+}
+
+@test "pages-coverage-upload-gate: push-main blocks push to non-main branches" {
+	GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/feature PAGES_COVERAGE_UPLOAD_ON=push-main \
+		run bash "$SCRIPT"
+	assert_success
+	grep -q '^should-upload=false$' "$GITHUB_OUTPUT"
+}
+
+@test "pages-coverage-upload-gate: rejects unknown upload-on values" {
+	GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/main PAGES_COVERAGE_UPLOAD_ON=always \
+		run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "Unsupported pages-coverage-upload-on"
+}

--- a/tests/bats/unit/actions/test_python_dist.bats
+++ b/tests/bats/unit/actions/test_python_dist.bats
@@ -178,6 +178,20 @@ _run_build() {
 	assert_equal "4.5.6" "$(get_github_output version)"
 }
 
+@test "python-dist extract-dist-metadata: reads hyphenated name from sdist" {
+	mkdir -p dist
+	touch dist/my-package-1.2.3.tar.gz
+
+	run env \
+		STEP=extract-dist-metadata \
+		WORKING_DIRECTORY=. \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/python-dist.sh"
+
+	assert_success
+	assert_equal "my-package" "$(get_github_output name)"
+	assert_equal "1.2.3" "$(get_github_output version)"
+}
+
 @test "python-dist extract-dist-metadata: prefers pyproject over wheel" {
 	_write_pyproject "9.9.9"
 	mkdir -p dist

--- a/tests/bats/unit/actions/test_python_dist.bats
+++ b/tests/bats/unit/actions/test_python_dist.bats
@@ -3,9 +3,11 @@
 # Purpose: Tests for scripts/ci/actions/python-dist.sh preflight step
 
 load "../../../helpers/common"
+load "../../../helpers/github_env"
 
 setup() {
 	setup_temp_dir
+	setup_github_env
 	export REPO_ROOT="${BATS_TEST_TMPDIR}/repo"
 	export ORIGIN="${BATS_TEST_TMPDIR}/origin.git"
 	mkdir -p "$REPO_ROOT"
@@ -13,6 +15,7 @@ setup() {
 }
 
 teardown() {
+	teardown_github_env
 	teardown_temp_dir
 }
 
@@ -145,4 +148,68 @@ _run_build() {
 
 	assert_failure
 	assert_output --partial "outside repository root"
+}
+
+@test "python-dist extract-dist-metadata: reads name and version from wheel" {
+	mkdir -p dist
+	touch dist/example-1.2.3-py3-none-any.whl
+
+	run env \
+		STEP=extract-dist-metadata \
+		WORKING_DIRECTORY=. \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/python-dist.sh"
+
+	assert_success
+	assert_equal "example" "$(get_github_output name)"
+	assert_equal "1.2.3" "$(get_github_output version)"
+}
+
+@test "python-dist extract-dist-metadata: reads name and version from sdist" {
+	mkdir -p dist
+	touch dist/example-4.5.6.tar.gz
+
+	run env \
+		STEP=extract-dist-metadata \
+		WORKING_DIRECTORY=. \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/python-dist.sh"
+
+	assert_success
+	assert_equal "example" "$(get_github_output name)"
+	assert_equal "4.5.6" "$(get_github_output version)"
+}
+
+@test "python-dist extract-dist-metadata: prefers pyproject over wheel" {
+	_write_pyproject "9.9.9"
+	mkdir -p dist
+	touch dist/example-1.2.3-py3-none-any.whl
+
+	run env \
+		STEP=extract-dist-metadata \
+		WORKING_DIRECTORY=. \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/python-dist.sh"
+
+	assert_success
+	assert_equal "example" "$(get_github_output name)"
+	assert_equal "9.9.9" "$(get_github_output version)"
+}
+
+@test "python-dist summary: uses PACKAGE_NAME and PACKAGE_VERSION env" {
+	mkdir -p dist
+	touch dist/example-1.2.3-py3-none-any.whl
+
+	run env \
+		STEP=summary \
+		WORKING_DIRECTORY=. \
+		PACKAGE_NAME=example \
+		PACKAGE_VERSION=1.2.3 \
+		PUBLISHED=true \
+		TEST_PYPI=false \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/python-dist.sh"
+
+	assert_success
+	local summary
+	summary=$(get_github_step_summary)
+	[[ "$summary" == *"| Package | example |"* ]]
+	[[ "$summary" == *"| Version | 1.2.3 |"* ]]
+	[[ "$summary" == *"https://pypi.org/project/example/1.2.3/"* ]]
 }

--- a/tests/bats/unit/actions/test_record_pages_coverage_upload_status.bats
+++ b/tests/bats/unit/actions/test_record_pages_coverage_upload_status.bats
@@ -17,32 +17,34 @@ setup() {
 	assert_success
 }
 
-@test "record-pages-coverage-upload-status: reports true after successful main push" {
-	UPLOAD_PAGES_COVERAGE_HTML=true COVERAGE=true \
-		TEST_COMMAND="" TEST_VITEST_RESULT=success TEST_CUSTOM_RESULT=skipped \
-		GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/main \
+@test "record-pages-coverage-upload-status: reports true when upload step succeeded" {
+	UPLOAD_PAGES_COVERAGE_HTML=true COVERAGE=true PAGES_UPLOAD_OUTCOME=success \
 		run bash "$SCRIPT"
 	assert_success
 	run grep -q '^uploaded=true$' "$GITHUB_OUTPUT"
 	assert_success
 }
 
-@test "record-pages-coverage-upload-status: reports false on pull requests" {
-	UPLOAD_PAGES_COVERAGE_HTML=true COVERAGE=true \
-		TEST_COMMAND="" TEST_VITEST_RESULT=success TEST_CUSTOM_RESULT=skipped \
-		GITHUB_EVENT_NAME=pull_request GITHUB_REF=refs/pull/1/merge \
+@test "record-pages-coverage-upload-status: reports false when upload step failed" {
+	UPLOAD_PAGES_COVERAGE_HTML=true COVERAGE=true PAGES_UPLOAD_OUTCOME=failure \
 		run bash "$SCRIPT"
 	assert_success
 	run grep -q '^uploaded=false$' "$GITHUB_OUTPUT"
 	assert_success
 }
 
-@test "record-pages-coverage-upload-status: uses custom test job result" {
-	UPLOAD_PAGES_COVERAGE_HTML=true COVERAGE=true \
-		TEST_COMMAND="bun run test:coverage" TEST_VITEST_RESULT=skipped \
-		TEST_CUSTOM_RESULT=success GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/main \
+@test "record-pages-coverage-upload-status: reports false when upload step skipped" {
+	UPLOAD_PAGES_COVERAGE_HTML=true COVERAGE=true PAGES_UPLOAD_OUTCOME=skipped \
 		run bash "$SCRIPT"
 	assert_success
-	run grep -q '^uploaded=true$' "$GITHUB_OUTPUT"
+	run grep -q '^uploaded=false$' "$GITHUB_OUTPUT"
+	assert_success
+}
+
+@test "record-pages-coverage-upload-status: reports false when upload outcome missing" {
+	UPLOAD_PAGES_COVERAGE_HTML=true COVERAGE=true PAGES_UPLOAD_OUTCOME="" \
+		run bash "$SCRIPT"
+	assert_success
+	run grep -q '^uploaded=false$' "$GITHUB_OUTPUT"
 	assert_success
 }

--- a/tests/bats/unit/actions/test_record_pages_coverage_upload_status.bats
+++ b/tests/bats/unit/actions/test_record_pages_coverage_upload_status.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for record-pages-coverage-upload-status.sh
+
+load "../../../helpers/common"
+load "../../../helpers/github_env"
+
+setup() {
+	setup_github_env
+	export SCRIPT="$PROJECT_ROOT/scripts/ci/actions/record-pages-coverage-upload-status.sh"
+}
+
+@test "record-pages-coverage-upload-status: reports false when upload disabled" {
+	UPLOAD_PAGES_COVERAGE_HTML=false COVERAGE=true run bash "$SCRIPT"
+	assert_success
+	run grep -q '^uploaded=false$' "$GITHUB_OUTPUT"
+	assert_success
+}
+
+@test "record-pages-coverage-upload-status: reports true after successful main push" {
+	UPLOAD_PAGES_COVERAGE_HTML=true COVERAGE=true \
+		TEST_COMMAND="" TEST_VITEST_RESULT=success TEST_CUSTOM_RESULT=skipped \
+		GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/main \
+		run bash "$SCRIPT"
+	assert_success
+	run grep -q '^uploaded=true$' "$GITHUB_OUTPUT"
+	assert_success
+}
+
+@test "record-pages-coverage-upload-status: reports false on pull requests" {
+	UPLOAD_PAGES_COVERAGE_HTML=true COVERAGE=true \
+		TEST_COMMAND="" TEST_VITEST_RESULT=success TEST_CUSTOM_RESULT=skipped \
+		GITHUB_EVENT_NAME=pull_request GITHUB_REF=refs/pull/1/merge \
+		run bash "$SCRIPT"
+	assert_success
+	run grep -q '^uploaded=false$' "$GITHUB_OUTPUT"
+	assert_success
+}
+
+@test "record-pages-coverage-upload-status: uses custom test job result" {
+	UPLOAD_PAGES_COVERAGE_HTML=true COVERAGE=true \
+		TEST_COMMAND="bun run test:coverage" TEST_VITEST_RESULT=skipped \
+		TEST_CUSTOM_RESULT=success GITHUB_EVENT_NAME=push GITHUB_REF=refs/heads/main \
+		run bash "$SCRIPT"
+	assert_success
+	run grep -q '^uploaded=true$' "$GITHUB_OUTPUT"
+	assert_success
+}

--- a/tests/bats/unit/actions/test_record_pages_upload_outcome.bats
+++ b/tests/bats/unit/actions/test_record_pages_upload_outcome.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for record-pages-upload-outcome.sh
+
+load "../../../helpers/common"
+load "../../../helpers/github_env"
+
+setup() {
+	setup_github_env
+	export SCRIPT="$PROJECT_ROOT/scripts/ci/actions/record-pages-upload-outcome.sh"
+}
+
+@test "record-pages-upload-outcome: writes upload step outcome" {
+	PAGES_UPLOAD_OUTCOME=success run bash "$SCRIPT"
+	assert_success
+	run grep -q '^outcome=success$' "$GITHUB_OUTPUT"
+	assert_success
+}
+
+@test "record-pages-upload-outcome: writes empty outcome when unset" {
+	run bash "$SCRIPT"
+	assert_success
+	run grep -q '^outcome=$' "$GITHUB_OUTPUT"
+	assert_success
+}

--- a/tests/bats/unit/actions/test_stage_node_coverage.bats
+++ b/tests/bats/unit/actions/test_stage_node_coverage.bats
@@ -6,7 +6,7 @@ load "../../../helpers/common"
 
 setup() {
 	setup_temp_dir
-	cd "$BATS_TEST_TMPDIR" || exit 1
+	cd "$BATS_TEST_TMPDIR" || return 1
 	export SCRIPT="$PROJECT_ROOT/scripts/ci/actions/stage-node-coverage.sh"
 }
 

--- a/tests/bats/unit/actions/test_stage_node_coverage.bats
+++ b/tests/bats/unit/actions/test_stage_node_coverage.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Regression tests for stage-node-coverage.sh matrix layout
+
+load "../../../helpers/common"
+
+setup() {
+	setup_temp_dir
+	cd "$BATS_TEST_TMPDIR" || exit 1
+	export SCRIPT="$PROJECT_ROOT/scripts/ci/actions/stage-node-coverage.sh"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "stage-node-coverage: keeps matrix-specific nested layout" {
+	mkdir -p apps/web/coverage
+	echo '{}' >apps/web/coverage/coverage-summary.json
+	echo '{}' >apps/web/vitest-results.json
+
+	NODE_VERSION=22 WORKING_DIRECTORY=apps/web run bash "$SCRIPT"
+	assert_success
+	assert_file_exists node-coverage-22/apps/web/coverage/coverage-summary.json
+	assert_file_exists node-coverage-22/apps/web/vitest-results.json
+	run test ! -e pages-coverage-html
+	assert_success
+}

--- a/tests/bats/unit/actions/test_stage_node_pages_coverage.bats
+++ b/tests/bats/unit/actions/test_stage_node_pages_coverage.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for stage-node-pages-coverage.sh
+
+load "../../../helpers/common"
+
+setup() {
+	setup_temp_dir
+	cd "$BATS_TEST_TMPDIR" || exit 1
+	export SCRIPT="$PROJECT_ROOT/scripts/ci/actions/stage-node-pages-coverage.sh"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "stage-node-pages-coverage: copies coverage tree to flat staging dir" {
+	mkdir -p apps/web/coverage
+	echo '<html>coverage</html>' >apps/web/coverage/index.html
+
+	WORKING_DIRECTORY=apps/web PAGES_COVERAGE_STAGING_DIR=flat-coverage \
+		run bash "$SCRIPT"
+	assert_success
+	assert_file_exists flat-coverage/index.html
+	run grep -q 'coverage' flat-coverage/index.html
+	assert_success
+}
+
+@test "stage-node-pages-coverage: fails when source directory is missing" {
+	WORKING_DIRECTORY=missing run bash "$SCRIPT"
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"Pages coverage source directory missing"* ]]
+}
+
+@test "stage-node-pages-coverage: fails when index.html is missing" {
+	mkdir -p coverage
+	WORKING_DIRECTORY=. run bash "$SCRIPT"
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"Pages coverage HTML missing index.html"* ]]
+}
+
+@test "stage-node-pages-coverage: honors pages-coverage-source-subpath" {
+	mkdir -p reports/html
+	echo '<html>report</html>' >reports/html/index.html
+
+	WORKING_DIRECTORY=. PAGES_COVERAGE_SOURCE_SUBPATH=reports/html \
+		PAGES_COVERAGE_STAGING_DIR=staged \
+		run bash "$SCRIPT"
+	assert_success
+	assert_file_exists staged/index.html
+}

--- a/tests/bats/unit/actions/test_stage_node_pages_coverage.bats
+++ b/tests/bats/unit/actions/test_stage_node_pages_coverage.bats
@@ -18,8 +18,7 @@ teardown() {
 	mkdir -p apps/web/coverage
 	echo '<html>coverage</html>' >apps/web/coverage/index.html
 
-	WORKING_DIRECTORY=apps/web PAGES_COVERAGE_STAGING_DIR=flat-coverage \
-		run bash "$SCRIPT"
+	run env WORKING_DIRECTORY=apps/web PAGES_COVERAGE_STAGING_DIR=flat-coverage bash "$SCRIPT"
 	assert_success
 	assert_file_exists flat-coverage/index.html
 	run grep -q 'coverage' flat-coverage/index.html

--- a/tests/bats/unit/actions/test_stage_node_pages_coverage.bats
+++ b/tests/bats/unit/actions/test_stage_node_pages_coverage.bats
@@ -6,7 +6,7 @@ load "../../../helpers/common"
 
 setup() {
 	setup_temp_dir
-	cd "$BATS_TEST_TMPDIR" || exit 1
+	cd "$BATS_TEST_TMPDIR" || return 1
 	export SCRIPT="$PROJECT_ROOT/scripts/ci/actions/stage-node-pages-coverage.sh"
 }
 
@@ -27,16 +27,16 @@ teardown() {
 }
 
 @test "stage-node-pages-coverage: fails when source directory is missing" {
-	WORKING_DIRECTORY=missing run bash "$SCRIPT"
-	[ "$status" -eq 1 ]
-	[[ "$output" == *"Pages coverage source directory missing"* ]]
+	run env WORKING_DIRECTORY=missing bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "Pages coverage source directory missing"
 }
 
 @test "stage-node-pages-coverage: fails when index.html is missing" {
 	mkdir -p coverage
-	WORKING_DIRECTORY=. run bash "$SCRIPT"
-	[ "$status" -eq 1 ]
-	[[ "$output" == *"Pages coverage HTML missing index.html"* ]]
+	run env WORKING_DIRECTORY=. bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "Pages coverage HTML missing index.html"
 }
 
 @test "stage-node-pages-coverage: honors pages-coverage-source-subpath" {

--- a/tests/bats/unit/actions/test_stage_node_pages_coverage.bats
+++ b/tests/bats/unit/actions/test_stage_node_pages_coverage.bats
@@ -42,9 +42,8 @@ teardown() {
 	mkdir -p reports/html
 	echo '<html>report</html>' >reports/html/index.html
 
-	WORKING_DIRECTORY=. PAGES_COVERAGE_SOURCE_SUBPATH=reports/html \
-		PAGES_COVERAGE_STAGING_DIR=staged \
-		run bash "$SCRIPT"
+	run env WORKING_DIRECTORY=. PAGES_COVERAGE_SOURCE_SUBPATH=reports/html \
+		PAGES_COVERAGE_STAGING_DIR=staged bash "$SCRIPT"
 	assert_success
 	assert_file_exists staged/index.html
 }

--- a/tests/bats/unit/lib/bundle/test_workflow_artifacts.bats
+++ b/tests/bats/unit/lib/bundle/test_workflow_artifacts.bats
@@ -272,6 +272,17 @@ EOF
 	assert_success
 }
 
+@test "bundle_run_manifest: copies rust-coverage-html artifact into site root" {
+	_setup_bundle_gh_mock
+	bundle_load_manifest '{"bundles":[{"id":"rust-coverage","workflow":"coverage-reports","artifact":"rust-coverage-html","dest":"coverage-rust"}]}'
+
+	run bundle_run_manifest
+	assert_success
+	assert_file_exists "${SITE_ROOT}/coverage-rust/index.html"
+	run grep -q 'report' "${SITE_ROOT}/coverage-rust/index.html"
+	assert_success
+}
+
 @test "bundle_run_manifest: records github outputs" {
 	_setup_bundle_gh_mock
 	bundle_load_manifest '{"bundles":[{"id":"coverage","workflow":"quality-ci-main","artifact":"coverage-html","dest":"coverage"}]}'

--- a/tests/bats/unit/lib/publish/test_validate.bats
+++ b/tests/bats/unit/lib/publish/test_validate.bats
@@ -117,7 +117,7 @@ teardown() {
 
 	run bash -c "
 		command() {
-			if [[ \"\$2\" == \"twine\" ]] || [[ \"\$2\" == \"uv\" ]]; then return 1; fi
+			if [[ \"\$1\" == \"-v\" && \"\$2\" == \"twine\" ]]; then return 1; fi
 			builtin command \"\$@\"
 		}
 		source \"\$LIB_DIR/log.sh\"

--- a/tests/bats/unit/lib/publish/test_validate.bats
+++ b/tests/bats/unit/lib/publish/test_validate.bats
@@ -116,6 +116,10 @@ teardown() {
 	mock_command_record "uv" "Checking dist/package-1.0.0.tar.gz: PASSED"
 
 	run bash -c "
+		command() {
+			if [[ \"\$2\" == \"twine\" ]] || [[ \"\$2\" == \"uv\" ]]; then return 1; fi
+			builtin command \"\$@\"
+		}
 		source \"\$LIB_DIR/log.sh\"
 		source \"\$LIB_DIR/publish/validate.sh\"
 		validate_pypi_package \"$dist_dir\" 2>&1

--- a/tests/bats/unit/lib/test_pages_coverage.bats
+++ b/tests/bats/unit/lib/test_pages_coverage.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for pages_coverage.sh helpers
+
+load "../../../helpers/common"
+load "../../../helpers/github_env"
+
+setup() {
+	setup_github_env
+	# shellcheck source=../../../../../scripts/ci/lib/pages_coverage.sh
+	source "${PROJECT_ROOT}/scripts/ci/lib/pages_coverage.sh"
+}
+
+@test "resolve_pages_coverage_should_upload: push-main allows push to main" {
+	run resolve_pages_coverage_should_upload push-main push refs/heads/main
+	assert_success
+	assert_output "true"
+}
+
+@test "resolve_pages_coverage_should_upload: push-main blocks pull requests" {
+	run resolve_pages_coverage_should_upload push-main pull_request refs/pull/1/merge
+	assert_success
+	assert_output "false"
+}
+
+@test "resolve_pages_coverage_should_upload: rejects unknown upload-on values" {
+	run resolve_pages_coverage_should_upload always push refs/heads/main
+	assert_failure
+	assert_output --partial "Unsupported pages-coverage-upload-on"
+}

--- a/tests/bats/unit/testing/rust/test_run_rust_coverage_html.bats
+++ b/tests/bats/unit/testing/rust/test_run_rust_coverage_html.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for run-rust-coverage-html.sh flatten layout
+
+load "../../../../helpers/common"
+
+setup() {
+	setup_temp_dir
+	cd "$BATS_TEST_TMPDIR" || exit 1
+	export SCRIPT="$PROJECT_ROOT/scripts/ci/testing/rust/run-rust-coverage-html.sh"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+_install_fake_cargo_llvm_cov() {
+	local bin_dir="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$bin_dir"
+	cat >"${bin_dir}/cargo-llvm-cov" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+	cat >"${bin_dir}/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "llvm-cov" && "${2:-}" == "report" && "${3:-}" == "--html" ]]; then
+	output_dir=""
+	for ((i = 4; i <= $#; i++)); do
+		if [[ "${!i}" == "--output-dir" ]]; then
+			next=$((i + 1))
+			output_dir="${!next}"
+		fi
+	done
+	mkdir -p "${output_dir}/html"
+	echo '<html>rust coverage</html>' >"${output_dir}/html/index.html"
+	exit 0
+fi
+echo "unexpected cargo invocation: $*" >&2
+exit 1
+EOF
+	chmod +x "${bin_dir}/cargo-llvm-cov" "${bin_dir}/cargo"
+	export PATH="${bin_dir}:$PATH"
+}
+
+@test "run-rust-coverage-html: flattens cargo llvm-cov html layout" {
+	_install_fake_cargo_llvm_cov
+
+	RUST_COVERAGE_HTML_DIR=rust-coverage-html run bash "$SCRIPT"
+	assert_success
+	assert_file_exists rust-coverage-html/index.html
+	run test ! -d rust-coverage-html/html
+	assert_success
+	run grep -q 'rust coverage' rust-coverage-html/index.html
+	assert_success
+}
+
+@test "run-rust-coverage-html: fails when cargo-llvm-cov is missing" {
+	local bash_dir
+	bash_dir="$(dirname "$(command -v bash)")"
+
+	run env PATH="${bash_dir}" bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "cargo-llvm-cov is required"
+}
+
+@test "run-rust-coverage-html: fails when html directory is missing" {
+	local bin_dir="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$bin_dir"
+	cat >"${bin_dir}/cargo-llvm-cov" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+	cat >"${bin_dir}/cargo" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+	chmod +x "${bin_dir}/cargo-llvm-cov" "${bin_dir}/cargo"
+	export PATH="${bin_dir}:$PATH"
+
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "Expected"
+}

--- a/tests/bats/unit/testing/rust/test_run_rust_coverage_html.bats
+++ b/tests/bats/unit/testing/rust/test_run_rust_coverage_html.bats
@@ -15,13 +15,20 @@ teardown() {
 }
 
 _install_fake_cargo_llvm_cov() {
+	local mode="${1:-html}"
 	local bin_dir="${BATS_TEST_TMPDIR}/bin"
 	mkdir -p "$bin_dir"
 	cat >"${bin_dir}/cargo-llvm-cov" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
-	cat >"${bin_dir}/cargo" <<'EOF'
+	if [[ "$mode" == "no-html" ]]; then
+		cat >"${bin_dir}/cargo" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+	else
+		cat >"${bin_dir}/cargo" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 if [[ "${1:-}" == "llvm-cov" && "${2:-}" == "report" && "${3:-}" == "--html" ]]; then
@@ -39,6 +46,7 @@ fi
 echo "unexpected cargo invocation: $*" >&2
 exit 1
 EOF
+	fi
 	chmod +x "${bin_dir}/cargo-llvm-cov" "${bin_dir}/cargo"
 	export PATH="${bin_dir}:$PATH"
 }
@@ -65,18 +73,7 @@ EOF
 }
 
 @test "run-rust-coverage-html: fails when html directory is missing" {
-	local bin_dir="${BATS_TEST_TMPDIR}/bin"
-	mkdir -p "$bin_dir"
-	cat >"${bin_dir}/cargo-llvm-cov" <<'EOF'
-#!/usr/bin/env bash
-exit 0
-EOF
-	cat >"${bin_dir}/cargo" <<'EOF'
-#!/usr/bin/env bash
-exit 0
-EOF
-	chmod +x "${bin_dir}/cargo-llvm-cov" "${bin_dir}/cargo"
-	export PATH="${bin_dir}:$PATH"
+	_install_fake_cargo_llvm_cov no-html
 
 	run bash "$SCRIPT"
 	assert_failure

--- a/tests/bats/unit/testing/rust/test_run_rust_coverage_html.bats
+++ b/tests/bats/unit/testing/rust/test_run_rust_coverage_html.bats
@@ -6,7 +6,7 @@ load "../../../../helpers/common"
 
 setup() {
 	setup_temp_dir
-	cd "$BATS_TEST_TMPDIR" || exit 1
+	cd "$BATS_TEST_TMPDIR" || return 1
 	export SCRIPT="$PROJECT_ROOT/scripts/ci/testing/rust/run-rust-coverage-html.sh"
 }
 

--- a/tests/bats/unit/testing/rust/test_run_rust_coverage_html.bats
+++ b/tests/bats/unit/testing/rust/test_run_rust_coverage_html.bats
@@ -79,3 +79,15 @@ EOF
 	assert_failure
 	assert_output --partial "Expected"
 }
+
+@test "run-rust-coverage-html: rejects unsafe output directory" {
+	_install_fake_cargo_llvm_cov
+
+	run env RUST_COVERAGE_HTML_DIR=".." bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "Unsafe RUST_COVERAGE_HTML_DIR"
+
+	run env RUST_COVERAGE_HTML_DIR="/tmp/rust-coverage" bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "repo-relative"
+}


### PR DESCRIPTION
## Summary

Add optional flat HTML coverage artifacts to `reusable-rust-coverage` and
`reusable-test-node` so Model B site deploys can bundle browsable coverage
reports without consumer repack jobs. Also fixes Rust coverage checkout order
and static Node job names for skipped-by-design matrix paths.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

**Consumer config (branch protection):** `reusable-test-node` matrix job check
names are now static — `Node.js tests (Vitest)` and
`Node.js tests (custom command)` — instead of caller-derived names from
`inputs.job-name` / matrix version (e.g. `Build & Test (20)`). Update required
status checks that matched the old names when upgrading. See `CHANGELOG.md`
`[Unreleased]` and `docs/reusable-workflows.md` (Job display names).

## Closes

- Closes #251
- Relates to #226
- Relates to lgtm-hq/Rustume#263

## Changes Made

- Add `run-rust-coverage-html.sh`, `stage-node-pages-coverage.sh`,
  `pages-coverage-upload-gate.sh`, and `record-pages-coverage-upload-status.sh`
- Extend `reusable-test-rust-coverage` / `reusable-rust-coverage` with
  `upload-pages-coverage-html`, artifact naming, push-main gating, and outputs
- Fix Rust coverage checkout order (harden → repo → tooling)
- Extend `reusable-test-node` with flat `coverage-html` upload from the first
  matrix leg, static Vitest/custom job names, and non-matrix upload status job
- Document inputs/outputs in `docs/reusable-workflows.md` and add
  `rust-coverage-html` to `examples/bundle-manifest-turbo-themes.json`
- Add BATS unit/integration coverage for scripts, workflows, and bundle fixtures

## Testing

- [x] `uv run lintro chk` (zero issues)
- [x] `uv run lintro tst` / BATS suite (1775+ tests)
- [x] CodeRabbit review — actionable findings addressed (remaining items are
  pre-existing or trivial DRY suggestions outside this scope)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Pages HTML coverage artifact upload support to Rust and Node reusable workflows
> - Adds `upload-pages-coverage-html`, `pages-coverage-artifact-name`, and `pages-coverage-upload-on` inputs to [`reusable-rust-coverage.yml`](https://github.com/lgtm-hq/lgtm-ci/pull/256/files#diff-78f1b9649095b64e3f3c5320484007dfcc0b13ba6d4e2e9050690f13c3d9afd1), [`reusable-test-rust-coverage.yml`](https://github.com/lgtm-hq/lgtm-ci/pull/256/files#diff-e0c8bd19c82bbecc2659e8bb77447e4ae4d6727b8e1320a69eeff6d608afad8a), and [`reusable-test-node.yml`](https://github.com/lgtm-hq/lgtm-ci/pull/256/files#diff-cfb6bc8637ac27e7e0117be0e18a78ae566c2239523a9ef5c4fa80b8db205c55), with matching `pages-coverage-artifact-name` and `pages-coverage-uploaded` outputs.
> - Adds [`run-rust-coverage-html.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/256/files#diff-21cb5c0437bd4a9c2cf5dea1c1586bd1db6178fcf28820029bc36b818af6a2e5) to generate a flat, browsable Rust HTML coverage directory using `cargo llvm-cov`, and [`stage-node-pages-coverage.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/256/files#diff-0dc29f436c703fec491de7cd855f70aaa156eaa2d43d5ad625b59f99472e65d0) to validate and stage Node.js HTML coverage for upload.
> - Gating logic in [`pages-coverage-upload-gate.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/256/files#diff-79dc91f148ace1eba5b25e02fac3133293cc51bf51068fd9ff11d9d5c0a8f583) and [`pages_coverage.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/256/files#diff-4d8489cf541f777fde3350350056ad40fae037e15e2c211d1e4d5eeab600c581) restricts uploads to push-to-main events (`push-main` mode); unknown gate values error out.
> - A new `pages-coverage-status` job in the Node workflow aggregates per-matrix-leg outcomes into a single `pages-coverage-uploaded` flag; the Rust workflow exposes the same flag directly from the coverage job.
> - Adds a `rust-coverage` bundle entry in [`bundle-manifest-turbo-themes.json`](https://github.com/lgtm-hq/lgtm-ci/pull/256/files#diff-5db0a399b29da175c1b97ca1a931c3a3edd1eb1a02b8f57eced3b0061a90f51b) mapping the `rust-coverage-html` artifact into the site at `coverage-rust`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ba1036.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Pages coverage HTML uploads for Node and Rust workflows with configurable artifact names, triggers, staging, and upload outcome reporting.

* **Documentation**
  * Docs updated with Pages coverage HTML inputs, examples, and usage guidance.

* **Tests**
  * Expanded Bats suites to validate workflow wiring, gating, staging, generation, and upload outcome behavior.

* **Chores**
  * Added Rust coverage bundle to manifests; improved CI scripts, runner hardening, and packaging metadata extraction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds optional flat HTML coverage artifact uploads to the `reusable-rust-coverage` and `reusable-test-node` reusable workflows for Model B Pages site bundling, along with a fix to the Rust coverage checkout order and static job names for the Node matrix.

- New scripts (`run-rust-coverage-html.sh`, `stage-node-pages-coverage.sh`, `pages-coverage-upload-gate.sh`, `record-pages-coverage-upload-status.sh`, `pages_coverage.sh`) wire up HTML generation, push-main gating, staging, and upload for both Rust and Node paths.
- For Node, only the first matrix version stages/uploads the Pages artifact; a non-matrix `pages-coverage-status` aggregation job surfaces the upload outcome to workflow outputs.
- `reusable-test-rust-coverage.yml` checkout order is corrected (harden → repo → tooling), and the new HTML generation step currently lacks `continue-on-error: true`, allowing optional HTML failures to fail the entire coverage job.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge with two targeted fixes: one in the Rust workflow and one in the Node matrix output plumbing.

The Rust coverage HTML generation step has no continue-on-error: true, so any failure in the supplemental HTML step marks the whole coverage job as failed and makes outputs.passed report false even when actual coverage succeeded. Separately, the Node matrix pages-upload-outcome job output is written by all matrix instances but only the first version produces a non-empty value; whichever instance finishes last wins, so on multi-version matrices the aggregated output is non-deterministic and can incorrectly report the artifact as not uploaded. All other changes are well-structured and correct.

.github/workflows/reusable-test-rust-coverage.yml (HTML generation step) and .github/workflows/reusable-test-node.yml (matrix job output aggregation for pages-upload-outcome)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-test-rust-coverage.yml | Adds pages coverage HTML upload steps; checkout order fixed; 'Generate Rust coverage HTML' lacks continue-on-error, causing coverage job to incorrectly report failure when HTML generation fails |
| .github/workflows/reusable-test-node.yml | Adds pages coverage HTML upload to matrix jobs and a status aggregation job; matrix output race condition on pages-upload-outcome for multi-version matrices |
| .github/workflows/reusable-rust-coverage.yml | Thin pass-through wrapper; correctly threads new inputs/outputs to the inner workflow |
| scripts/ci/testing/rust/run-rust-coverage-html.sh | New script; validates output dir, runs cargo llvm-cov report --html, and promotes the html/ subdir; path-traversal guard and existence checks are solid |
| scripts/ci/actions/stage-node-pages-coverage.sh | New script; validates source dir and index.html presence before staging; straightforward and correct |
| scripts/ci/lib/pages_coverage.sh | New library; resolve_pages_coverage_should_upload correctly gates on push-to-main and exits 1 for unsupported policies |
| scripts/ci/actions/record-pages-coverage-upload-status.sh | New script; now observes the real pages-upload step outcome forwarded from the matrix job rather than re-deriving it |
| scripts/ci/actions/python-dist.sh | Adds extract-dist-metadata step and hardens validate_working_directory; validation now runs for all STEP values including summary/set-published which previously didn't require a valid directory |
| .github/actions/build-python-package/action.yml | Fixes SCRIPTS_DIR resolution to use git rev-parse rather than fragile path arithmetic; correctly falls back to string trimming outside a git repo |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant P as prepare
    participant TV as test-vitest (matrix)
    participant TC as test-custom (matrix)
    participant PCS as pages-coverage-status
    participant AT as aggregate-tests

    P->>TV: matrix + pages-coverage-node-version
    P->>TC: matrix + pages-coverage-node-version

    TV->>TV: run vitest + coverage
    TV->>TV: pages-upload-gate (push-main check)
    TV->>TV: stage-node-pages-coverage (first version only)
    TV->>TV: upload-artifact (first version only)
    TV->>TV: record-pages-upload-outcome (first version only)
    TV-->>PCS: pages-upload-outcome (race: last matrix instance wins)

    TC->>TC: run custom command + coverage
    TC->>TC: pages-upload-gate (push-main check)
    TC->>TC: stage-node-pages-coverage (first version only)
    TC->>TC: upload-artifact (first version only)
    TC->>TC: record-pages-upload-outcome (first version only)
    TC-->>PCS: pages-upload-outcome (race: last matrix instance wins)

    PCS->>PCS: record-pages-coverage-upload-status
    PCS-->>AT: pages-coverage-uploaded output
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/reusable-test-node.yml`, line 266-272 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/8ba1036c10724aa841d16ea0168c15c3ee1230e5/.github/workflows/reusable-test-node.yml#L266-L272)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Matrix output race condition for `pages-upload-outcome`**

   `test-vitest` (and `test-custom`) is a matrix job. Every matrix instance writes the job-level `pages-upload-outcome` output, but only the instance whose `matrix.node-version` matches `pages-coverage-node-version` runs `record-pages-upload-outcome` — all other instances set this output to empty string (skipped step → no output value). GitHub Actions "last writer wins" aggregation means that if any non-first version instance completes last, `needs.test-vitest.outputs.pages-upload-outcome` is empty in `pages-coverage-status`, `PAGES_UPLOAD_OUTCOME` is empty, and `record-pages-coverage-upload-status.sh` emits `uploaded=false` even though the artifact was successfully uploaded.

   The same race applies to `test-custom.outputs.pages-upload-outcome`. Single-version matrices aren't affected, but any consumer that passes multiple `node-versions` will be flaky on this output.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-test-node.yml%0ALine%3A%20266-272%0A%0AComment%3A%0A**Matrix%20output%20race%20condition%20for%20%60pages-upload-outcome%60**%0A%0A%60test-vitest%60%20%28and%20%60test-custom%60%29%20is%20a%20matrix%20job.%20Every%20matrix%20instance%20writes%20the%20job-level%20%60pages-upload-outcome%60%20output%2C%20but%20only%20the%20instance%20whose%20%60matrix.node-version%60%20matches%20%60pages-coverage-node-version%60%20runs%20%60record-pages-upload-outcome%60%20%E2%80%94%20all%20other%20instances%20set%20this%20output%20to%20empty%20string%20%28skipped%20step%20%E2%86%92%20no%20output%20value%29.%20GitHub%20Actions%20%22last%20writer%20wins%22%20aggregation%20means%20that%20if%20any%20non-first%20version%20instance%20completes%20last%2C%20%60needs.test-vitest.outputs.pages-upload-outcome%60%20is%20empty%20in%20%60pages-coverage-status%60%2C%20%60PAGES_UPLOAD_OUTCOME%60%20is%20empty%2C%20and%20%60record-pages-coverage-upload-status.sh%60%20emits%20%60uploaded%3Dfalse%60%20even%20though%20the%20artifact%20was%20successfully%20uploaded.%0A%0AThe%20same%20race%20applies%20to%20%60test-custom.outputs.pages-upload-outcome%60.%20Single-version%20matrices%20aren't%20affected%2C%20but%20any%20consumer%20that%20passes%20multiple%20%60node-versions%60%20will%20be%20flaky%20on%20this%20output.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=256&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-test-node.yml%0ALine%3A%20266-272%0A%0AComment%3A%0A**Matrix%20output%20race%20condition%20for%20%60pages-upload-outcome%60**%0A%0A%60test-vitest%60%20%28and%20%60test-custom%60%29%20is%20a%20matrix%20job.%20Every%20matrix%20instance%20writes%20the%20job-level%20%60pages-upload-outcome%60%20output%2C%20but%20only%20the%20instance%20whose%20%60matrix.node-version%60%20matches%20%60pages-coverage-node-version%60%20runs%20%60record-pages-upload-outcome%60%20%E2%80%94%20all%20other%20instances%20set%20this%20output%20to%20empty%20string%20%28skipped%20step%20%E2%86%92%20no%20output%20value%29.%20GitHub%20Actions%20%22last%20writer%20wins%22%20aggregation%20means%20that%20if%20any%20non-first%20version%20instance%20completes%20last%2C%20%60needs.test-vitest.outputs.pages-upload-outcome%60%20is%20empty%20in%20%60pages-coverage-status%60%2C%20%60PAGES_UPLOAD_OUTCOME%60%20is%20empty%2C%20and%20%60record-pages-coverage-upload-status.sh%60%20emits%20%60uploaded%3Dfalse%60%20even%20though%20the%20artifact%20was%20successfully%20uploaded.%0A%0AThe%20same%20race%20applies%20to%20%60test-custom.outputs.pages-upload-outcome%60.%20Single-version%20matrices%20aren't%20affected%2C%20but%20any%20consumer%20that%20passes%20multiple%20%60node-versions%60%20will%20be%20flaky%20on%20this%20output.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=256&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F251-pages-model-b-coverage-html-artifacts%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F251-pages-model-b-coverage-html-artifacts%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-test-node.yml%0ALine%3A%20266-272%0A%0AComment%3A%0A**Matrix%20output%20race%20condition%20for%20%60pages-upload-outcome%60**%0A%0A%60test-vitest%60%20%28and%20%60test-custom%60%29%20is%20a%20matrix%20job.%20Every%20matrix%20instance%20writes%20the%20job-level%20%60pages-upload-outcome%60%20output%2C%20but%20only%20the%20instance%20whose%20%60matrix.node-version%60%20matches%20%60pages-coverage-node-version%60%20runs%20%60record-pages-upload-outcome%60%20%E2%80%94%20all%20other%20instances%20set%20this%20output%20to%20empty%20string%20%28skipped%20step%20%E2%86%92%20no%20output%20value%29.%20GitHub%20Actions%20%22last%20writer%20wins%22%20aggregation%20means%20that%20if%20any%20non-first%20version%20instance%20completes%20last%2C%20%60needs.test-vitest.outputs.pages-upload-outcome%60%20is%20empty%20in%20%60pages-coverage-status%60%2C%20%60PAGES_UPLOAD_OUTCOME%60%20is%20empty%2C%20and%20%60record-pages-coverage-upload-status.sh%60%20emits%20%60uploaded%3Dfalse%60%20even%20though%20the%20artifact%20was%20successfully%20uploaded.%0A%0AThe%20same%20race%20applies%20to%20%60test-custom.outputs.pages-upload-outcome%60.%20Single-version%20matrices%20aren't%20affected%2C%20but%20any%20consumer%20that%20passes%20multiple%20%60node-versions%60%20will%20be%20flaky%20on%20this%20output.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Freusable-test-rust-coverage.yml%3A161-184%0AHTML%20generation%20failure%20fails%20the%20whole%20coverage%20job%2C%20incorrectly%20reporting%20%60passed%3Dfalse%60%20even%20when%20actual%20Rust%20coverage%20succeeded.%20When%20%60run-rust-coverage-html.sh%60%20exits%20non-zero%20%28e.g.%20disk%20full%2C%20missing%20profdata%2C%20unexpected%20%60cargo%20llvm-cov%60%20output%20layout%29%2C%20the%20job%20enters%20a%20failed%20state%2C%20all%20subsequent%20non-%60always%28%29%60%20steps%20are%20skipped%2C%20and%20%60Record%20coverage%20result%60%20reads%20%60job.status%20%3D%3D%20'failure'%60%20%E2%80%94%20causing%20callers%20to%20see%20%60outputs.passed%20%3D%3D%20'false'%60%20for%20a%20run%20where%20coverage%20itself%20passed.%20Adding%20%60continue-on-error%3A%20true%60%20keeps%20the%20HTML%20step%20supplemental.%20The%20upload%20step%20condition%20should%20then%20also%20check%20%60steps.generate-html.outcome%20%3D%3D%20'success'%60%20to%20prevent%20uploading%20an%20empty%2Fmissing%20directory.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Generate%20Rust%20coverage%20HTML%0A%20%20%20%20%20%20%20%20id%3A%20generate-html%0A%20%20%20%20%20%20%20%20if%3A%20%3E-%0A%20%20%20%20%20%20%20%20%20%20inputs.upload-pages-coverage-html%0A%20%20%20%20%20%20%20%20%20%20%26%26%20steps.rust-coverage.outcome%20%3D%3D%20'success'%0A%20%20%20%20%20%20%20%20shell%3A%20bash%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20RUST_COVERAGE_HTML_DIR%3A%20%24%7B%7B%20inputs.pages-coverage-artifact-name%20%7D%7D%0A%20%20%20%20%20%20%20%20run%3A%20%3E-%0A%20%20%20%20%20%20%20%20%20%20bash%20.lgtm-ci-tooling%2Fscripts%2Fci%2Ftesting%2Frust%2Frun-rust-coverage-html.sh%0A%20%20%20%20%20%20%20%20continue-on-error%3A%20true%0A%0A%20%20%20%20%20%20-%20name%3A%20Evaluate%20pages%20coverage%20upload%20gate%0A%20%20%20%20%20%20%20%20id%3A%20pages-upload-gate%0A%20%20%20%20%20%20%20%20if%3A%20inputs.upload-pages-coverage-html%0A%20%20%20%20%20%20%20%20shell%3A%20bash%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20PAGES_COVERAGE_UPLOAD_ON%3A%20%24%7B%7B%20inputs.pages-coverage-upload-on%20%7D%7D%0A%20%20%20%20%20%20%20%20run%3A%20bash%20.lgtm-ci-tooling%2Fscripts%2Fci%2Factions%2Fpages-coverage-upload-gate.sh%0A%0A%20%20%20%20%20%20-%20name%3A%20Upload%20pages%20coverage%20HTML%20artifact%0A%20%20%20%20%20%20%20%20id%3A%20pages-upload%0A%20%20%20%20%20%20%20%20if%3A%20%3E-%0A%20%20%20%20%20%20%20%20%20%20inputs.upload-pages-coverage-html%0A%20%20%20%20%20%20%20%20%20%20%26%26%20steps.rust-coverage.outcome%20%3D%3D%20'success'%0A%20%20%20%20%20%20%20%20%20%20%26%26%20steps.generate-html.outcome%20%3D%3D%20'success'%0A%20%20%20%20%20%20%20%20%20%20%26%26%20steps.pages-upload-gate.outputs.should-upload%20%3D%3D%20'true'%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Freusable-test-node.yml%3A266-272%0A**Matrix%20output%20race%20condition%20for%20%60pages-upload-outcome%60**%0A%0A%60test-vitest%60%20%28and%20%60test-custom%60%29%20is%20a%20matrix%20job.%20Every%20matrix%20instance%20writes%20the%20job-level%20%60pages-upload-outcome%60%20output%2C%20but%20only%20the%20instance%20whose%20%60matrix.node-version%60%20matches%20%60pages-coverage-node-version%60%20runs%20%60record-pages-upload-outcome%60%20%E2%80%94%20all%20other%20instances%20set%20this%20output%20to%20empty%20string%20%28skipped%20step%20%E2%86%92%20no%20output%20value%29.%20GitHub%20Actions%20%22last%20writer%20wins%22%20aggregation%20means%20that%20if%20any%20non-first%20version%20instance%20completes%20last%2C%20%60needs.test-vitest.outputs.pages-upload-outcome%60%20is%20empty%20in%20%60pages-coverage-status%60%2C%20%60PAGES_UPLOAD_OUTCOME%60%20is%20empty%2C%20and%20%60record-pages-coverage-upload-status.sh%60%20emits%20%60uploaded%3Dfalse%60%20even%20though%20the%20artifact%20was%20successfully%20uploaded.%0A%0AThe%20same%20race%20applies%20to%20%60test-custom.outputs.pages-upload-outcome%60.%20Single-version%20matrices%20aren't%20affected%2C%20but%20any%20consumer%20that%20passes%20multiple%20%60node-versions%60%20will%20be%20flaky%20on%20this%20output.%0A%0A&pr=256&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Freusable-test-rust-coverage.yml%3A161-184%0AHTML%20generation%20failure%20fails%20the%20whole%20coverage%20job%2C%20incorrectly%20reporting%20%60passed%3Dfalse%60%20even%20when%20actual%20Rust%20coverage%20succeeded.%20When%20%60run-rust-coverage-html.sh%60%20exits%20non-zero%20%28e.g.%20disk%20full%2C%20missing%20profdata%2C%20unexpected%20%60cargo%20llvm-cov%60%20output%20layout%29%2C%20the%20job%20enters%20a%20failed%20state%2C%20all%20subsequent%20non-%60always%28%29%60%20steps%20are%20skipped%2C%20and%20%60Record%20coverage%20result%60%20reads%20%60job.status%20%3D%3D%20'failure'%60%20%E2%80%94%20causing%20callers%20to%20see%20%60outputs.passed%20%3D%3D%20'false'%60%20for%20a%20run%20where%20coverage%20itself%20passed.%20Adding%20%60continue-on-error%3A%20true%60%20keeps%20the%20HTML%20step%20supplemental.%20The%20upload%20step%20condition%20should%20then%20also%20check%20%60steps.generate-html.outcome%20%3D%3D%20'success'%60%20to%20prevent%20uploading%20an%20empty%2Fmissing%20directory.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Generate%20Rust%20coverage%20HTML%0A%20%20%20%20%20%20%20%20id%3A%20generate-html%0A%20%20%20%20%20%20%20%20if%3A%20%3E-%0A%20%20%20%20%20%20%20%20%20%20inputs.upload-pages-coverage-html%0A%20%20%20%20%20%20%20%20%20%20%26%26%20steps.rust-coverage.outcome%20%3D%3D%20'success'%0A%20%20%20%20%20%20%20%20shell%3A%20bash%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20RUST_COVERAGE_HTML_DIR%3A%20%24%7B%7B%20inputs.pages-coverage-artifact-name%20%7D%7D%0A%20%20%20%20%20%20%20%20run%3A%20%3E-%0A%20%20%20%20%20%20%20%20%20%20bash%20.lgtm-ci-tooling%2Fscripts%2Fci%2Ftesting%2Frust%2Frun-rust-coverage-html.sh%0A%20%20%20%20%20%20%20%20continue-on-error%3A%20true%0A%0A%20%20%20%20%20%20-%20name%3A%20Evaluate%20pages%20coverage%20upload%20gate%0A%20%20%20%20%20%20%20%20id%3A%20pages-upload-gate%0A%20%20%20%20%20%20%20%20if%3A%20inputs.upload-pages-coverage-html%0A%20%20%20%20%20%20%20%20shell%3A%20bash%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20PAGES_COVERAGE_UPLOAD_ON%3A%20%24%7B%7B%20inputs.pages-coverage-upload-on%20%7D%7D%0A%20%20%20%20%20%20%20%20run%3A%20bash%20.lgtm-ci-tooling%2Fscripts%2Fci%2Factions%2Fpages-coverage-upload-gate.sh%0A%0A%20%20%20%20%20%20-%20name%3A%20Upload%20pages%20coverage%20HTML%20artifact%0A%20%20%20%20%20%20%20%20id%3A%20pages-upload%0A%20%20%20%20%20%20%20%20if%3A%20%3E-%0A%20%20%20%20%20%20%20%20%20%20inputs.upload-pages-coverage-html%0A%20%20%20%20%20%20%20%20%20%20%26%26%20steps.rust-coverage.outcome%20%3D%3D%20'success'%0A%20%20%20%20%20%20%20%20%20%20%26%26%20steps.generate-html.outcome%20%3D%3D%20'success'%0A%20%20%20%20%20%20%20%20%20%20%26%26%20steps.pages-upload-gate.outputs.should-upload%20%3D%3D%20'true'%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Freusable-test-node.yml%3A266-272%0A**Matrix%20output%20race%20condition%20for%20%60pages-upload-outcome%60**%0A%0A%60test-vitest%60%20%28and%20%60test-custom%60%29%20is%20a%20matrix%20job.%20Every%20matrix%20instance%20writes%20the%20job-level%20%60pages-upload-outcome%60%20output%2C%20but%20only%20the%20instance%20whose%20%60matrix.node-version%60%20matches%20%60pages-coverage-node-version%60%20runs%20%60record-pages-upload-outcome%60%20%E2%80%94%20all%20other%20instances%20set%20this%20output%20to%20empty%20string%20%28skipped%20step%20%E2%86%92%20no%20output%20value%29.%20GitHub%20Actions%20%22last%20writer%20wins%22%20aggregation%20means%20that%20if%20any%20non-first%20version%20instance%20completes%20last%2C%20%60needs.test-vitest.outputs.pages-upload-outcome%60%20is%20empty%20in%20%60pages-coverage-status%60%2C%20%60PAGES_UPLOAD_OUTCOME%60%20is%20empty%2C%20and%20%60record-pages-coverage-upload-status.sh%60%20emits%20%60uploaded%3Dfalse%60%20even%20though%20the%20artifact%20was%20successfully%20uploaded.%0A%0AThe%20same%20race%20applies%20to%20%60test-custom.outputs.pages-upload-outcome%60.%20Single-version%20matrices%20aren't%20affected%2C%20but%20any%20consumer%20that%20passes%20multiple%20%60node-versions%60%20will%20be%20flaky%20on%20this%20output.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=256&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F251-pages-model-b-coverage-html-artifacts%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F251-pages-model-b-coverage-html-artifacts%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Freusable-test-rust-coverage.yml%3A161-184%0AHTML%20generation%20failure%20fails%20the%20whole%20coverage%20job%2C%20incorrectly%20reporting%20%60passed%3Dfalse%60%20even%20when%20actual%20Rust%20coverage%20succeeded.%20When%20%60run-rust-coverage-html.sh%60%20exits%20non-zero%20%28e.g.%20disk%20full%2C%20missing%20profdata%2C%20unexpected%20%60cargo%20llvm-cov%60%20output%20layout%29%2C%20the%20job%20enters%20a%20failed%20state%2C%20all%20subsequent%20non-%60always%28%29%60%20steps%20are%20skipped%2C%20and%20%60Record%20coverage%20result%60%20reads%20%60job.status%20%3D%3D%20'failure'%60%20%E2%80%94%20causing%20callers%20to%20see%20%60outputs.passed%20%3D%3D%20'false'%60%20for%20a%20run%20where%20coverage%20itself%20passed.%20Adding%20%60continue-on-error%3A%20true%60%20keeps%20the%20HTML%20step%20supplemental.%20The%20upload%20step%20condition%20should%20then%20also%20check%20%60steps.generate-html.outcome%20%3D%3D%20'success'%60%20to%20prevent%20uploading%20an%20empty%2Fmissing%20directory.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20name%3A%20Generate%20Rust%20coverage%20HTML%0A%20%20%20%20%20%20%20%20id%3A%20generate-html%0A%20%20%20%20%20%20%20%20if%3A%20%3E-%0A%20%20%20%20%20%20%20%20%20%20inputs.upload-pages-coverage-html%0A%20%20%20%20%20%20%20%20%20%20%26%26%20steps.rust-coverage.outcome%20%3D%3D%20'success'%0A%20%20%20%20%20%20%20%20shell%3A%20bash%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20RUST_COVERAGE_HTML_DIR%3A%20%24%7B%7B%20inputs.pages-coverage-artifact-name%20%7D%7D%0A%20%20%20%20%20%20%20%20run%3A%20%3E-%0A%20%20%20%20%20%20%20%20%20%20bash%20.lgtm-ci-tooling%2Fscripts%2Fci%2Ftesting%2Frust%2Frun-rust-coverage-html.sh%0A%20%20%20%20%20%20%20%20continue-on-error%3A%20true%0A%0A%20%20%20%20%20%20-%20name%3A%20Evaluate%20pages%20coverage%20upload%20gate%0A%20%20%20%20%20%20%20%20id%3A%20pages-upload-gate%0A%20%20%20%20%20%20%20%20if%3A%20inputs.upload-pages-coverage-html%0A%20%20%20%20%20%20%20%20shell%3A%20bash%0A%20%20%20%20%20%20%20%20env%3A%0A%20%20%20%20%20%20%20%20%20%20PAGES_COVERAGE_UPLOAD_ON%3A%20%24%7B%7B%20inputs.pages-coverage-upload-on%20%7D%7D%0A%20%20%20%20%20%20%20%20run%3A%20bash%20.lgtm-ci-tooling%2Fscripts%2Fci%2Factions%2Fpages-coverage-upload-gate.sh%0A%0A%20%20%20%20%20%20-%20name%3A%20Upload%20pages%20coverage%20HTML%20artifact%0A%20%20%20%20%20%20%20%20id%3A%20pages-upload%0A%20%20%20%20%20%20%20%20if%3A%20%3E-%0A%20%20%20%20%20%20%20%20%20%20inputs.upload-pages-coverage-html%0A%20%20%20%20%20%20%20%20%20%20%26%26%20steps.rust-coverage.outcome%20%3D%3D%20'success'%0A%20%20%20%20%20%20%20%20%20%20%26%26%20steps.generate-html.outcome%20%3D%3D%20'success'%0A%20%20%20%20%20%20%20%20%20%20%26%26%20steps.pages-upload-gate.outputs.should-upload%20%3D%3D%20'true'%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Freusable-test-node.yml%3A266-272%0A**Matrix%20output%20race%20condition%20for%20%60pages-upload-outcome%60**%0A%0A%60test-vitest%60%20%28and%20%60test-custom%60%29%20is%20a%20matrix%20job.%20Every%20matrix%20instance%20writes%20the%20job-level%20%60pages-upload-outcome%60%20output%2C%20but%20only%20the%20instance%20whose%20%60matrix.node-version%60%20matches%20%60pages-coverage-node-version%60%20runs%20%60record-pages-upload-outcome%60%20%E2%80%94%20all%20other%20instances%20set%20this%20output%20to%20empty%20string%20%28skipped%20step%20%E2%86%92%20no%20output%20value%29.%20GitHub%20Actions%20%22last%20writer%20wins%22%20aggregation%20means%20that%20if%20any%20non-first%20version%20instance%20completes%20last%2C%20%60needs.test-vitest.outputs.pages-upload-outcome%60%20is%20empty%20in%20%60pages-coverage-status%60%2C%20%60PAGES_UPLOAD_OUTCOME%60%20is%20empty%2C%20and%20%60record-pages-coverage-upload-status.sh%60%20emits%20%60uploaded%3Dfalse%60%20even%20though%20the%20artifact%20was%20successfully%20uploaded.%0A%0AThe%20same%20race%20applies%20to%20%60test-custom.outputs.pages-upload-outcome%60.%20Single-version%20matrices%20aren't%20affected%2C%20but%20any%20consumer%20that%20passes%20multiple%20%60node-versions%60%20will%20be%20flaky%20on%20this%20output.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["fix(ci): parse hyphenated sdist names in..."](https://github.com/lgtm-hq/lgtm-ci/commit/8ba1036c10724aa841d16ea0168c15c3ee1230e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34700831)</sub>

<!-- /greptile_comment -->