### PR TITLE
fix(harden-runner): resolve egress before step-security pre-hook

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -118,25 +118,51 @@ Setup Rust toolchain with cargo caching.
 
 ## Security Actions
 
+### resolve-egress-allowlist
+
+Resolves `allowed-endpoints` from explicit lists or `egress-preset` names. Run as a
+**workflow step before** `harden-runner` so step-security's pre-hook receives the
+allowlist (composite step outputs are not available at pre-hook time).
+
+```yaml
+- name: Resolve egress allowlist
+  id: egress
+  uses: ./.github/actions/resolve-egress-allowlist
+  with:
+    egress-policy: block
+    egress-preset: quality
+    allowed-endpoints: |
+      private.registry.example:443
+    allowed-endpoints-mode: append # default: replace
+
+- uses: ./.github/actions/harden-runner
+  with:
+    egress-policy: block
+    allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+```
+
+`allowed-endpoints-mode`: `replace` drops the preset when `allowed-endpoints` is
+non-empty; `append` merges preset + extras with deduplication.
+
+Presets are defined in `scripts/ci/lib/egress/presets.sh` and bundled under
+`.github/actions/harden-runner/lib/`.
+
 ### harden-runner
 
-Security hardening using [StepSecurity](https://stepsecurity.io).
+Security hardening using [StepSecurity](https://stepsecurity.io). Pass
+**resolved** `allowed-endpoints` from a prior `resolve-egress-allowlist` step.
 
 ```yaml
 - uses: ./.github/actions/harden-runner
   with:
     egress-policy: block # default; use audit to log only
-    egress-preset: quality # set by the workflow; composite default is empty
+    allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
     disable-sudo: "false" # optional
 ```
 
-In **lgtm-ci reusables**, checkout the repository before this step so the runner
-can load the composite from the workflow ref. External callers pin the **workflow**
-`@ref`, not a separate action SHA. The composite bundles
-resolver + egress lib; canonical presets are maintained in
-`scripts/ci/lib/egress/presets.sh` and synced via `sync-harden-runner-bundle.sh`.
-Non-empty `allowed-endpoints` replaces the preset. Reusables pass `egress-preset`
-with workflow-appropriate defaults.
+In **lgtm-ci reusables**, checkout the repository before these steps so the runner
+can load composites from the workflow ref. External callers pin the **workflow**
+`@ref`, not a separate action SHA.
 
 **Features:**
 

--- a/.github/actions/harden-runner/action.yml
+++ b/.github/actions/harden-runner/action.yml
@@ -8,17 +8,11 @@ inputs:
     description: "Egress policy: audit (log) or block (enforce allowlist)"
     required: false
     default: "block"
-  egress-preset:
-    description: >-
-      Named allowlist when allowed-endpoints is empty and egress-policy is block
-      (github-minimal, github-pages, github-tooling, docker, playwright, pypi,
-      rubygems, npm-publish, quality, sbom, scorecard)
-    required: false
-    default: ""
   allowed-endpoints:
     description: >-
-      Allowed endpoints when egress-policy is block; replaces egress-preset when
-      non-empty
+      Allowed endpoints when egress-policy is block. Use
+      ./.github/actions/resolve-egress-allowlist in a prior workflow step when
+      applying egress-preset or merging presets with caller overrides.
     required: false
     default: ""
   disable-sudo:
@@ -38,16 +32,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Resolve egress allowlist
-      id: resolve
-      shell: bash
-      env:
-        EGRESS_POLICY: ${{ inputs['egress-policy'] }}
-        EGRESS_PRESET: ${{ inputs['egress-preset'] }}
-        ALLOWED_ENDPOINTS: ${{ inputs['allowed-endpoints'] }}
-      run: >-
-        bash "${{ github.action_path }}/resolve-egress-endpoints.sh"
-
     # Create agent state before harden-runner; uses sudo while disable-sudo is still off.
     - name: Ensure agent state for post cleanup
       shell: bash
@@ -61,7 +45,7 @@ runs:
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
       with:
         egress-policy: ${{ inputs['egress-policy'] }}
-        allowed-endpoints: ${{ steps.resolve.outputs['allowed-endpoints'] }}
+        allowed-endpoints: ${{ inputs['allowed-endpoints'] }}
         disable-sudo: ${{ inputs['disable-sudo'] }}
         disable-telemetry: ${{ inputs['disable-telemetry'] }}
 

--- a/.github/actions/harden-runner/lib/egress.sh
+++ b/.github/actions/harden-runner/lib/egress.sh
@@ -16,5 +16,89 @@ _LGTM_CI_EGRESS_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/egress" && pwd)" || {
 	echo "egress.sh: missing presets.sh in $_LGTM_CI_EGRESS_DIR" >&2
 	return 1
 }
+# shellcheck source=egress/presets.sh
 source "$_LGTM_CI_EGRESS_DIR/presets.sh"
 readonly _LGTM_CI_EGRESS_LOADED=1
+
+# Normalize multiline host:port list (trim lines, drop blanks).
+egress_normalize_endpoint_lines() {
+	local raw="$1"
+	local -a lines=()
+	local line trimmed
+
+	if [[ -z "${raw//[[:space:]]/}" ]]; then
+		printf ''
+		return
+	fi
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		trimmed="${line#"${line%%[![:space:]]*}"}"
+		trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+		if [[ -n "$trimmed" ]]; then
+			lines+=("$trimmed")
+		fi
+	done <<<"$raw"
+
+	if ((${#lines[@]} == 0)); then
+		printf ''
+		return
+	fi
+
+	local IFS=$'\n'
+	printf '%s' "${lines[*]}"
+}
+
+# Deduplicate host:port lines; preserve first-seen order (bash 3.2 compatible).
+egress_dedupe_endpoint_lines() {
+	local raw="$1"
+	local -a unique=()
+	local line existing found
+
+	if [[ -z "${raw//[[:space:]]/}" ]]; then
+		printf ''
+		return
+	fi
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		line="${line#"${line%%[![:space:]]*}"}"
+		line="${line%"${line##*[![:space:]]}"}"
+		[[ -z "$line" ]] && continue
+		found=0
+		if ((${#unique[@]} > 0)); then
+			for existing in "${unique[@]}"; do
+				if [[ "$existing" == "$line" ]]; then
+					found=1
+					break
+				fi
+			done
+		fi
+		if [[ "$found" -eq 0 ]]; then
+			unique+=("$line")
+		fi
+	done <<<"$raw"
+
+	if ((${#unique[@]} == 0)); then
+		printf ''
+		return
+	fi
+
+	local IFS=$'\n'
+	printf '%s' "${unique[*]}"
+}
+
+# Merge multiple multiline endpoint lists (empty parts skipped), then dedupe.
+egress_merge_endpoint_lines() {
+	local combined="" part normalized
+	for part in "$@"; do
+		normalized="$(egress_normalize_endpoint_lines "$part")"
+		[[ -z "$normalized" ]] && continue
+		if [[ -z "$combined" ]]; then
+			combined="$normalized"
+		else
+			combined="${combined}"$'\n'"${normalized}"
+		fi
+	done
+	egress_dedupe_endpoint_lines "$combined"
+}
+
+export -f egress_normalize_endpoint_lines egress_dedupe_endpoint_lines egress_merge_endpoint_lines

--- a/.github/actions/harden-runner/resolve-egress-endpoints.sh
+++ b/.github/actions/harden-runner/resolve-egress-endpoints.sh
@@ -5,8 +5,9 @@
 # Required environment variables:
 #   GITHUB_OUTPUT - GitHub Actions output file
 #   EGRESS_POLICY - audit or block
-#   ALLOWED_ENDPOINTS - Caller override (multiline host:port)
-#   EGRESS_PRESET     - Preset name when allowed-endpoints is empty (optional)
+#   ALLOWED_ENDPOINTS - Caller host:port list (multiline)
+#   EGRESS_PRESET     - Preset name when using preset baseline (optional)
+#   ALLOWED_ENDPOINTS_MODE - replace (default) or append
 #
 # Outputs (GITHUB_OUTPUT):
 #   allowed-endpoints - Resolved allowlist for bundled harden-runner composite
@@ -25,6 +26,7 @@ source "$LIB_DIR/github/output.sh"
 : "${EGRESS_POLICY:=block}"
 : "${ALLOWED_ENDPOINTS:=}"
 : "${EGRESS_PRESET:=}"
+: "${ALLOWED_ENDPOINTS_MODE:=replace}"
 
 case "$EGRESS_POLICY" in
 audit | block) ;;
@@ -34,41 +36,39 @@ audit | block) ;;
 	;;
 esac
 
-normalize_allowed_endpoints() {
-	local raw="$1"
-	local -a lines=()
-	local line trimmed
+case "$ALLOWED_ENDPOINTS_MODE" in
+replace | append) ;;
+*)
+	echo "resolve-egress-endpoints.sh: invalid ALLOWED_ENDPOINTS_MODE '$ALLOWED_ENDPOINTS_MODE' (expected 'replace' or 'append')" >&2
+	exit 1
+	;;
+esac
 
-	if [[ -z "${raw//[[:space:]]/}" ]]; then
-		printf ''
-		return
-	fi
-
-	while IFS= read -r line || [[ -n "$line" ]]; do
-		trimmed="${line#"${line%%[![:space:]]*}"}"
-		trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
-		if [[ -n "$trimmed" ]]; then
-			lines+=("$trimmed")
-		fi
-	done <<<"$raw"
-
-	if ((${#lines[@]} == 0)); then
-		printf ''
-		return
-	fi
-
-	local IFS=$'\n'
-	printf '%s' "${lines[*]}"
-}
-
-resolved=""
-resolved="$(normalize_allowed_endpoints "$ALLOWED_ENDPOINTS")"
+explicit=""
+explicit="$(egress_normalize_endpoint_lines "$ALLOWED_ENDPOINTS")"
 
 preset_trimmed="${EGRESS_PRESET#"${EGRESS_PRESET%%[![:space:]]*}"}"
 preset_trimmed="${preset_trimmed%"${preset_trimmed##*[![:space:]]}"}"
 
-if [[ -z "$resolved" && "$EGRESS_POLICY" == "block" && -n "$preset_trimmed" ]]; then
-	resolved="$(egress_preset_endpoints "$preset_trimmed")" || exit 1
+preset_lines=""
+if [[ "$EGRESS_POLICY" == "block" && -n "$preset_trimmed" ]]; then
+	preset_lines="$(egress_preset_endpoints "$preset_trimmed")" || exit 1
+fi
+
+resolved=""
+
+if [[ "$EGRESS_POLICY" == "audit" ]]; then
+	resolved="$explicit"
+elif [[ "$ALLOWED_ENDPOINTS_MODE" == "replace" ]]; then
+	if [[ -n "$explicit" ]]; then
+		resolved="$explicit"
+	elif [[ -n "$preset_lines" ]]; then
+		resolved="$preset_lines"
+	fi
+else
+	if [[ -n "$preset_lines" || -n "$explicit" ]]; then
+		resolved="$(egress_merge_endpoint_lines "$preset_lines" "$explicit")"
+	fi
 fi
 
 if [[ "$EGRESS_POLICY" == "block" && -z "${resolved//[[:space:]]/}" ]]; then

--- a/.github/actions/harden-runner/resolve-egress-endpoints.sh
+++ b/.github/actions/harden-runner/resolve-egress-endpoints.sh
@@ -44,7 +44,6 @@ replace | append) ;;
 	;;
 esac
 
-explicit=""
 explicit="$(egress_normalize_endpoint_lines "$ALLOWED_ENDPOINTS")"
 
 preset_trimmed="${EGRESS_PRESET#"${EGRESS_PRESET%%[![:space:]]*}"}"

--- a/.github/actions/resolve-egress-allowlist/action.yml
+++ b/.github/actions/resolve-egress-allowlist/action.yml
@@ -1,0 +1,52 @@
+---
+name: "Resolve egress allowlist"
+description: >-
+  Resolve allowed-endpoints for step-security/harden-runner. Run as a workflow
+  step before ./.github/actions/harden-runner so the inner pre-hook receives
+  endpoints (composite step outputs are not available at pre-hook time).
+author: "lgtm-hq"
+inputs:
+  egress-policy:
+    description: "Egress policy: audit (log) or block (enforce allowlist)"
+    required: false
+    default: "block"
+  egress-preset:
+    description: >-
+      Named baseline allowlist for block policy (github-minimal, github-pages,
+      github-tooling, docker, playwright, pypi, rubygems, npm-publish, quality,
+      sbom, scorecard)
+    required: false
+    default: ""
+  allowed-endpoints:
+    description: >-
+      Host:port list (multiline). replace mode: overrides preset when non-empty;
+      append mode: merged with preset (deduped)
+    required: false
+    default: ""
+  allowed-endpoints-mode:
+    description: "replace (override preset) or append (merge with preset, deduped)"
+    required: false
+    default: "replace"
+
+outputs:
+  allowed-endpoints:
+    description: "Resolved allowlist for step-security/harden-runner"
+    value: ${{ steps.resolve.outputs['allowed-endpoints'] }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve egress allowlist
+      id: resolve
+      shell: bash
+      env:
+        EGRESS_POLICY: ${{ inputs['egress-policy'] }}
+        EGRESS_PRESET: ${{ inputs['egress-preset'] }}
+        ALLOWED_ENDPOINTS: ${{ inputs['allowed-endpoints'] }}
+        ALLOWED_ENDPOINTS_MODE: ${{ inputs['allowed-endpoints-mode'] }}
+      run: >-
+        bash "${{ github.action_path }}/../harden-runner/resolve-egress-endpoints.sh"
+
+branding:
+  icon: "list"
+  color: "blue"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -33,10 +33,12 @@ jobs:
           persist-credentials: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Harden Runner
-        uses: ./.github/actions/harden-runner
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
         with:
           egress-policy: block
+          allowed-endpoints-mode: replace
           allowed-endpoints: >
             github.com:443
             api.github.com:443
@@ -47,6 +49,12 @@ jobs:
             objects.githubusercontent.com:443
             pypi.org:443
             files.pythonhosted.org:443
+
+      - name: Harden Runner
+        uses: ./.github/actions/harden-runner
+        with:
+          egress-policy: block
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Self-hosted Renovate
         # yamllint disable-line rule:line-length

--- a/.github/workflows/reusable-artifact-pr-comment.yml
+++ b/.github/workflows/reusable-artifact-pr-comment.yml
@@ -47,6 +47,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -82,13 +90,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length

--- a/.github/workflows/reusable-build-python-dist.yml
+++ b/.github/workflows/reusable-build-python-dist.yml
@@ -63,6 +63,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -114,13 +122,20 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -36,6 +36,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -64,13 +72,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Initialize CodeQL
         if: inputs.config-file == '' && inputs.languages != ''

--- a/.github/workflows/reusable-coverage-pr-comment.yml
+++ b/.github/workflows/reusable-coverage-pr-comment.yml
@@ -44,6 +44,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -84,13 +92,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-coverage.yml
+++ b/.github/workflows/reusable-coverage.yml
@@ -51,6 +51,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -113,13 +121,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -201,13 +216,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: github-pages
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: github-pages
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/reusable-dependency-review.yml
+++ b/.github/workflows/reusable-dependency-review.yml
@@ -31,6 +31,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -60,13 +68,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Dependency review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/reusable-deploy-pages.yml
+++ b/.github/workflows/reusable-deploy-pages.yml
@@ -61,6 +61,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -95,13 +103,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -172,13 +187,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: github-pages
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: github-pages
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/reusable-deploy-site-with-reports.yml
+++ b/.github/workflows/reusable-deploy-site-with-reports.yml
@@ -87,6 +87,14 @@ on:
         required: false
         type: string
         default: ""
+
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
       allowed-endpoints-build:
         description: >-
           Allowed endpoints for the build job when egress-policy is block
@@ -167,18 +175,25 @@ jobs:
             ${{ inputs.commit-sha != '' && inputs.commit-sha || github.sha }}
           persist-credentials: false
 
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.github/actions/harden-runner
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
         with:
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: >-
             ${{ inputs.egress-build-preset != '' && inputs.egress-build-preset ||
             'playwright' }}
           allowed-endpoints: >-
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
             ${{ inputs.allowed-endpoints-build != '' && inputs.allowed-endpoints-build ||
             inputs.allowed-endpoints }}
 
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -271,18 +286,25 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.github/actions/harden-runner
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
         with:
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: >-
             ${{ inputs.egress-deploy-preset != '' && inputs.egress-deploy-preset ||
             'github-pages' }}
           allowed-endpoints: >-
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
             ${{ inputs.allowed-endpoints-deploy != '' && inputs.allowed-endpoints-deploy ||
             inputs.allowed-endpoints }}
 
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/reusable-deploy-site-with-reports.yml
+++ b/.github/workflows/reusable-deploy-site-with-reports.yml
@@ -183,8 +183,8 @@ jobs:
           egress-preset: >-
             ${{ inputs.egress-build-preset != '' && inputs.egress-build-preset ||
             'playwright' }}
-          allowed-endpoints: >-
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+          allowed-endpoints: >-
             ${{ inputs.allowed-endpoints-build != '' && inputs.allowed-endpoints-build ||
             inputs.allowed-endpoints }}
 
@@ -294,8 +294,8 @@ jobs:
           egress-preset: >-
             ${{ inputs.egress-deploy-preset != '' && inputs.egress-deploy-preset ||
             'github-pages' }}
-          allowed-endpoints: >-
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+          allowed-endpoints: >-
             ${{ inputs.allowed-endpoints-deploy != '' && inputs.allowed-endpoints-deploy ||
             inputs.allowed-endpoints }}
 

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -1045,7 +1045,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          sparse-checkout: .github/actions/harden-runner
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
           sparse-checkout-cone-mode: true
           persist-credentials: false
 

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -162,6 +162,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -209,13 +217,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Resolve tooling ref
         id: tooling
         shell: bash
@@ -295,13 +310,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -497,13 +519,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -682,13 +711,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -780,13 +816,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -943,13 +986,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -999,12 +1049,19 @@ jobs:
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Harden runner
-        uses: ./.github/actions/harden-runner
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
         with:
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+      - name: Harden runner
+        uses: ./.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Run Trivy vulnerability scanner
         # Pinned to SHA for supply chain security

--- a/.github/workflows/reusable-ghcr-cleanup.yml
+++ b/.github/workflows/reusable-ghcr-cleanup.yml
@@ -78,7 +78,9 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          sparse-checkout: .github/actions/harden-runner
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
           sparse-checkout-cone-mode: true
           persist-credentials: false
 

--- a/.github/workflows/reusable-ghcr-cleanup.yml
+++ b/.github/workflows/reusable-ghcr-cleanup.yml
@@ -39,6 +39,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -74,13 +82,20 @@ jobs:
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-github-release.yml
+++ b/.github/workflows/reusable-github-release.yml
@@ -57,6 +57,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -113,13 +121,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-link-check.yml
+++ b/.github/workflows/reusable-link-check.yml
@@ -64,6 +64,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -96,13 +104,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-pr-auto-assign.yml
+++ b/.github/workflows/reusable-pr-auto-assign.yml
@@ -33,6 +33,14 @@ name: Reusable PR Auto Assign
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -54,17 +62,27 @@ jobs:
       - name: Checkout repository (harden-runner action)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          sparse-checkout: .github/actions/harden-runner
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
           sparse-checkout-cone-mode: true
           persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
 
       - name: Harden Runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout repository CODEOWNERS
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-pr-labeler.yml
+++ b/.github/workflows/reusable-pr-labeler.yml
@@ -33,6 +33,14 @@ name: Reusable PR Auto Label
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -54,17 +62,27 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          sparse-checkout: .github/actions/harden-runner
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
           sparse-checkout-cone-mode: true
           persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
 
       - name: Harden Runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-publish-gem.yml
+++ b/.github/workflows/reusable-publish-gem.yml
@@ -40,6 +40,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -88,13 +96,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-publish-homebrew.yml
+++ b/.github/workflows/reusable-publish-homebrew.yml
@@ -56,6 +56,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -110,13 +118,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-publish-npm.yml
+++ b/.github/workflows/reusable-publish-npm.yml
@@ -50,6 +50,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -100,13 +108,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-quality-lint.yml
+++ b/.github/workflows/reusable-quality-lint.yml
@@ -50,6 +50,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -106,13 +114,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length

--- a/.github/workflows/reusable-quality-pr-comment.yml
+++ b/.github/workflows/reusable-quality-pr-comment.yml
@@ -29,6 +29,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -69,13 +77,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length

--- a/.github/workflows/reusable-release-auto-tag.yml
+++ b/.github/workflows/reusable-release-auto-tag.yml
@@ -38,6 +38,14 @@ name: "Reusable: Release Auto Tag"
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -91,13 +99,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Create GitHub App installation token
         id: app-token

--- a/.github/workflows/reusable-release-version-pr.yml
+++ b/.github/workflows/reusable-release-version-pr.yml
@@ -85,6 +85,14 @@ name: "Reusable: Release Version PR"
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -124,13 +132,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Create GitHub App installation token
         id: app-token
         # yamllint disable-line rule:line-length

--- a/.github/workflows/reusable-required-check.yml
+++ b/.github/workflows/reusable-required-check.yml
@@ -50,6 +50,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -102,13 +110,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length

--- a/.github/workflows/reusable-rust-build.yml
+++ b/.github/workflows/reusable-rust-build.yml
@@ -36,6 +36,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -71,5 +79,6 @@ jobs:
       egress-policy: ${{ inputs.egress-policy }}
       egress-preset: ${{ inputs.egress-preset }}
       allowed-endpoints: ${{ inputs.allowed-endpoints }}
+      allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       runner-image: ${{ inputs.runner-image }}
       timeout-minutes: ${{ inputs.timeout-minutes }}

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -103,6 +103,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -175,13 +183,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -204,13 +204,10 @@ jobs:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: scripts/ci/
+          sparse-checkout: |
+            .github/actions/
+            scripts/ci/
           sparse-checkout-cone-mode: true
-          persist-credentials: false
-
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
           persist-credentials: false
 
       - name: Setup Rust

--- a/.github/workflows/reusable-sbom.yml
+++ b/.github/workflows/reusable-sbom.yml
@@ -61,6 +61,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -110,13 +118,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/reusable-scorecards.yml
+++ b/.github/workflows/reusable-scorecards.yml
@@ -31,6 +31,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -60,13 +68,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Run OpenSSF Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3

--- a/.github/workflows/reusable-semantic-pr-title.yml
+++ b/.github/workflows/reusable-semantic-pr-title.yml
@@ -41,6 +41,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -71,13 +79,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-test-e2e-matrix.yml
+++ b/.github/workflows/reusable-test-e2e-matrix.yml
@@ -71,6 +71,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -125,13 +133,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: github-tooling
+          allowed-endpoints: ""
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: github-tooling
-          allowed-endpoints: ""
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout for scripts
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -179,13 +194,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -258,13 +280,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: github-tooling
+          allowed-endpoints: ""
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: github-tooling
-          allowed-endpoints: ""
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -327,13 +356,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.publish-egress-preset }}
+          allowed-endpoints: ${{ inputs.publish-allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.publish-egress-preset }}
-          allowed-endpoints: ${{ inputs.publish-allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/reusable-test-e2e.yml
+++ b/.github/workflows/reusable-test-e2e.yml
@@ -93,6 +93,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -137,13 +145,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/reusable-test-node-custom.yml
+++ b/.github/workflows/reusable-test-node-custom.yml
@@ -117,6 +117,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -168,13 +176,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
@@ -219,13 +234,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
@@ -422,13 +444,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Aggregate matrix custom test results
         id: aggregate
@@ -461,13 +490,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -520,13 +556,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-test-node-publish.yml
+++ b/.github/workflows/reusable-test-node-publish.yml
@@ -36,6 +36,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -91,13 +99,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
           disable-sudo: false
           disable-telemetry: false
 

--- a/.github/workflows/reusable-test-node.yml
+++ b/.github/workflows/reusable-test-node.yml
@@ -152,6 +152,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -215,13 +223,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
@@ -272,13 +287,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -564,13 +586,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -621,13 +650,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
@@ -686,13 +722,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.github/actions/harden-runner
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
         with:
           # PR comment job: GitHub API only (#204); do not inherit parent presets
           egress-policy: block
           egress-preset: github-minimal
+
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.github/actions/harden-runner
+        with:
+          egress-policy: block
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-test-pr-comment.yml
+++ b/.github/workflows/reusable-test-pr-comment.yml
@@ -59,6 +59,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -94,13 +102,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length

--- a/.github/workflows/reusable-test-python-publish.yml
+++ b/.github/workflows/reusable-test-python-publish.yml
@@ -31,6 +31,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -86,13 +94,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
           disable-sudo: false
           disable-telemetry: false
 

--- a/.github/workflows/reusable-test-python.yml
+++ b/.github/workflows/reusable-test-python.yml
@@ -86,6 +86,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -162,13 +170,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: github-tooling
+          allowed-endpoints: ""
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: github-tooling
-          allowed-endpoints: ""
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
@@ -218,13 +233,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -412,13 +434,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: github-tooling
+          allowed-endpoints: ""
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: github-tooling
-          allowed-endpoints: ""
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length

--- a/.github/workflows/reusable-test-rust-build.yml
+++ b/.github/workflows/reusable-test-rust-build.yml
@@ -36,6 +36,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -84,13 +92,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-test-shell.yml
+++ b/.github/workflows/reusable-test-shell.yml
@@ -90,6 +90,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -145,13 +153,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-validate-action-pinning.yml
+++ b/.github/workflows/reusable-validate-action-pinning.yml
@@ -39,6 +39,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -61,13 +69,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-validate.yml
+++ b/.github/workflows/reusable-validate.yml
@@ -55,6 +55,14 @@ on:
         type: string
         default: ""
 
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
       egress-preset:
         description: >-
           Named allowlist when allowed-endpoints is empty and egress-policy is
@@ -90,13 +98,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner
         # yamllint disable-line rule:line-length
         uses: ./.github/actions/harden-runner
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **actions**: `resolve-egress-allowlist` composite for preset/explicit egress resolution
+  before `harden-runner` (#276)
+- **egress**: `allowed-endpoints-mode` (`replace` | `append`) with deduped merge when
+  appending project endpoints to presets (#276)
+
 ### Changed
+
+- **workflows**: Reusables resolve egress in a prior workflow step, then pass
+  `steps.egress.outputs['allowed-endpoints']` into `harden-runner` (#276)
+- **workflows**: Reusables accept `allowed-endpoints-mode` (default `replace`) (#276)
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- **actions**: `harden-runner` passes `inputs['allowed-endpoints']` to step-security
+  so the pre-hook receives the allowlist (fixes v0.30.0 blocking all egress) (#276)
 
 ### Security
 

--- a/docs/python-release-publish.md
+++ b/docs/python-release-publish.md
@@ -6,13 +6,13 @@ workflows (tag push or manual dispatch). Callers keep product-specific steps
 
 ## Components
 
-| Component                        | Purpose                                                 |
-| -------------------------------- | ------------------------------------------------------- |
-| `reusable-build-python-dist.yml` | Build sdist/wheel and upload workflow artifact          |
-| `prepare-pypi-upload` action     | Download artifact, validate, expose dist metadata       |
-| `pypa/gh-action-pypi-publish`    | OIDC upload (caller workflow step only)                 |
-| `build-python-package` action    | Build/validate (used inside build reusable)             |
-| `reusable-github-release.yml`    | Attach artifacts to a GitHub Release                    |
+| Component                        | Purpose                                           |
+| -------------------------------- | ------------------------------------------------- |
+| `reusable-build-python-dist.yml` | Build sdist/wheel and upload workflow artifact    |
+| `prepare-pypi-upload` action     | Download artifact, validate, expose dist metadata |
+| `pypa/gh-action-pypi-publish`    | OIDC upload (caller workflow step only)           |
+| `build-python-package` action    | Build/validate (used inside build reusable)       |
+| `reusable-github-release.yml`    | Attach artifacts to a GitHub Release              |
 
 There is **no orchestrator** workflow. Compose jobs in the caller repository.
 

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -160,12 +160,16 @@ Quality lint-only checks use `reusable-quality-lint.yml`; PR lint summaries use
 
 ### Pages coverage HTML inputs (`reusable-test-node`)
 
-| Input | Type | Required | Default | Purpose |
-| ----- | ---- | -------- | ------- | ------- |
-| `upload-pages-coverage-html` | boolean | no | `false` | Upload flat HTML for Model B bundling |
-| `pages-coverage-artifact-name` | string | no | `coverage-html` | Flat HTML artifact name |
-| `pages-coverage-upload-on` | string | no | `push-main` | Upload gate selector (v1) |
-| `pages-coverage-source-subpath` | string | no | `coverage` | HTML dir under `working-directory` |
+<!-- markdownlint-disable MD013 -- prettier table column alignment -->
+
+| Input                           | Type    | Required | Default         | Purpose                               |
+| ------------------------------- | ------- | -------- | --------------- | ------------------------------------- |
+| `upload-pages-coverage-html`    | boolean | no       | `false`         | Upload flat HTML for Model B bundling |
+| `pages-coverage-artifact-name`  | string  | no       | `coverage-html` | Flat HTML artifact name               |
+| `pages-coverage-upload-on`      | string  | no       | `push-main`     | Upload gate selector (v1)             |
+| `pages-coverage-source-subpath` | string  | no       | `coverage`      | HTML dir under `working-directory`    |
+
+<!-- markdownlint-enable MD013 -->
 
 Outputs: `pages-coverage-artifact-name`, `pages-coverage-uploaded` (`true`/`false`).
 
@@ -174,8 +178,8 @@ upload-gating behavior. Additional values may be added in later releases without
 breaking existing callers. Use the literal string values below — they are not
 Git ref aliases.
 
-| Value | Meaning |
-| ----- | ------- |
+| Value       | Meaning                                                                          |
+| ----------- | -------------------------------------------------------------------------------- |
 | `push-main` | Upload only when `github.event_name == push` and `github.ref == refs/heads/main` |
 
 When `node-versions` is a matrix, only the **first** listed version uploads the
@@ -239,11 +243,15 @@ jobs:
 
 ### Pages coverage HTML inputs (`reusable-rust-test` with `coverage: true`)
 
-| Input | Type | Required | Default | Purpose |
-| ----- | ---- | -------- | ------- | ------- |
-| `upload-pages-coverage-html` | boolean | no | `false` | Upload flat HTML for Model B sites |
-| `pages-coverage-artifact-name` | string | no | `rust-coverage-html` | Rust HTML artifact name |
-| `pages-coverage-upload-on` | string | no | `push-main` | Upload gate selector (v1) |
+<!-- markdownlint-disable MD013 -- prettier table column alignment -->
+
+| Input                          | Type    | Required | Default              | Purpose                            |
+| ------------------------------ | ------- | -------- | -------------------- | ---------------------------------- |
+| `upload-pages-coverage-html`   | boolean | no       | `false`              | Upload flat HTML for Model B sites |
+| `pages-coverage-artifact-name` | string  | no       | `rust-coverage-html` | Rust HTML artifact name            |
+| `pages-coverage-upload-on`     | string  | no       | `push-main`          | Upload gate selector (v1)          |
+
+<!-- markdownlint-enable MD013 -->
 
 Outputs: `pages-coverage-artifact-name`, `pages-coverage-uploaded` (`true`/`false`).
 

--- a/docs/rust-testing.md
+++ b/docs/rust-testing.md
@@ -32,10 +32,10 @@ path = "target/nextest/ci/junit.xml"
 Use the **`coverage`** input on a single `reusable-rust-test.yml` job. The workflow
 never runs both uninstrumented nextest and llvm-cov in the same pipeline.
 
-| `coverage` | What runs                         | PR comment contract        |
-| ---------- | --------------------------------- | -------------------------- |
-| `false`    | `cargo nextest run --profile ci`  | Tests only (Python-style)  |
-| `true`     | `cargo llvm-cov nextest` + LCOV   | Tests + coverage line      |
+| `coverage` | What runs                        | PR comment contract       |
+| ---------- | -------------------------------- | ------------------------- |
+| `false`    | `cargo nextest run --profile ci` | Tests only (Python-style) |
+| `true`     | `cargo llvm-cov nextest` + LCOV  | Tests + coverage line     |
 
 PR comments use **`reusable-test-pr-comment`** and `generate-test-comment.sh`
 (same pattern as Python), not `generate-coverage-comment`.

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -13,8 +13,9 @@ Where applicable, workflows accept:
 | ---------------------------------- | ------------------------------------------------------------- |
 | `tooling-ref`                      | Pin lgtm-ci scripts/actions (defaults to caller workflow SHA) |
 | `egress-policy`                    | `block` (default) or `audit` for StepSecurity harden-runner   |
-| `egress-preset`                    | Named allowlist when `allowed-endpoints` is empty under block |
-| `allowed-endpoints`                | Explicit allowlist; **replaces** preset when non-empty        |
+| `egress-preset`                    | Named baseline allowlist under block                          |
+| `allowed-endpoints`                | Multiline `host:port` list (see `allowed-endpoints-mode`)     |
+| `allowed-endpoints-mode`           | `replace` (default) or `append` (merge with preset, deduped)  |
 | `job-name`                         | Check name on always-run jobs; PR comment suite name          |
 | `runner-image`                     | Runner label for long-running jobs                            |
 | `timeout-minutes`                  | Job timeout                                                   |
@@ -74,10 +75,11 @@ would worsen check-name readability) and to access matrix-specific artifacts.
 caller repository checkout must initialize `.git` before tooling is added:
 
 1. Checkout repository (caller repo at workspace root)
-2. Harden runner (`uses: ./.github/actions/harden-runner` — resolved from the
+2. Resolve egress allowlist (`uses: ./.github/actions/resolve-egress-allowlist`)
+3. Harden runner (`uses: ./.github/actions/harden-runner` — resolved from the
    ref used to call the reusable workflow)
-3. Checkout lgtm-ci tooling (`.lgtm-ci-tooling/` alongside the repo)
-4. Download artifacts, badge generation, GitHub Pages publish (local tooling actions)
+4. Checkout lgtm-ci tooling (`.lgtm-ci-tooling/` alongside the repo)
+5. Download artifacts, badge generation, GitHub Pages publish (local tooling actions)
 
 Deploy uses official `actions/deploy-pages` (not gh-pages branch push). See
 [pages-publishing.md](pages-publishing.md) for permissions, egress, and
@@ -111,11 +113,11 @@ is skipped by `if:`. lgtm-ci uses a **hybrid** policy (issue #168 §12):
 
 <!-- markdownlint-disable MD013 -->
 
-| Pattern | When | Check name behavior |
-| ------- | ---- | ------------------- |
-| **Split reusables** | Consumer-facing modes (Vitest vs custom Node) | Matching workflow only; `job-name` drives test check name. |
-| **`job-name` input** | Always-run jobs (quality, publish, Rust test, split Node) | Caller passes the visible check label. |
-| **Static inner names** | Internal matrix legs (Python, Docker, E2E) | Fixed labels; GitHub appends matrix suffix. Brand via caller `name:`. |
+| Pattern                | When                                                      | Check name behavior                                                   |
+| ---------------------- | --------------------------------------------------------- | --------------------------------------------------------------------- |
+| **Split reusables**    | Consumer-facing modes (Vitest vs custom Node)             | Matching workflow only; `job-name` drives test check name.            |
+| **`job-name` input**   | Always-run jobs (quality, publish, Rust test, split Node) | Caller passes the visible check label.                                |
+| **Static inner names** | Internal matrix legs (Python, Docker, E2E)                | Fixed labels; GitHub appends matrix suffix. Brand via caller `name:`. |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -177,12 +179,20 @@ Reusable workflows in this repo invoke the composite with a **relative path**
   with:
     persist-credentials: false
 
-- name: Harden runner
-  uses: ./.github/actions/harden-runner
+- name: Resolve egress allowlist
+  id: egress
+  uses: ./.github/actions/resolve-egress-allowlist
   with:
     egress-policy: ${{ inputs.egress-policy }}
     egress-preset: ${{ inputs.egress-preset }}
     allowed-endpoints: ${{ inputs.allowed-endpoints }}
+    allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+
+- name: Harden runner
+  uses: ./.github/actions/harden-runner
+  with:
+    egress-policy: ${{ inputs.egress-policy }}
+    allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 ```
 
 GitHub resolves `./.github/actions/harden-runner` from the **git ref used to call**
@@ -195,32 +205,43 @@ and platform limitation).
 
 <!-- markdownlint-enable MD013 -->
 
-The action bundle is **self-contained** (resolver + `lib/egress/`). Canonical
-preset definitions live in `scripts/ci/lib/egress/presets.sh`; release maintainers
-run `scripts/ci/actions/sync-harden-runner-bundle.sh` before tagging.
+The `harden-runner` bundle is **self-contained** (`lib/egress/`). Canonical preset
+definitions live in `scripts/ci/lib/egress/presets.sh`; release maintainers run
+`scripts/ci/actions/sync-harden-runner-bundle.sh` before tagging.
+`resolve-egress-allowlist` invokes the bundled resolver script in a **prior workflow
+step** because step-security's pre-hook runs before composite steps and cannot read
+`steps.resolve.outputs` from inside `harden-runner`.
 
 Do **not** use `.lgtm-ci-egress` sparse checkouts for the composite.
 
 ## Egress presets
 
-Reusable workflows default to `egress-policy: block`. When `allowed-endpoints` is
-empty, the `harden-runner` composite expands `egress-preset` via bundled
-`lib/egress/presets.sh` (synced from `scripts/ci/lib/egress/presets.sh`). Explicit
-`allowed-endpoints` **replaces** the preset (no merge).
+Reusable workflows default to `egress-policy: block` and
+`allowed-endpoints-mode: replace`. `resolve-egress-allowlist` expands presets via
+bundled `lib/egress/presets.sh` (synced from `scripts/ci/lib/egress/presets.sh`).
 
-| Preset           | Use case                                                  |
-| ---------------- | --------------------------------------------------------- |
-| `github-minimal` | PR comments (API, tooling checkout, workflow artifacts)   |
-| `github-pages`   | GitHub Pages deploy/publish (OIDC)                        |
-| `github-tooling` | Validate action pinning + GitHub raw/codeload             |
-| `docker`         | Docker build/pull/push (`reusable-docker.yml`)            |
-| `playwright`     | Playwright E2E + browser CDN downloads                    |
-| `pypi`           | PyPI/TestPyPI publish and availability checks             |
-| `rubygems`       | RubyGems publish                                          |
-| `npm-publish`    | npm publish + Sigstore attestation                        |
-| `quality`        | Docker `lintro chk` (default on quality lint)             |
-| `sbom`           | SBOM, Grype scan, Sigstore attestation                    |
-| `scorecard`      | OpenSSF Scorecard (`reusable-scorecards.yml`)             |
+| Mode      | Behavior                                                                        |
+| --------- | ------------------------------------------------------------------------------- |
+| `replace` | Non-empty `allowed-endpoints` overrides `egress-preset`; empty uses preset only |
+| `append`  | Merges preset + `allowed-endpoints` (deduped, first-seen wins)                  |
+
+Use `append` to keep lgtm-ci defaults and add project-specific hosts. Empty
+`allowed-endpoints` under `append` still means preset-only (same as omitting extras).
+`audit` mode is unchanged (no enforced allowlist).
+
+| Preset           | Use case                                                |
+| ---------------- | ------------------------------------------------------- |
+| `github-minimal` | PR comments (API, tooling checkout, workflow artifacts) |
+| `github-pages`   | GitHub Pages deploy/publish (OIDC)                      |
+| `github-tooling` | Validate action pinning + GitHub raw/codeload           |
+| `docker`         | Docker build/pull/push (`reusable-docker.yml`)          |
+| `playwright`     | Playwright E2E + browser CDN downloads                  |
+| `pypi`           | PyPI/TestPyPI publish and availability checks           |
+| `rubygems`       | RubyGems publish                                        |
+| `npm-publish`    | npm publish + Sigstore attestation                      |
+| `quality`        | Docker `lintro chk` (default on quality lint)           |
+| `sbom`           | SBOM, Grype scan, Sigstore attestation                  |
+| `scorecard`      | OpenSSF Scorecard (`reusable-scorecards.yml`)           |
 
 ```yaml
 egress-policy: block
@@ -285,7 +306,7 @@ egress-preset: github-pages
 `reusable-deploy-site-with-reports.yml` uses `egress-build-preset` (default
 `playwright`) on the build job and `egress-deploy-preset` (default `github-pages`)
 on deploy. Use `allowed-endpoints-build` or `allowed-endpoints-deploy` for
-per-job overrides; shared `allowed-endpoints` still replaces presets on both jobs
+per-job overrides; shared `allowed-endpoints` / `allowed-endpoints-mode` apply to both jobs
 when the per-job inputs are empty.
 
 ### PyPI build

--- a/examples/publish-python-release.yml
+++ b/examples/publish-python-release.yml
@@ -6,10 +6,10 @@
 ---
 name: Publish - PyPI Production
 
-'on':
+"on":
   push:
     tags:
-      - '*.*.*'
+      - "*.*.*"
   workflow_dispatch:
 
 permissions: {}

--- a/scripts/ci/actions/resolve-egress-endpoints.sh
+++ b/scripts/ci/actions/resolve-egress-endpoints.sh
@@ -5,8 +5,9 @@
 # Required environment variables:
 #   GITHUB_OUTPUT - GitHub Actions output file
 #   EGRESS_POLICY - audit or block
-#   ALLOWED_ENDPOINTS - Caller override (multiline host:port)
-#   EGRESS_PRESET     - Preset name when allowed-endpoints is empty (optional)
+#   ALLOWED_ENDPOINTS - Caller host:port list (multiline)
+#   EGRESS_PRESET     - Preset name when using preset baseline (optional)
+#   ALLOWED_ENDPOINTS_MODE - replace (default) or append
 #
 # Outputs (GITHUB_OUTPUT):
 #   allowed-endpoints - Resolved allowlist for step-security/harden-runner
@@ -25,6 +26,7 @@ source "$LIB_DIR/github/output.sh"
 : "${EGRESS_POLICY:=block}"
 : "${ALLOWED_ENDPOINTS:=}"
 : "${EGRESS_PRESET:=}"
+: "${ALLOWED_ENDPOINTS_MODE:=replace}"
 
 case "$EGRESS_POLICY" in
 audit | block) ;;
@@ -34,41 +36,39 @@ audit | block) ;;
 	;;
 esac
 
-normalize_allowed_endpoints() {
-	local raw="$1"
-	local -a lines=()
-	local line trimmed
+case "$ALLOWED_ENDPOINTS_MODE" in
+replace | append) ;;
+*)
+	echo "resolve-egress-endpoints.sh: invalid ALLOWED_ENDPOINTS_MODE '$ALLOWED_ENDPOINTS_MODE' (expected 'replace' or 'append')" >&2
+	exit 1
+	;;
+esac
 
-	if [[ -z "${raw//[[:space:]]/}" ]]; then
-		printf ''
-		return
-	fi
-
-	while IFS= read -r line || [[ -n "$line" ]]; do
-		trimmed="${line#"${line%%[![:space:]]*}"}"
-		trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
-		if [[ -n "$trimmed" ]]; then
-			lines+=("$trimmed")
-		fi
-	done <<<"$raw"
-
-	if ((${#lines[@]} == 0)); then
-		printf ''
-		return
-	fi
-
-	local IFS=$'\n'
-	printf '%s' "${lines[*]}"
-}
-
-resolved=""
-resolved="$(normalize_allowed_endpoints "$ALLOWED_ENDPOINTS")"
+explicit=""
+explicit="$(egress_normalize_endpoint_lines "$ALLOWED_ENDPOINTS")"
 
 preset_trimmed="${EGRESS_PRESET#"${EGRESS_PRESET%%[![:space:]]*}"}"
 preset_trimmed="${preset_trimmed%"${preset_trimmed##*[![:space:]]}"}"
 
-if [[ -z "$resolved" && "$EGRESS_POLICY" == "block" && -n "$preset_trimmed" ]]; then
-	resolved="$(egress_preset_endpoints "$preset_trimmed")" || exit 1
+preset_lines=""
+if [[ "$EGRESS_POLICY" == "block" && -n "$preset_trimmed" ]]; then
+	preset_lines="$(egress_preset_endpoints "$preset_trimmed")" || exit 1
+fi
+
+resolved=""
+
+if [[ "$EGRESS_POLICY" == "audit" ]]; then
+	resolved="$explicit"
+elif [[ "$ALLOWED_ENDPOINTS_MODE" == "replace" ]]; then
+	if [[ -n "$explicit" ]]; then
+		resolved="$explicit"
+	elif [[ -n "$preset_lines" ]]; then
+		resolved="$preset_lines"
+	fi
+else
+	if [[ -n "$preset_lines" || -n "$explicit" ]]; then
+		resolved="$(egress_merge_endpoint_lines "$preset_lines" "$explicit")"
+	fi
 fi
 
 if [[ "$EGRESS_POLICY" == "block" && -z "${resolved//[[:space:]]/}" ]]; then

--- a/scripts/ci/actions/resolve-egress-endpoints.sh
+++ b/scripts/ci/actions/resolve-egress-endpoints.sh
@@ -44,7 +44,6 @@ replace | append) ;;
 	;;
 esac
 
-explicit=""
 explicit="$(egress_normalize_endpoint_lines "$ALLOWED_ENDPOINTS")"
 
 preset_trimmed="${EGRESS_PRESET#"${EGRESS_PRESET%%[![:space:]]*}"}"

--- a/scripts/ci/actions/validate-harden-runner-action-ref.sh
+++ b/scripts/ci/actions/validate-harden-runner-action-ref.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+HARDEN_ACTION="$REPO_ROOT/.github/actions/harden-runner/action.yml"
 
 violations=0
 while IFS= read -r -d '' file; do
@@ -27,9 +28,37 @@ while IFS= read -r -d '' file; do
 	done <"$file"
 done < <(find "$REPO_ROOT/.github/workflows" -name 'reusable-*.yml' -print0)
 
+if grep -qE "steps\.resolve\.outputs\['allowed-endpoints'\]" "$HARDEN_ACTION"; then
+	echo "harden-runner/action.yml: must pass inputs['allowed-endpoints'] (pre-hook cannot read composite step outputs)" >&2
+	violations=$((violations + 1))
+fi
+
+if grep -qE "^\s+egress-preset:" "$HARDEN_ACTION"; then
+	echo "harden-runner/action.yml: egress-preset belongs on resolve-egress-allowlist, not harden-runner" >&2
+	violations=$((violations + 1))
+fi
+
+for workflow in "$REPO_ROOT"/.github/workflows/reusable-*.yml "$REPO_ROOT"/.github/workflows/renovate.yml; do
+	[[ -f "$workflow" ]] || continue
+	if ! grep -qE '^[[:space:]]+uses:[[:space:]]+\./\.github/actions/harden-runner([[:space:]]|$)' "$workflow"; then
+		continue
+	fi
+	if ! grep -qE '^[[:space:]]+uses:[[:space:]]+\./\.github/actions/resolve-egress-allowlist([[:space:]]|$)' "$workflow"; then
+		echo "${workflow##*/}: uses harden-runner but missing resolve-egress-allowlist step" >&2
+		violations=$((violations + 1))
+	fi
+	if grep -A20 'uses: \./\.github/actions/harden-runner' "$workflow" | grep -qE 'egress-preset:'; then
+		echo "${workflow##*/}: pass egress-preset to resolve-egress-allowlist, not harden-runner" >&2
+		violations=$((violations + 1))
+	fi
+	if ! grep -qF "steps.egress.outputs['allowed-endpoints']" "$workflow"; then
+		echo "${workflow##*/}: harden-runner must use steps.egress.outputs['allowed-endpoints']" >&2
+		violations=$((violations + 1))
+	fi
+done
+
 for workflow in "$REPO_ROOT"/.github/workflows/reusable-*.yml; do
 	[[ -f "$workflow" ]] || continue
-	# Thin wrappers that only delegate to other reusable workflows have no steps
 	if ! grep -qE '^[[:space:]]*steps:[[:space:]]*$' "$workflow"; then
 		continue
 	fi
@@ -43,4 +72,4 @@ if [[ $violations -gt 0 ]]; then
 	exit 1
 fi
 
-echo "All reusables use ./.github/actions/harden-runner (same-repo composite)"
+echo "All reusables use resolve-egress-allowlist + ./.github/actions/harden-runner"

--- a/scripts/ci/actions/validate-harden-runner-action-ref.sh
+++ b/scripts/ci/actions/validate-harden-runner-action-ref.sh
@@ -45,7 +45,7 @@ _check_job_egress_order() {
 			!in_jobs {
 				next
 			}
-			/^  [a-zA-Z][a-zA-Z0-9_-]*: *$/ {
+			/^  [a-zA-Z_][a-zA-Z0-9_-]*: *$/ {
 				resolve_line = 0
 				next
 			}
@@ -69,7 +69,7 @@ _check_harden_with_blocks() {
 	local wf_name="${workflow##*/}"
 	local line_num
 	local block
-	local next_step_re='^[[:space:]]{6}- name:'
+	local next_step_re='^[[:space:]]{6}- (name|uses|run):'
 
 	while IFS= read -r line_num; do
 		[[ -z "$line_num" ]] && continue
@@ -109,6 +109,11 @@ done < <(discover_workflow_files)
 
 if grep -qE "steps\.resolve\.outputs\['allowed-endpoints'\]" "$HARDEN_ACTION"; then
 	echo "harden-runner/action.yml: must pass inputs['allowed-endpoints'] (pre-hook cannot read composite step outputs)" >&2
+	violations=$((violations + 1))
+fi
+
+if ! grep -qE 'allowed-endpoints:[[:space:]]+\$\{\{[[:space:]]+inputs\[.allowed-endpoints.\]' "$HARDEN_ACTION"; then
+	echo "harden-runner/action.yml: must forward allowed-endpoints from inputs['allowed-endpoints']" >&2
 	violations=$((violations + 1))
 fi
 

--- a/scripts/ci/actions/validate-harden-runner-action-ref.sh
+++ b/scripts/ci/actions/validate-harden-runner-action-ref.sh
@@ -10,8 +10,87 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 HARDEN_ACTION="$REPO_ROOT/.github/actions/harden-runner/action.yml"
+WORKFLOWS_DIR="$REPO_ROOT/.github/workflows"
+
+HARDEN_USES_RE='^[[:space:]]+uses:[[:space:]]+\./\.github/actions/harden-runner([[:space:]]|$)'
+RESOLVE_USES_RE='^[[:space:]]+uses:[[:space:]]+\./\.github/actions/resolve-egress-allowlist([[:space:]]|$)'
 
 violations=0
+
+discover_workflow_files() {
+	find "$WORKFLOWS_DIR" \( -name 'reusable-*.yml' -o -name 'renovate.yml' \) -print0
+}
+
+_check_job_egress_order() {
+	local workflow="$1"
+	local wf_name="${workflow##*/}"
+
+	while IFS= read -r msg; do
+		[[ -z "$msg" ]] && continue
+		echo "$msg" >&2
+		violations=$((violations + 1))
+	done < <(
+		awk -v wf="$wf_name" '
+			function report(msg) {
+				print wf ": " msg
+			}
+			BEGIN {
+				in_jobs = 0
+				resolve_line = 0
+			}
+			/^jobs:/ {
+				in_jobs = 1
+				next
+			}
+			!in_jobs {
+				next
+			}
+			/^  [a-zA-Z][a-zA-Z0-9_-]*: *$/ {
+				resolve_line = 0
+				next
+			}
+			$0 ~ /^[[:space:]]+uses:[[:space:]]+\.\/\.github\/actions\/resolve-egress-allowlist([[:space:]]|$)/ {
+				resolve_line = NR
+				next
+			}
+			$0 ~ /^[[:space:]]+uses:[[:space:]]+\.\/\.github\/actions\/harden-runner([[:space:]]|$)/ {
+				if (resolve_line == 0 || resolve_line >= NR) {
+					report("resolve-egress-allowlist must appear before harden-runner (harden-runner at line " NR ")")
+				}
+				resolve_line = 0
+				next
+			}
+		' "$workflow"
+	)
+}
+
+_check_harden_with_blocks() {
+	local workflow="$1"
+	local wf_name="${workflow##*/}"
+	local line_num
+	local block
+	local next_step_re='^[[:space:]]{6}- name:'
+
+	while IFS= read -r line_num; do
+		[[ -z "$line_num" ]] && continue
+		block="$(
+			awk -v start="$line_num" -v stop_re="$next_step_re" '
+				NR == start { print; next }
+				NR > start {
+					if ($0 ~ stop_re) {
+						exit
+					}
+					print
+				}
+			' "$workflow"
+		)"
+		if grep -qE 'egress-preset:' <<<"$block"; then
+			echo "${wf_name}:${line_num}: pass egress-preset to resolve-egress-allowlist, not harden-runner" >&2
+			violations=$((violations + 1))
+		fi
+	done < <(grep -nE "$HARDEN_USES_RE" "$workflow" | cut -d: -f1)
+}
+
 while IFS= read -r -d '' file; do
 	line_num=0
 	while IFS= read -r line || [[ -n "$line" ]]; do
@@ -26,7 +105,7 @@ while IFS= read -r -d '' file; do
 			violations=$((violations + 1))
 		fi
 	done <"$file"
-done < <(find "$REPO_ROOT/.github/workflows" -name 'reusable-*.yml' -print0)
+done < <(discover_workflow_files)
 
 if grep -qE "steps\.resolve\.outputs\['allowed-endpoints'\]" "$HARDEN_ACTION"; then
 	echo "harden-runner/action.yml: must pass inputs['allowed-endpoints'] (pre-hook cannot read composite step outputs)" >&2
@@ -38,35 +117,33 @@ if grep -qE "^\s+egress-preset:" "$HARDEN_ACTION"; then
 	violations=$((violations + 1))
 fi
 
-for workflow in "$REPO_ROOT"/.github/workflows/reusable-*.yml "$REPO_ROOT"/.github/workflows/renovate.yml; do
+while IFS= read -r -d '' workflow; do
 	[[ -f "$workflow" ]] || continue
-	if ! grep -qE '^[[:space:]]+uses:[[:space:]]+\./\.github/actions/harden-runner([[:space:]]|$)' "$workflow"; then
+	if ! grep -qE "$HARDEN_USES_RE" "$workflow"; then
 		continue
 	fi
-	if ! grep -qE '^[[:space:]]+uses:[[:space:]]+\./\.github/actions/resolve-egress-allowlist([[:space:]]|$)' "$workflow"; then
+	if ! grep -qE "$RESOLVE_USES_RE" "$workflow"; then
 		echo "${workflow##*/}: uses harden-runner but missing resolve-egress-allowlist step" >&2
-		violations=$((violations + 1))
-	fi
-	if grep -A20 'uses: \./\.github/actions/harden-runner' "$workflow" | grep -qE 'egress-preset:'; then
-		echo "${workflow##*/}: pass egress-preset to resolve-egress-allowlist, not harden-runner" >&2
 		violations=$((violations + 1))
 	fi
 	if ! grep -qF "steps.egress.outputs['allowed-endpoints']" "$workflow"; then
 		echo "${workflow##*/}: harden-runner must use steps.egress.outputs['allowed-endpoints']" >&2
 		violations=$((violations + 1))
 	fi
-done
+	_check_job_egress_order "$workflow"
+	_check_harden_with_blocks "$workflow"
+done < <(discover_workflow_files)
 
-for workflow in "$REPO_ROOT"/.github/workflows/reusable-*.yml; do
+while IFS= read -r -d '' workflow; do
 	[[ -f "$workflow" ]] || continue
 	if ! grep -qE '^[[:space:]]*steps:[[:space:]]*$' "$workflow"; then
 		continue
 	fi
-	if ! grep -qE '^[[:space:]]+uses:[[:space:]]+\./\.github/actions/harden-runner([[:space:]]|$)' "$workflow"; then
+	if ! grep -qE "$HARDEN_USES_RE" "$workflow"; then
 		echo "${workflow##*/}: missing ./.github/actions/harden-runner step" >&2
 		violations=$((violations + 1))
 	fi
-done
+done < <(find "$WORKFLOWS_DIR" -name 'reusable-*.yml' -print0)
 
 if [[ $violations -gt 0 ]]; then
 	exit 1

--- a/scripts/ci/lib/egress.sh
+++ b/scripts/ci/lib/egress.sh
@@ -16,5 +16,89 @@ _LGTM_CI_EGRESS_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/egress" && pwd)" || {
 	echo "egress.sh: missing presets.sh in $_LGTM_CI_EGRESS_DIR" >&2
 	return 1
 }
+# shellcheck source=egress/presets.sh
 source "$_LGTM_CI_EGRESS_DIR/presets.sh"
 readonly _LGTM_CI_EGRESS_LOADED=1
+
+# Normalize multiline host:port list (trim lines, drop blanks).
+egress_normalize_endpoint_lines() {
+	local raw="$1"
+	local -a lines=()
+	local line trimmed
+
+	if [[ -z "${raw//[[:space:]]/}" ]]; then
+		printf ''
+		return
+	fi
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		trimmed="${line#"${line%%[![:space:]]*}"}"
+		trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+		if [[ -n "$trimmed" ]]; then
+			lines+=("$trimmed")
+		fi
+	done <<<"$raw"
+
+	if ((${#lines[@]} == 0)); then
+		printf ''
+		return
+	fi
+
+	local IFS=$'\n'
+	printf '%s' "${lines[*]}"
+}
+
+# Deduplicate host:port lines; preserve first-seen order (bash 3.2 compatible).
+egress_dedupe_endpoint_lines() {
+	local raw="$1"
+	local -a unique=()
+	local line existing found
+
+	if [[ -z "${raw//[[:space:]]/}" ]]; then
+		printf ''
+		return
+	fi
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		line="${line#"${line%%[![:space:]]*}"}"
+		line="${line%"${line##*[![:space:]]}"}"
+		[[ -z "$line" ]] && continue
+		found=0
+		if ((${#unique[@]} > 0)); then
+			for existing in "${unique[@]}"; do
+				if [[ "$existing" == "$line" ]]; then
+					found=1
+					break
+				fi
+			done
+		fi
+		if [[ "$found" -eq 0 ]]; then
+			unique+=("$line")
+		fi
+	done <<<"$raw"
+
+	if ((${#unique[@]} == 0)); then
+		printf ''
+		return
+	fi
+
+	local IFS=$'\n'
+	printf '%s' "${unique[*]}"
+}
+
+# Merge multiple multiline endpoint lists (empty parts skipped), then dedupe.
+egress_merge_endpoint_lines() {
+	local combined="" part normalized
+	for part in "$@"; do
+		normalized="$(egress_normalize_endpoint_lines "$part")"
+		[[ -z "$normalized" ]] && continue
+		if [[ -z "$combined" ]]; then
+			combined="$normalized"
+		else
+			combined="${combined}"$'\n'"${normalized}"
+		fi
+	done
+	egress_dedupe_endpoint_lines "$combined"
+}
+
+export -f egress_normalize_endpoint_lines egress_dedupe_endpoint_lines egress_merge_endpoint_lines

--- a/tests/bats/integration/test_reusable_quality_lint_workflow.bats
+++ b/tests/bats/integration/test_reusable_quality_lint_workflow.bats
@@ -37,14 +37,19 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-quality-lint.yml"
 	assert_success
 }
 
-@test "reusable-quality-lint: harden step uses local composite harden-runner" {
+@test "reusable-quality-lint: resolve egress before harden-runner composite" {
+	run grep -E '^\s*uses:\s*\./\.github/actions/resolve-egress-allowlist\s*$' "$WORKFLOW"
+	assert_success
 	run grep -E '^\s*uses:\s*\./\.github/actions/harden-runner\s*$' "$WORKFLOW"
 	assert_success
 	run grep -F 'egress-preset: ${{ inputs.egress-preset }}' "$WORKFLOW"
 	assert_success
+	run grep -F "allowed-endpoints: \${{ steps.egress.outputs['allowed-endpoints'] }}" "$WORKFLOW"
+	assert_success
 	run awk '
 		/- name: Checkout repository/ { checkout = 1 }
-		checkout && /- name: Harden runner/ { found = 1 }
+		checkout && /- name: Resolve egress allowlist/ { resolve = 1 }
+		resolve && /- name: Harden runner/ { found = 1 }
 		END { exit !found }
 	' "$WORKFLOW"
 	assert_success

--- a/tests/bats/unit/actions/test_harden_runner_bundle.bats
+++ b/tests/bats/unit/actions/test_harden_runner_bundle.bats
@@ -22,6 +22,14 @@ teardown() {
 	assert_success
 }
 
+@test "harden-runner action: passes allowed-endpoints from inputs not step outputs" {
+	run grep -F "allowed-endpoints: \${{ inputs['allowed-endpoints'] }}" \
+		"${PROJECT_ROOT}/.github/actions/harden-runner/action.yml"
+	assert_success
+	run grep -F "steps.resolve.outputs" "${PROJECT_ROOT}/.github/actions/harden-runner/action.yml"
+	assert_failure
+}
+
 @test "sync-harden-runner-bundle: bundle resolver resolves quality preset" {
 	run bash "$SYNC"
 	assert_success

--- a/tests/bats/unit/actions/test_resolve_egress_endpoints.bats
+++ b/tests/bats/unit/actions/test_resolve_egress_endpoints.bats
@@ -93,6 +93,92 @@ teardown() {
 	assert_equal 0 "$output"
 }
 
+@test "resolve-egress: append merges preset with extra endpoints" {
+	output_file="$(mktemp)"
+	run env \
+		EGRESS_POLICY=block \
+		EGRESS_PRESET=quality \
+		ALLOWED_ENDPOINTS=$'registry.example.com:443\n' \
+		ALLOWED_ENDPOINTS_MODE=append \
+		GITHUB_OUTPUT="$output_file" \
+		bash "$RESOLVE"
+	assert_success
+	run grep -E '^docker\.io:443$' "$output_file"
+	assert_success
+	run grep -E '^registry\.example\.com:443$' "$output_file"
+	assert_success
+}
+
+@test "resolve-egress: append dedupes duplicate host:port lines" {
+	output_file="$(mktemp)"
+	run env \
+		EGRESS_POLICY=block \
+		EGRESS_PRESET=quality \
+		ALLOWED_ENDPOINTS=$'docker.io:443\nregistry.example.com:443\n' \
+		ALLOWED_ENDPOINTS_MODE=append \
+		GITHUB_OUTPUT="$output_file" \
+		bash "$RESOLVE"
+	assert_success
+	run grep -cE '^docker\.io:443$' "$output_file"
+	assert_equal 1 "$output"
+	run grep -cE '^registry\.example\.com:443$' "$output_file"
+	assert_equal 1 "$output"
+}
+
+@test "resolve-egress: append with empty allowed-endpoints uses preset only" {
+	output_file="$(mktemp)"
+	run env \
+		EGRESS_POLICY=block \
+		EGRESS_PRESET=github-minimal \
+		ALLOWED_ENDPOINTS="" \
+		ALLOWED_ENDPOINTS_MODE=append \
+		GITHUB_OUTPUT="$output_file" \
+		bash "$RESOLVE"
+	assert_success
+	run grep -E '^api\.github\.com:443$' "$output_file"
+	assert_success
+}
+
+@test "resolve-egress: append without preset uses explicit list only" {
+	output_file="$(mktemp)"
+	run env \
+		EGRESS_POLICY=block \
+		EGRESS_PRESET="" \
+		ALLOWED_ENDPOINTS=$'cdn.example.com:443\n' \
+		ALLOWED_ENDPOINTS_MODE=append \
+		GITHUB_OUTPUT="$output_file" \
+		bash "$RESOLVE"
+	assert_success
+	run grep -E '^cdn\.example\.com:443$' "$output_file"
+	assert_success
+}
+
+@test "resolve-egress: replace mode is default when ALLOWED_ENDPOINTS_MODE unset" {
+	output_file="$(mktemp)"
+	run env \
+		EGRESS_POLICY=block \
+		EGRESS_PRESET=quality \
+		ALLOWED_ENDPOINTS=$'github.com:443\n' \
+		GITHUB_OUTPUT="$output_file" \
+		bash "$RESOLVE"
+	assert_success
+	run grep -c 'docker\.io:443' "$output_file"
+	assert_equal 0 "$output"
+}
+
+@test "resolve-egress: rejects invalid allowed-endpoints-mode" {
+	output_file="$(mktemp)"
+	run env \
+		EGRESS_POLICY=block \
+		EGRESS_PRESET=github-minimal \
+		ALLOWED_ENDPOINTS="" \
+		ALLOWED_ENDPOINTS_MODE=merge \
+		GITHUB_OUTPUT="$output_file" \
+		bash "$RESOLVE"
+	assert_failure
+	assert_output --partial "invalid ALLOWED_ENDPOINTS_MODE"
+}
+
 @test "resolve-egress: rejects invalid egress-policy" {
 	output_file="$(mktemp)"
 	run env \

--- a/tests/bats/unit/lib/egress/test_egress_lib.bats
+++ b/tests/bats/unit/lib/egress/test_egress_lib.bats
@@ -24,3 +24,21 @@ EGRESS_LIB="${PROJECT_ROOT}/scripts/ci/lib/egress.sh"
 	assert_output --partial 'archive.ubuntu.com:80'
 	assert_output --partial 'security.ubuntu.com:80'
 }
+
+@test "egress_dedupe_endpoint_lines: keeps first occurrence order" {
+	run bash -c "
+		source '$EGRESS_LIB'
+		egress_dedupe_endpoint_lines \$'b:2\na:1\nb:2\na:1\n'
+	"
+	assert_success
+	assert_output $'b:2\na:1'
+}
+
+@test "egress_merge_endpoint_lines: merges and dedupes lists" {
+	run bash -c "
+		source '$EGRESS_LIB'
+		egress_merge_endpoint_lines \$'x:1\ny:2\n' \$'y:2\nz:3\n'
+	"
+	assert_success
+	assert_output $'x:1\ny:2\nz:3'
+}

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "lgtm-ci"
-version = "0.26.0"
+version = "0.30.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Fixes #276: `step-security/harden-runner` configures eBPF egress in a pre-hook before composite steps run, so `allowed-endpoints` cannot come from an inner resolve step output. This PR moves allowlist resolution to a workflow-level `resolve-egress-allowlist` step and passes the resolved list into the `harden-runner` composite as a static input. Also adds `allowed-endpoints-mode` (`replace` | `append`) with deduplication for preset plus explicit endpoints.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None for callers that already pass explicit `allowed-endpoints`. Reusable workflows now require the two-step resolve + harden pattern; the validation script enforces this.

## Closes

- Closes #276

## Changes Made

- Add `resolve-egress-allowlist` composite action; simplify `harden-runner` to pass `inputs['allowed-endpoints']` only
- Wire resolve step before harden-runner in all reusable workflows and `renovate.yml`
- Add `allowed-endpoints-mode` (`replace` default, `append` merges preset + explicit with dedupe)
- Extend `validate-harden-runner-action-ref.sh` and BATS coverage for bundle sync and wiring
- Document contract in `CHANGELOG.md`, `docs/workflow-contract.md`, and `docs/reusable-workflows.md`

## Testing

- [x] `uv run lintro chk` (zero issues)
- [x] `uv run lintro fmt`
- [x] BATS: `test_resolve_egress_endpoints.bats`, `test_egress_lib.bats`, `test_harden_runner_bundle.bats`, `test_reusable_quality_lint_workflow.bats`
- [x] `validate-harden-runner-bundle.sh` and `validate-harden-runner-action-ref.sh`

## Quality Checks

- [x] Lint/format (`lintro`)
- [x] Shell script validation (shellcheck via lintro)
- [x] YAML validation (yamllint via lintro)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve egress allowlist before harden-runner to fix step-security pre-hook
> - Extracts egress resolution into a new [resolve-egress-allowlist](https://github.com/lgtm-hq/lgtm-ci/pull/277/files#diff-f09621f6e51fa3f0c169cce5cc971dcb8592e894cd5c59945a144f1b3cc662df) composite action that must run as a dedicated step before `harden-runner`, because the step-security pre-hook executes before the composite's internal steps can run.
> - Removes internal preset resolution from [harden-runner/action.yml](https://github.com/lgtm-hq/lgtm-ci/pull/277/files#diff-065391f36a0cf7e66dd790966dac62d80842a84cc25cc23561dbb6da65158c64), which now forwards `inputs['allowed-endpoints']` directly to `step-security/harden-runner`.
> - Adds `allowed-endpoints-mode` input (`replace` | `append`, default `replace`) to all reusable workflows; `append` merges preset and explicit endpoints with deduplication via new `egress_merge_endpoint_lines` and `egress_dedupe_endpoint_lines` helpers in [egress.sh](https://github.com/lgtm-hq/lgtm-ci/pull/277/files#diff-be8cb88495b710df77bac702ecf98ea8ba917fea70d02d604541cb2434a0ed4b).
> - Updates all reusable workflow files (~30) to insert a `Resolve egress allowlist` step before `Harden runner` and wire `steps.egress.outputs['allowed-endpoints']` into the hardener.
> - Adds a [validate-harden-runner-action-ref.sh](https://github.com/lgtm-hq/lgtm-ci/pull/277/files#diff-f5f87811a526ede14f9c17292ffacb2775cb0ab51432f9507ca4256568c27f2b) CI check that fails when workflows omit the resolver step, misordering steps, or pass `egress-preset` directly to `harden-runner`.
> - Behavioral Change: `harden-runner` no longer resolves presets internally; callers must run `resolve-egress-allowlist` first or `allowed-endpoints` will be empty.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d3ce03.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New composite action resolves egress allowlists and an `allowed-endpoints-mode` (replace|append) used across reusable workflows; runner hardening now consumes the resolved allowlist.

* **Bug Fixes**
  * Harden-runner now forwards configured endpoints correctly to the security pre-step, preventing unintended blocked egress.

* **Documentation**
  * Updated workflow and contract docs to describe resolution step ordering and mode semantics.

* **Tests**
  * Added unit and integration tests for allowlist resolution, merge/dedupe behavior, and wiring into hardening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the egress allowlist ordering bug introduced by `step-security/harden-runner`'s eBPF pre-hook, which fires before composite step outputs are available. Resolution is now split into a dedicated `resolve-egress-allowlist` composite action that runs as a workflow step before `harden-runner`, which then receives the resolved list as a plain input.

- Introduces `resolve-egress-allowlist` composite action with `allowed-endpoints-mode: replace|append`, wires it before `harden-runner` across all ~30 reusable workflows, and removes the now-unnecessary `egress-preset` input from `harden-runner` itself.
- Adds `egress_normalize_endpoint_lines`, `egress_dedupe_endpoint_lines`, and `egress_merge_endpoint_lines` helpers to both `egress.sh` copies (harden-runner lib and scripts/ci/lib), with first-seen order deduplication.
- Extends `validate-harden-runner-action-ref.sh` with an awk-based per-job ordering checker and a block-level `egress-preset` placement validator, replacing the fragile `grep -A20` heuristic flagged in earlier reviews.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the core fix is correctly implemented and the validate script now enforces the two-step pattern across all reusable workflows.

The root-cause fix is sound: harden-runner now forwards inputs['allowed-endpoints'] directly to the step-security action, and all workflows correctly insert a resolve-egress-allowlist step before it. The new append mode merge/dedupe logic is well-tested with BATS unit coverage. The two findings are a documentation gap about the action's same-repo-only constraint, and a minor awk pattern edge case in the validator that no current workflow triggers.

The new resolve-egress-allowlist/action.yml and the _check_job_egress_order awk function in validate-harden-runner-action-ref.sh are the two places worth a second look.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/resolve-egress-allowlist/action.yml | New composite action that resolves the egress allowlist before harden-runner runs; references a sibling script via ../harden-runner/resolve-egress-endpoints.sh, which is safe for same-repo local use but creates implicit coupling to the harden-runner directory. |
| .github/actions/harden-runner/action.yml | Removes egress-preset input and internal resolve step; now passes inputs['allowed-endpoints'] directly to step-security/harden-runner, correctly fixing the pre-hook timing issue. |
| .github/actions/harden-runner/lib/egress.sh | Adds egress_normalize_endpoint_lines, egress_dedupe_endpoint_lines, and egress_merge_endpoint_lines helpers with correct whitespace trimming and first-seen-order deduplication. |
| .github/actions/harden-runner/resolve-egress-endpoints.sh | Refactored to support allowed-endpoints-mode (replace/append); replaces local normalize helper with shared egress.sh functions; logic for audit vs block and replace vs append is clean and well-guarded. |
| scripts/ci/actions/validate-harden-runner-action-ref.sh | Significantly extended validation; adds per-job awk-based ordering check and block-level egress-preset detection; job boundary pattern has a minor gap for job headers with trailing comments but is robust for all real workflows in the repo. |
| scripts/ci/lib/egress.sh | Identical additions to the harden-runner library copy; exports new helpers for use in child processes. |
| .github/workflows/reusable-rust-test.yml | Adds resolve step; removes a duplicate Checkout repository step (caller's full checkout is already done at the start of the job); sparse-checkout for tooling now includes .github/actions/ for setup-rust. |
| .github/workflows/reusable-docker.yml | All six jobs updated with resolve → harden pattern; sparse-checkout for the sbom job correctly expanded to include both harden-runner and resolve-egress-allowlist directories. |

</details>

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Factions%2Fresolve-egress-allowlist%2Faction.yml%3A48%0A**Cross-action%20path%20traversal%20couples%20this%20action%20to%20a%20sibling%20directory**%0A%0AThe%20%60..%2Fharden-runner%2F%60%20traversal%20works%20correctly%20for%20all%20current%20internal%20uses%20because%20GitHub%20makes%20the%20full%20lgtm-ci%20repo%20available%20when%20resolving%20same-repo%20relative-path%20composite%20actions.%20However%2C%20if%20this%20action%20is%20ever%20referenced%20externally%20%28e.g.%2C%20%60lgtm-hq%2Flgtm-ci%2F.github%2Factions%2Fresolve-egress-allowlist%40sha%60%29%2C%20GitHub%20fetches%20only%20the%20action's%20own%20directory%20%E2%80%94%20%60..%2Fharden-runner%2Fresolve-egress-endpoints.sh%60%20would%20not%20exist%20on%20the%20runner%20and%20the%20step%20would%20fail%20at%20runtime.%20Consider%20adding%20a%20note%20to%20the%20%60description%60%20field%20%28or%20the%20README%29%20that%20this%20action%20must%20always%20be%20used%20as%20a%20local%20%60.%2F.github%2Factions%2F%60%20reference%20within%20lgtm-ci.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Factions%2Fvalidate-harden-runner-action-ref.sh%3A48-51%0A**Job-boundary%20reset%20silently%20misses%20headers%20with%20trailing%20comments**%0A%0AThe%20awk%20pattern%20%60%2F%5E%20%20%5Ba-zA-Z_%5D%5Ba-zA-Z0-9_-%5D*%3A%20*%24%2F%60%20resets%20%60resolve_line%60%20only%20when%20a%20job-name%20line%20matches%20exactly%20%E2%80%94%20no%20trailing%20non-space%20characters.%20A%20job%20header%20like%20%60%20%20my-job%3A%20%23%20comment%60%20has%20non-space%20text%20after%20the%20colon%2C%20so%20%60%3A%20*%24%60%20fails%20to%20match%20and%20%60resolve_line%60%20is%20never%20reset.%20If%20%60resolve-egress-allowlist%60%20is%20found%20in%20Job%20A%20and%20%60harden-runner%60%20is%20found%20in%20a%20subsequent%20Job%20B%20whose%20header%20carries%20a%20comment%2C%20the%20validator%20would%20see%20%60resolve_line%20%3E%200%60%20and%20incorrectly%20pass%20the%20ordering%20check.%20No%20current%20workflow%20in%20the%20repo%20uses%20this%20style%2C%20but%20a%20future%20addition%20could%20silently%20slip%20through.%20Changing%20%60%3A%20*%24%60%20to%20%60%3A%28%5B%5B%3Aspace%3A%5D%5D%7C%24%29%60%20or%20stripping%20trailing%20comments%20before%20matching%20would%20close%20the%20gap.%0A%0A%60%60%60suggestion%0A%09%09%09%2F%5E%20%20%5Ba-zA-Z_%5D%5Ba-zA-Z0-9_-%5D*%3A%28%5B%5B%3Aspace%3A%5D%5D%7C%24%29%2F%20%7B%0A%09%09%09%09resolve_line%20%3D%200%0A%09%09%09%09next%0A%09%09%09%7D%0A%60%60%60%0A%0A&pr=277&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Factions%2Fresolve-egress-allowlist%2Faction.yml%3A48%0A**Cross-action%20path%20traversal%20couples%20this%20action%20to%20a%20sibling%20directory**%0A%0AThe%20%60..%2Fharden-runner%2F%60%20traversal%20works%20correctly%20for%20all%20current%20internal%20uses%20because%20GitHub%20makes%20the%20full%20lgtm-ci%20repo%20available%20when%20resolving%20same-repo%20relative-path%20composite%20actions.%20However%2C%20if%20this%20action%20is%20ever%20referenced%20externally%20%28e.g.%2C%20%60lgtm-hq%2Flgtm-ci%2F.github%2Factions%2Fresolve-egress-allowlist%40sha%60%29%2C%20GitHub%20fetches%20only%20the%20action's%20own%20directory%20%E2%80%94%20%60..%2Fharden-runner%2Fresolve-egress-endpoints.sh%60%20would%20not%20exist%20on%20the%20runner%20and%20the%20step%20would%20fail%20at%20runtime.%20Consider%20adding%20a%20note%20to%20the%20%60description%60%20field%20%28or%20the%20README%29%20that%20this%20action%20must%20always%20be%20used%20as%20a%20local%20%60.%2F.github%2Factions%2F%60%20reference%20within%20lgtm-ci.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Factions%2Fvalidate-harden-runner-action-ref.sh%3A48-51%0A**Job-boundary%20reset%20silently%20misses%20headers%20with%20trailing%20comments**%0A%0AThe%20awk%20pattern%20%60%2F%5E%20%20%5Ba-zA-Z_%5D%5Ba-zA-Z0-9_-%5D*%3A%20*%24%2F%60%20resets%20%60resolve_line%60%20only%20when%20a%20job-name%20line%20matches%20exactly%20%E2%80%94%20no%20trailing%20non-space%20characters.%20A%20job%20header%20like%20%60%20%20my-job%3A%20%23%20comment%60%20has%20non-space%20text%20after%20the%20colon%2C%20so%20%60%3A%20*%24%60%20fails%20to%20match%20and%20%60resolve_line%60%20is%20never%20reset.%20If%20%60resolve-egress-allowlist%60%20is%20found%20in%20Job%20A%20and%20%60harden-runner%60%20is%20found%20in%20a%20subsequent%20Job%20B%20whose%20header%20carries%20a%20comment%2C%20the%20validator%20would%20see%20%60resolve_line%20%3E%200%60%20and%20incorrectly%20pass%20the%20ordering%20check.%20No%20current%20workflow%20in%20the%20repo%20uses%20this%20style%2C%20but%20a%20future%20addition%20could%20silently%20slip%20through.%20Changing%20%60%3A%20*%24%60%20to%20%60%3A%28%5B%5B%3Aspace%3A%5D%5D%7C%24%29%60%20or%20stripping%20trailing%20comments%20before%20matching%20would%20close%20the%20gap.%0A%0A%60%60%60suggestion%0A%09%09%09%2F%5E%20%20%5Ba-zA-Z_%5D%5Ba-zA-Z0-9_-%5D*%3A%28%5B%5B%3Aspace%3A%5D%5D%7C%24%29%2F%20%7B%0A%09%09%09%09resolve_line%20%3D%200%0A%09%09%09%09next%0A%09%09%09%7D%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=277&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22fix%2F276-harden-runner-pre-hook-egress%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F276-harden-runner-pre-hook-egress%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Factions%2Fresolve-egress-allowlist%2Faction.yml%3A48%0A**Cross-action%20path%20traversal%20couples%20this%20action%20to%20a%20sibling%20directory**%0A%0AThe%20%60..%2Fharden-runner%2F%60%20traversal%20works%20correctly%20for%20all%20current%20internal%20uses%20because%20GitHub%20makes%20the%20full%20lgtm-ci%20repo%20available%20when%20resolving%20same-repo%20relative-path%20composite%20actions.%20However%2C%20if%20this%20action%20is%20ever%20referenced%20externally%20%28e.g.%2C%20%60lgtm-hq%2Flgtm-ci%2F.github%2Factions%2Fresolve-egress-allowlist%40sha%60%29%2C%20GitHub%20fetches%20only%20the%20action's%20own%20directory%20%E2%80%94%20%60..%2Fharden-runner%2Fresolve-egress-endpoints.sh%60%20would%20not%20exist%20on%20the%20runner%20and%20the%20step%20would%20fail%20at%20runtime.%20Consider%20adding%20a%20note%20to%20the%20%60description%60%20field%20%28or%20the%20README%29%20that%20this%20action%20must%20always%20be%20used%20as%20a%20local%20%60.%2F.github%2Factions%2F%60%20reference%20within%20lgtm-ci.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Factions%2Fvalidate-harden-runner-action-ref.sh%3A48-51%0A**Job-boundary%20reset%20silently%20misses%20headers%20with%20trailing%20comments**%0A%0AThe%20awk%20pattern%20%60%2F%5E%20%20%5Ba-zA-Z_%5D%5Ba-zA-Z0-9_-%5D*%3A%20*%24%2F%60%20resets%20%60resolve_line%60%20only%20when%20a%20job-name%20line%20matches%20exactly%20%E2%80%94%20no%20trailing%20non-space%20characters.%20A%20job%20header%20like%20%60%20%20my-job%3A%20%23%20comment%60%20has%20non-space%20text%20after%20the%20colon%2C%20so%20%60%3A%20*%24%60%20fails%20to%20match%20and%20%60resolve_line%60%20is%20never%20reset.%20If%20%60resolve-egress-allowlist%60%20is%20found%20in%20Job%20A%20and%20%60harden-runner%60%20is%20found%20in%20a%20subsequent%20Job%20B%20whose%20header%20carries%20a%20comment%2C%20the%20validator%20would%20see%20%60resolve_line%20%3E%200%60%20and%20incorrectly%20pass%20the%20ordering%20check.%20No%20current%20workflow%20in%20the%20repo%20uses%20this%20style%2C%20but%20a%20future%20addition%20could%20silently%20slip%20through.%20Changing%20%60%3A%20*%24%60%20to%20%60%3A%28%5B%5B%3Aspace%3A%5D%5D%7C%24%29%60%20or%20stripping%20trailing%20comments%20before%20matching%20would%20close%20the%20gap.%0A%0A%60%60%60suggestion%0A%09%09%09%2F%5E%20%20%5Ba-zA-Z_%5D%5Ba-zA-Z0-9_-%5D*%3A%28%5B%5B%3Aspace%3A%5D%5D%7C%24%29%2F%20%7B%0A%09%09%09%09resolve_line%20%3D%200%0A%09%09%09%09next%0A%09%09%09%7D%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["ci: tighten harden-runner validator edge..."](https://github.com/lgtm-hq/lgtm-ci/commit/1d3ce03b8bdf8186b4d7eab741755e6d0f4d5155) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35307551)</sub>

<!-- /greptile_comment -->