### PR TITLE
fix(ci): include scripts/ci in coverage test summary sparse checkout

### DIFF
--- a/.github/workflows/reusable-test-node.yml
+++ b/.github/workflows/reusable-test-node.yml
@@ -735,6 +735,7 @@ jobs:
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
             .github/actions/
+            scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

`publish-test-summary-coverage` in `reusable-test-node.yml` sparse-checkouts only `.github/actions/`, but `post-pr-comment` needs `scripts/ci/actions/post-pr-comment.sh`. Callers with `publish-test-summary: true` fail with exit 127.

## Test plan

- [ ] Merge and tag v0.32.1
- [ ] Re-run Rustume PR CI (pins to this SHA until release)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Include `scripts/ci` in sparse checkout for coverage test summary
> Adds `scripts/ci/` to the sparse-checkout path list in the 'Checkout lgtm-ci tooling' step of [reusable-test-node.yml](.github/workflows/reusable-test-node.yml), so the coverage test summary scripts are available during CI runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8e50c1f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration to adjust tooling access paths.

*No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds `scripts/ci/` to the sparse-checkout list in the `publish-test-summary-coverage` job so that `post-pr-comment` action can locate its backing shell script (`scripts/ci/actions/post-pr-comment.sh`). Without this entry, callers with `publish-test-summary: true` and `coverage: true` fail with exit 127 because the script is not present on the runner.

- **Root cause fix**: the `post-pr-comment` composite action resolves its script path as `${GITHUB_ACTION_PATH}/../../../scripts/ci/actions/post-pr-comment.sh`; the sparse checkout previously only included `.github/actions/`, leaving `scripts/ci/` absent.
- **Consistency**: the other four sparse-checkout blocks in the same file already include `scripts/ci/`; this patch brings the coverage-summary job in line with the rest.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change adds exactly one missing path to a sparse checkout, directly unblocking a documented runtime failure.

The one-line addition mirrors the same pattern already present in the four other sparse-checkout blocks in the same file. The post-pr-comment composite action path-resolves its script to scripts/ci/; once that directory is checked out the failure disappears and no other behaviour changes.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-test-node.yml | Single-line addition of `scripts/ci/` to the sparse-checkout in `publish-test-summary-coverage`; aligns it with every other checkout block in the file and unblocks the exit-127 failure. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Job as publish-test-summary-coverage
    participant GHA as actions/checkout (sparse)
    participant Tooling as .lgtm-ci-tooling/
    participant Script as scripts/ci/actions/post-pr-comment.sh

    Job->>GHA: checkout lgtm-hq/lgtm-ci
    Note over GHA: sparse-checkout:<br/>.github/actions/<br/>scripts/ci/  ← added by this PR
    GHA-->>Tooling: writes .github/actions/ tree
    GHA-->>Tooling: writes scripts/ci/ tree
    Job->>Tooling: uses .lgtm-ci-tooling/.github/actions/post-pr-comment
    Tooling->>Script: $GITHUB_ACTION_PATH/../../../scripts/ci/actions/post-pr-comment.sh
    Script-->>Job: posts/upserts PR comment ✓
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): include scripts/ci in coverage ..."](https://github.com/lgtm-hq/lgtm-ci/commit/8e50c1fdef21f010d207206e0a89557f47b24d1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35699131)</sub>

<!-- /greptile_comment -->