### PR TITLE
fix(ci): include scripts/ci/ in tooling sparse checkouts

### DIFF
--- a/.github/workflows/reusable-build-python-dist.yml
+++ b/.github/workflows/reusable-build-python-dist.yml
@@ -131,6 +131,7 @@ jobs:
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
             .github/actions/
+            scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
 

--- a/.github/workflows/reusable-coverage.yml
+++ b/.github/workflows/reusable-coverage.yml
@@ -133,6 +133,7 @@ jobs:
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
             .github/actions/
+            scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
@@ -230,6 +231,7 @@ jobs:
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
             .github/actions/
+            scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
 

--- a/.github/workflows/reusable-publish-artifact-report.yml
+++ b/.github/workflows/reusable-publish-artifact-report.yml
@@ -99,6 +99,7 @@ jobs:
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
             .github/actions/
+            scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
 

--- a/.github/workflows/reusable-publish-gem.yml
+++ b/.github/workflows/reusable-publish-gem.yml
@@ -105,6 +105,7 @@ jobs:
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
             .github/actions/
+            scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
 

--- a/.github/workflows/reusable-publish-homebrew.yml
+++ b/.github/workflows/reusable-publish-homebrew.yml
@@ -127,6 +127,7 @@ jobs:
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
             .github/actions/
+            scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
 

--- a/.github/workflows/reusable-publish-npm.yml
+++ b/.github/workflows/reusable-publish-npm.yml
@@ -117,6 +117,7 @@ jobs:
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
             .github/actions/
+            scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
 

--- a/.github/workflows/reusable-sbom.yml
+++ b/.github/workflows/reusable-sbom.yml
@@ -127,6 +127,7 @@ jobs:
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
             .github/actions/
+            scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
 

--- a/.github/workflows/reusable-test-e2e-matrix.yml
+++ b/.github/workflows/reusable-test-e2e-matrix.yml
@@ -295,6 +295,7 @@ jobs:
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
             .github/actions/
+            scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
@@ -373,6 +374,7 @@ jobs:
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
             .github/actions/
+            scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
 

--- a/.github/workflows/reusable-test-e2e.yml
+++ b/.github/workflows/reusable-test-e2e.yml
@@ -154,6 +154,7 @@ jobs:
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
             .github/actions/
+            scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
 

--- a/.github/workflows/reusable-test-node-custom.yml
+++ b/.github/workflows/reusable-test-node-custom.yml
@@ -584,6 +584,7 @@ jobs:
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
             .github/actions/
+            scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
 

--- a/.github/workflows/reusable-test-python-publish.yml
+++ b/.github/workflows/reusable-test-python-publish.yml
@@ -103,6 +103,7 @@ jobs:
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
             .github/actions/
+            scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
 

--- a/.github/workflows/reusable-validate-action-pinning.yml
+++ b/.github/workflows/reusable-validate-action-pinning.yml
@@ -78,6 +78,7 @@ jobs:
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
             .github/actions/
+            scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
 

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -176,6 +176,17 @@ Contract enforcement: `scripts/ci/quality/validate-static-job-names.sh` (also
 covered by BATS). Do not use `matrix.`, `format(`, or ternary `&& … ||`
 expressions in `job.name` on jobs that have `if:`.
 
+### Tooling sparse-checkout
+
+When a reusable workflow job invokes a script-backed composite from
+`.lgtm-ci-tooling/.github/actions/`, the job's `Checkout lgtm-ci tooling` step
+must sparse-checkout `scripts/ci/` alongside `.github/actions/` (cone mode).
+Egress-only jobs that load only `harden-runner` and `resolve-egress-allowlist`
+are exempt.
+
+Contract enforcement: `scripts/ci/quality/validate-tooling-sparse-checkout.sh`
+(covered by BATS).
+
 **Node testing:** Vitest callers use `reusable-test-node.yml` with `job-name`.
 Custom package scripts use `reusable-test-node-custom.yml` with required
 `test-command` and `job-name`.

--- a/scripts/ci/quality/validate-tooling-sparse-checkout.sh
+++ b/scripts/ci/quality/validate-tooling-sparse-checkout.sh
@@ -52,8 +52,6 @@ def has_scripts_ci(paths: list[str]) -> bool:
     for path in paths:
         if path.removesuffix("/") == "scripts/ci":
             return True
-        if path.startswith("scripts/ci/"):
-            return True
     return False
 
 

