### PR TITLE
fix(ci): pipe bundle workflow lookups through jq instead of gh api --arg

### DIFF
--- a/scripts/ci/lib/bundle/workflow_artifacts.sh
+++ b/scripts/ci/lib/bundle/workflow_artifacts.sh
@@ -89,8 +89,8 @@ bundle_find_workflow_run() {
 		jq_filter="first(.workflow_runs[] | select(${workflow_match} and .conclusion == \"success\") | .id) // empty"
 	fi
 
-	gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${commit_sha}&per_page=${BUNDLE_WORKFLOW_RUNS_PER_PAGE}" \
-		--jq "$jq_filter" --arg wf "$workflow_key"
+	gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${commit_sha}&per_page=${BUNDLE_WORKFLOW_RUNS_PER_PAGE}" |
+		jq -r --arg wf "$workflow_key" "$jq_filter"
 }
 
 # Find the latest workflow run on a fallback branch (e.g. main).
@@ -110,8 +110,8 @@ bundle_find_workflow_run_on_ref() {
 		jq_filter="first(.workflow_runs[] | select(${workflow_match} and .head_branch == \$branch and .conclusion == \"success\") | .id) // empty"
 	fi
 
-	gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${fallback_ref}&per_page=${BUNDLE_WORKFLOW_RUNS_PER_PAGE}" \
-		--jq "$jq_filter" --arg wf "$workflow_key" --arg branch "$fallback_ref"
+	gh api "repos/${GITHUB_REPOSITORY}/actions/runs?branch=${fallback_ref}&per_page=${BUNDLE_WORKFLOW_RUNS_PER_PAGE}" |
+		jq -r --arg wf "$workflow_key" --arg branch "$fallback_ref" "$jq_filter"
 }
 
 # Resolve artifact ID from a workflow run.
@@ -125,9 +125,10 @@ bundle_get_artifact_id() {
 	fi
 
 	# shellcheck disable=SC2016
-	gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts" \
-		--jq 'first(.artifacts[] | select(.name == $name) | .id) // empty' \
-		--arg name "$artifact_name" 2>/dev/null || true
+	gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts" |
+		jq -r --arg name "$artifact_name" \
+			'first(.artifacts[] | select(.name == $name) | .id) // empty' \
+			2>/dev/null || true
 }
 
 # Validate zip member paths and types before extraction (zip-slip / symlink defense).

