### PR TITLE
fix(ci): pass github.token to composite actions that call gh

### DIFF
--- a/.github/actions/bundle-workflow-artifacts/action.yml
+++ b/.github/actions/bundle-workflow-artifacts/action.yml
@@ -48,6 +48,7 @@ runs:
       id: bundle
       shell: bash
       env:
+        GITHUB_TOKEN: ${{ github.token }}
         COMMIT_SHA: >-
           ${{ inputs.commit-sha != '' && inputs.commit-sha || github.sha }}
         SITE_ROOT: ${{ inputs.site-root }}

--- a/.github/actions/bundle-workflow-artifacts/action.yml
+++ b/.github/actions/bundle-workflow-artifacts/action.yml
@@ -48,7 +48,7 @@ runs:
       id: bundle
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ github.token }}
         COMMIT_SHA: >-
           ${{ inputs.commit-sha != '' && inputs.commit-sha || github.sha }}
         SITE_ROOT: ${{ inputs.site-root }}

--- a/.github/actions/post-pr-comment/action.yml
+++ b/.github/actions/post-pr-comment/action.yml
@@ -58,7 +58,6 @@ runs:
       env:
         STEP: pr-number
         GH_TOKEN: ${{ github.token }}
-        GITHUB_TOKEN: ${{ github.token }}
         INPUT_PR_NUMBER: ${{ inputs.pr-number }}
         EVENT_NAME: ${{ github.event_name }}
         EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -80,7 +79,6 @@ runs:
       env:
         STEP: post
         GH_TOKEN: ${{ github.token }}
-        GITHUB_TOKEN: ${{ github.token }}
         GITHUB_REPOSITORY: ${{ github.repository }}
         PR_NUMBER: ${{ steps.pr.outputs.number }}
         MARKER: ${{ inputs.marker }}

--- a/.github/actions/verify-attestation/action.yml
+++ b/.github/actions/verify-attestation/action.yml
@@ -41,6 +41,7 @@ runs:
       id: verify
       shell: bash
       env:
+        GH_TOKEN: ${{ github.token }}
         STEP: verify
         TARGET: ${{ inputs.target }}
         TARGET_TYPE: ${{ inputs.target-type }}

--- a/scripts/ci/actions/bundle-workflow-artifacts.sh
+++ b/scripts/ci/actions/bundle-workflow-artifacts.sh
@@ -9,6 +9,7 @@
 #   GITHUB_REPOSITORY - owner/repo for GitHub API calls
 #
 # Optional environment variables:
+#   GH_TOKEN - GitHub token for gh CLI (required in CI; set by composite action)
 #   FALLBACK_REF - Branch ref for fallback workflow lookup (e.g. main)
 #   STRICT - Fail when any bundle entry is missing (default: false)
 
@@ -28,8 +29,8 @@ source "$SCRIPT_DIR/../lib/bundle/workflow_artifacts.sh"
 : "${FALLBACK_REF:=}"
 : "${STRICT:=false}"
 
-if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-	gh auth status >/dev/null 2>&1 || echo "${GITHUB_TOKEN}" | gh auth login --with-token 2>/dev/null || true
+if [[ -n "${GH_TOKEN:-}" ]]; then
+	gh auth status >/dev/null 2>&1 || echo "${GH_TOKEN}" | gh auth login --with-token 2>/dev/null || true
 fi
 
 bundle_load_manifest "$BUNDLE_MANIFEST"

--- a/tests/bats/integration/test_bundle_workflow_artifacts.bats
+++ b/tests/bats/integration/test_bundle_workflow_artifacts.bats
@@ -27,6 +27,17 @@ load "../../helpers/common"
 	assert_success
 }
 
+@test "bundle-workflow-artifacts action: passes GH_TOKEN for gh CLI" {
+	local action="${PROJECT_ROOT}/.github/actions/bundle-workflow-artifacts/action.yml"
+	run awk '
+		/^    - name: Bundle workflow artifacts/ { in_bundle = 1 }
+		in_bundle && /GH_TOKEN: \$\{\{ github\.token \}\}/ { gh_token = 1 }
+		in_bundle && /GITHUB_TOKEN:/ { github_token = 1 }
+		END { exit !(gh_token && !github_token) }
+	' "$action"
+	assert_success
+}
+
 @test "reusable-deploy-site-with-reports: build job has actions read permission" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-deploy-site-with-reports.yml"
 	run awk '

--- a/tests/bats/integration/test_bundle_workflow_artifacts.bats
+++ b/tests/bats/integration/test_bundle_workflow_artifacts.bats
@@ -31,6 +31,7 @@ load "../../helpers/common"
 	local action="${PROJECT_ROOT}/.github/actions/bundle-workflow-artifacts/action.yml"
 	run awk '
 		/^    - name: Bundle workflow artifacts/ { in_bundle = 1 }
+		in_bundle && /^    - name:/ && $0 !~ /Bundle workflow artifacts/ { in_bundle = 0 }
 		in_bundle && /GH_TOKEN: \$\{\{ github\.token \}\}/ { gh_token = 1 }
 		in_bundle && /GITHUB_TOKEN:/ { github_token = 1 }
 		END { exit !(gh_token && !github_token) }


