### PR TITLE
feat(workflows): add reusable-required-check for org ruleset gates (#168 §4)

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1400,6 +1400,43 @@ jobs:
 
 ---
 
+### reusable-required-check.yml
+
+Org ruleset gate: asserts an upstream reusable job succeeded (and optional
+outputs) under a caller-controlled `job-name`. Replaces consumer-local shim
+`runs-on` jobs. See `docs/workflow-contract.md` (Org ruleset check names).
+
+```yaml
+lintro-code-quality:
+  needs: dogfooding-lint
+  if: always()
+  uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@main
+  permissions:
+    contents: read
+  with:
+    job-name: "🛠️ Lintro Code Quality"
+    upstream-result: ${{ needs.dogfooding-lint.result }}
+    status-output: ${{ needs.dogfooding-lint.outputs.status }}
+```
+
+**Inputs:**
+
+- `job-name` - **Required.** GitHub check name for this gate
+- `upstream-result` - **Required.** Upstream `needs.*.result`
+- `passed-output` - When set, must be the string `true`
+- `status-output` / `status-expected` - Optional status string gate (default
+  expected `passed`)
+- `draft-pr-skip` - Skip gate on draft PRs (default: false)
+- `tooling-ref`, `egress-policy`, `allowed-endpoints`, `runner-image`,
+  `timeout-minutes`
+
+**Outputs:**
+
+- `exit-code` - `0` or `1`
+- `status` - `passed` or `failed`
+
+---
+
 ### reusable-test-e2e.yml
 
 E2E testing workflow with Playwright.

--- a/.github/workflows/reusable-required-check.yml
+++ b/.github/workflows/reusable-required-check.yml
@@ -1,0 +1,115 @@
+---
+name: Reusable Required Check Gate
+
+on:
+  workflow_call:
+    inputs:
+      job-name:
+        description: "GitHub check run name reported for this gate job"
+        required: true
+        type: string
+      upstream-result:
+        description: "Result of the upstream job (e.g. needs.test.result)"
+        required: true
+        type: string
+      passed-output:
+        description: >-
+          When non-empty, must be the string true (e.g. needs.test.outputs.passed)
+        required: false
+        type: string
+        default: ""
+      status-output:
+        description: >-
+          When non-empty, must equal status-expected (e.g. needs.quality.outputs.status)
+        required: false
+        type: string
+        default: ""
+      status-expected:
+        description: "Expected status-output value when status-output is set"
+        required: false
+        type: string
+        default: "passed"
+      draft-pr-skip:
+        description: "Skip this gate on draft pull requests"
+        required: false
+        type: boolean
+        default: false
+      tooling-ref:
+        description: "Git ref to use when checking out lgtm-ci tooling scripts"
+        required: false
+        type: string
+        default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "audit"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 5
+
+    outputs:
+      exit-code:
+        description: "0 when the gate passed, 1 when it failed"
+        value: ${{ jobs.gate.outputs.exit-code }}
+      status:
+        description: "passed or failed"
+        value: ${{ jobs.gate.outputs.status }}
+
+jobs:
+  gate:
+    name: ${{ inputs.job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    if: >-
+      always()
+      && (
+        !inputs.draft-pr-skip
+        || github.event_name != 'pull_request'
+        || github.event.pull_request.draft == false
+      )
+    permissions:
+      contents: read
+    outputs:
+      exit-code: ${{ steps.gate.outputs.exit-code }}
+      status: ${{ steps.gate.outputs.status }}
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Assert required check
+        id: gate
+        shell: bash
+        env:
+          UPSTREAM_RESULT: ${{ inputs.upstream-result }}
+          PASSED_OUTPUT: ${{ inputs.passed-output }}
+          STATUS_OUTPUT: ${{ inputs.status-output }}
+          STATUS_EXPECTED: ${{ inputs.status-expected }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/assert-required-check.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **workflows**: `reusable-required-check.yml` org-ruleset gate for legacy required check names
+- **ci**: `assert-required-check.sh` for reusable required-check upstream validation
+
 ### Changed
 
 ### Deprecated
@@ -16,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+- **ci**: `validate-static-job-names.sh` detects dynamic expressions in YAML block-scalar
+  `job.name` continuations (#168 §12 guardrail)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **workflows**: `reusable-required-check.yml` org-ruleset gate for legacy required check names
+- **workflows**: `reusable-required-check.yml` org-ruleset gate for branch-protection check
+  names that differ from the reusable workflow `job-name`
 - **ci**: `assert-required-check.sh` for reusable required-check upstream validation
 
 ### Changed

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -83,6 +83,26 @@ jobs:
       script: scripts/ci/validate.sh
 ```
 
+### Org ruleset gate (`reusable-required-check.yml`)
+
+Thin aggregate-status gate for branch-protection check names that differ from
+the work reusable’s `job-name`. See [workflow-contract.md](workflow-contract.md)
+(Org ruleset check names).
+
+```yaml
+test-suite-coverage:
+  needs: test
+  if: always()
+  uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@<sha>
+  permissions:
+    contents: read
+  with:
+    tooling-ref: <sha>
+    job-name: "🧪 Test Suite & Coverage"
+    upstream-result: ${{ needs.test.result }}
+    passed-output: ${{ needs.test.outputs.passed }}
+```
+
 ## Tests
 
 ```yaml

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -125,6 +125,42 @@ expressions in `job.name` on jobs that have `if:`.
 Custom package scripts use `reusable-test-node-custom.yml` with required
 `test-command` and `job-name`.
 
+## Org ruleset check names
+
+Reusable workflows report checks as **`caller_job_id / inner_job_name`**. Org
+rulesets may require a **legacy display name** that does not match the inner
+`job-name` on the work job (for example ruleset `🧪 Test Suite & Coverage` vs
+`test / Python Compatibility`).
+
+**Preferred (no shim):** Update the org ruleset to require the actual check path
+after repinning, and set `job-name` (and caller job `id` when helpful) to match.
+
+**Legacy gate:** When the ruleset cannot change yet, add a thin caller job that
+calls `reusable-required-check.yml` instead of hand-rolled `runs-on` shims. Pass
+`upstream-result` and optional `passed-output` / `status-output` from the work
+job. Use `always()` on the caller job so the gate still runs when the upstream
+job fails.
+
+```yaml
+test:
+  uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@<sha>
+  with:
+    job-name: Python Compatibility
+    tooling-ref: <sha>
+
+test-suite-coverage:
+  needs: test
+  if: always()
+  uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-required-check.yml@<sha>
+  with:
+    tooling-ref: <sha>
+    job-name: "🧪 Test Suite & Coverage"
+    upstream-result: ${{ needs.test.result }}
+    passed-output: ${{ needs.test.outputs.passed }}
+```
+
+Do not add per-consumer `job-name` aliases inside work reusables.
+
 ## Egress block examples
 
 ### Node / Bun (web)

--- a/scripts/ci/actions/assert-required-check.sh
+++ b/scripts/ci/actions/assert-required-check.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Fail when an upstream reusable job did not pass required outputs.
+
+set -euo pipefail
+
+write_gate_outputs() {
+	local exit_code="$1"
+	local status="$2"
+	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+		echo "exit-code=${exit_code}" >>"${GITHUB_OUTPUT}"
+		echo "status=${status}" >>"${GITHUB_OUTPUT}"
+	fi
+}
+
+if [[ ! ${UPSTREAM_RESULT+x} ]]; then
+	echo "::error::UPSTREAM_RESULT not set"
+	write_gate_outputs 1 failed
+	exit 1
+fi
+
+STATUS_EXPECTED="${STATUS_EXPECTED:-passed}"
+
+if [[ "${UPSTREAM_RESULT}" != "success" ]]; then
+	echo "::error::Upstream job failed (result=${UPSTREAM_RESULT})"
+	write_gate_outputs 1 failed
+	exit 1
+fi
+
+if [[ -n "${PASSED_OUTPUT:-}" && "${PASSED_OUTPUT}" != "true" ]]; then
+	echo "::error::Upstream passed output is not true (passed=${PASSED_OUTPUT})"
+	write_gate_outputs 1 failed
+	exit 1
+fi
+
+if [[ -n "${STATUS_OUTPUT:-}" && "${STATUS_OUTPUT}" != "${STATUS_EXPECTED}" ]]; then
+	echo "::error::Upstream status is not ${STATUS_EXPECTED} (status=${STATUS_OUTPUT})"
+	write_gate_outputs 1 failed
+	exit 1
+fi
+
+echo "Required check satisfied (upstream=${UPSTREAM_RESULT})"
+write_gate_outputs 0 passed

--- a/scripts/ci/quality/validate-static-job-names.sh
+++ b/scripts/ci/quality/validate-static-job-names.sh
@@ -48,6 +48,18 @@ while IFS= read -r -d '' workflow; do
 			name = $0
 			sub(/^    name:[[:space:]]*/, "", name)
 			name_line = NR
+			if (name ~ /^[>|][-+]?$/) {
+				while ((getline continuation) > 0) {
+					if (continuation ~ /^    [a-zA-Z0-9_-]+:/) {
+						break
+					}
+					if (continuation !~ /^[[:space:]]/) {
+						break
+					}
+					sub(/^[[:space:]]+/, "", continuation)
+					name = continuation
+				}
+			}
 			next
 		}
 		END {

--- a/scripts/ci/quality/validate-static-job-names.sh
+++ b/scripts/ci/quality/validate-static-job-names.sh
@@ -33,6 +33,19 @@ while IFS= read -r -d '' workflow; do
 			job_id = ""
 			name_line = 0
 		}
+		function append_pending(line) {
+			if (pending == "") {
+				pending = line
+			} else {
+				pending = pending " " line
+			}
+		}
+		function finalize_name() {
+			if (pending != "") {
+				name = pending
+				pending = ""
+			}
+		}
 		/^  [a-zA-Z0-9_-]+:$/ {
 			flush_job()
 			job_id = $1
@@ -48,8 +61,12 @@ while IFS= read -r -d '' workflow; do
 			name = $0
 			sub(/^    name:[[:space:]]*/, "", name)
 			name_line = NR
+			pending = ""
 			if (name ~ /^[>|][-+]?$/) {
 				while ((getline continuation) > 0) {
+					if (continuation ~ /^    if:/) {
+						has_if = 1
+					}
 					if (continuation ~ /^    [a-zA-Z0-9_-]+:/) {
 						break
 					}
@@ -57,8 +74,9 @@ while IFS= read -r -d '' workflow; do
 						break
 					}
 					sub(/^[[:space:]]+/, "", continuation)
-					name = continuation
+					append_pending(continuation)
 				}
+				finalize_name()
 			}
 			next
 		}

--- a/tests/bats/integration/test_reusable_required_check.bats
+++ b/tests/bats/integration/test_reusable_required_check.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-required-check workflow
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-required-check.yml"
+
+@test "reusable-required-check: job-name input is required" {
+	run awk '
+		/^      job-name:/ { if ($0 ~ /required: true/) found = 1 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-required-check: gate job uses job-name for display name" {
+	run awk '
+		/^  gate:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  gate:/ { in_job = 0 }
+		in_job && /^    name: \$\{\{ inputs\.job-name \}\}$/ { found = 1 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-required-check: upstream-result input is required" {
+	run awk '
+		/^      upstream-result:/ { if ($0 ~ /required: true/) found = 1 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-required-check: uses harden-runner and tooling checkout" {
+	run grep -F 'step-security/harden-runner@' "$WORKFLOW"
+	assert_success
+	run awk '
+		/Checkout lgtm-ci tooling/ { found = 1 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+	run grep -F 'scripts/ci/' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-required-check: assert step invokes assert-required-check.sh" {
+	run awk '
+		/Assert required check/ { in_step = 1 }
+		in_step && /assert-required-check\.sh/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-required-check: passes upstream-result to assert script env" {
+	run awk '
+		/UPSTREAM_RESULT: \$\{\{ inputs\.upstream-result \}\}/ { found = 1 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-required-check: gate job uses always() with draft-pr-skip guard" {
+	run awk '
+		/^  gate:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  gate:/ { in_job = 0 }
+		in_job && /^    if:/ { if_line = 1 }
+		if_line && /always\(\)/ { found_always = 1 }
+		if_line && /draft-pr-skip/ { found_draft = 1 }
+		END { exit !(found_always && found_draft) }
+	' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_required_check.bats
+++ b/tests/bats/integration/test_reusable_required_check.bats
@@ -8,7 +8,17 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-required-check.yml"
 
 @test "reusable-required-check: job-name input is required" {
 	run awk '
-		/^      job-name:/ { if ($0 ~ /required: true/) found = 1 }
+		/^      job-name:/ {
+			while ((getline line) > 0) {
+				if (line ~ /^      [a-zA-Z0-9_-]+:/) {
+					break
+				}
+				if (line ~ /^        required: true$/) {
+					found = 1
+					break
+				}
+			}
+		}
 		END { exit !found }
 	' "$WORKFLOW"
 	assert_success
@@ -26,7 +36,17 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-required-check.yml"
 
 @test "reusable-required-check: upstream-result input is required" {
 	run awk '
-		/^      upstream-result:/ { if ($0 ~ /required: true/) found = 1 }
+		/^      upstream-result:/ {
+			while ((getline line) > 0) {
+				if (line ~ /^      [a-zA-Z0-9_-]+:/) {
+					break
+				}
+				if (line ~ /^        required: true$/) {
+					found = 1
+					break
+				}
+			}
+		}
 		END { exit !found }
 	' "$WORKFLOW"
 	assert_success

--- a/tests/bats/integration/test_reusable_static_job_names.bats
+++ b/tests/bats/integration/test_reusable_static_job_names.bats
@@ -12,6 +12,36 @@ VALIDATOR="${PROJECT_ROOT}/scripts/ci/quality/validate-static-job-names.sh"
 	assert_output --partial "OK:"
 }
 
+@test "validate-static-job-names: flags block-scalar job.name with dynamic continuation" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	mkdir -p "${workflows_dir}"
+	cat >"${workflows_dir}/reusable-block-scalar-bad.yml" <<'YAML'
+---
+name: Block scalar bad example
+on:
+  workflow_call:
+    inputs:
+      flag:
+        type: boolean
+        default: false
+jobs:
+  matrix-job:
+    name: >-
+      ${{ matrix.platform }}
+    if: ${{ inputs.flag }}
+    strategy:
+      matrix:
+        platform: [linux]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" run "${VALIDATOR}"
+	assert_failure
+	assert_output --partial "dynamic job.name"
+}
+
 @test "validate-static-job-names: flags dynamic matrix job.name on skippable jobs" {
 	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
 	mkdir -p "${workflows_dir}"

--- a/tests/bats/integration/test_reusable_static_job_names.bats
+++ b/tests/bats/integration/test_reusable_static_job_names.bats
@@ -42,6 +42,34 @@ YAML
 	assert_output --partial "dynamic job.name"
 }
 
+@test "validate-static-job-names: flags multi-line block-scalar with dynamic first line" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	mkdir -p "${workflows_dir}"
+	cat >"${workflows_dir}/reusable-block-scalar-multiline-bad.yml" <<'YAML'
+---
+name: Block scalar multiline bad example
+on:
+  workflow_call:
+    inputs:
+      flag:
+        type: boolean
+        default: false
+jobs:
+  matrix-job:
+    name: >-
+      ${{ matrix.platform }}
+      suffix label
+    if: ${{ inputs.flag }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" run "${VALIDATOR}"
+	assert_failure
+	assert_output --partial "dynamic job.name"
+}
+
 @test "validate-static-job-names: flags dynamic matrix job.name on skippable jobs" {
 	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
 	mkdir -p "${workflows_dir}"

--- a/tests/bats/unit/actions/test_assert_required_check.bats
+++ b/tests/bats/unit/actions/test_assert_required_check.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/assert-required-check.sh
+
+load "../../../helpers/common"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/assert-required-check.sh"
+
+@test "assert-required-check: passes when upstream succeeded" {
+	run env UPSTREAM_RESULT=success bash "${SCRIPT}"
+
+	assert_success
+	assert_output --partial "Required check satisfied"
+}
+
+@test "assert-required-check: passes with passed and status outputs" {
+	run env \
+		UPSTREAM_RESULT=success \
+		PASSED_OUTPUT=true \
+		STATUS_OUTPUT=passed \
+		bash "${SCRIPT}"
+
+	assert_success
+}
+
+@test "assert-required-check: fails when upstream did not succeed" {
+	run env UPSTREAM_RESULT=failure bash "${SCRIPT}"
+
+	assert_failure
+	assert_output --partial "Upstream job failed"
+}
+
+@test "assert-required-check: fails when passed output is not true" {
+	run env \
+		UPSTREAM_RESULT=success \
+		PASSED_OUTPUT=false \
+		bash "${SCRIPT}"
+
+	assert_failure
+	assert_output --partial "passed output is not true"
+}
+
+@test "assert-required-check: fails when status output mismatches expected" {
+	run env \
+		UPSTREAM_RESULT=success \
+		STATUS_OUTPUT=failed \
+		STATUS_EXPECTED=passed \
+		bash "${SCRIPT}"
+
+	assert_failure
+	assert_output --partial "status is not passed"
+}
+
+@test "assert-required-check: writes github outputs on success" {
+	local output_file="${BATS_TEST_TMPDIR}/github_output"
+	run env \
+		UPSTREAM_RESULT=success \
+		GITHUB_OUTPUT="${output_file}" \
+		bash "${SCRIPT}"
+
+	assert_success
+	assert [ -f "${output_file}" ]
+	run grep -F 'exit-code=0' "${output_file}"
+	assert_success
+	run grep -F 'status=passed' "${output_file}"
+	assert_success
+}
+
+@test "assert-required-check: rejects unset upstream result" {
+	run env -u UPSTREAM_RESULT bash "${SCRIPT}"
+
+	assert_failure
+	assert_output --partial "UPSTREAM_RESULT not set"
+}


### PR DESCRIPTION
## Summary

Add a drop-in `reusable-required-check.yml` gate so consumers can replace hand-rolled org-ruleset shim jobs (for example py-lintro `test-suite-coverage` and `lintro-code-quality`). Document how reusable check paths relate to branch-protection names and harden the §12 static job-name validator for YAML block-scalar continuations.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. New optional reusable; no changes to existing workflow contracts.

## Closes

- Relates to #168

## Changes Made

- Add `reusable-required-check.yml` with `job-name`, `upstream-result`, optional `passed-output` / `status-output`, and `draft-pr-skip`
- Add `scripts/ci/actions/assert-required-check.sh` for upstream validation and gate outputs
- Document org ruleset check naming in `docs/workflow-contract.md` and `docs/reusable-workflows.md`
- Document the reusable in `.github/actions/README.md`
- Extend `validate-static-job-names.sh` for multi-line block-scalar `job.name` values
- Add BATS unit and integration contract tests
- Update `CHANGELOG.md` under `[Unreleased]`

## Testing

- [x] `uv run lintro fmt`
- [x] `uv run lintro chk` (0 issues)
- [x] `uv run lintro tst` (BATS unit + integration)

## Quality Checks

- [x] Lint/format (`uv run lintro fmt`, `uv run lintro chk`)
- [x] Tests (`uv run lintro tst`)
- [x] actionlint (via lintro)

## Consumer migration (follow-up)

After repinning, py-lintro can replace shim `runs-on` jobs with `reusable-required-check.yml`, or update org rulesets to match `caller_job_id / job-name` and remove shims entirely.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `reusable-required-check` workflow for org ruleset gates
> - Adds [reusable-required-check.yml](.github/workflows/reusable-required-check.yml), a reusable workflow that exposes a named gate job for use with GitHub org ruleset required checks.
> - The gate runs [assert-required-check.sh](scripts/ci/actions/assert-required-check.sh), which validates `UPSTREAM_RESULT == success` and optionally checks `PASSED_OUTPUT` and `STATUS_OUTPUT`; outputs `exit-code` (0/1) and `status` (passed/failed).
> - Supports skipping for draft PRs via `draft-pr-skip` input and uses harden-runner with configurable egress policy.
> - Fixes [validate-static-job-names.sh](scripts/ci/quality/validate-static-job-names.sh) to detect dynamic expressions in YAML block-scalar `job.name` fields.
> - Adds unit and integration tests for the new workflow and script, and documents usage in [docs/reusable-workflows.md](docs/reusable-workflows.md) and [docs/workflow-contract.md](docs/workflow-contract.md).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 24881b9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable workflow gate for organization ruleset compliance.
  * Added a CI gate script to validate upstream job results and emit gate outputs.
  * Enhanced job-name validation to support multi-line YAML definitions.

* **Documentation**
  * Added guidance on org ruleset check names, legacy display-name handling, and an example workflow.
  * Updated changelog with CI guardrail entries.

* **Tests**
  * Added integration and unit tests covering the reusable gate and validation changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lgtm-hq/lgtm-ci/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a reusable `reusable-required-check.yml` workflow that acts as an org-ruleset gate, asserting that an upstream job succeeded before reporting a named GitHub check. It also extends `validate-static-job-names.sh` to detect dynamic `${{ }}` expressions in YAML block-scalar (`>` / `|`) `job.name` continuations.

- **New workflow & script**: `reusable-required-check.yml` accepts `upstream-result`, optional `passed-output`/`status-output`, and a caller-supplied `job-name` so consumers can satisfy org-ruleset check-name requirements that differ from the inner reusable's job name. `assert-required-check.sh` performs the validation and writes `exit-code`/`status` to `GITHUB_OUTPUT`.
- **Validator fix**: The AWK script's new block-scalar loop addresses both previously flagged issues — `has_if` is now set _inside_ the `getline` loop before breaking, and `append_pending` accumulates all continuation lines so every line is checked for dynamic expressions.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The new workflow and backing script are well-structured, and the AWK validator fix correctly handles all relevant orderings of block-scalar continuations relative to the if: field.

All changed paths are additive (new reusable workflow, new gate script, validator extension). The two previously flagged AWK issues — has_if not being set when if: was consumed by getline, and only the last continuation line reaching flush_job — are both addressed: has_if=1 is now assigned inside the getline loop before the break, and append_pending accumulates every continuation line into the name used by flush_job. The assert-required-check.sh script correctly handles all exit paths with proper GITHUB_OUTPUT writes. No regressions to existing reusable workflow contracts are introduced.

No files require special attention. The AWK block-scalar handler in validate-static-job-names.sh was the most complex change and its logic checks out for all tested orderings.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/quality/validate-static-job-names.sh | Extends AWK to handle block-scalar job.name continuations. Both previously flagged issues (has_if not set when if: is consumed by getline; only last continuation line reaching flush_job) are addressed: has_if=1 is set inside the getline loop before the break, and append_pending accumulates all continuation lines into name. Logic is correct for all tested orderings of name/if/runs-on. |
| scripts/ci/actions/assert-required-check.sh | New gate script. Correctly guards UPSTREAM_RESULT with ${var+x} unset check, validates success/passed-output/status-output sequentially, and writes outputs to GITHUB_OUTPUT only when set. Error paths all call write_gate_outputs before exit 1. No issues found. |
| .github/workflows/reusable-required-check.yml | New reusable workflow. draft-pr-skip guard logic is correct for all event types. tooling-ref fallback to github.workflow_sha is idiomatic. Output chain (steps → job → workflow) is wired correctly. Actions are pinned by SHA. Passes the static-job-name validator since inputs.job-name does not contain matrix. or format(. |
| tests/bats/unit/actions/test_assert_required_check.bats | New unit tests cover success, partial outputs, upstream failure, passed-output mismatch, status mismatch, GITHUB_OUTPUT writing, and unset UPSTREAM_RESULT. Good coverage of all script branches. |
| tests/bats/integration/test_reusable_static_job_names.bats | Adds two new block-scalar test fixtures: single-continuation dynamic name and multi-line continuation with dynamic first line. Both fixtures exercise the fixed getline loop and append_pending accumulation paths. |
| tests/bats/integration/test_reusable_required_check.bats | Contract tests verify YAML structure of the new workflow: required inputs, gate job display name, harden-runner/checkout presence, script invocation, env wiring, and always()/draft-pr-skip guard. All assertions are well-scoped. |
| docs/workflow-contract.md | Adds org-ruleset check-name section documenting the caller_job_id/inner_job_name pattern, preferred vs. legacy-gate approaches, and a concrete YAML example. No issues. |
| .github/actions/README.md | Adds documentation for reusable-required-check.yml with all inputs and outputs listed. No issues. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Caller Workflow
    participant Gate as reusable-required-check<br/>(gate job)
    participant Script as assert-required-check.sh
    participant GHOutput as GITHUB_OUTPUT

    Caller->>Gate: workflow_call(job-name, upstream-result, passed-output?, status-output?)
    Note over Gate: if: always() && draft-pr-skip guard
    Gate->>Gate: Checkout lgtm-ci tooling (sparse)
    Gate->>Script: bash assert-required-check.sh
    Script->>Script: "Check UPSTREAM_RESULT == success"
    alt upstream succeeded
        Script->>Script: "Check PASSED_OUTPUT == true (if set)"
        Script->>Script: "Check STATUS_OUTPUT == STATUS_EXPECTED (if set)"
        Script->>GHOutput: "exit-code=0, status=passed"
        Script-->>Gate: exit 0
    else upstream failed / output mismatch
        Script->>GHOutput: "exit-code=1, status=failed"
        Script-->>Gate: exit 1
    end
    Gate-->>Caller: outputs(exit-code, status)
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): address PR review for static jo..."](https://github.com/lgtm-hq/lgtm-ci/commit/24881b90fc1fdf7d1df82064941a13e498e07687) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34741557)</sub>

<!-- /greptile_comment -->