--- a/scripts/ci/lib/bundle/workflow_artifacts.sh
+++ b/scripts/ci/lib/bundle/workflow_artifacts.sh
@@ -124,8 +124,9 @@ bundle_get_artifact_id() {
 		return 0
 	fi
 
+	# Degrade silently when the run has no matching artifact (warn handled by caller).
 	# shellcheck disable=SC2016
-	gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts" |
+	gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts" 2>/dev/null |
 		jq -r --arg name "$artifact_name" \
 			'first(.artifacts[] | select(.name == $name) | .id) // empty' \
 			2>/dev/null || true

--- a/tests/bats/unit/lib/bundle/test_workflow_artifacts.bats
+++ b/tests/bats/unit/lib/bundle/test_workflow_artifacts.bats
@@ -115,39 +115,42 @@ _setup_bundle_gh_mock() {
 	cat >"${mock_bin}/gh" <<EOF
 #!/usr/bin/env bash
 url=""
-workflow=""
 for ((i = 1; i <= \$#; i++)); do
 	case "\${!i}" in
 	repos/*) url="\${!i}" ;;
-	--arg)
-		next=\$((i + 1))
-		if [[ "\${!next}" == "wf" ]]; then
-			wf_index=\$((i + 2))
-			workflow="\${!wf_index}"
-		fi
-		;;
 	esac
 done
 
 case "\$url" in
 *actions/runs?head_sha=abc123*)
-	if [[ "\$workflow" == "missing-workflow" ]]; then
-		echo ""
-	else
-		echo "${run_id}"
-	fi
+	cat <<'JSON'
+{"workflow_runs":[
+  {"id":${run_id},"name":"quality-ci-main","path":".github/workflows/quality-ci-main.yml","conclusion":"success","head_branch":"main"},
+  {"id":${run_id},"name":"coverage-reports","path":".github/workflows/coverage-reports.yml","conclusion":"success","head_branch":"main"}
+]}
+JSON
 	;;
 *actions/runs?branch=main*)
-	echo "${run_id}"
+	cat <<'JSON'
+{"workflow_runs":[
+  {"id":${run_id},"name":"quality-ci-main","path":".github/workflows/quality-ci-main.yml","conclusion":"success","head_branch":"main"},
+  {"id":${run_id},"name":"coverage-reports","path":".github/workflows/coverage-reports.yml","conclusion":"success","head_branch":"main"}
+]}
+JSON
 	;;
 *actions/runs/${run_id}/artifacts*)
-	echo "${artifact_id}"
+	cat <<'JSON'
+{"artifacts":[
+  {"id":${artifact_id},"name":"coverage-html"},
+  {"id":${artifact_id},"name":"rust-coverage-html"}
+]}
+JSON
 	;;
 *actions/artifacts/${artifact_id}/zip*)
 	cat "${zip_path}"
 	;;
 *)
-	echo ""
+	echo '{"workflow_runs":[],"artifacts":[]}'
 	;;
 esac
 exit 0
@@ -226,7 +229,7 @@ PY
 	mkdir -p "$mock_bin"
 	cat >"${mock_bin}/gh" <<'EOF'
 #!/usr/bin/env bash
-echo ""
+echo '{"workflow_runs":[],"artifacts":[]}'
 exit 0
 EOF
 	chmod +x "${mock_bin}/gh"
@@ -321,6 +324,15 @@ EOF
 	assert_success
 	assert_output --partial "must not contain .. segments"
 	run test ! -e "${BATS_TEST_TMPDIR}/outside"
+	assert_success
+}
+
+@test "workflow_artifacts.sh: does not pass jq --arg to gh api" {
+	local script="${PROJECT_ROOT}/scripts/ci/lib/bundle/workflow_artifacts.sh"
+
+	run bash -c 'grep "gh api" "$1" | grep -q -- "--arg"' _ "$script"
+	assert_failure
+	run grep -q 'jq -r --arg' "$script"
 	assert_success
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Fix bundle workflow artifact resolution by piping `gh api` JSON into `jq -r --arg`
instead of passing `--arg` to `gh api` (which fails with `unknown flag: --arg`).
This unblocks GitHub Pages deploys that bundle coverage artifacts via
`reusable-deploy-site-with-reports`.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #296
- Relates to lgtm-hq/Rustume#268

## Changes Made

- Pipe `gh api` output to `jq -r --arg` in `bundle_find_workflow_run`,
  `bundle_find_workflow_run_on_ref`, and `bundle_get_artifact_id`
- Rewrite BATS `gh` mock to return realistic JSON (no fake `--arg` support)
- Add contract test asserting `gh api` invocations do not use `--arg`

## Testing

- [x] `bats tests/bats/unit/lib/bundle/test_workflow_artifacts.bats` (18/18)
- [x] `uv run lintro chk` (zero issues)
- [x] CodeRabbit review (1 minor pre-existing note on `bundle_get_artifact_id` error suppression — unchanged)

## Deployment Notes

After merge and patch release (e.g. v0.32.2), downstream repos (Rustume) must bump
`tooling-ref` and reusable workflow SHAs to the new tag, then re-run Pages deploy.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CI bundle workflow lookups to pipe `gh api` output through `jq` instead of using `gh --arg`
> - Replaces `gh api --jq ... --arg` with piping raw `gh api` JSON output into a separate `jq -r --arg` invocation in [`workflow_artifacts.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/297/files#diff-052f474e28f9d1a6deb3c9148426a41934e4bf884f4fa2bb9f61db3a2364f3b4).
> - Suppresses stderr from both `gh api` and `jq` in `bundle_get_artifact_id` to reduce noise when an artifact is missing.
> - Updates [`test_workflow_artifacts.bats`](https://github.com/lgtm-hq/lgtm-ci/pull/297/files#diff-ee0c7ffe0abcc8bd0d4590d9c236fd9cbff83f22534165630c1214c4e9051e3d) so mocks emit full JSON payloads instead of pre-filtered scalars, and adds a regression test asserting `gh api` is never called with `--arg`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ea2701.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow artifact query logic and related test coverage for internal tooling improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes `gh api` invocations in `workflow_artifacts.sh` that were incorrectly passing `--arg` (an unsupported flag) by instead piping the API response into `jq -r --arg`. The test mock is updated to emit realistic JSON payloads, and a static contract test is added to prevent the pattern from regressing.

- **`workflow_artifacts.sh`**: All three lookup functions (`bundle_find_workflow_run`, `bundle_find_workflow_run_on_ref`, `bundle_get_artifact_id`) now pipe `gh api` stdout into `jq -r --arg …`; `bundle_get_artifact_id` continues to suppress `gh api` stderr with `2>/dev/null` for silent degradation.
- **`test_workflow_artifacts.bats`**: The `gh` mock now returns schema-correct JSON for all API routes; the empty/fallback mock returns `{\"workflow_runs\":[],\"artifacts\":[]}` instead of an empty string so jq can parse it cleanly; a new `does not pass jq --arg to gh api` test guards the fix at the file level.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, well-tested fix with equivalent error-handling behavior to the original.

The refactor is mechanical: `gh api … --jq … --arg` becomes `gh api … | jq -r --arg …`. Error-handling contracts are preserved (`2>/dev/null` on `gh api` in `bundle_get_artifact_id`, `|| true` after `jq`), and the behavior on API failure is equivalent to the original. The updated mock correctly emits parseable JSON so jq no longer receives bare strings, and the new contract test closes the regression loop. No functional logic changed outside of the invocation path.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/lib/bundle/workflow_artifacts.sh | Pipes `gh api` output to `jq -r --arg` across all three lookup functions; `bundle_get_artifact_id` correctly retains `2>/dev/null` on the `gh api` call. |
| tests/bats/unit/lib/bundle/test_workflow_artifacts.bats | Mock updated to emit realistic JSON payloads; fallback/empty mock now returns valid empty JSON; new contract test guards against `--arg` regressing onto `gh api`. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant BRM as bundle_run_manifest
    participant FWR as bundle_find_workflow_run
    participant FWRR as bundle_find_workflow_run_on_ref
    participant GAI as bundle_get_artifact_id
    participant GH as gh api
    participant JQ as jq -r

    BRM->>FWR: workflow, commit_sha
    FWR->>GH: "GET /actions/runs?head_sha=..."
    GH-->>JQ: JSON stdout (pipe)
    JQ-->>FWR: run_id or empty
    FWR-->>BRM: run_id

    alt run_id empty and FALLBACK_REF set
        BRM->>FWRR: workflow, fallback_ref
        FWRR->>GH: "GET /actions/runs?branch=..."
        GH-->>JQ: JSON stdout (pipe)
        JQ-->>FWRR: run_id or empty
        FWRR-->>BRM: run_id
    end

    BRM->>GAI: run_id, artifact_name
    GAI->>GH: "GET /actions/runs/{id}/artifacts 2>/dev/null"
    GH-->>JQ: JSON stdout (pipe)
    JQ-->>GAI: artifact_id or empty
    GAI-->>BRM: artifact_id
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fbats%2Funit%2Flib%2Fbundle%2Ftest_workflow_artifacts.bats%3A333-334%0A**Contract%20test%20only%20catches%20same-line%20%60--arg%60%20after%20%60gh%20api%60**%0A%0AThe%20check%20greps%20only%20lines%20that%20contain%20both%20%60gh%20api%60%20and%20%60--arg%60%20on%20the%20same%20line.%20If%20a%20future%20caller%20places%20%60--arg%60%20on%20a%20continuation%20line%20%28after%20a%20%60%5C%60%29%2C%20the%20guard%20silently%20misses%20it.%20A%20more%20defensive%20scan%20would%20include%20trailing%20lines%20%E2%80%94%20e.g.%20%60grep%20-A3%20%22gh%20api%22%20%22%24script%22%20%7C%20grep%20-q%20--%20%22--arg%22%60.%20Low%20urgency%20given%20the%20current%20code%20is%20clean%2C%20but%20worth%20hardening%20before%20the%20pattern%20is%20copy-pasted.%0A%0A&pr=297&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fbats%2Funit%2Flib%2Fbundle%2Ftest_workflow_artifacts.bats%3A333-334%0A**Contract%20test%20only%20catches%20same-line%20%60--arg%60%20after%20%60gh%20api%60**%0A%0AThe%20check%20greps%20only%20lines%20that%20contain%20both%20%60gh%20api%60%20and%20%60--arg%60%20on%20the%20same%20line.%20If%20a%20future%20caller%20places%20%60--arg%60%20on%20a%20continuation%20line%20%28after%20a%20%60%5C%60%29%2C%20the%20guard%20silently%20misses%20it.%20A%20more%20defensive%20scan%20would%20include%20trailing%20lines%20%E2%80%94%20e.g.%20%60grep%20-A3%20%22gh%20api%22%20%22%24script%22%20%7C%20grep%20-q%20--%20%22--arg%22%60.%20Low%20urgency%20given%20the%20current%20code%20is%20clean%2C%20but%20worth%20hardening%20before%20the%20pattern%20is%20copy-pasted.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=297&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22fix%2F296-bundle-gh-api-jq-pipe%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F296-bundle-gh-api-jq-pipe%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fbats%2Funit%2Flib%2Fbundle%2Ftest_workflow_artifacts.bats%3A333-334%0A**Contract%20test%20only%20catches%20same-line%20%60--arg%60%20after%20%60gh%20api%60**%0A%0AThe%20check%20greps%20only%20lines%20that%20contain%20both%20%60gh%20api%60%20and%20%60--arg%60%20on%20the%20same%20line.%20If%20a%20future%20caller%20places%20%60--arg%60%20on%20a%20continuation%20line%20%28after%20a%20%60%5C%60%29%2C%20the%20guard%20silently%20misses%20it.%20A%20more%20defensive%20scan%20would%20include%20trailing%20lines%20%E2%80%94%20e.g.%20%60grep%20-A3%20%22gh%20api%22%20%22%24script%22%20%7C%20grep%20-q%20--%20%22--arg%22%60.%20Low%20urgency%20given%20the%20current%20code%20is%20clean%2C%20but%20worth%20hardening%20before%20the%20pattern%20is%20copy-pasted.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): restore gh api stderr suppressi..."](https://github.com/lgtm-hq/lgtm-ci/commit/2ea270155e4247543380b0ed6c759bfcc7372b2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35806589)</sub>

<!-- /greptile_comment -->