### PR TITLE
fix(ci): hybrid job display names for skipped matrix jobs (#168 §12)

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1337,13 +1337,16 @@ jobs:
 
 ### reusable-test-node.yml
 
-Complete Node.js testing workflow with vitest and optional coverage.
+Node.js Vitest testing workflow with optional coverage and PR comments. Custom
+package scripts (for example `bun run test:coverage`) use
+`reusable-test-node-custom.yml` instead.
 
 ```yaml
 jobs:
   test:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@main
     with:
+      job-name: "Web Unit Tests"
       node-version: "20"
       coverage: true
       coverage-threshold: 80
@@ -1352,19 +1355,51 @@ jobs:
 
 **Inputs:**
 
+- `job-name` - GitHub check name for the Vitest job (default: `Node.js Tests`)
 - `node-version` - Node.js version (default: '20')
 - `test-path` - Path to tests (default: '.')
 - `coverage` - Collect coverage (default: false)
 - `coverage-format` - Format: json, lcov, html (default: 'json')
 - `coverage-threshold` - Minimum coverage % (default: 0)
 - `upload-coverage` - Upload as artifact (default: false)
-- `publish-results` - Publish to GitHub Pages (default: false)
+- `publish-results` - Deprecated; use `reusable-test-node-publish.yml`
 
 **Outputs:**
 
 - `tests-passed`, `tests-failed`, `tests-total`
 - `coverage-percent`
 - `passed` - Whether all tests passed
+
+---
+
+### reusable-test-node-custom.yml
+
+Node.js testing via a caller-provided shell command (after dependency install).
+Use when Vitest is not the test runner or when a package script owns coverage.
+
+```yaml
+jobs:
+  web-coverage:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node-custom.yml@main
+    with:
+      job-name: "Web Coverage"
+      test-command: bun run test:coverage
+      package-manager: bun
+      coverage: true
+      coverage-pr-comment: true
+```
+
+**Inputs:**
+
+- `test-command` - **Required.** Shell command run in `working-directory`
+- `job-name` - GitHub check name (default: `Node.js Tests`)
+- `node-version`, `node-versions`, `package-manager`, `pre-test-command`
+- Pages coverage HTML inputs (same as Vitest workflow)
+
+**Outputs:**
+
+- `passed` - Whether the custom command succeeded
+- `pages-coverage-artifact-name`, `pages-coverage-uploaded`
 
 ---
 

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1314,7 +1314,6 @@ jobs:
       coverage: true
       coverage-threshold: 80
       upload-coverage: true
-      publish-results: false
 ```
 
 **Inputs:**
@@ -1325,7 +1324,6 @@ jobs:
 - `coverage-format` - Format: xml, json, lcov (default: 'json')
 - `coverage-threshold` - Minimum coverage % (default: 0)
 - `upload-coverage` - Upload as artifact (default: false)
-- `publish-results` - Publish to GitHub Pages (default: false)
 
 **Outputs:**
 
@@ -1362,7 +1360,6 @@ jobs:
 - `coverage-format` - Format: json, lcov, html (default: 'json')
 - `coverage-threshold` - Minimum coverage % (default: 0)
 - `upload-coverage` - Upload as artifact (default: false)
-- `publish-results` - Deprecated; use `reusable-test-node-publish.yml`
 
 **Outputs:**
 

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -460,7 +460,7 @@ jobs:
   # Per-platform native build leg (multi-arch split path).
   # One matrix entry per platform; runner and QEMU config resolved by classify.
   build-per-platform:
-    name: Build ${{ matrix.platform }}
+    name: Docker build per platform
     needs: classify
     if: ${{ needs.classify.outputs.use-split == 'true' }}
     strategy:
@@ -642,7 +642,7 @@ jobs:
   #   - smoke-test (shorthand): `docker run --rm --platform <p> <image> <cmd>`
   #   - smoke-test-script: caller-owned script with env IMAGE/PLATFORM/REGISTRY
   verify-per-platform:
-    name: Verify ${{ matrix.platform }}
+    name: Docker verify per platform
     needs: [classify, build-per-platform]
     if: >-
       needs.classify.outputs.use-split == 'true' &&

--- a/.github/workflows/reusable-test-e2e-matrix.yml
+++ b/.github/workflows/reusable-test-e2e-matrix.yml
@@ -130,7 +130,7 @@ jobs:
         run: .lgtm-ci-tooling/scripts/ci/actions/generate-matrix.sh
 
   test:
-    name: E2E ${{ matrix.suite }} (${{ matrix.browser }})
+    name: E2E tests
     needs: setup
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}

--- a/.github/workflows/reusable-test-node-custom.yml
+++ b/.github/workflows/reusable-test-node-custom.yml
@@ -129,8 +129,8 @@ on:
 
     outputs:
       passed:
-        description: "Whether the custom test command succeeded"
-        value: ${{ jobs.test.outputs.passed == 'true' }}
+        description: "Whether every matrix test leg succeeded"
+        value: ${{ jobs.aggregate-tests.outputs.passed == 'true' }}
       pages-coverage-artifact-name:
         description: "Resolved flat HTML coverage artifact name"
         value: ${{ inputs.pages-coverage-artifact-name }}
@@ -378,6 +378,35 @@ jobs:
             echo "passed=false" >>"$GITHUB_OUTPUT"
           fi
 
