### PR TITLE
feat(ci): finalize PyPI publish contract (#168 §5)

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1111,6 +1111,10 @@ a job defined in the **caller** repository workflow (see
 **Requirements:** `contents: read`, `id-token: write`, `attestations: write` on the
 job; `environment: pypi`; PyPI trusted publisher matches the caller workflow file.
 
+When `validate: true` (default), distribution validation runs with
+`VALIDATE_STRICT=true` — the step fails if twine check cannot run (via twine or
+`uv run --with twine`).
+
 Provenance attestation uses `continue-on-error: true` so Sigstore failures do not
 block `published` or downstream release jobs after a successful PyPI upload.
 

--- a/.github/actions/upload-pypi-oidc/action.yml
+++ b/.github/actions/upload-pypi-oidc/action.yml
@@ -77,6 +77,7 @@ runs:
       env:
         STEP: validate-dist
         WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        VALIDATE_STRICT: "true"
       run: "$SCRIPTS_DIR/ci/actions/python-dist.sh"
 
     - name: Upload to PyPI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **examples**: `publish-python-release.yml` canonical caller template for PyPI tag
+  releases (#168 §5)
+
 ### Changed
+
+- **ci**: `upload-pypi-oidc` fails upload validation when twine check cannot run
+  (`VALIDATE_STRICT=true`) (#168 §5)
+- **docs**: PyPI upload egress allowlist includes artifact download hosts (#168 §5)
 
 ### Deprecated
 

--- a/docs/python-release-publish.md
+++ b/docs/python-release-publish.md
@@ -26,6 +26,8 @@ Typical caller jobs:
 5. **GitHub Release** — `reusable-github-release.yml` (`needs: upload`)
 6. **Product-specific** — Homebrew, Docker, etc.
 
+Copy-paste starter: [`examples/publish-python-release.yml`](../examples/publish-python-release.yml).
+
 ```yaml
 permissions: {}
 
@@ -73,6 +75,10 @@ jobs:
           allowed-endpoints: >
             github.com:443
             api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            actions.githubusercontent.com:443
+            blob.core.windows.net:443
             ghcr.io:443
             pkg-containers.githubusercontent.com:443
             pypi.org:443
@@ -140,6 +146,14 @@ Cross-repo reusables cannot perform OIDC upload until PyPI supports it
 after a successful PyPI upload. Sigstore outages must not fail the release job or
 skip `published: true` — the wheel is already on the index and retries would not
 be idempotent.
+
+## Upload validation
+
+When `validate: true` (default), `upload-pypi-oidc` runs twine check with
+`VALIDATE_STRICT=true` after `setup-python`. Validation tries `twine check`
+directly, then `uv run --with twine twine check` when twine is not on PATH. The
+upload job **fails** if neither method can run — distributions are never uploaded
+without a passing check.
 
 ## Egress allowlists
 

--- a/docs/python-release-publish.md
+++ b/docs/python-release-publish.md
@@ -83,6 +83,8 @@ jobs:
             pkg-containers.githubusercontent.com:443
             pypi.org:443
             upload.pypi.org:443
+            test.pypi.org:443
+            upload.test.pypi.org:443
             files.pythonhosted.org:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -324,6 +324,8 @@ jobs:
             pkg-containers.githubusercontent.com:443
             pypi.org:443
             upload.pypi.org:443
+            test.pypi.org:443
+            upload.test.pypi.org:443
             files.pythonhosted.org:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -308,6 +308,27 @@ jobs:
       id-token: write
       attestations: write
     steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@<pin> # v2.19.4
+        with:
+          egress-policy: block
+          # workflow-contract.md § PyPI upload (OIDC)
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            actions.githubusercontent.com:443
+            blob.core.windows.net:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            pypi.org:443
+            upload.pypi.org:443
+            files.pythonhosted.org:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+            oauth2.sigstore.dev:443
       - uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@<sha>
         with:
           artifact-name: python-dist

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -240,15 +240,20 @@ allowed-endpoints: >
 ### PyPI upload (OIDC + attestation)
 
 Used on the **caller** upload job (`upload-pypi-oidc` composite). Set
-`environment: pypi` on that job. `pypa/gh-action-pypi-publish` pulls
-`ghcr.io/pypa/gh-action-pypi-publish` — include `ghcr.io:443` and
-`pkg-containers.githubusercontent.com:443`.
+`environment: pypi` on that job. The composite downloads workflow artifacts and
+checks out lgtm-ci tooling — include artifact and GitHub hosts below.
+`pypa/gh-action-pypi-publish` pulls `ghcr.io/pypa/gh-action-pypi-publish` —
+include `ghcr.io:443` and `pkg-containers.githubusercontent.com:443`.
 
 ```yaml
 egress-policy: block
 allowed-endpoints: >
   github.com:443
   api.github.com:443
+  codeload.github.com:443
+  objects.githubusercontent.com:443
+  actions.githubusercontent.com:443
+  blob.core.windows.net:443
   ghcr.io:443
   pkg-containers.githubusercontent.com:443
   pypi.org:443

--- a/examples/publish-python-release.yml
+++ b/examples/publish-python-release.yml
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: MIT
+# Canonical caller layout for Python tag releases using lgtm-ci reusables.
+# Copy into your repository as .github/workflows/publish-pypi-on-tag.yml (or similar).
+# PyPI trusted publishing must reference THIS workflow filename and the upload job.
+# See docs/python-release-publish.md and docs/workflow-contract.md.
+---
+name: Publish - PyPI Production
+
+'on':
+  push:
+    tags:
+      - '*.*.*'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: publish-pypi-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  pypi-build:
+    name: Build Python distribution
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@<sha> # vX.Y.Z
+    permissions:
+      contents: read
+    with:
+      python-version: "3.12"
+      artifact-name: python-dist
+      tooling-ref: "<sha>"
+      egress-policy: block
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        release-assets.githubusercontent.com:443
+        objects.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        astral.sh:443
+        releases.astral.sh:443
+        pypi.org:443
+        files.pythonhosted.org:443
+
+  pypi-upload:
+    name: Upload to PyPI
+    needs: [pypi-build]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            actions.githubusercontent.com:443
+            blob.core.windows.net:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            pypi.org:443
+            upload.pypi.org:443
+            files.pythonhosted.org:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+            oauth2.sigstore.dev:443
+      - uses: lgtm-hq/lgtm-ci/.github/actions/upload-pypi-oidc@<sha>
+        with:
+          artifact-name: python-dist
+          python-version: "3.12"
+          tooling-ref: "<sha>"
+
+  github-release:
+    name: Create GitHub Release
+    needs: [pypi-upload]
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-github-release.yml@<sha> # vX.Y.Z
+    permissions:
+      contents: write
+    with:
+      artifact-name: python-dist
+      generate-release-notes: true
+      tooling-ref: "<sha>"
+      egress-policy: block
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        uploads.github.com:443
+        codeload.github.com:443
+        release-assets.githubusercontent.com:443
+        objects.githubusercontent.com:443

--- a/examples/publish-python-release.yml
+++ b/examples/publish-python-release.yml
@@ -67,6 +67,8 @@ jobs:
             pkg-containers.githubusercontent.com:443
             pypi.org:443
             upload.pypi.org:443
+            test.pypi.org:443
+            upload.test.pypi.org:443
             files.pythonhosted.org:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443

--- a/scripts/ci/actions/python-dist.sh
+++ b/scripts/ci/actions/python-dist.sh
@@ -14,6 +14,7 @@
 #   DRY_RUN: Whether this is a dry run
 #   TEST_PYPI: Whether publishing to TestPyPI
 #   PUBLISHED: Whether the package was published
+#   VALIDATE_STRICT: When true, fail validate-dist if twine/uv cannot run twine check
 set -euo pipefail
 
 : "${STEP:?STEP is required}"

--- a/scripts/ci/lib/publish/validate.sh
+++ b/scripts/ci/lib/publish/validate.sh
@@ -49,6 +49,10 @@ validate_pypi_package() {
 		fi
 		log_success "twine check passed"
 	else
+		if [[ "${VALIDATE_STRICT:-false}" == "true" ]]; then
+			log_error "twine and uv unavailable; cannot validate distribution (VALIDATE_STRICT=true)"
+			return 1
+		fi
 		log_warn "twine not available, skipping package validation"
 	fi
 

--- a/tests/bats/integration/test_reusable_build_python_dist.bats
+++ b/tests/bats/integration/test_reusable_build_python_dist.bats
@@ -120,6 +120,44 @@ _tooling_sparse_cone_ok() {
 	assert_success
 }
 
+@test "upload-pypi-oidc: validate step uses strict distribution validation" {
+	local action="${PROJECT_ROOT}/.github/actions/upload-pypi-oidc/action.yml"
+	run awk '
+		/Validate distribution/ { in_step = 1; next }
+		in_step && /^      - name:/ { in_step = 0 }
+		in_step && /STEP: validate-dist/ { step = 1 }
+		in_step && /VALIDATE_STRICT: "true"/ { strict = 1 }
+		END { exit !(step && strict) }
+	' "$action"
+	assert_success
+}
+
+@test "upload-pypi-oidc: sparse checkout includes actions and scripts" {
+	local action="${PROJECT_ROOT}/.github/actions/upload-pypi-oidc/action.yml"
+	run awk '
+		/sparse-checkout: \|/ { in_sparse = 1; next }
+		in_sparse && /^        [^ ]/ { in_sparse = 0 }
+		in_sparse && /\.github\/actions\// { actions = 1 }
+		in_sparse && /scripts\/ci\// { scripts = 1 }
+		END { exit !(actions && scripts) }
+	' "$action"
+	assert_success
+}
+
+@test "examples/publish-python-release: references split PyPI publish contract" {
+	local example="${PROJECT_ROOT}/examples/publish-python-release.yml"
+	run grep -q 'reusable-build-python-dist.yml' "$example"
+	assert_success
+	run grep -q 'upload-pypi-oidc' "$example"
+	assert_success
+	run grep -q 'reusable-github-release.yml' "$example"
+	assert_success
+	run grep -q 'step-security/harden-runner@' "$example"
+	assert_success
+	run grep -q 'reusable-publish-pypi' "$example"
+	assert_failure
+}
+
 @test "reusable-github-release: downloads artifact and creates release via gh script" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-github-release.yml"
 	run awk '

--- a/tests/bats/integration/test_reusable_build_python_dist.bats
+++ b/tests/bats/integration/test_reusable_build_python_dist.bats
@@ -124,10 +124,22 @@ _tooling_sparse_cone_ok() {
 	local action="${PROJECT_ROOT}/.github/actions/upload-pypi-oidc/action.yml"
 	run awk '
 		/Validate distribution/ { in_step = 1; next }
-		in_step && /^      - name:/ { in_step = 0 }
+		in_step && /^    - name:/ { in_step = 0 }
 		in_step && /STEP: validate-dist/ { step = 1 }
 		in_step && /VALIDATE_STRICT: "true"/ { strict = 1 }
 		END { exit !(step && strict) }
+	' "$action"
+	assert_success
+}
+
+@test "upload-pypi-oidc: VALIDATE_STRICT is scoped to validate step only" {
+	local action="${PROJECT_ROOT}/.github/actions/upload-pypi-oidc/action.yml"
+	run awk '
+		/Validate distribution/ { in_validate = 1; next }
+		in_validate && /^    - name:/ { in_validate = 0 }
+		in_validate && /VALIDATE_STRICT: "true"/ { in_validate_strict = 1 }
+		!in_validate && /VALIDATE_STRICT: "true"/ { outside_strict = 1 }
+		END { exit !(in_validate_strict && !outside_strict) }
 	' "$action"
 	assert_success
 }
@@ -153,6 +165,10 @@ _tooling_sparse_cone_ok() {
 	run grep -q 'reusable-github-release.yml' "$example"
 	assert_success
 	run grep -q 'step-security/harden-runner@' "$example"
+	assert_success
+	run grep -q 'test.pypi.org:443' "$example"
+	assert_success
+	run grep -q 'upload.test.pypi.org:443' "$example"
 	assert_success
 	run grep -q 'reusable-publish-pypi' "$example"
 	assert_failure

--- a/tests/bats/unit/lib/publish/test_validate.bats
+++ b/tests/bats/unit/lib/publish/test_validate.bats
@@ -44,7 +44,7 @@ teardown() {
 	assert_output --partial "No distribution files found"
 }
 
-@test "validate_pypi_package: passes with wheel files and no twine" {
+@test "validate_pypi_package: passes with wheel files and no twine when not strict" {
 	local dist_dir="${BATS_TEST_TMPDIR}/dist"
 	mkdir -p "$dist_dir"
 	touch "$dist_dir/package-1.0.0-py3-none-any.whl"
@@ -60,6 +60,24 @@ teardown() {
 	"
 	assert_success
 	assert_output --partial "twine not available"
+}
+
+@test "validate_pypi_package: fails with wheel files when strict and no twine or uv" {
+	local dist_dir="${BATS_TEST_TMPDIR}/dist"
+	mkdir -p "$dist_dir"
+	touch "$dist_dir/package-1.0.0-py3-none-any.whl"
+
+	run bash -c "
+		command() {
+			if [[ \"\$2\" == \"twine\" ]] || [[ \"\$2\" == \"uv\" ]]; then return 1; fi
+			builtin command \"\$@\"
+		}
+		source \"\$LIB_DIR/log.sh\"
+		source \"\$LIB_DIR/publish/validate.sh\"
+		VALIDATE_STRICT=true validate_pypi_package \"$dist_dir\" 2>&1
+	"
+	assert_failure
+	assert_output --partial "cannot validate distribution"
 }
 
 @test "validate_pypi_package: passes with tar.gz files" {


### PR DESCRIPTION
## Summary

Completes the lgtm-ci platform work for umbrella #168 §5 (PyPI and Python release
publishing). Documents the split build + caller-upload + GitHub Release architecture,
adds a canonical caller example, enforces strict distribution validation on upload,
and expands PyPI upload egress allowlists for artifact download.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. `upload-pypi-oidc` with `validate: true` (default) now fails when twine check
cannot run (`VALIDATE_STRICT=true`) instead of silently skipping — stricter but
correct for release uploads.

## Closes

- Relates to #168
- Relates to #204

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Finalize PyPI publish contract with strict distribution validation
> - Adds `VALIDATE_STRICT=true` to the validate step in [upload-pypi-oidc/action.yml](https://github.com/lgtm-hq/lgtm-ci/pull/266/files#diff-b0018696dada5c9cdad85cf885b088acda3b5bd4758f412066e6e05640edc9f5), causing the upload job to fail if neither `twine` nor `uv`-based `twine` is available to run `twine check`.
> - Adds [examples/publish-python-release.yml](https://github.com/lgtm-hq/lgtm-ci/pull/266/files#diff-746ea896aa02885e385a8635dff2041e38f6d127ee614ce44acfd34603cd9df5) as a canonical example workflow covering build, upload, and GitHub release steps with a hardened runner and expanded egress allowlist.
> - Expands documented egress allowlists across docs and examples to include GitHub artifact download hosts (`codeload.github.com`, `objects.githubusercontent.com`, `blob.core.windows.net`) and TestPyPI endpoints.
> - Adds unit and integration tests covering the strict validation failure path and verifying that `VALIDATE_STRICT` is scoped only to the validate step.
> - Behavioral Change: validation now hard-fails instead of warning and skipping when `VALIDATE_STRICT=true` and no `twine` runtime is found.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f9002d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Strict distribution validation for PyPI uploads enabled by default (fails if validation cannot run).

* **Documentation**
  * Added Python release publish example workflow and updated guides with validation details and expanded network allowlists.
  * Changelog updated with release/CI notes.

* **Tests**
  * Added contract and unit tests covering strict validation behavior and workflow references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR finalises the PyPI publish contract for lgtm-ci (umbrella #168 §5) by making distribution validation mandatory — the upload step now fails hard when neither `twine` nor `uv` can run `twine check` — and ships a canonical caller template with a hardened, split egress allowlist.

- **`validate.sh`**: adds a `VALIDATE_STRICT` guard so a missing twine/uv combination is a hard failure; `VALIDATE_STRICT: \"true\"` is correctly scoped to the `Validate distribution` step in `action.yml`.
- **`examples/publish-python-release.yml`**: new three-job template (build → upload → GitHub Release) with full harden-runner allowlists including `test.pypi.org:443` / `upload.test.pypi.org:443`.
- **Docs and tests**: six new BATS tests cover strict-mode behaviour and contract assertions; workflow-contract.md and docs are updated with expanded artifact/GitHub hosting endpoints.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the behavioral change is intentional, correctly scoped, and well-covered by new tests.

All changed paths are narrow and well-tested. The strict-mode guard in validate.sh is logically correct, VALIDATE_STRICT is confined to the right step in action.yml, the new example file includes the required test.pypi.org allowlist entries, and the six new BATS tests cover both unit and integration contracts.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/lib/publish/validate.sh | Adds VALIDATE_STRICT guard to the else-branch when neither twine nor uv is available; logic is correct and all paths return cleanly. |
| .github/actions/upload-pypi-oidc/action.yml | Adds VALIDATE_STRICT: "true" scoped to the Validate distribution step only; step boundary and scoping are correct. |
| examples/publish-python-release.yml | New canonical caller template with split build/upload/release jobs, hardened egress allowlists, and correct test.pypi.org entries. |
| tests/bats/unit/lib/publish/test_validate.bats | Adds unit test for strict-mode failure; command mock correctly intercepts -v checks for both twine and uv. |
| tests/bats/integration/test_reusable_build_python_dist.bats | Adds four integration contract tests; step-boundary AWK pattern uses 4-space indentation matching action.yml. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[upload-pypi-oidc composite action] --> B[Checkout lgtm-ci tooling sparse]
    B --> C[Download Python distribution artifact]
    C --> D{validate == 'true'?}
    D -- No --> G[Upload to PyPI via OIDC]
    D -- Yes --> E[Validate distribution\nVALIDATE_STRICT=true]
    E --> F{twine available?}
    F -- Yes --> F1[twine check dist/*]
    F -- No --> F2{uv available?}
    F2 -- Yes --> F3[uv run --with twine twine check dist/*]
    F2 -- No --> F4{VALIDATE_STRICT=true?}
    F4 -- Yes --> FAIL[❌ Fail — cannot validate]
    F4 -- No --> WARN[⚠️ Warn and continue]
    F1 -- Pass --> G
    F3 -- Pass --> G
    F1 -- Fail --> FAIL
    F3 -- Fail --> FAIL
    G --> H[Attest build provenance\ncontinue-on-error: true]
    H --> I[Set published output]
    I --> J[Generate upload summary]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Flib%2Fpublish%2Fvalidate.sh%3A44-49%0AWhen%20%60uv%20run%20--with%20twine%60%20fails%2C%20the%20error%20message%20%22twine%20check%20failed%22%20is%20identical%20to%20the%20message%20emitted%20when%20twine%20runs%20successfully%20but%20the%20package%20fails%20its%20checks.%20If%20%60uv%60%20is%20present%20but%20cannot%20install%20twine%20%28e.g.%2C%20a%20transient%20PyPI%20outage%20during%20the%20validation%20step%2C%20even%20though%20the%20egress%20allowlist%20permits%20it%29%2C%20the%20log%20entry%20is%20indistinguishable%20from%20an%20actual%20package%20metadata%20error%2C%20making%20it%20harder%20to%20diagnose.%0A%0A%60%60%60suggestion%0A%09elif%20command%20-v%20uv%20%3E%2Fdev%2Fnull%202%3E%261%3B%20then%0A%09%09log_info%20%22Running%20twine%20check%20via%20uv...%22%0A%09%09if%20!%20uv%20run%20--with%20twine%20twine%20check%20%22%24dist_dir%22%2F*%3B%20then%0A%09%09%09log_error%20%22twine%20check%20via%20uv%20failed%20%28uv%20run%20--with%20twine%20twine%20check%29%22%0A%09%09%09return%201%0A%09%09fi%0A%60%60%60%0A%0A&pr=266&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Flib%2Fpublish%2Fvalidate.sh%3A44-49%0AWhen%20%60uv%20run%20--with%20twine%60%20fails%2C%20the%20error%20message%20%22twine%20check%20failed%22%20is%20identical%20to%20the%20message%20emitted%20when%20twine%20runs%20successfully%20but%20the%20package%20fails%20its%20checks.%20If%20%60uv%60%20is%20present%20but%20cannot%20install%20twine%20%28e.g.%2C%20a%20transient%20PyPI%20outage%20during%20the%20validation%20step%2C%20even%20though%20the%20egress%20allowlist%20permits%20it%29%2C%20the%20log%20entry%20is%20indistinguishable%20from%20an%20actual%20package%20metadata%20error%2C%20making%20it%20harder%20to%20diagnose.%0A%0A%60%60%60suggestion%0A%09elif%20command%20-v%20uv%20%3E%2Fdev%2Fnull%202%3E%261%3B%20then%0A%09%09log_info%20%22Running%20twine%20check%20via%20uv...%22%0A%09%09if%20!%20uv%20run%20--with%20twine%20twine%20check%20%22%24dist_dir%22%2F*%3B%20then%0A%09%09%09log_error%20%22twine%20check%20via%20uv%20failed%20%28uv%20run%20--with%20twine%20twine%20check%29%22%0A%09%09%09return%201%0A%09%09fi%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=266&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F168-pypi-python-release-publish%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F168-pypi-python-release-publish%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Flib%2Fpublish%2Fvalidate.sh%3A44-49%0AWhen%20%60uv%20run%20--with%20twine%60%20fails%2C%20the%20error%20message%20%22twine%20check%20failed%22%20is%20identical%20to%20the%20message%20emitted%20when%20twine%20runs%20successfully%20but%20the%20package%20fails%20its%20checks.%20If%20%60uv%60%20is%20present%20but%20cannot%20install%20twine%20%28e.g.%2C%20a%20transient%20PyPI%20outage%20during%20the%20validation%20step%2C%20even%20though%20the%20egress%20allowlist%20permits%20it%29%2C%20the%20log%20entry%20is%20indistinguishable%20from%20an%20actual%20package%20metadata%20error%2C%20making%20it%20harder%20to%20diagnose.%0A%0A%60%60%60suggestion%0A%09elif%20command%20-v%20uv%20%3E%2Fdev%2Fnull%202%3E%261%3B%20then%0A%09%09log_info%20%22Running%20twine%20check%20via%20uv...%22%0A%09%09if%20!%20uv%20run%20--with%20twine%20twine%20check%20%22%24dist_dir%22%2F*%3B%20then%0A%09%09%09log_error%20%22twine%20check%20via%20uv%20failed%20%28uv%20run%20--with%20twine%20twine%20check%29%22%0A%09%09%09return%201%0A%09%09fi%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): address P2 review findings for ..."](https://github.com/lgtm-hq/lgtm-ci/commit/2f9002dc407d24c322bb92fdfce424e4472e385e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34743993)</sub>

<!-- /greptile_comment -->