--- a/scripts/ci/quality/validate-tooling-sparse-checkout.sh
+++ b/scripts/ci/quality/validate-tooling-sparse-checkout.sh
@@ -16,6 +16,11 @@ if [[ ! -d "${WORKFLOWS_DIR}" ]]; then
 	exit 1
 fi
 
+if [[ ! -d "${ACTIONS_DIR}" ]]; then
+	echo "ERROR: actions directory not found: ${ACTIONS_DIR}" >&2
+	exit 1
+fi
+
 python3 - "${WORKFLOWS_DIR}" "${ACTIONS_DIR}" <<'PY'
 """Validate lgtm-ci tooling sparse-checkout includes scripts/ci/ when needed."""
 from __future__ import annotations
@@ -56,28 +61,27 @@ for workflow in sorted(workflows_dir.glob("reusable-*.yml")):
         job_match = re.match(r"  ([\w-]+):", job_chunk)
         job_id = job_match.group(1) if job_match else "?"
 
-        last_paths: list[str] = []
-        job_composites: set[str] = set()
         for block in re.split(r"(?=      - name: Checkout lgtm-ci tooling)", job_chunk):
             if "Checkout lgtm-ci tooling" not in block:
                 continue
-            last_paths = parse_sparse(block)
-            job_composites |= set(
+
+            paths = parse_sparse(block)
+            block_composites = set(
                 re.findall(
                     r"uses:\s+\./\.lgtm-ci-tooling/\.github/actions/([^\s#]+)",
                     block,
                 )
             ) & script_composites
 
-        has_scripts = any(path.startswith("scripts/ci") for path in last_paths)
-        has_actions = any(path.startswith(".github/actions") for path in last_paths)
-        if job_composites and has_actions and not has_scripts:
-            composites = ", ".join(sorted(job_composites))
-            paths = ", ".join(last_paths)
-            violations.append(
-                f"{workflow.name}:{job_id}: sparse-checkout missing scripts/ci/ "
-                f"(paths: {paths}; composites: {composites})"
-            )
+            has_scripts = any(path.startswith("scripts/ci") for path in paths)
+            has_actions = any(path.startswith(".github/actions") for path in paths)
+            if block_composites and has_actions and not has_scripts:
+                composites = ", ".join(sorted(block_composites))
+                path_list = ", ".join(paths)
+                violations.append(
+                    f"{workflow.name}:{job_id}: sparse-checkout missing scripts/ci/ "
+                    f"(paths: {path_list}; composites: {composites})"
+                )
 
 if violations:
     print("ERROR: tooling sparse-checkout contract violations:", file=sys.stderr)

--- a/scripts/ci/quality/validate-tooling-sparse-checkout.sh
+++ b/scripts/ci/quality/validate-tooling-sparse-checkout.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Fail when reusable workflows sparse-checkout tooling composites without scripts/ci/.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -z "${REPO_ROOT:-}" ]]; then
+	REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+fi
+WORKFLOWS_DIR="${WORKFLOWS_DIR:-${REPO_ROOT}/.github/workflows}"
+ACTIONS_DIR="${ACTIONS_DIR:-${REPO_ROOT}/.github/actions}"
+
+if [[ ! -d "${WORKFLOWS_DIR}" ]]; then
+	echo "ERROR: workflows directory not found: ${WORKFLOWS_DIR}" >&2
+	exit 1
+fi
+
+python3 - "${WORKFLOWS_DIR}" "${ACTIONS_DIR}" <<'PY'
+"""Validate lgtm-ci tooling sparse-checkout includes scripts/ci/ when needed."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+workflows_dir = Path(sys.argv[1])
+actions_dir = Path(sys.argv[2])
+
+script_composites: set[str] = set()
+for action_yml in actions_dir.glob("*/action.yml"):
+    text = action_yml.read_text()
+    if re.search(r"scripts/ci|SCRIPTS_DIR/ci/|GITHUB_ACTION_PATH.*scripts", text):
+        script_composites.add(action_yml.parent.name)
+script_composites -= {"harden-runner", "resolve-egress-allowlist"}
+
+
+def parse_sparse(block: str) -> list[str]:
+    match = re.search(r"sparse-checkout:\s*\|\s*\n((?:\s{12}.+\n)+)", block)
+    if match:
+        return [line[12:].strip() for line in match.group(1).splitlines() if line.strip()]
+    single = re.search(r"sparse-checkout:\s*([^\n]+)", block)
+    return [single.group(1).strip()] if single else []
+
+
+violations: list[str] = []
+for workflow in sorted(workflows_dir.glob("reusable-*.yml")):
+    content = workflow.read_text()
+    if ".lgtm-ci-tooling/.github/actions/" not in content:
+        continue
+
+    for job_chunk in re.split(r"(?=^  [a-zA-Z][\w-]*:\n)", content, flags=re.M):
+        if "Checkout lgtm-ci tooling" not in job_chunk:
+            continue
+
+        job_match = re.match(r"  ([\w-]+):", job_chunk)
+        job_id = job_match.group(1) if job_match else "?"
+
+        last_paths: list[str] = []
+        job_composites: set[str] = set()
+        for block in re.split(r"(?=      - name: Checkout lgtm-ci tooling)", job_chunk):
+            if "Checkout lgtm-ci tooling" not in block:
+                continue
+            last_paths = parse_sparse(block)
+            job_composites |= set(
+                re.findall(
+                    r"uses:\s+\./\.lgtm-ci-tooling/\.github/actions/([^\s#]+)",
+                    block,
+                )
+            ) & script_composites
+
+        has_scripts = any(path.startswith("scripts/ci") for path in last_paths)
+        has_actions = any(path.startswith(".github/actions") for path in last_paths)
+        if job_composites and has_actions and not has_scripts:
+            composites = ", ".join(sorted(job_composites))
+            paths = ", ".join(last_paths)
+            violations.append(
+                f"{workflow.name}:{job_id}: sparse-checkout missing scripts/ci/ "
+                f"(paths: {paths}; composites: {composites})"
+            )
+
+if violations:
+    print("ERROR: tooling sparse-checkout contract violations:", file=sys.stderr)
+    for violation in violations:
+        print(f"  - {violation}", file=sys.stderr)
+    sys.exit(1)
+
+print("OK: reusable workflow tooling sparse-checkout satisfies scripts/ci/ policy")
+PY

--- a/scripts/ci/quality/validate-tooling-sparse-checkout.sh
+++ b/scripts/ci/quality/validate-tooling-sparse-checkout.sh
@@ -48,13 +48,22 @@ def parse_sparse(block: str) -> list[str]:
     return [single.group(1).strip()] if single else []
 
 
+def has_scripts_ci(paths: list[str]) -> bool:
+    for path in paths:
+        if path.removesuffix("/") == "scripts/ci":
+            return True
+        if path.startswith("scripts/ci/"):
+            return True
+    return False
+
+
 violations: list[str] = []
 for workflow in sorted(workflows_dir.glob("reusable-*.yml")):
     content = workflow.read_text()
     if ".lgtm-ci-tooling/.github/actions/" not in content:
         continue
 
-    for job_chunk in re.split(r"(?=^  [a-zA-Z][\w-]*:\n)", content, flags=re.M):
+    for job_chunk in re.split(r"(?=^  [_a-zA-Z][\w-]*:\n)", content, flags=re.M):
         if "Checkout lgtm-ci tooling" not in job_chunk:
             continue
 
@@ -73,7 +82,7 @@ for workflow in sorted(workflows_dir.glob("reusable-*.yml")):
                 )
             ) & script_composites
 
-            has_scripts = any(path.startswith("scripts/ci") for path in paths)
+            has_scripts = has_scripts_ci(paths)
             has_actions = any(path.startswith(".github/actions") for path in paths)
             if block_composites and has_actions and not has_scripts:
                 composites = ", ".join(sorted(block_composites))

--- a/tests/bats/integration/test_reusable_tooling_sparse_checkout.bats
+++ b/tests/bats/integration/test_reusable_tooling_sparse_checkout.bats
@@ -185,15 +185,14 @@ jobs:
         with:
           sparse-checkout: |
             .github/actions/
-      - name: Validate action pinning
-        uses: ./.lgtm-ci-tooling/.github/actions/validate-action-pinning
+            scripts/ci/
       - name: Checkout lgtm-ci tooling
         uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .github/actions/
             scripts/cicd/
-      - name: Post PR comment
+      - name: Validate action pinning
         uses: ./.lgtm-ci-tooling/.github/actions/validate-action-pinning
 YAML
 

--- a/tests/bats/integration/test_reusable_tooling_sparse_checkout.bats
+++ b/tests/bats/integration/test_reusable_tooling_sparse_checkout.bats
@@ -92,3 +92,68 @@ YAML
 	WORKFLOWS_DIR="${workflows_dir}" ACTIONS_DIR="${actions_dir}" run "${VALIDATOR}"
 	assert_success
 }
+
+@test "validate-tooling-sparse-checkout: fails when ACTIONS_DIR is missing" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	mkdir -p "${workflows_dir}"
+
+	WORKFLOWS_DIR="${workflows_dir}" ACTIONS_DIR="${BATS_TEST_TMPDIR}/missing-actions" \
+		run "${VALIDATOR}"
+	assert_failure
+	assert_output --partial "actions directory not found"
+}
+
+@test "validate-tooling-sparse-checkout: flags early checkout missing scripts/ci/ in multi-checkout job" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	local actions_dir="${BATS_TEST_TMPDIR}/.github/actions"
+	mkdir -p "${workflows_dir}" \
+		"${actions_dir}/validate-action-pinning" \
+		"${actions_dir}/post-pr-comment"
+	cat >"${actions_dir}/validate-action-pinning/action.yml" <<'YAML'
+---
+name: Validate action pinning
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: $SCRIPTS_DIR/ci/actions/validate-action-pinning.sh
+YAML
+	cat >"${actions_dir}/post-pr-comment/action.yml" <<'YAML'
+---
+name: Post PR comment
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: $SCRIPTS_DIR/ci/actions/post-pr-comment.sh
+YAML
+	cat >"${workflows_dir}/reusable-multi-checkout-bad.yml" <<'YAML'
+---
+name: Multi checkout bad example
+on:
+  workflow_call:
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/
+      - name: Validate action pinning
+        uses: ./.lgtm-ci-tooling/.github/actions/validate-action-pinning
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/
+            scripts/ci/
+      - name: Post PR comment
+        uses: ./.lgtm-ci-tooling/.github/actions/post-pr-comment
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" ACTIONS_DIR="${actions_dir}" run "${VALIDATOR}"
+	assert_failure
+	assert_output --partial "validate-action-pinning"
+}

--- a/tests/bats/integration/test_reusable_tooling_sparse_checkout.bats
+++ b/tests/bats/integration/test_reusable_tooling_sparse_checkout.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for lgtm-ci tooling sparse-checkout paths
+
+load "../../helpers/common"
+
+VALIDATOR="${PROJECT_ROOT}/scripts/ci/quality/validate-tooling-sparse-checkout.sh"
+
+@test "validate-tooling-sparse-checkout: passes on repository reusables" {
+	run "${VALIDATOR}"
+	assert_success
+	assert_output --partial "OK:"
+}
+
+@test "validate-tooling-sparse-checkout: flags script composite without scripts/ci/" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	local actions_dir="${BATS_TEST_TMPDIR}/.github/actions/validate-action-pinning"
+	mkdir -p "${workflows_dir}" "${actions_dir}"
+	cat >"${actions_dir}/action.yml" <<'YAML'
+---
+name: Validate action pinning
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: $SCRIPTS_DIR/ci/actions/validate-action-pinning.sh
+YAML
+	cat >"${workflows_dir}/reusable-bad-sparse.yml" <<'YAML'
+---
+name: Bad sparse example
+on:
+  workflow_call:
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/
+      - name: Validate action pinning
+        uses: ./.lgtm-ci-tooling/.github/actions/validate-action-pinning
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" ACTIONS_DIR="${BATS_TEST_TMPDIR}/.github/actions" \
+		run "${VALIDATOR}"
+	assert_failure
+	assert_output --partial "scripts/ci/"
+}
+
+@test "validate-tooling-sparse-checkout: allows egress-only tooling checkout" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	local actions_dir="${BATS_TEST_TMPDIR}/.github/actions"
+	mkdir -p "${workflows_dir}" "${actions_dir}/harden-runner" "${actions_dir}/resolve-egress-allowlist"
+	cat >"${actions_dir}/harden-runner/action.yml" <<'YAML'
+---
+name: Harden runner
+runs:
+  using: composite
+  steps:
+    - uses: step-security/harden-runner@v2
+YAML
+	cat >"${actions_dir}/resolve-egress-allowlist/action.yml" <<'YAML'
+---
+name: Resolve egress allowlist
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: echo ok
+YAML
+	cat >"${workflows_dir}/reusable-egress-only.yml" <<'YAML'
+---
+name: Egress only example
+on:
+  workflow_call:
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+      - name: Harden runner
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" ACTIONS_DIR="${actions_dir}" run "${VALIDATOR}"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_tooling_sparse_checkout.bats
+++ b/tests/bats/integration/test_reusable_tooling_sparse_checkout.bats
@@ -157,3 +157,48 @@ YAML
 	assert_failure
 	assert_output --partial "validate-action-pinning"
 }
+
+@test "validate-tooling-sparse-checkout: rejects scripts/cicd/ near-miss path" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	local actions_dir="${BATS_TEST_TMPDIR}/.github/actions/validate-action-pinning"
+	mkdir -p "${workflows_dir}" "${actions_dir}"
+	cat >"${actions_dir}/action.yml" <<'YAML'
+---
+name: Validate action pinning
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: $SCRIPTS_DIR/ci/actions/validate-action-pinning.sh
+YAML
+	cat >"${workflows_dir}/reusable-near-miss-sparse.yml" <<'YAML'
+---
+name: Near miss sparse example
+on:
+  workflow_call:
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/
+      - name: Validate action pinning
+        uses: ./.lgtm-ci-tooling/.github/actions/validate-action-pinning
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/
+            scripts/cicd/
+      - name: Post PR comment
+        uses: ./.lgtm-ci-tooling/.github/actions/validate-action-pinning
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" ACTIONS_DIR="${BATS_TEST_TMPDIR}/.github/actions" \
+		run "${VALIDATOR}"
+	assert_failure
+	assert_output --partial "validate-action-pinning"
+}

--- a/tests/bats/integration/test_reusable_tooling_sparse_checkout.bats
+++ b/tests/bats/integration/test_reusable_tooling_sparse_checkout.bats
@@ -201,3 +201,41 @@ YAML
 	assert_failure
 	assert_output --partial "validate-action-pinning"
 }
+
+@test "validate-tooling-sparse-checkout: rejects scripts/ci/ subdirectory (cone-mode insufficient)" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	local actions_dir="${BATS_TEST_TMPDIR}/.github/actions/validate-action-pinning"
+	mkdir -p "${workflows_dir}" "${actions_dir}"
+	cat >"${actions_dir}/action.yml" <<'YAML'
+---
+name: Validate action pinning
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: $SCRIPTS_DIR/ci/actions/validate-action-pinning.sh
+YAML
+	cat >"${workflows_dir}/reusable-subdir-sparse.yml" <<'YAML'
+---
+name: Subdirectory sparse example
+on:
+  workflow_call:
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/
+            scripts/ci/quality/
+      - name: Validate action pinning
+        uses: ./.lgtm-ci-tooling/.github/actions/validate-action-pinning
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" ACTIONS_DIR="${BATS_TEST_TMPDIR}/.github/actions" \
+		run "${VALIDATOR}"
+	assert_failure
+	assert_output --partial "validate-action-pinning"
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Fix all reusable workflows that sparse-checkout `.github/actions/` without `scripts/ci/` when running script-backed tooling composites (exit 127 on pinned release SHAs). Adds a contract validator so this class of regression cannot land again.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #294

## Changes Made

- Add `scripts/ci/` to tooling sparse-checkout in 12 workflows (14 jobs)
- Add `scripts/ci/quality/validate-tooling-sparse-checkout.sh` contract validator
- Add BATS integration tests and document rule in `docs/workflow-contract.md`

## Affected workflows

- `reusable-validate-action-pinning.yml`
- `reusable-build-python-dist.yml`
- `reusable-coverage.yml`
- `reusable-publish-artifact-report.yml`
- `reusable-publish-gem.yml`
- `reusable-publish-homebrew.yml`
- `reusable-publish-npm.yml`
- `reusable-sbom.yml`
- `reusable-test-e2e.yml`
- `reusable-test-e2e-matrix.yml`
- `reusable-test-node-custom.yml`
- `reusable-test-python-publish.yml`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `scripts/ci/` to lgtm-ci tooling sparse checkouts across reusable workflows
> - Adds `scripts/ci/` to the sparse-checkout path list in all `Checkout lgtm-ci tooling` steps across 12 reusable workflow files, so script-backed composite actions can access their supporting scripts.
> - Adds a new validator script at [validate-tooling-sparse-checkout.sh](https://github.com/lgtm-hq/lgtm-ci/pull/295/files#diff-a3c5c9e282ef0f4b823a13f47d18e5f93934d31959cfee5b296ae9771b1b3f0b) that scans reusable workflows and fails if any job uses script-backed composites from `.lgtm-ci-tooling` without including `scripts/ci/` in its sparse checkout.
> - Adds BATS integration tests covering both passing and failing scenarios, including egress-only exemptions and near-miss path rejections.
> - Documents the sparse-checkout contract in [workflow-contract.md](https://github.com/lgtm-hq/lgtm-ci/pull/295/files#diff-516a439fe86a0212ef098570637d887a6ef2bb796c179416edee44bc92be0a5f), including exemptions for egress-only jobs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa22b4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reusable workflows updated so tooling checkouts now include CI scripts.

* **New Features**
  * Added an automated validator that enforces the tooling sparse-checkout contract for reusable workflows.

* **Tests**
  * Added integration tests covering validator success, failure, edge cases, and multi-checkout scenarios.

* **Documentation**
  * Documented the tooling sparse-checkout contract and noted exemptions for egress-only jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes exit-127 failures caused by script-backed composite actions not having `scripts/ci/` available in sparse-checked-out tooling repos. It adds the missing path to 12 reusable workflow files (14 jobs) and ships a Python/Bash contract validator plus BATS integration tests to prevent the regression class from recurring.

- **Workflow fixes**: Each of the 12 affected `reusable-*.yml` files gains `scripts/ci/` in its `Checkout lgtm-ci tooling` sparse-checkout block (cone mode), directly resolving the exit-127 runtime failure on pinned release SHAs.
- **Validator** (`scripts/ci/quality/validate-tooling-sparse-checkout.sh`): Parses every `reusable-*.yml`, detects script-backed composites per checkout block, and fails if any block uses script-backed composites without `scripts/ci/` in paths; exact-equality matching (`removesuffix("/") == "scripts/ci"`) prevents near-miss false negatives, and per-block attribution prevents multi-checkout false negatives.
- **BATS tests**: Six integration scenarios cover the passing case, the basic violation, egress-only exemption, missing `ACTIONS_DIR`, multi-checkout per-block scoping, `scripts/cicd/` near-miss, and `scripts/ci/quality/` subdirectory near-miss.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge: the workflow changes are mechanical one-line additions and the validator correctly addresses both previously-flagged concerns with good test coverage.

All 12 workflow fixes are straightforward identical additions of scripts/ci/ to an existing sparse-checkout block. The validator's core logic — per-checkout-block composite attribution and exact-equality path matching — correctly handles the multi-checkout and near-miss scenarios that prior review rounds flagged, and six BATS tests confirm each case. No new logic defects were found.

The parse_sparse regex in validate-tooling-sparse-checkout.sh hardcodes 12-space indentation; it works correctly for every current workflow but is worth noting if indentation conventions ever change.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/quality/validate-tooling-sparse-checkout.sh | New contract validator; Python inline script uses exact removesuffix equality and per-checkout-block scoping to correctly attribute composites; parse_sparse regex hardcodes 12-space indentation which is structurally correct for all current workflows but brittle if indentation ever changes. |
| tests/bats/integration/test_reusable_tooling_sparse_checkout.bats | Six BATS integration tests thoroughly cover passing, failure, egress-only exemption, missing directory, multi-checkout scoping, near-miss path (scripts/cicd/), and subdirectory path (scripts/ci/quality/) — all key contract edge cases are represented. |
| .github/workflows/reusable-coverage.yml | Both jobs gain scripts/ci/ in their tooling sparse-checkout; straightforward one-line addition per job. |
| .github/workflows/reusable-test-e2e-matrix.yml | Both matrix jobs gain scripts/ci/ in their tooling sparse-checkout; straightforward fixes. |
| docs/workflow-contract.md | Documents the new sparse-checkout contract with the egress-only exemption and references the enforcement script; accurate and consistent with the implementation. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[scan actions_dir for action.yml files] --> B{contains scripts/ci?}
    B -- yes --> C[add to script_composites]
    B -- no --> D[skip]
    C --> E[remove exempted composites]
    E --> F[for each reusable-*.yml]
    F --> G{references .lgtm-ci-tooling?}
    G -- no --> F
    G -- yes --> H[split into job chunks]
    H --> I{has Checkout lgtm-ci tooling?}
    I -- no --> H
    I -- yes --> J[split into per-checkout blocks]
    J --> K[parse sparse paths from block]
    K --> L[find composite uses in block]
    L --> M{composites + has actions + no scripts/ci?}
    M -- no --> J
    M -- yes --> N[record violation]
    N --> O{any violations?}
    O -- yes --> P[exit 1]
    O -- no --> Q[exit 0]
```
</details>

<sub>Reviews (8): Last reviewed commit: ["fix(ci): reject subdirectory paths in sp..."](https://github.com/lgtm-hq/lgtm-ci/commit/fa22b4ac031d2d22fbb78cdb505e3f01ecb8f496) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35800275)</sub>

<!-- /greptile_comment -->