### PR DESCRIPTION
## Summary

`bundle-workflow-artifacts` and `verify-attestation` composite actions both
invoke the `gh` CLI via delegated shell scripts but never set `GITHUB_TOKEN`
or `GH_TOKEN` in their step `env:` blocks. In GitHub Actions, composite action
steps do not inherit the automatic `GITHUB_TOKEN` env var — it must be
explicitly passed.

This causes any caller to fail with:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
```

**Observed in:** [Rustume deploy run 27016958305](https://github.com/lgtm-hq/Rustume/actions/runs/27016958305) —
site build succeeds, bundle step fails.

**Fix:** Add `GITHUB_TOKEN: ${{ github.token }}` (bundle) and `GH_TOKEN: ${{ github.token }}` (verify-attestation)
to the respective composite action step env blocks.

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [ ] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Relates to lgtm-hq/Rustume#264
- Relates to lgtm-hq/Rustume#270

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix GitHub token passing in CI composite actions by switching to `GH_TOKEN`
> - Updates [`bundle-workflow-artifacts`](.github/actions/bundle-workflow-artifacts/action.yml) and [`verify-attestation`](.github/actions/verify-attestation/action.yml) composite actions to pass `GH_TOKEN: ${{ github.token }}` to steps that invoke the `gh` CLI.
> - Updates [`bundle-workflow-artifacts.sh`](scripts/ci/actions/bundle-workflow-artifacts.sh) to authenticate using `GH_TOKEN` instead of `GITHUB_TOKEN`.
> - Removes redundant `GITHUB_TOKEN` from [`post-pr-comment`](.github/actions/post-pr-comment/action.yml), leaving only `GH_TOKEN`.
> - Adds a Bats integration test asserting the correct env var is set in the composite action.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 397ae92.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized CI environment variables to use GH_TOKEN across workflow steps and scripts, ensuring the repository token is exposed consistently where needed.
  * Updated composite actions to pass GH_TOKEN into relevant step environments.
* **Tests**
  * Added an integration test to verify GH_TOKEN is injected into the workflow step environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a GitHub Actions composite-action bug where `bundle-workflow-artifacts` and `verify-attestation` did not pass a token to steps that invoke `gh` CLI, causing those steps to fail with an auth error in any caller workflow.

- Adds `GH_TOKEN: ${{ github.token }}` to the specific step env blocks that invoke the `gh` CLI in `bundle-workflow-artifacts` and `verify-attestation`; only the steps that actually call `gh` are targeted (the `parse` and `summary` steps in `verify-attestation` correctly omit the token since they use `jq`/`GITHUB_STEP_SUMMARY` only).
- Updates `bundle-workflow-artifacts.sh` to check and use `GH_TOKEN` (instead of `GITHUB_TOKEN`) in the best-effort `gh auth login` fallback block, and removes the now-redundant `GITHUB_TOKEN` env entries from `post-pr-comment` (which already exposed `GH_TOKEN`).
- Adds a Bats contract test that parses the action YAML with `awk` to assert `GH_TOKEN` is present and `GITHUB_TOKEN` is absent in the bundle step's env block, guarding against future regressions.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, well-scoped token-passing fix with no logic changes and a new regression test.

All three composite actions now correctly expose only the env vars each step needs. The verify-attestation fix is precise: only the verify step (which calls gh) receives GH_TOKEN; the parse and summary steps use jq and GITHUB_STEP_SUMMARY respectively and are left unchanged. The post-pr-comment cleanup removes a truly redundant duplicate. The bundle-workflow-artifacts.sh script update is a one-line variable rename with no behavioral change since gh CLI auto-authenticates via the env var. The new Bats test guards the contract going forward.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/bundle-workflow-artifacts/action.yml | Adds GH_TOKEN to the bundle step env block; correctly scoped to only the step that invokes the gh CLI via bundle-workflow-artifacts.sh. |
| .github/actions/post-pr-comment/action.yml | Removes redundant GITHUB_TOKEN from two step env blocks; both steps already had GH_TOKEN set, so the removal is safe — gh CLI prefers GH_TOKEN over GITHUB_TOKEN. |
| .github/actions/verify-attestation/action.yml | Adds GH_TOKEN only to the verify step, which is the sole step that calls gh; the parse and summary steps use jq/GITHUB_STEP_SUMMARY and correctly omit GH_TOKEN. |
| scripts/ci/actions/bundle-workflow-artifacts.sh | Updates the best-effort gh auth login fallback to read GH_TOKEN instead of GITHUB_TOKEN; adds a doc comment noting GH_TOKEN is required in CI. The || true guard keeps the block non-fatal. |
| tests/bats/integration/test_bundle_workflow_artifacts.bats | Adds a Bats contract test that uses awk to assert GH_TOKEN is present and GITHUB_TOKEN is absent in the bundle step's env block; logic is correct and will catch regressions. |

</details>

</details>

<sub>Reviews (4): Last reviewed commit: ["test(ci): scope GH\_TOKEN contract test t..."](https://github.com/lgtm-hq/lgtm-ci/commit/397ae92f843af2e6d06db5a71a432696f51c0b69) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35835185)</sub>

<!-- /greptile_comment -->