### PR TITLE
fix(ci): set GH_TOKEN in reusable-github-release workflow

### DIFF
--- a/.github/workflows/reusable-github-release.yml
+++ b/.github/workflows/reusable-github-release.yml
@@ -147,5 +147,6 @@ jobs:
             ${{ inputs.files != '' && inputs.files ||
             format('{0}/*', inputs.artifact-path) }}
           REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
         run: >-
           .lgtm-ci-tooling/scripts/ci/release/create-github-release.sh

--- a/tests/bats/integration/test_reusable_build_python_dist.bats
+++ b/tests/bats/integration/test_reusable_build_python_dist.bats
@@ -93,9 +93,10 @@ _tooling_sparse_cone_ok() {
 		/verify-release-assets\.sh/ { verify_script = 1 }
 		/Create GitHub Release/ { in_release_step = 1; release = 1; next }
 		in_release_step && /create-github-release\.sh/ { release_script = 1 }
+		in_release_step && /GH_TOKEN:/ { gh_token = 1 }
 		in_release_step && /^      - name:/ { in_release_step = 0 }
 		in_release_step && /run: \|/ { inline_shell = 1 }
-		END { exit !(download && verify && verify_script && release && release_script && !inline_shell) }
+		END { exit !(download && verify && verify_script && release && release_script && gh_token && !inline_shell) }
 	' "$workflow"
 	assert_success
 	run grep -Eq 'format\(\s*['\''"]\{0\}/\*\s*['\''"],\s*inputs\.artifact-path\s*\)' "$workflow"


### PR DESCRIPTION
## Summary

`reusable-github-release.yml` called `create-github-release.sh` without `GH_TOKEN`, so `gh release create` failed in GitHub Actions while PyPI publish could still succeed. This adds `GH_TOKEN: ${{ github.token }}` to the Create GitHub Release step and extends the BATS contract test to require it.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #272

## Testing

- [x] `uv run lintro fmt` and `uv run lintro chk` (zero issues)
- [x] `bats tests/bats/integration/test_reusable_build_python_dist.bats` (contract test for `GH_TOKEN`)

## Quality Checks

- [x] `uv run lintro chk` (full run, 27 tools)
- [x] `actionlint` on changed workflow

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `GH_TOKEN` in the `create-github-release.sh` step of the reusable GitHub release workflow
> The `GH_TOKEN` environment variable was missing from the [reusable-github-release.yml](https://github.com/lgtm-hq/lgtm-ci/pull/273/files#diff-ffaa20bbaf8f4a145e092ebfc87ea0f96a726bacbb5ecf3ed246a0f8aa3e00f3) step that invokes `create-github-release.sh`, causing the script to run without authentication. An integration test in [test_reusable_build_python_dist.bats](https://github.com/lgtm-hq/lgtm-ci/pull/273/files#diff-710c7d56562af09fb43f1d3cfd8110ffb20addd1f86b2f62359a1ec961014792) is updated to verify that `GH_TOKEN` is present in the 'Create GitHub Release' step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5046553.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Actions release workflow by adding authentication token credentials to the release publication step, enabling secure asset uploads and reliable release publishing.

* **Tests**
  * Enhanced integration tests to verify GitHub authentication token is correctly configured and passed to the release workflow during asset publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a missing `GH_TOKEN` environment variable in the `reusable-github-release.yml` workflow, which caused `gh release create` to fail even when the PyPI publish step had already succeeded. The job already held the required `contents: write` permission; only the token injection into the step environment was absent.

- Adds `GH_TOKEN: ${{ github.token }}` to the `env` block of the **Create GitHub Release** step so the `gh` CLI can authenticate against the API.
- Updates the BATS AWK contract test to assert `GH_TOKEN:` is present within that step, preventing future regressions.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line env addition that supplies the token the gh CLI was already expecting, backed by a matching contract test update.

The workflow already granted contents: write, so the only missing piece was threading github.token into the step environment. The fix is minimal and targeted, the BATS test now guards the contract, and no other steps or permissions are touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-github-release.yml | Adds GH_TOKEN: ${{ github.token }} to the Create GitHub Release step env block so the gh CLI can authenticate; the job already holds contents: write permission, making this a correct and complete fix. |
| tests/bats/integration/test_reusable_build_python_dist.bats | Extends the AWK contract test to require GH_TOKEN: inside the Create GitHub Release step; the in_release_step scoping and END condition are updated correctly. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Caller Workflow
    participant Release as reusable-github-release job
    participant Artifact as actions/download-artifact
    participant Script as create-github-release.sh
    participant GH as GitHub API (gh CLI)

    Caller->>Release: workflow_call (tag, files, …)
    Release->>Artifact: Download release assets
    Artifact-->>Release: dist/ files
    Release->>Script: run (env: TAG, FILE_PATTERNS, REPO, GH_TOKEN)
    Script->>GH: gh release create $TAG --repo $REPO [assets]
    Note over Script,GH: GH_TOKEN now injected via env — auth succeeds
    GH-->>Script: release URL + ID
    Script->>Release: set_github_output release-url / release-id
    Release-->>Caller: outputs.release-url, outputs.release-id
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): set GH\_TOKEN in reusable-github..."](https://github.com/lgtm-hq/lgtm-ci/commit/50465535b3760324e2f3eead8d1e6fb82a75e9af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35069700)</sub>

<!-- /greptile_comment -->