+  aggregate-tests:
+    name: Aggregate Node.js Results
+    needs:
+      - prepare
+      - test
+    if: >-
+      always()
+      && (
+        !inputs.draft-pr-skip ||
+        github.event_name != 'pull_request' ||
+        github.event.pull_request.draft == false
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      passed: ${{ steps.aggregate.outputs.passed }}
+
+    steps:
+      - name: Aggregate matrix custom test results
+        id: aggregate
+        shell: bash
+        run: |
+          if [[ "${{ needs.test.result }}" == "success" ]]; then
+            echo "passed=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "passed=false" >>"$GITHUB_OUTPUT"
+          fi
+
   pages-coverage-status:
     name: Pages coverage upload status
     needs:
@@ -434,7 +463,6 @@ jobs:
       && needs.test.result == 'success'
       && (
         !inputs.draft-pr-skip ||
-        github.event_name != 'pull_request' ||
         github.event.pull_request.draft == false
       )
     runs-on: ${{ inputs.runner-image }}

--- a/.github/workflows/reusable-test-node-custom.yml
+++ b/.github/workflows/reusable-test-node-custom.yml
@@ -1,5 +1,5 @@
 ---
-name: Reusable Node.js Vitest Test Workflow
+name: Reusable Node.js Custom Test Workflow
 
 on:
   workflow_call:
@@ -14,28 +14,14 @@ on:
         required: false
         type: string
         default: ""
-      test-path:
-        description: "Path to test files or directory"
-        required: false
+      test-command:
+        description: >-
+          Shell command to run after dependency install (e.g. bun run
+          test:coverage). Runs in working-directory.
+        required: true
         type: string
-        default: "."
       coverage:
-        description: "Whether to collect coverage"
-        required: false
-        type: boolean
-        default: false
-      coverage-format:
-        description: "Coverage output format: json, lcov, html"
-        required: false
-        type: string
-        default: "json"
-      coverage-threshold:
-        description: "Minimum coverage percentage to pass"
-        required: false
-        type: number
-        default: 0
-      upload-coverage:
-        description: "Upload coverage report as artifact"
+        description: "Whether the custom command produces coverage output"
         required: false
         type: boolean
         default: false
@@ -61,18 +47,6 @@ on:
         required: false
         type: string
         default: "coverage"
-      publish-results:
-        description: >-
-          Deprecated: use reusable-test-node-publish.yml in a separate caller job.
-          Ignored in this workflow so callers are not required to grant pages write.
-        required: false
-        type: boolean
-        default: false
-      extra-args:
-        description: "Additional arguments to pass to vitest"
-        required: false
-        type: string
-        default: ""
       working-directory:
         description: "Working directory for running tests"
         required: false
@@ -88,26 +62,11 @@ on:
         required: false
         type: string
         default: ""
-      upload-build-artifact:
-        description: "Upload a build artifact after the pre-test command"
-        required: false
-        type: boolean
-        default: false
-      build-artifact-path:
-        description: "Path to upload when upload-build-artifact is true"
-        required: false
-        type: string
-        default: "dist"
       post-pr-comment:
-        description: "Post or update a Node test summary comment on pull requests"
+        description: "Post or update a coverage PR comment when coverage-pr-comment is true"
         required: false
         type: boolean
         default: true
-      comment-marker:
-        description: "Unique marker for the Node test PR comment"
-        required: false
-        type: string
-        default: "node-test-results"
       job-name:
         description: "GitHub check name for the test job"
         required: false
@@ -115,8 +74,7 @@ on:
         default: "Node.js Tests"
       coverage-pr-comment:
         description: >-
-          Post a generate-coverage-comment PR summary instead of the default
-          Node test results comment
+          Post a generate-coverage-comment PR summary when coverage output exists
         required: false
         type: boolean
         default: false
@@ -170,21 +128,9 @@ on:
         default: 60
 
     outputs:
-      tests-passed:
-        description: "Number of tests passed"
-        value: ${{ jobs.aggregate-tests.outputs.tests-passed }}
-      tests-failed:
-        description: "Number of tests failed"
-        value: ${{ jobs.aggregate-tests.outputs.tests-failed }}
-      tests-total:
-        description: "Total number of tests"
-        value: ${{ jobs.aggregate-tests.outputs.tests-total }}
-      coverage-percent:
-        description: "Coverage percentage"
-        value: ${{ jobs.aggregate-tests.outputs.coverage-percent }}
       passed:
-        description: "Whether all tests passed"
-        value: ${{ jobs.aggregate-tests.outputs.passed }}
+        description: "Whether the custom test command succeeded"
+        value: ${{ jobs.test.outputs.passed == 'true' }}
       pages-coverage-artifact-name:
         description: "Resolved flat HTML coverage artifact name"
         value: ${{ inputs.pages-coverage-artifact-name }}
@@ -232,7 +178,7 @@ jobs:
           NODE_VERSIONS: ${{ inputs.node-versions }}
         run: bash .lgtm-ci-tooling/scripts/ci/actions/generate-node-matrix.sh
 
-  test-vitest:
+  test:
     name: ${{ inputs.job-name }}
     needs: prepare
     runs-on: ${{ inputs.runner-image }}
@@ -246,24 +192,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
-
     outputs:
-      tests-passed: ${{ steps.parse.outputs.tests-passed }}
-      tests-failed: ${{ steps.parse.outputs.tests-failed }}
-      tests-total: ${{ steps.parse.outputs.tests-total }}
-      coverage-percent: ${{ steps.parse.outputs.coverage-percent }}
-      passed: ${{ steps.run.outputs.exit-code == '0' }}
+      passed: ${{ steps.record.outputs.passed }}
       pages-upload-outcome: ${{ steps.record-pages-upload-outcome.outputs.outcome }}
 
     steps:
       - name: Harden runner
-        # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: ${{ inputs.egress-policy }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
+
       - name: Checkout repository
-        # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -311,7 +251,6 @@ jobs:
           path: |
             ${{ steps.bun-cache.outputs.dir }}
             ${{ inputs.working-directory }}/node_modules
-          # yamllint disable-line rule:line-length
           key: bun-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/bun.lock', '**/bun.lockb') }}
           restore-keys: |
             bun-${{ runner.os }}-${{ matrix.node-version }}-
@@ -333,94 +272,13 @@ jobs:
           WORKING_DIRECTORY: ${{ inputs.working-directory }}
         run: bash .lgtm-ci-tooling/scripts/ci/actions/run-command.sh
 
-      - name: Upload build artifact
-        if: inputs.upload-build-artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: node-build-${{ matrix.node-version }}
-          path: ${{ inputs.working-directory }}/${{ inputs.build-artifact-path }}
-          retention-days: 7
-          if-no-files-found: error
-
-      - name: Setup vitest
+      - name: Run custom test command
+        id: custom-run
         shell: bash
         env:
-          STEP: setup
-          COVERAGE: ${{ inputs.coverage }}
+          COMMAND: ${{ inputs.test-command }}
           WORKING_DIRECTORY: ${{ inputs.working-directory }}
-        run: bash .lgtm-ci-tooling/scripts/ci/actions/run-vitest.sh
-
-      - name: Run vitest
-        id: run
-        shell: bash
-        env:
-          STEP: run
-          TEST_PATH: ${{ inputs.test-path }}
-          COVERAGE: ${{ inputs.coverage }}
-          COVERAGE_FORMAT: ${{ inputs.coverage-format }}
-          EXTRA_ARGS: ${{ inputs.extra-args }}
-          WORKING_DIRECTORY: ${{ inputs.working-directory }}
-        run: bash .lgtm-ci-tooling/scripts/ci/actions/run-vitest.sh
-        continue-on-error: true
-
-      - name: Parse results
-        id: parse
-        if: always()
-        shell: bash
-        env:
-          STEP: parse
-          RESULTS_FILE: ${{ inputs.working-directory }}/vitest-results.json
-          COVERAGE_FILE: ${{ inputs.working-directory }}/coverage/coverage-summary.json
-        run: bash .lgtm-ci-tooling/scripts/ci/actions/run-vitest.sh
-
-      - name: Generate summary
-        if: always()
-        shell: bash
-        env:
-          STEP: summary
-          TESTS_PASSED: ${{ steps.parse.outputs.tests-passed }}
-          TESTS_FAILED: ${{ steps.parse.outputs.tests-failed }}
-          TESTS_SKIPPED: ${{ steps.parse.outputs.tests-skipped }}
-          TESTS_TOTAL: ${{ steps.parse.outputs.tests-total }}
-          COVERAGE_PERCENT: ${{ steps.parse.outputs.coverage-percent }}
-          EXIT_CODE: ${{ steps.run.outputs.exit-code }}
-        run: bash .lgtm-ci-tooling/scripts/ci/actions/run-vitest.sh
-
-      - name: Check coverage threshold
-        id: coverage-gate
-        if: inputs.coverage && inputs.coverage-threshold > 0
-        uses: ./.lgtm-ci-tooling/.github/actions/check-coverage-threshold
-        with:
-          coverage-percent: ${{ steps.parse.outputs.coverage-percent }}
-          threshold: ${{ inputs.coverage-threshold }}
-
-      - name: Write matrix test summary
-        if: always()
-        shell: bash
-        env:
-          NODE_VERSION: ${{ matrix.node-version }}
-          TESTS_PASSED: ${{ steps.parse.outputs.tests-passed }}
-          TESTS_FAILED: ${{ steps.parse.outputs.tests-failed }}
-          TESTS_TOTAL: ${{ steps.parse.outputs.tests-total }}
-          COVERAGE_PERCENT: ${{ steps.parse.outputs.coverage-percent }}
-          PASSED: >-
-            ${{
-              steps.run.outputs.exit-code == '0'
-              && (
-                steps.coverage-gate.outcome == 'success'
-                || steps.coverage-gate.outcome == 'skipped'
-              )
-            }}
-        run: bash .lgtm-ci-tooling/scripts/ci/actions/write-node-summary.sh
-
-      - name: Upload matrix test summary
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: node-results-${{ matrix.node-version }}
-          path: node-result-${{ matrix.node-version }}/summary.json
-          retention-days: 7
-          if-no-files-found: error
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/run-command.sh
 
       - name: Generate coverage PR comment
         id: generate-coverage-comment
@@ -456,24 +314,6 @@ jobs:
         with:
           name: node-coverage-pr-comment-${{ matrix.node-version }}
           path: node-coverage-pr-comment.txt
-
-      - name: Stage coverage report
-        if: always() && inputs.upload-coverage && inputs.coverage
-        shell: bash
-        env:
-          NODE_VERSION: ${{ matrix.node-version }}
-          WORKING_DIRECTORY: ${{ inputs.working-directory }}
-        run: bash .lgtm-ci-tooling/scripts/ci/actions/stage-node-coverage.sh
-
-      - name: Upload coverage report
-        if: always() && inputs.upload-coverage && inputs.coverage
-        # Pinned to SHA for supply chain security
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: node-coverage-${{ matrix.node-version }}
-          path: node-coverage-${{ matrix.node-version }}/
-          retention-days: 7
-          if-no-files-found: ignore
 
       - name: Evaluate pages coverage upload gate
         id: pages-upload-gate
@@ -523,20 +363,26 @@ jobs:
           PAGES_UPLOAD_OUTCOME: ${{ steps.pages-upload.outcome }}
         run: bash .lgtm-ci-tooling/scripts/ci/actions/record-pages-upload-outcome.sh
 
-      - name: Fail on vitest errors
-        if: >-
-          steps.run.outputs.exit-code != ''
-          && steps.run.outputs.exit-code != '0'
+      - name: Fail on custom test command errors
+        if: steps.custom-run.outcome == 'failure'
+        run: exit 1
+
+      - name: Record custom test result
+        if: always()
+        id: record
         shell: bash
-        env:
-          EXIT_CODE: ${{ steps.run.outputs.exit-code }}
-        run: bash .lgtm-ci-tooling/scripts/ci/actions/fail-with-exit-code.sh
+        run: |
+          if [[ "${{ job.status }}" == "success" ]]; then
+            echo "passed=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "passed=false" >>"$GITHUB_OUTPUT"
+          fi
 
   pages-coverage-status:
     name: Pages coverage upload status
     needs:
       - prepare
-      - test-vitest
+      - test
     if: >-
       always()
       && inputs.upload-pages-coverage-html
@@ -569,70 +415,15 @@ jobs:
         env:
           UPLOAD_PAGES_COVERAGE_HTML: ${{ inputs.upload-pages-coverage-html }}
           COVERAGE: ${{ inputs.coverage }}
-          PAGES_UPLOAD_OUTCOME: ${{ needs.test-vitest.outputs.pages-upload-outcome }}
+          PAGES_UPLOAD_OUTCOME: ${{ needs.test.outputs.pages-upload-outcome }}
         run: >-
           bash .lgtm-ci-tooling/scripts/ci/actions/record-pages-coverage-upload-status.sh
-
-  aggregate-tests:
-    name: Aggregate Node.js Results
-    needs:
-      - prepare
-      - test-vitest
-    if: >-
-      always()
-      && (
-        !inputs.draft-pr-skip ||
-        github.event_name != 'pull_request' ||
-        github.event.pull_request.draft == false
-      )
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      tests-passed: ${{ steps.aggregate.outputs.tests-passed }}
-      tests-failed: ${{ steps.aggregate.outputs.tests-failed }}
-      tests-total: ${{ steps.aggregate.outputs.tests-total }}
-      coverage-percent: ${{ steps.aggregate.outputs.coverage-percent }}
-      passed: ${{ needs.test-vitest.result == 'success' && steps.aggregate.outputs.passed == 'true' }}
-
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
-
-      - name: Checkout lgtm-ci tooling
-        # yamllint disable-line rule:line-length
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: scripts/ci/
-          sparse-checkout-cone-mode: true
-          persist-credentials: false
-
-      - name: Download matrix test summaries
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          pattern: node-results-*
-          path: node-results
-          merge-multiple: false
-
-      - name: Aggregate matrix test summaries
-        id: aggregate
-        shell: bash
-        env:
-          RESULTS_DIR: node-results
-          MATRIX_JSON: ${{ needs.prepare.outputs.matrix }}
-        run: bash .lgtm-ci-tooling/scripts/ci/actions/aggregate-node-results.sh
 
   coverage-pr-comment:
     name: Node coverage PR comment
     needs:
       - prepare
-      - test-vitest
+      - test
     if: >-
       always()
       && inputs.coverage-pr-comment
@@ -640,7 +431,7 @@ jobs:
       && github.event_name == 'pull_request'
       && github.event.pull_request.head.repo.fork == false
       && inputs.post-pr-comment
-      && needs.test-vitest.result == 'success'
+      && needs.test.result == 'success'
       && (
         !inputs.draft-pr-skip ||
         github.event_name != 'pull_request' ||
@@ -684,33 +475,3 @@ jobs:
             ${{ inputs.node-versions != '' && format('{0}-{1}',
             inputs.coverage-comment-marker, matrix.node-version) ||
             inputs.coverage-comment-marker }}
-
-  comment-pr:
-    needs: aggregate-tests
-    if: >-
-      always()
-      && github.event_name == 'pull_request'
-      && github.event.pull_request.head.repo.fork == false
-      && inputs.post-pr-comment
-      && !inputs.coverage-pr-comment
-      && (
-        !inputs.draft-pr-skip ||
-        github.event_name != 'pull_request' ||
-        github.event.pull_request.draft == false
-      )
-    uses: ./.github/workflows/reusable-test-pr-comment.yml
-    permissions:
-      contents: read
-      pull-requests: write
-    with:
-      test-suite-name: ${{ inputs.job-name }}
-      comment-marker: ${{ inputs.comment-marker }}
-      tests-passed: ${{ needs.aggregate-tests.outputs.tests-passed }}
-      tests-failed: ${{ needs.aggregate-tests.outputs.tests-failed }}
-      tests-total: ${{ needs.aggregate-tests.outputs.tests-total }}
-      coverage-percent: ${{ needs.aggregate-tests.outputs.coverage-percent }}
-      coverage-threshold: ${{ inputs.coverage-threshold }}
-      job-result: ${{ needs.aggregate-tests.outputs.passed == 'true' && 'success' || 'failure' }}
-      tooling-ref: ${{ inputs.tooling-ref }}
-      egress-policy: ${{ inputs.egress-policy }}
-      allowed-endpoints: ${{ inputs.allowed-endpoints }}

--- a/.github/workflows/reusable-test-node.yml
+++ b/.github/workflows/reusable-test-node.yml
@@ -61,13 +61,6 @@ on:
         required: false
         type: string
         default: "coverage"
-      publish-results:
-        description: >-
-          Deprecated: use reusable-test-node-publish.yml in a separate caller job.
-          Ignored in this workflow so callers are not required to grant pages write.
-        required: false
-        type: boolean
-        default: false
       extra-args:
         description: "Additional arguments to pass to vitest"
         required: false

--- a/.github/workflows/reusable-test-python.yml
+++ b/.github/workflows/reusable-test-python.yml
@@ -180,11 +180,7 @@ jobs:
         run: bash .lgtm-ci-tooling/scripts/ci/actions/generate-python-matrix.sh
 
   test:
-    name: >-
-      ${{
-        inputs.python-versions == '' && inputs.job-name ||
-        format('{0} ({1})', inputs.job-name, matrix.python-version)
-      }}
+    name: Python tests
     needs: prepare
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}

--- a/.github/workflows/reusable-test-python.yml
+++ b/.github/workflows/reusable-test-python.yml
@@ -39,13 +39,6 @@ on:
         required: false
         type: boolean
         default: false
-      publish-results:
-        description: >-
-          Deprecated: use reusable-test-python-publish.yml in a separate caller
-          job instead. Ignored by this workflow.
-        required: false
-        type: boolean
-        default: false
       markers:
         description: "pytest markers to filter tests"
         required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,17 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **workflows**: hybrid job display names (#168 §12) — `reusable-test-node.yml` is
   Vitest-only; custom commands use `reusable-test-node-custom.yml`; static inner
   names for Python, Docker per-platform, and E2E matrix jobs; `job-name` drives
-  Vitest/custom check labels (supersedes #256 interim static Node names)
-
-### Deprecated
-
-- **workflows**: `test-command` on `reusable-test-node.yml` — use
-  `reusable-test-node-custom.yml` instead (removed without shim)
+  Vitest/custom check labels
 
 ### Removed
 
+- **workflows**: `test-command` on `reusable-test-node.yml` — use
+  `reusable-test-node-custom.yml`
 - **workflows**: `reusable-test-rust-test.yml`, `reusable-test-rust-coverage.yml`,
-  `reusable-rust-coverage.yml`, `reusable-test-rust.yml` (no compatibility shim)
+  `reusable-rust-coverage.yml`, `reusable-test-rust.yml`
 - **scripts**: `run-cargo-test.sh`, `parse-cargo-test-results.sh`, `setup-rust-coverage.sh`,
   `run-rust-coverage.sh`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **rust**: `setup-rust-nextest.sh`, `run-rust-nextest.sh`, `run-rust-nextest-coverage.sh`,
   and `parse-rust-test-results.sh` (JUnit + optional LCOV) for unified Rust CI
 - **examples**: `examples/nextest-ci.toml` profile for consumer `.config/nextest.toml`
+- **workflows**: `reusable-test-node-custom.yml` for package-manager custom test commands
+- **ci**: `validate-static-job-names.sh` and BATS contract tests for job display name policy
 
 ### Changed
 
@@ -19,8 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `coverage: true` runs `cargo llvm-cov nextest` once; `coverage: false` runs
   `cargo nextest` only. PR comments align with Python via `reusable-test-pr-comment`
   (#168 §13)
+- **workflows**: hybrid job display names (#168 §12) — `reusable-test-node.yml` is
+  Vitest-only; custom commands use `reusable-test-node-custom.yml`; static inner
+  names for Python, Docker per-platform, and E2E matrix jobs; `job-name` drives
+  Vitest/custom check labels (supersedes #256 interim static Node names)
 
 ### Deprecated
+
+- **workflows**: `test-command` on `reusable-test-node.yml` — use
+  `reusable-test-node-custom.yml` instead (removed without shim)
 
 ### Removed
 
@@ -30,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `run-rust-coverage.sh`
 
 ### Fixed
+
+- **workflows**: skipped matrix jobs no longer show unevaluated `job.name` expressions
+  in the GitHub checks UI (#168 §12)
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ steps:
 | `reusable-docker.yml`                  | Docker build and publish               |
 | `reusable-coverage.yml`                | Test coverage collection               |
 | `reusable-test-python.yml`             | Python tests with PR comments          |
-| `reusable-test-node.yml`               | Node.js tests with PR comments         |
+| `reusable-test-node.yml`               | Node.js Vitest tests with PR comments  |
+| `reusable-test-node-custom.yml`        | Node.js custom test command workflow   |
 | `reusable-test-shell.yml`              | BATS shell tests with PR comments      |
 | `reusable-test-pr-comment.yml`         | Shared test PR comment workflow        |
 | `reusable-test-e2e.yml`                | E2E testing with Playwright            |

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -162,15 +162,12 @@ When `node-versions` is a matrix, only the **first** listed version uploads the
 flat artifact (avoids `upload-artifact` name collisions). Matrix debug artifacts
 (`node-coverage-<version>/…`) are unchanged when `upload-coverage: true`.
 
-**Job display names:** `test-vitest` and `test-custom` use static names
-(`Node.js tests (Vitest)` / `Node.js tests (custom command)`) so skipped matrix
-jobs do not show unevaluated `${{ … }}` in the PR checks UI. This replaces the
-previous dynamic names derived from `inputs.job-name` and matrix versions.
-Update branch protection required-status checks that matched the old names when
-upgrading to this tooling version.
-
-**Skipped jobs:** When `test-command` is set, Vitest is skipped and the
-custom-command job runs; when `test-command` is empty, the opposite applies.
+**Job display names:** Vitest and custom Node tests are **split workflows**
+(`reusable-test-node.yml` and `reusable-test-node-custom.yml`). Each test job uses
+`${{ inputs.job-name }}` for the GitHub check label — there are no mutually
+skipped Vitest/custom siblings. For Python, Docker per-platform, and E2E matrix
+jobs, inner names are static; see [workflow-contract.md](workflow-contract.md)
+(§ Job display names).
 
 **PR comments:** `coverage-pr-comment: true` builds the comment artifact inside
 the test job, but the separate `Node coverage PR comment` job also requires

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -43,7 +43,7 @@ Pass `tooling-ref` when testing an unreleased lgtm-ci branch. Production callers
 should pin the workflow ref to a commit SHA.
 
 See [workflow-contract.md](workflow-contract.md) for the standard input contract,
-permissions by mode, egress allowlists, and Rustume migration examples.
+permissions by mode, egress allowlists, and Rustume examples.
 
 For GitHub Pages (coverage, test reports, and static sites), see
 [pages-publishing.md](pages-publishing.md).

--- a/docs/rust-testing.md
+++ b/docs/rust-testing.md
@@ -110,8 +110,8 @@ jobs:
 
 ## Rust workspace with a frontend package
 
-Use **`reusable-test-node`** for the web app (Vitest/Istanbul or a package
-`test:coverage` script). Do not bundle web jobs into the Rust reusable.
+Use **`reusable-test-node`** (Vitest) or **`reusable-test-node-custom`** (package
+`test:coverage` scripts). Do not bundle web jobs into the Rust reusable.
 
 Pin `uses:` and `tooling-ref` to the same commit SHA. Path filters belong on the
 caller workflow (`on.push.paths` / `on.pull_request.paths`).
@@ -119,8 +119,10 @@ caller workflow (`on.push.paths` / `on.pull_request.paths`).
 ## Example: Rustume
 
 Rustume composes quality (lintro), build, and rust-test reusables (test and
-coverage as separate jobs with `coverage: false` / `true`). Override `job-name`
-inputs to match org ruleset check names (for example emoji-prefixed labels).
+coverage as separate jobs with `coverage: false` / `true`). Pass `job-name` on
+always-run jobs (Rust build/test, split Node workflows) to match org ruleset
+check names. Matrix and internal Docker jobs use static inner names — set caller
+job `name:` for branding; see [workflow-contract.md](workflow-contract.md).
 
 See [reusable-workflows.md](reusable-workflows.md) for quality and release
 callers.

--- a/docs/rust-testing.md
+++ b/docs/rust-testing.md
@@ -6,12 +6,12 @@ scans run through **`reusable-quality-lint`** (lintro); this repo provides
 **`reusable-rust-test.yml`** for workspace tests (cargo-nextest or
 `cargo llvm-cov nextest` when `coverage: true`).
 
-| Language          | Reusable                     |
-| ----------------- | ---------------------------- |
-| Python            | `reusable-test-python.yml`   |
-| Node / TypeScript | `reusable-test-node.yml`     |
-| Rust (build)      | `reusable-rust-build.yml`    |
-| Rust (tests)      | `reusable-rust-test.yml`     |
+| Language          | Reusable                                                    |
+| ----------------- | ----------------------------------------------------------- |
+| Python            | `reusable-test-python.yml`                                  |
+| Node / TypeScript | `reusable-test-node.yml` or `reusable-test-node-custom.yml` |
+| Rust (build)      | `reusable-rust-build.yml`                                   |
+| Rust (tests)      | `reusable-rust-test.yml`                                    |
 
 ## Nextest configuration (required)
 
@@ -126,15 +126,3 @@ job `name:` for branding; see [workflow-contract.md](workflow-contract.md).
 
 See [reusable-workflows.md](reusable-workflows.md) for quality and release
 callers.
-
-## Migration from split workflows (v0.26 and earlier)
-
-Removed without shim (issue #168 §13):
-
-- `reusable-test-rust-test.yml`, `reusable-test-rust-coverage.yml`,
-  `reusable-rust-coverage.yml`, `reusable-test-rust.yml`
-- `cargo test` scripts (`run-cargo-test.sh`, `parse-cargo-test-results.sh`, etc.)
-
-Replace two jobs that called separate test and coverage reusables with two jobs
-(both `reusable-rust-test.yml`) differing only in `coverage` and `job-name`, or
-collapse to one job if your rulesets allow. Update required check names accordingly.

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -14,7 +14,7 @@ Where applicable, workflows accept:
 | `tooling-ref`                      | Pin lgtm-ci scripts/actions (defaults to caller workflow SHA) |
 | `egress-policy`                    | `audit` or `block` for StepSecurity harden-runner             |
 | `allowed-endpoints`                | Allowlist when `egress-policy: block`                         |
-| `job-name`                         | Visible GitHub check name                                     |
+| `job-name`                         | Check name on always-run jobs; PR comment suite name          |
 | `runner-image`                     | Runner label for long-running jobs                            |
 | `timeout-minutes`                  | Job timeout                                                   |
 | `post-pr-comment`                  | Enable PR summary comments                                    |
@@ -96,11 +96,35 @@ Prefer split workflows to avoid skipped checks in PR UI:
 | Rust build only     | `reusable-rust-build.yml` or `reusable-test-rust-build.yml` |
 | Rust test (fast)    | `reusable-rust-test.yml` with `coverage: false`             |
 | Rust test + cov     | `reusable-rust-test.yml` with `coverage: true`              |
-| Node Vitest tests   | `reusable-test-node.yml` with `test-command` empty          |
-| Node custom command | `reusable-test-node.yml` with `test-command` set            |
+| Node Vitest tests   | `reusable-test-node.yml` (Vitest)                           |
+| Node custom command | `reusable-test-node-custom.yml` (required `test-command`)   |
 
-Use separate caller jobs (different `job-name`) when rulesets require distinct
-required checks; the reusable never runs nextest and llvm-cov in one job.
+Use separate caller jobs (different `name:` and/or `job-name`) when rulesets
+require distinct required checks; the reusable never runs nextest and llvm-cov in
+one job.
+
+## Job display names
+
+GitHub can render unevaluated `job.name` expressions in the checks UI when a job
+is skipped by `if:`. lgtm-ci uses a **hybrid** policy (issue #168 §12):
+
+<!-- markdownlint-disable MD013 -->
+
+| Pattern | When | Check name behavior |
+| ------- | ---- | ------------------- |
+| **Split reusables** | Consumer-facing modes (Vitest vs custom Node) | Matching workflow only; `job-name` drives test check name. |
+| **`job-name` input** | Always-run jobs (quality, publish, Rust test, split Node) | Caller passes the visible check label. |
+| **Static inner names** | Internal matrix legs (Python, Docker, E2E) | Fixed labels; GitHub appends matrix suffix. Brand via caller `name:`. |
+
+<!-- markdownlint-enable MD013 -->
+
+Contract enforcement: `scripts/ci/quality/validate-static-job-names.sh` (also
+covered by BATS). Do not use `matrix.`, `format(`, or ternary `&& … ||`
+expressions in `job.name` on jobs that have `if:`.
+
+**Node migration:** Replace `reusable-test-node.yml` + `test-command: …` with
+`reusable-test-node-custom.yml` and required `test-command`. Vitest callers keep
+`reusable-test-node.yml` and set `job-name` for check labels.
 
 ## Egress block examples
 
@@ -416,7 +440,7 @@ jobs:
         crates.io:443
 
   web-coverage:
-    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@<sha>
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node-custom.yml@<sha>
     permissions:
       contents: read
       pull-requests: write

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -63,9 +63,8 @@ would worsen check-name readability) and to access matrix-specific artifacts.
 
 <!-- markdownlint-enable MD013 -->
 
-`reusable-test-node.yml` no longer includes a publish job. Use
-`reusable-test-node-publish.yml` in a separate caller job when publishing is
-required.
+`reusable-test-node.yml` does not include a publish job. Use
+`reusable-test-node-publish.yml` in a separate caller job for Pages publishing.
 
 ### Isolated publish jobs (Pages / coverage badge)
 
@@ -122,9 +121,9 @@ Contract enforcement: `scripts/ci/quality/validate-static-job-names.sh` (also
 covered by BATS). Do not use `matrix.`, `format(`, or ternary `&& … ||`
 expressions in `job.name` on jobs that have `if:`.
 
-**Node migration:** Replace `reusable-test-node.yml` + `test-command: …` with
-`reusable-test-node-custom.yml` and required `test-command`. Vitest callers keep
-`reusable-test-node.yml` and set `job-name` for check labels.
+**Node testing:** Vitest callers use `reusable-test-node.yml` with `job-name`.
+Custom package scripts use `reusable-test-node-custom.yml` with required
+`test-command` and `job-name`.
 
 ## Egress block examples
 
@@ -351,7 +350,7 @@ PR comments are skipped automatically on fork PRs (`head.repo.fork == true`).
 This is enforced in `scripts/ci/actions/post-pr-comment.sh` and workflow `if`
 conditions.
 
-## Rustume migration example
+## Rustume example
 
 Tag/release pipelines should call lint-only reusables (no `pull-requests: write`):
 

--- a/scripts/ci/quality/validate-static-job-names.sh
+++ b/scripts/ci/quality/validate-static-job-names.sh
@@ -5,8 +5,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+if [[ -z "${REPO_ROOT:-}" ]]; then
+	REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+fi
+WORKFLOWS_DIR="${WORKFLOWS_DIR:-${REPO_ROOT}/.github/workflows}"
 
 if [[ ! -d "${WORKFLOWS_DIR}" ]]; then
 	echo "ERROR: workflows directory not found: ${WORKFLOWS_DIR}" >&2
@@ -16,7 +18,8 @@ fi
 violations=0
 
 while IFS= read -r -d '' workflow; do
-	awk -v file="${workflow#"${REPO_ROOT}/"}" '
+	set +e
+	awk -v file="${workflow#"${WORKFLOWS_DIR%/}/"}" '
 		function flush_job() {
 			if (in_job && has_if && name ~ /\$\{\{|format\(/) {
 				if (name ~ /matrix\./ || name ~ /format\(/ || name ~ /&&.*\|\|/) {
@@ -53,8 +56,9 @@ while IFS= read -r -d '' workflow; do
 		}
 	' "${workflow}"
 	awk_exit=$?
+	set -e
 	if [[ ${awk_exit} -gt 0 ]]; then
-		violations=${awk_exit}
+		violations=$((violations + awk_exit))
 	fi
 done < <(find "${WORKFLOWS_DIR}" -maxdepth 1 -name 'reusable-*.yml' -print0)
 

--- a/scripts/ci/quality/validate-static-job-names.sh
+++ b/scripts/ci/quality/validate-static-job-names.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Fail when reusable workflow jobs combine skip conditions with dynamic job.name expressions.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+WORKFLOWS_DIR="${REPO_ROOT}/.github/workflows"
+
+if [[ ! -d "${WORKFLOWS_DIR}" ]]; then
+	echo "ERROR: workflows directory not found: ${WORKFLOWS_DIR}" >&2
+	exit 1
+fi
+
+violations=0
+
+while IFS= read -r -d '' workflow; do
+	awk -v file="${workflow#"${REPO_ROOT}/"}" '
+		function flush_job() {
+			if (in_job && has_if && name ~ /\$\{\{|format\(/) {
+				if (name ~ /matrix\./ || name ~ /format\(/ || name ~ /&&.*\|\|/) {
+					printf("%s:%d: job %s uses dynamic job.name with if:\n  %s\n", file, name_line, job_id, name)
+					violations++
+				}
+			}
+			in_job = 0
+			has_if = 0
+			name = ""
+			job_id = ""
+			name_line = 0
+		}
+		/^  [a-zA-Z0-9_-]+:$/ {
+			flush_job()
+			job_id = $1
+			sub(/:$/, "", job_id)
+			in_job = 1
+			next
+		}
+		in_job && /^    if:/ {
+			has_if = 1
+			next
+		}
+		in_job && /^    name:/ {
+			name = $0
+			sub(/^    name:[[:space:]]*/, "", name)
+			name_line = NR
+			next
+		}
+		END {
+			flush_job()
+			exit violations
+		}
+	' "${workflow}"
+	awk_exit=$?
+	if [[ ${awk_exit} -gt 0 ]]; then
+		violations=${awk_exit}
+	fi
+done < <(find "${WORKFLOWS_DIR}" -maxdepth 1 -name 'reusable-*.yml' -print0)
+
+if [[ ${violations} -gt 0 ]]; then
+	echo "ERROR: ${violations} reusable workflow job(s) violate static job.name policy" >&2
+	exit 1
+fi
+
+echo "OK: reusable workflow job names satisfy static-name policy"

--- a/tests/bats/integration/test_reusable_docker_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_workflow.bats
@@ -6,6 +6,13 @@ load "../../helpers/common"
 
 WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
 
+@test "reusable-docker: per-platform jobs use static display names" {
+	run grep -F 'name: Docker build per platform' "$WORKFLOW"
+	assert_success
+	run grep -F 'name: Docker verify per platform' "$WORKFLOW"
+	assert_success
+}
+
 @test "reusable-docker: build job passes target input to build-push-action" {
 	run grep -E '^[[:space:]]+target: \$\{\{ inputs\.target \}\}$' "$WORKFLOW"
 	assert_success

--- a/tests/bats/integration/test_reusable_static_job_names.bats
+++ b/tests/bats/integration/test_reusable_static_job_names.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for static reusable workflow job display names
+
+load "../../helpers/common"
+
+VALIDATOR="${PROJECT_ROOT}/scripts/ci/quality/validate-static-job-names.sh"
+
+@test "validate-static-job-names: passes on repository reusables" {
+	run "${VALIDATOR}"
+	assert_success
+	assert_output --partial "OK:"
+}
+
+@test "validate-static-job-names: flags dynamic matrix job.name on skippable jobs" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	mkdir -p "${workflows_dir}"
+	cat >"${workflows_dir}/reusable-bad-example.yml" <<'YAML'
+---
+name: Bad example
+on:
+  workflow_call:
+    inputs:
+      flag:
+        type: boolean
+        default: false
+jobs:
+  matrix-job:
+    name: Build ${{ matrix.platform }}
+    if: ${{ inputs.flag }}
+    strategy:
+      matrix:
+        platform: [linux]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+YAML
+
+	REPO_ROOT="${BATS_TEST_TMPDIR}" run "${VALIDATOR}"
+	assert_failure
+	assert_output --partial "dynamic job.name"
+}
+
+@test "reusable-test-python: test job uses static name" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-test-python.yml"
+	run awk '
+		/^  test:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  test:/ { in_job = 0 }
+		in_job && /^    name: Python tests$/ { found = 1 }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-docker: per-platform jobs use static names" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
+	run grep -F 'name: Docker build per platform' "$workflow"
+	assert_success
+	run grep -F 'name: Docker verify per platform' "$workflow"
+	assert_success
+}
+
+@test "reusable-test-e2e-matrix: test job uses static name" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-test-e2e-matrix.yml"
+	run awk '
+		/^  test:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  test:/ { in_job = 0 }
+		in_job && /^    name: E2E tests$/ { found = 1 }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_static_job_names.bats
+++ b/tests/bats/integration/test_reusable_static_job_names.bats
@@ -36,7 +36,7 @@ jobs:
       - run: echo ok
 YAML
 
-	REPO_ROOT="${BATS_TEST_TMPDIR}" run "${VALIDATOR}"
+	WORKFLOWS_DIR="${workflows_dir}" run "${VALIDATOR}"
 	assert_failure
 	assert_output --partial "dynamic job.name"
 }

--- a/tests/bats/integration/test_reusable_test_node.bats
+++ b/tests/bats/integration/test_reusable_test_node.bats
@@ -1,51 +1,26 @@
 #!/usr/bin/env bats
 # SPDX-License-Identifier: MIT
-# Purpose: Contract tests for reusable-test-node workflow
+# Purpose: Contract tests for reusable-test-node Vitest workflow
 
 load "../../helpers/common"
 
 WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node.yml"
 
-_test_custom_checkout_order_ok() {
-	awk '
-		/^  test-custom:/ { in_job = 1 }
-		/^  [a-zA-Z0-9_-]+:/ && !/^  test-custom:/ { in_job = 0 }
-		in_job && /^    steps:/ { in_steps = 1 }
-		in_job && in_steps && /^      - name: Harden runner/ { harden = NR }
-		in_job && in_steps && /^      - name: Checkout repository/ { repo = NR }
-		in_job && in_steps && /^      - name: Checkout lgtm-ci tooling/ { tooling = NR }
-		END {
-			ok = (harden > 0 && repo > 0 && tooling > 0 && harden < repo && repo < tooling)
-			exit !ok
-		}
-	' "$WORKFLOW"
-}
-
-@test "reusable-test-node: test-custom checkout order preserves tooling" {
-	run _test_custom_checkout_order_ok
-	assert_success
-}
-
-@test "reusable-test-node: test-custom does not rely on clean: false workaround" {
+@test "reusable-test-node: vitest job name uses job-name input" {
 	run awk '
-		/^  test-custom:/ { in_job = 1 }
-		/^  [a-zA-Z0-9_-]+:/ && !/^  test-custom:/ { in_job = 0 }
-		in_job && /clean: false/ { found = 1 }
-		END { exit found }
+		/^  test-vitest:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  test-vitest:/ { in_job = 0 }
+		in_job && /^    name: \$\{\{ inputs\.job-name \}\}$/ { found = 1 }
+		END { exit !found }
 	' "$WORKFLOW"
 	assert_success
 }
 
-@test "reusable-test-node: skipped jobs use static names without expressions" {
-	run awk '
-		/^  test-vitest:/ { vitest = 1; custom = 0 }
-		/^  test-custom:/ { custom = 1; vitest = 0 }
-		/^  [a-zA-Z0-9_-]+:/ && !/^  test-vitest:/ && !/^  test-custom:/ { vitest = 0; custom = 0 }
-		vitest && /^    name:/ { if ($0 ~ /\$\{\{/) bad_vitest = 1 }
-		custom && /^    name:/ { if ($0 ~ /\$\{\{/) bad_custom = 1 }
-		END { exit (bad_vitest || bad_custom) }
-	' "$WORKFLOW"
-	assert_success
+@test "reusable-test-node: does not define test-command input or custom job" {
+	run grep -q '^      test-command:$' "$WORKFLOW"
+	assert_failure
+	run grep -q 'test-custom:' "$WORKFLOW"
+	assert_failure
 }
 
 @test "reusable-test-node: exposes pages coverage HTML inputs and staging script" {

--- a/tests/bats/integration/test_reusable_test_node_custom.bats
+++ b/tests/bats/integration/test_reusable_test_node_custom.bats
@@ -29,7 +29,12 @@ _test_checkout_order_ok() {
 @test "reusable-test-node-custom: requires test-command input" {
 	run grep -E '^      test-command:$' "$WORKFLOW"
 	assert_success
-	run awk '/^      test-command:/{getline; print}' "$WORKFLOW" | grep -q 'required: true'
+	run awk '
+		/^      test-command:/ { in_input = 1 }
+		in_input && /^      [a-zA-Z0-9_-]+:/ && !/^      test-command:/ { in_input = 0 }
+		in_input && /required: true/ { found = 1 }
+		END { exit !found }
+	' "$WORKFLOW"
 	assert_success
 }
 
@@ -43,9 +48,17 @@ _test_checkout_order_ok() {
 	assert_success
 }
 
-@test "reusable-test-node-custom: does not define vitest-only test-command branching" {
-	run grep -q 'test-vitest:' "$WORKFLOW"
-	assert_failure
-	run grep -q 'test-custom:' "$WORKFLOW"
-	assert_failure
+@test "reusable-test-node-custom: aggregate-tests derives passed from matrix result" {
+	run awk '
+		/^  aggregate-tests:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  aggregate-tests:/ { in_job = 0 }
+		in_job && /needs\.test\.result/ { found = 1 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+	run awk '
+		/value: \$\{\{ jobs\.test\.outputs\.passed/ { bad = 1 }
+		END { exit bad }
+	' "$WORKFLOW"
+	assert_success
 }

--- a/tests/bats/integration/test_reusable_test_node_custom.bats
+++ b/tests/bats/integration/test_reusable_test_node_custom.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-test-node-custom workflow
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node-custom.yml"
+
+_test_checkout_order_ok() {
+	awk '
+		/^  test:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  test:/ { in_job = 0 }
+		in_job && /^    steps:/ { in_steps = 1 }
+		in_job && in_steps && /^      - name: Harden runner/ { harden = NR }
+		in_job && in_steps && /^      - name: Checkout repository/ { repo = NR }
+		in_job && in_steps && /^      - name: Checkout lgtm-ci tooling/ { tooling = NR }
+		END {
+			ok = (harden > 0 && repo > 0 && tooling > 0 && harden < repo && repo < tooling)
+			exit !ok
+		}
+	' "$WORKFLOW"
+}
+
+@test "reusable-test-node-custom: test job checkout order preserves tooling" {
+	run _test_checkout_order_ok
+	assert_success
+}
+
+@test "reusable-test-node-custom: requires test-command input" {
+	run grep -E '^      test-command:$' "$WORKFLOW"
+	assert_success
+	run awk '/^      test-command:/{getline; print}' "$WORKFLOW" | grep -q 'required: true'
+	assert_success
+}
+
+@test "reusable-test-node-custom: test job name uses job-name input" {
+	run awk '
+		/^  test:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  test:/ { in_job = 0 }
+		in_job && /^    name: \$\{\{ inputs\.job-name \}\}$/ { found = 1 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-test-node-custom: does not define vitest-only test-command branching" {
+	run grep -q 'test-vitest:' "$WORKFLOW"
+	assert_failure
+	run grep -q 'test-custom:' "$WORKFLOW"
+	assert_failure
+}


### PR DESCRIPTION
## Summary

Implement #168 §12 with a hybrid job display name contract: split Node Vitest vs custom commands into separate reusables (no skipped siblings), use static inner names for skippable matrix legs (Python, Docker per-platform, E2E), restore `job-name` for always-run Node test checks, and add a lint guard plus documentation.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

- **`reusable-test-node.yml` is Vitest-only** — remove `test-command`; use `reusable-test-node-custom.yml` for package scripts (e.g. `bun run test:coverage`).
- **Check names change** for Python (`Python tests`), Docker per-platform jobs, and E2E matrix; update branch protection when repinning.
- **`job-name` again drives Vitest/custom test check labels** (supersedes #256 interim static Node names).

## Closes

- Relates to #168

## Changes Made

- Add `reusable-test-node-custom.yml` (required `test-command`, `job-name` on test job)
- Trim `reusable-test-node.yml` to Vitest-only; restore `${{ inputs.job-name }}` on test job
- Static inner job names: `reusable-test-python.yml`, `reusable-docker.yml`, `reusable-test-e2e-matrix.yml`
- Add `scripts/ci/quality/validate-static-job-names.sh` and BATS contract tests
- Document job display name policy in `docs/workflow-contract.md` and related docs
- Update `CHANGELOG.md` under `[Unreleased]`

## Testing

- [x] `uv run lintro fmt`
- [x] `uv run lintro chk` (0 issues)
- [x] `uv run lintro tst` (BATS integration tests for Node split, static names, Docker)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix skipped matrix job display names and add `reusable-test-node-custom` workflow
> - Converts dynamic job `name:` expressions (matrix interpolation) to static labels in Docker, E2E, and Python reusable workflows so skipped matrix legs no longer produce broken check names.
> - Adds a new [`reusable-test-node-custom.yml`](.github/workflows/reusable-test-node-custom.yml) reusable workflow for caller-provided Node test commands, replacing the removed `test-command` input in the Vitest workflow.
> - Renames `reusable-test-node.yml` to a Vitest-only workflow; adds a `job-name` input so the Vitest job check name is caller-controlled.
> - Adds [`validate-static-job-names.sh`](scripts/ci/quality/validate-static-job-names.sh), a script that fails if any reusable workflow job combines an `if:` condition with a dynamic `name:` expression.
> - Behavioral Change: callers using `test-command` in `reusable-test-node.yml` must migrate to `reusable-test-node-custom.yml`; `publish-results` input is removed from Node and Python workflows.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a3bed17.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable workflow for custom Node.js test commands with coverage and PR-commenting controls.

* **Documentation**
  * Updated Node/Rust workflow docs, README, CHANGELOG, and workflow-contract to describe split Node Vitest vs custom workflows and job-name behavior.
  * Removed deprecated `publish-results` from Python workflow docs.

* **Tests**
  * Added Bats integration tests for new/updated workflows and static job-name checks.

* **Chores**
  * Added CI script to validate static job display names; simplified Node Vitest workflow outputs and unified job display names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Implements the hybrid job display-name contract from #168 §12 by splitting `reusable-test-node.yml` into a Vitest-only workflow and a new `reusable-test-node-custom.yml`, replacing dynamic `${{ matrix.* }}` / ternary expressions in Python, Docker per-platform, and E2E matrix job names with static strings, and adding a `validate-static-job-names.sh` awk lint guard with BATS contract tests.

- **Workflow split**: `reusable-test-node.yml` drops `test-command` and the `test-custom` job entirely; `reusable-test-node-custom.yml` is a faithful extraction of that logic with `test-command` required and `name: ${{ inputs.job-name }}` on the test job — no skipped sibling means the dynamic input expression is safe.
- **Static names**: `reusable-test-python.yml`, `reusable-docker.yml`, and `reusable-test-e2e-matrix.yml` now use fixed literal job names, stopping GitHub from rendering unevaluated expressions in the checks UI for skipped matrix legs.
- **Lint guard**: `validate-static-job-names.sh` uses `set +e` / `set -e` around awk to accumulate violations across all files; accepts `WORKFLOWS_DIR` env override so the BATS violation-detection test can inject a synthetic bad workflow without touching the real workflows directory.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; all functional workflow logic is correct and the split cleanly removes the skipped-sibling problem.

The workflow split, static name substitutions, and lint guard are all mechanically straightforward. The set +e / set -e fix around awk is correct. The WORKFLOWS_DIR env-var override in the validator makes the BATS violation-detection test viable. The one gap in the awk parser for multi-line YAML block-scalar names is a future-proofing concern that does not affect any name in the current codebase.

scripts/ci/quality/validate-static-job-names.sh — the awk name parser needs a one-line continuation read to close the block-scalar bypass path.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/quality/validate-static-job-names.sh | New lint guard that rejects dynamic job.name on jobs with if: — correctly uses set +e / set -e around awk and accepts WORKFLOWS_DIR override; has a coverage gap for multi-line YAML block-scalar names. |
| .github/workflows/reusable-test-node-custom.yml | New 505-line custom Node.js test reusable extracted from the old test-custom job; mirrors the Vitest workflow structure; uses job-name input correctly; aggregate-tests/pages-coverage-status patterns match the Vitest workflow. |
| .github/workflows/reusable-test-node.yml | Trimmed to Vitest-only by removing test-command input, test-custom job, and associated conditional expressions; test-vitest now uses job-name input for its display name without skipped-sibling interference. |
| tests/bats/integration/test_reusable_static_job_names.bats | New BATS tests covering validator pass/fail, Python/Docker/E2E static names; violation-detection test correctly exercises the WORKFLOWS_DIR override path now that the script respects the env var. |
| tests/bats/integration/test_reusable_test_node_custom.bats | New BATS contract tests for reusable-test-node-custom.yml; verifies checkout order, required test-command, job-name usage, and aggregate-tests result derivation. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller workflow] -->|Vitest runner| B["reusable-test-node.yml\n(Vitest-only)"]
    A -->|Custom command| C["reusable-test-node-custom.yml\n(required: test-command)"]
    B --> B1["prepare"]
    B1 --> B2["test-vitest\nname: inputs.job-name"]
    B2 --> B3[aggregate-tests]
    C --> C1["prepare"]
    C1 --> C2["test\nname: inputs.job-name"]
    C2 --> C3[aggregate-tests]
    D["reusable-test-python.yml"] --> D1["test\nname: Python tests - static"]
    E["reusable-docker.yml"] --> E1["build-per-platform\nname: Docker build per platform - static"]
    E --> E2["verify-per-platform\nname: Docker verify per platform - static"]
    F["reusable-test-e2e-matrix.yml"] --> F1["test\nname: E2E tests - static"]
    G[validate-static-job-names.sh] -.->|lint guard| D
    G -.-> E
    G -.-> F
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fquality%2Fvalidate-static-job-names.sh%3A47-52%0AThe%20awk%20parser%20captures%20only%20the%20first%20token%20of%20a%20%60name%3A%60%20line%2C%20so%20a%20YAML%20block-scalar%20like%20%60name%3A%20%3E-%60%20followed%20by%20%60%24%7B%7B%20matrix.platform%20%7D%7D%60%20on%20the%20next%20line%20sets%20%60name%20%3D%20%22%3E%22%60%20%E2%80%94%20the%20expression%20on%20the%20continuation%20line%20is%20never%20read%2C%20and%20the%20violation%20is%20silently%20missed.%20The%20prior%20Python%20job%20name%20used%20exactly%20this%20multi-line%20%60%3E-%60%20form%20%28removed%20in%20this%20PR%29%2C%20so%20the%20guard%20would%20not%20have%20caught%20a%20reintroduction%20via%20a%20block%20scalar.%20Adding%20a%20continuation-line%20check%20prevents%20future%20bypasses.%0A%0A%60%60%60suggestion%0A%09%09in_job%20%26%26%20%2F%5E%20%20%20%20name%3A%2F%20%7B%0A%09%09%09name%20%3D%20%240%0A%09%09%09sub%28%2F%5E%20%20%20%20name%3A%5B%5B%3Aspace%3A%5D%5D*%2F%2C%20%22%22%2C%20name%29%0A%09%09%09name_line%20%3D%20NR%0A%09%09%09%23%20Collect%20block-scalar%20continuation%20lines%20%28e.g.%20name%3A%20%3E-%29%0A%09%09%09if%20%28name%20~%20%2F%5E%5B%3E%7C%5D%5B-%2B%5D%3F%24%2F%29%20%7B%0A%09%09%09%09getline%20continuation%0A%09%09%09%09name%20%3D%20continuation%0A%09%09%09%09sub%28%2F%5E%5B%5B%3Aspace%3A%5D%5D%2B%2F%2C%20%22%22%2C%20name%29%0A%09%09%09%7D%0A%09%09%09next%0A%09%09%7D%0A%60%60%60%0A%0A&pr=263&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fquality%2Fvalidate-static-job-names.sh%3A47-52%0AThe%20awk%20parser%20captures%20only%20the%20first%20token%20of%20a%20%60name%3A%60%20line%2C%20so%20a%20YAML%20block-scalar%20like%20%60name%3A%20%3E-%60%20followed%20by%20%60%24%7B%7B%20matrix.platform%20%7D%7D%60%20on%20the%20next%20line%20sets%20%60name%20%3D%20%22%3E%22%60%20%E2%80%94%20the%20expression%20on%20the%20continuation%20line%20is%20never%20read%2C%20and%20the%20violation%20is%20silently%20missed.%20The%20prior%20Python%20job%20name%20used%20exactly%20this%20multi-line%20%60%3E-%60%20form%20%28removed%20in%20this%20PR%29%2C%20so%20the%20guard%20would%20not%20have%20caught%20a%20reintroduction%20via%20a%20block%20scalar.%20Adding%20a%20continuation-line%20check%20prevents%20future%20bypasses.%0A%0A%60%60%60suggestion%0A%09%09in_job%20%26%26%20%2F%5E%20%20%20%20name%3A%2F%20%7B%0A%09%09%09name%20%3D%20%240%0A%09%09%09sub%28%2F%5E%20%20%20%20name%3A%5B%5B%3Aspace%3A%5D%5D*%2F%2C%20%22%22%2C%20name%29%0A%09%09%09name_line%20%3D%20NR%0A%09%09%09%23%20Collect%20block-scalar%20continuation%20lines%20%28e.g.%20name%3A%20%3E-%29%0A%09%09%09if%20%28name%20~%20%2F%5E%5B%3E%7C%5D%5B-%2B%5D%3F%24%2F%29%20%7B%0A%09%09%09%09getline%20continuation%0A%09%09%09%09name%20%3D%20continuation%0A%09%09%09%09sub%28%2F%5E%5B%5B%3Aspace%3A%5D%5D%2B%2F%2C%20%22%22%2C%20name%29%0A%09%09%09%7D%0A%09%09%09next%0A%09%09%7D%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=263&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22fix%2F168-hybrid-job-display-names%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F168-hybrid-job-display-names%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fquality%2Fvalidate-static-job-names.sh%3A47-52%0AThe%20awk%20parser%20captures%20only%20the%20first%20token%20of%20a%20%60name%3A%60%20line%2C%20so%20a%20YAML%20block-scalar%20like%20%60name%3A%20%3E-%60%20followed%20by%20%60%24%7B%7B%20matrix.platform%20%7D%7D%60%20on%20the%20next%20line%20sets%20%60name%20%3D%20%22%3E%22%60%20%E2%80%94%20the%20expression%20on%20the%20continuation%20line%20is%20never%20read%2C%20and%20the%20violation%20is%20silently%20missed.%20The%20prior%20Python%20job%20name%20used%20exactly%20this%20multi-line%20%60%3E-%60%20form%20%28removed%20in%20this%20PR%29%2C%20so%20the%20guard%20would%20not%20have%20caught%20a%20reintroduction%20via%20a%20block%20scalar.%20Adding%20a%20continuation-line%20check%20prevents%20future%20bypasses.%0A%0A%60%60%60suggestion%0A%09%09in_job%20%26%26%20%2F%5E%20%20%20%20name%3A%2F%20%7B%0A%09%09%09name%20%3D%20%240%0A%09%09%09sub%28%2F%5E%20%20%20%20name%3A%5B%5B%3Aspace%3A%5D%5D*%2F%2C%20%22%22%2C%20name%29%0A%09%09%09name_line%20%3D%20NR%0A%09%09%09%23%20Collect%20block-scalar%20continuation%20lines%20%28e.g.%20name%3A%20%3E-%29%0A%09%09%09if%20%28name%20~%20%2F%5E%5B%3E%7C%5D%5B-%2B%5D%3F%24%2F%29%20%7B%0A%09%09%09%09getline%20continuation%0A%09%09%09%09name%20%3D%20continuation%0A%09%09%09%09sub%28%2F%5E%5B%5B%3Aspace%3A%5D%5D%2B%2F%2C%20%22%22%2C%20name%29%0A%09%09%09%7D%0A%09%09%09next%0A%09%09%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["docs: state forward-only consumer contra..."](https://github.com/lgtm-hq/lgtm-ci/commit/a3bed17313984eb96428b75667695c6e8b6d877e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34738345)</sub>

<!-- /greptile_comment -->