### PR TITLE
fix(ci): retain egress composites in release tooling sparse checkout

### DIFF
--- a/.github/workflows/reusable-release-auto-tag.yml
+++ b/.github/workflows/reusable-release-auto-tag.yml
@@ -166,7 +166,10 @@ jobs:
           repository: lgtm-hq/lgtm-ci
           path: .lgtm-ci-tooling
           ref: ${{ steps.tooling.outputs.ref }}
-          sparse-checkout: scripts/ci/
+          sparse-checkout: |
+            scripts/ci/
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
           sparse-checkout-cone-mode: true
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/reusable-release-version-pr.yml
+++ b/.github/workflows/reusable-release-version-pr.yml
@@ -184,7 +184,10 @@ jobs:
           path: .lgtm-ci-tooling
           # yamllint disable-line rule:line-length
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: scripts/ci/
+          sparse-checkout: |
+            scripts/ci/
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
           sparse-checkout-cone-mode: true
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}
@@ -383,7 +386,10 @@ jobs:
           path: .lgtm-ci-tooling
           # yamllint disable-line rule:line-length
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: scripts/ci/
+          sparse-checkout: |
+            scripts/ci/
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
           sparse-checkout-cone-mode: true
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}

--- a/scripts/ci/actions/validate-harden-runner-action-ref.sh
+++ b/scripts/ci/actions/validate-harden-runner-action-ref.sh
@@ -135,12 +135,14 @@ _check_release_two_phase_sparse() {
 			block && /^[[:space:]]+sparse-checkout: \|/ {
 				in_sparse = 1
 				has_harden = 0
+				has_resolve = 0
 				next
 			}
 			in_sparse && /\.github\/actions\/harden-runner/ { has_harden = 1 }
+			in_sparse && /\.github\/actions\/resolve-egress-allowlist/ { has_resolve = 1 }
 			in_sparse && /^[[:space:]]+[a-zA-Z]/ && !/^[[:space:]]+\./ && !/^[[:space:]]+scripts/ {
-				if (!has_harden) {
-					print wf ": multiline sparse-checkout after egress tooling must include harden-runner"
+				if (!has_harden || !has_resolve) {
+					print wf ": multiline sparse-checkout after egress tooling must include harden-runner and resolve-egress-allowlist"
 				}
 				in_sparse = 0
 				block = 0

--- a/scripts/ci/actions/validate-harden-runner-action-ref.sh
+++ b/scripts/ci/actions/validate-harden-runner-action-ref.sh
@@ -134,15 +134,17 @@ _check_release_two_phase_sparse() {
 			}
 			block && /^[[:space:]]+sparse-checkout: \|/ {
 				in_sparse = 1
+				has_scripts = 0
 				has_harden = 0
 				has_resolve = 0
 				next
 			}
+			in_sparse && /scripts\/ci\// { has_scripts = 1 }
 			in_sparse && /\.github\/actions\/harden-runner/ { has_harden = 1 }
 			in_sparse && /\.github\/actions\/resolve-egress-allowlist/ { has_resolve = 1 }
 			in_sparse && /^[[:space:]]+[a-zA-Z]/ && !/^[[:space:]]+\./ && !/^[[:space:]]+scripts/ {
-				if (!has_harden || !has_resolve) {
-					print wf ": multiline sparse-checkout after egress tooling must include harden-runner and resolve-egress-allowlist"
+				if (!has_scripts || !has_harden || !has_resolve) {
+					print wf ": multiline sparse-checkout after egress tooling must include scripts/ci/, harden-runner, and resolve-egress-allowlist"
 				}
 				in_sparse = 0
 				block = 0

--- a/scripts/ci/actions/validate-harden-runner-action-ref.sh
+++ b/scripts/ci/actions/validate-harden-runner-action-ref.sh
@@ -112,6 +112,43 @@ _check_harden_with_blocks() {
 	done < <(grep -nE "$TOOLING_HARDEN_RE" "$workflow" | cut -d: -f1)
 }
 
+_check_release_two_phase_sparse() {
+	local workflow="$1"
+	local wf_name="${workflow##*/}"
+
+	[[ -f "$workflow" ]] || return 0
+	grep -q 'Checkout lgtm-ci egress tooling' "$workflow" || return 0
+
+	while IFS= read -r msg; do
+		[[ -z "$msg" ]] && continue
+		echo "$msg" >&2
+		violations=$((violations + 1))
+	done < <(
+		awk -v wf="$wf_name" '
+			/Checkout lgtm-ci egress tooling/ { saw_egress = 1 }
+			saw_egress && /- name: Checkout lgtm-ci tooling/ { block = 1 }
+			saw_egress && /- name: Restore tooling for post-PR steps/ { block = 1 }
+			block && /^[[:space:]]+sparse-checkout: scripts\/ci\/$/ {
+				print wf ": sparse-checkout after egress tooling must include egress composites (not scripts/ci/ only)"
+				block = 0
+			}
+			block && /^[[:space:]]+sparse-checkout: \|/ {
+				in_sparse = 1
+				has_harden = 0
+				next
+			}
+			in_sparse && /\.github\/actions\/harden-runner/ { has_harden = 1 }
+			in_sparse && /^[[:space:]]+[a-zA-Z]/ && !/^[[:space:]]+\./ && !/^[[:space:]]+scripts/ {
+				if (!has_harden) {
+					print wf ": multiline sparse-checkout after egress tooling must include harden-runner"
+				}
+				in_sparse = 0
+				block = 0
+			}
+		' "$workflow"
+	)
+}
+
 while IFS= read -r -d '' file; do
 	line_num=0
 	while IFS= read -r line || [[ -n "$line" ]]; do
@@ -168,6 +205,9 @@ while IFS= read -r -d '' workflow; do
 	_check_job_egress_order "$workflow"
 	_check_harden_with_blocks "$workflow"
 done < <(discover_reusable_workflows)
+
+_check_release_two_phase_sparse "$WORKFLOWS_DIR/reusable-release-auto-tag.yml"
+_check_release_two_phase_sparse "$WORKFLOWS_DIR/reusable-release-version-pr.yml"
 
 renovate="$WORKFLOWS_DIR/renovate.yml"
 if [[ -f "$renovate" ]]; then

--- a/tests/bats/integration/test_reusable_release_tooling_sparse.bats
+++ b/tests/bats/integration/test_reusable_release_tooling_sparse.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Release reusables must keep egress composites after scripts/ci sparse checkout
+
+load "../../helpers/common"
+
+_release_scripts_sparse_keeps_egress() {
+	local workflow="$1"
+	awk '
+		/Checkout lgtm-ci egress tooling/ { saw_egress = 1 }
+		saw_egress && /- name: Checkout lgtm-ci tooling/ { block = 1 }
+		saw_egress && /- name: Restore tooling for post-PR steps/ { block = 1 }
+		block && /^          sparse-checkout: scripts\/ci\/$/ { bad = 1 }
+		block && /sparse-checkout: \|/ {
+			in_sparse = 1
+			has_scripts = has_harden = has_resolve = 0
+			next
+		}
+		in_sparse && /scripts\/ci\// { has_scripts = 1 }
+		in_sparse && /\.github\/actions\/harden-runner/ { has_harden = 1 }
+		in_sparse && /\.github\/actions\/resolve-egress-allowlist/ { has_resolve = 1 }
+		in_sparse && /^          [a-zA-Z]/ && !/^          \./ && !/^          scripts/ {
+			if (!(has_scripts && has_harden && has_resolve)) {
+				bad = 1
+			}
+			in_sparse = 0
+			block = 0
+		}
+		END { exit bad }
+	' "$workflow"
+}
+
+@test "reusable-release-auto-tag: scripts sparse checkout retains egress composites" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-auto-tag.yml"
+	run _release_scripts_sparse_keeps_egress "$workflow"
+	assert_success
+}
+
+@test "reusable-release-version-pr: scripts sparse checkout retains egress composites" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
+	run _release_scripts_sparse_keeps_egress "$workflow"
+	assert_success
+}


### PR DESCRIPTION
## Summary

Release reusables `reusable-release-auto-tag` and `reusable-release-version-pr` re-checkout `.lgtm-ci-tooling` with sparse `scripts/ci/` only after the egress phase, which removes `harden-runner` and breaks post-job cleanup. This PR extends all scripts-phase and restore sparse lists to keep egress composites alongside `scripts/ci/`, and adds validator + BATS guards against regression.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [ ] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #287

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sparse checkout in release workflows to retain egress composite actions
> - Updates sparse-checkout in [reusable-release-auto-tag.yml](https://github.com/lgtm-hq/lgtm-ci/pull/288/files#diff-9029c6ffc07d573f6df930a91ea59eded9a0f588356d5b11c902e070189aa298) and [reusable-release-version-pr.yml](https://github.com/lgtm-hq/lgtm-ci/pull/288/files#diff-d61fae79363325466e1f95221611b67147acc63cce67db555b10ac20d3efe4ec) to include `.github/actions/harden-runner` and `.github/actions/resolve-egress-allowlist` alongside `scripts/ci/`.
> - Adds a `_check_release_two_phase_sparse` validation function in [validate-harden-runner-action-ref.sh](https://github.com/lgtm-hq/lgtm-ci/pull/288/files#diff-f5f87811a526ede14f9c17292ffacb2775cb0ab51432f9507ca4256568c27f2b) that flags release workflow checkout steps missing the required egress composite action paths.
> - Adds integration tests in [test_reusable_release_tooling_sparse.bats](https://github.com/lgtm-hq/lgtm-ci/pull/288/files#diff-bf98674dc2a25bf1b0d33c53e519b7ec037e1c09cd3b702580a1a69dc9a428f9) covering both release workflow files.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff0ec75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflows updated to ensure additional security/egress tooling is included during checkout and release steps.

* **Tests**
  * Added integration tests to verify release workflows retain and include required security/egress tooling during automated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a regression where re-checking out `.lgtm-ci-tooling` during the scripts phase of `reusable-release-auto-tag` and `reusable-release-version-pr` overwrote the initial egress-only sparse checkout with `scripts/ci/` alone, stripping `harden-runner` and `resolve-egress-allowlist` and breaking their post-job cleanup hooks. It also adds a shell validator and BATS integration tests to guard against the regression recurring.

- Both release workflows now use a three-entry multiline `sparse-checkout` (`scripts/ci/`, `.github/actions/harden-runner`, `.github/actions/resolve-egress-allowlist`) for every post-egress checkout, including the `if: always()` restore step in `reusable-release-version-pr`.
- A new `_check_release_two_phase_sparse` function in `validate-harden-runner-action-ref.sh` detects both the old single-line form and any multiline sparse list that omits the egress composite paths, with `has_harden` and `has_resolve` both tracked and required.
- Two BATS tests parse both workflow files with matching AWK logic and fail if either sparse list is incomplete.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the workflow and validator changes are straightforward additive fixes with no destructive side effects.

All three sparse-checkout sites in both workflows now carry the full required path set. The validator and BATS tests cover the exact regression scenario described in the bug report. The AWK logic in both the validator and the tests is internally consistent, and the has_resolve tracking gap noted in the prior review thread was confirmed addressed before this review. The only open edge case — an unterminated in_sparse block at EOF — is theoretical given YAML structure always provides a subsequent key, and has no impact on the current files.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-release-auto-tag.yml | Second sparse checkout (scripts phase) now includes `.github/actions/harden-runner` and `.github/actions/resolve-egress-allowlist` alongside `scripts/ci/`, fixing the dropped egress composites bug. |
| .github/workflows/reusable-release-version-pr.yml | Both the scripts-phase checkout and the "Restore tooling for post-PR steps" checkout are updated to include egress composite paths; both sparse lists are now consistent and complete. |
| scripts/ci/actions/validate-harden-runner-action-ref.sh | New `_check_release_two_phase_sparse` function validates that both release workflows include all three required paths in every post-egress sparse checkout; logic handles both single-line and multiline forms correctly. |
| tests/bats/integration/test_reusable_release_tooling_sparse.bats | Two integration tests assert both release workflows contain the full sparse-checkout path set after the egress phase; AWK logic mirrors the shell validator and covers both path-missing and single-line bad cases. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Job as GitHub Actions Job
    participant Egress as Egress Checkout<br/>(harden-runner +<br/>resolve-egress-allowlist)
    participant HR as Harden Runner<br/>(post-job cleanup)
    participant Scripts as Scripts Checkout<br/>(scripts/ci/ +<br/>harden-runner +<br/>resolve-egress-allowlist)
    participant Restore as Restore Tooling<br/>(scripts/ci/ +<br/>harden-runner +<br/>resolve-egress-allowlist)

    Job->>Egress: sparse checkout (.github/actions only)
    Egress-->>Job: harden-runner + resolve-egress-allowlist available
    Job->>Job: resolve-egress-allowlist → harden-runner (registers post-job hook)
    Job->>Scripts: sparse checkout (scripts/ci/ + egress composites)
    Note over Scripts: Bug fix: egress composites retained<br/>so harden-runner post-job hook<br/>can still resolve its action path
    Scripts-->>Job: scripts/ci/ + harden-runner + resolve-egress-allowlist available
    Job->>Job: Run release scripts…
    Job->>Restore: restore tooling (if: always())
    Note over Restore: Bug fix: egress composites retained<br/>for post-PR cleanup steps
    Restore-->>Job: tooling fully restored
    HR-->>Job: post-job egress cleanup executes successfully
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fvalidate-harden-runner-action-ref.sh%3A145-151%0A**Missing%20%60END%60%20clause%20%E2%80%94%20incomplete%20multiline%20block%20silently%20passes**%0A%0AThe%20AWK%20termination%20condition%20%28line%20145%29%20fires%20only%20when%20a%20non-%60.%60%2Fnon-%60scripts%60%20letter-prefixed%20line%20appears%20after%20the%20sparse%20entries.%20If%20a%20workflow%20file%20ends%20while%20%60in_sparse%60%20is%20still%20active%20%28e.g.%20because%20%60sparse-checkout-cone-mode%60%20was%20removed%20or%20renamed%29%2C%20the%20collected%20%60has_*%60%20flags%20are%20never%20evaluated%20and%20the%20function%20returns%20without%20printing%20any%20violation.%20The%20BATS%20counterpart%20has%20the%20same%20gap.%20Adding%20%60END%20%7B%20if%20%28in_sparse%20%26%26%20%28!has_scripts%20%7C%7C%20!has_harden%20%7C%7C%20!has_resolve%29%29%20print%20wf%20%22%3A%20...%22%20%7D%60%20would%20close%20this.%0A%0A&pr=288&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fvalidate-harden-runner-action-ref.sh%3A145-151%0A**Missing%20%60END%60%20clause%20%E2%80%94%20incomplete%20multiline%20block%20silently%20passes**%0A%0AThe%20AWK%20termination%20condition%20%28line%20145%29%20fires%20only%20when%20a%20non-%60.%60%2Fnon-%60scripts%60%20letter-prefixed%20line%20appears%20after%20the%20sparse%20entries.%20If%20a%20workflow%20file%20ends%20while%20%60in_sparse%60%20is%20still%20active%20%28e.g.%20because%20%60sparse-checkout-cone-mode%60%20was%20removed%20or%20renamed%29%2C%20the%20collected%20%60has_*%60%20flags%20are%20never%20evaluated%20and%20the%20function%20returns%20without%20printing%20any%20violation.%20The%20BATS%20counterpart%20has%20the%20same%20gap.%20Adding%20%60END%20%7B%20if%20%28in_sparse%20%26%26%20%28!has_scripts%20%7C%7C%20!has_harden%20%7C%7C%20!has_resolve%29%29%20print%20wf%20%22%3A%20...%22%20%7D%60%20would%20close%20this.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=288&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22fix%2F287-release-tooling-wipes-egress%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F287-release-tooling-wipes-egress%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fvalidate-harden-runner-action-ref.sh%3A145-151%0A**Missing%20%60END%60%20clause%20%E2%80%94%20incomplete%20multiline%20block%20silently%20passes**%0A%0AThe%20AWK%20termination%20condition%20%28line%20145%29%20fires%20only%20when%20a%20non-%60.%60%2Fnon-%60scripts%60%20letter-prefixed%20line%20appears%20after%20the%20sparse%20entries.%20If%20a%20workflow%20file%20ends%20while%20%60in_sparse%60%20is%20still%20active%20%28e.g.%20because%20%60sparse-checkout-cone-mode%60%20was%20removed%20or%20renamed%29%2C%20the%20collected%20%60has_*%60%20flags%20are%20never%20evaluated%20and%20the%20function%20returns%20without%20printing%20any%20violation.%20The%20BATS%20counterpart%20has%20the%20same%20gap.%20Adding%20%60END%20%7B%20if%20%28in_sparse%20%26%26%20%28!has_scripts%20%7C%7C%20!has_harden%20%7C%7C%20!has_resolve%29%29%20print%20wf%20%22%3A%20...%22%20%7D%60%20would%20close%20this.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["fix(ci): require scripts/ci/ in release ..."](https://github.com/lgtm-hq/lgtm-ci/commit/ff0ec756c12134b0f55ddfceff328f4dc5218fbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35625363)</sub>

<!-- /greptile_comment -->