### PR TITLE
feat(ci): implement comprehensive version-drift prevention

### DIFF
--- a/.github/actions/validate-action-pinning/action.yml
+++ b/.github/actions/validate-action-pinning/action.yml
@@ -25,11 +25,24 @@ inputs:
       (default: .github/workflows .github/actions)
     required: false
     default: ".github/workflows .github/actions"
+  verify-tags:
+    description: >-
+      Verify Renovate version comments resolve to the pinned SHA via GitHub API
+    required: false
+    default: "false"
+  audit-transitive:
+    description: >-
+      Warn when pinned composite actions reference nested actions by mutable tag
+    required: false
+    default: "false"
 
 outputs:
   offenders:
     description: "Count of pinning policy violations found"
     value: ${{ steps.validate.outputs.offenders }}
+  warnings:
+    description: "Count of transitive audit and tag-resolution warnings"
+    value: ${{ steps.validate.outputs.warnings }}
 
 runs:
   using: "composite"
@@ -48,6 +61,8 @@ runs:
         INPUT_ALLOW_TAG_EXCEPTIONS: ${{ inputs['allow-tag-exceptions'] }}
         INPUT_ALLOW_ORG_VERSIONS: ${{ inputs['allow-org-versions'] }}
         INPUT_SCAN_PATHS: ${{ inputs['scan-paths'] }}
+        INPUT_VERIFY_TAGS: ${{ inputs['verify-tags'] }}
+        INPUT_AUDIT_TRANSITIVE: ${{ inputs['audit-transitive'] }}
       run: $SCRIPTS_DIR/ci/actions/validate-action-pinning.sh
 
 branding:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+---
+name: Security - Dependency Review
+
+'on':
+  pull_request:
+    branches: [main]
+  merge_group:
+
+permissions: {}
+
+concurrency:
+  group: dependency-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    uses: ./.github/workflows/reusable-dependency-review.yml
+    with:
+      fail-on-severity: high
+      tooling-ref: ${{ github.sha }}
+      egress-policy: block
+      egress-preset: scorecard
+      allowed-endpoints-mode: append
+      allowed-endpoints: |
+        api.deps.dev:443
+        release-assets.githubusercontent.com:443
+    permissions:
+      # Read repository contents for dependency-review-action
+      contents: read
+      # Read PR metadata for review comments
+      pull-requests: read

--- a/.github/workflows/registry-health-check.yml
+++ b/.github/workflows/registry-health-check.yml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+---
+name: Maintenance - Registry Health Check
+
+'on':
+  schedule:
+    - cron: '0 2 * * 1'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: registry-health-check
+  cancel-in-progress: false
+
+jobs:
+  registry-health:
+    uses: ./.github/workflows/reusable-registry-health-check.yml
+    with:
+      tooling-ref: ${{ github.sha }}
+      open-issue-on-failure: true
+    permissions:
+      # Read repository and lgtm-ci tooling for health checks
+      contents: read
+      # Create issues on digest verification failures
+      issues: write
+      # Verify container image manifests
+      packages: read

--- a/.github/workflows/reusable-registry-health-check.yml
+++ b/.github/workflows/reusable-registry-health-check.yml
@@ -61,6 +61,8 @@ jobs:
   registry-health:
     name: ${{ inputs.job-name }}
     runs-on: ubuntu-latest
+    outputs:
+      digest-failure: ${{ steps.health.outputs.digest-failure }}
     permissions:
       # Read repository to scan for digest-pinned images
       contents: read
@@ -120,7 +122,9 @@ jobs:
   open-registry-health-issue:
     name: Open Registry Health Issue
     needs: registry-health
-    if: failure() && inputs.open-issue-on-failure
+    if: >-
+      needs.registry-health.outputs.digest-failure == 'true' &&
+      inputs.open-issue-on-failure
     runs-on: ubuntu-latest
     permissions:
       # Read lgtm-ci tooling repository

--- a/.github/workflows/reusable-registry-health-check.yml
+++ b/.github/workflows/reusable-registry-health-check.yml
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+---
+name: Reusable Registry Health Check
+
+on:
+  workflow_call:
+    inputs:
+      scan-paths:
+        description: "Space-separated paths to scan for digest-pinned images"
+        required: false
+        type: string
+        default: ".github"
+      open-issue-on-failure:
+        description: "Open a GitHub issue when unreachable digests are found"
+        required: false
+        type: boolean
+        default: false
+      issue-labels:
+        description: "Comma-separated labels for auto-opened issues"
+        required: false
+        type: string
+        default: "ci,maintenance"
+      tooling-ref:
+        description: "Git ref for lgtm-ci tooling checkout"
+        required: false
+        type: string
+        default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "block"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+      egress-preset:
+        description: >-
+          Named allowlist when allowed-endpoints is empty and egress-policy is
+          block (github-minimal, github-pages, github-tooling, docker, playwright, pypi,
+          rubygems, npm-publish, quality, sbom, scorecard)
+        required: false
+        type: string
+        default: "docker"
+      job-name:
+        description: "GitHub check name"
+        required: false
+        type: string
+        default: "Registry Health Check"
+
+jobs:
+  registry-health:
+    name: ${{ inputs.job-name }}
+    runs-on: ubuntu-latest
+    permissions:
+      # Read repository to scan for digest-pinned images
+      contents: read
+      # Read packages to verify container image manifests
+      packages: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Verify pinned container image digests
+        id: health
+        shell: bash
+        env:
+          INPUT_SCAN_PATHS: ${{ inputs.scan-paths }}
+        run: .lgtm-ci-tooling/scripts/ci/maintenance/registry-health-check.sh
+
+  open-registry-health-issue:
+    name: Open Registry Health Issue
+    needs: registry-health
+    if: failure() && inputs.open-issue-on-failure
+    runs-on: ubuntu-latest
+    permissions:
+      # Read lgtm-ci tooling repository
+      contents: read
+      # Create issue for unreachable digest failures
+      issues: write
+
+    steps:
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress-issue
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          # Issue job: GitHub API only; do not inherit docker preset
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: github-minimal
+
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress-issue.outputs['allowed-endpoints'] }}
+
+      - name: Open issue for unreachable digests
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_LABELS: ${{ inputs.issue-labels }}
+        run: .lgtm-ci-tooling/scripts/ci/maintenance/open-registry-health-issue.sh

--- a/.github/workflows/reusable-validate-action-pinning.yml
+++ b/.github/workflows/reusable-validate-action-pinning.yml
@@ -22,6 +22,18 @@ on:
         required: false
         type: string
         default: ".github/workflows .github/actions"
+      verify-tags:
+        description: >-
+          Verify Renovate version comments resolve to the pinned SHA via GitHub API
+        required: false
+        type: boolean
+        default: false
+      audit-transitive:
+        description: >-
+          Warn when pinned composite actions reference nested actions by mutable tag
+        required: false
+        type: boolean
+        default: false
       tooling-ref:
         description: "Git ref to use when checking out lgtm-ci tooling scripts"
         required: false
@@ -103,3 +115,5 @@ jobs:
           enforce: ${{ inputs.fail-on-error }}
           allow-tag-exceptions: ${{ inputs.allow-tag-exceptions }}
           scan-paths: ${{ inputs.scan-paths }}
+          verify-tags: ${{ inputs.verify-tags }}
+          audit-transitive: ${{ inputs.audit-transitive }}

--- a/.github/workflows/reusable-validate-lintro-version.yml
+++ b/.github/workflows/reusable-validate-lintro-version.yml
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+---
+name: Reusable Validate Lintro Version
+
+on:
+  workflow_call:
+    inputs:
+      lintro-image:
+        description: >-
+          Pinned ghcr.io/lgtm-hq/py-lintro image. When empty, resolves the digest
+          from reusable-quality-lint.yml and run-quality/action.yml in the repo.
+        required: false
+        type: string
+        default: ""
+      pyproject:
+        description: "Path to pyproject.toml"
+        required: false
+        type: string
+        default: "pyproject.toml"
+      tooling-ref:
+        description: "Git ref for lgtm-ci tooling checkout"
+        required: false
+        type: string
+        default: ""
+      tooling-ref-fallback:
+        description: >-
+          Fallback lgtm-ci tooling ref when required scripts are missing at
+          tooling-ref (for example PR head SHA during bootstrap)
+        required: false
+        type: string
+        default: ""
+      tooling-bootstrap-script:
+        description: >-
+          Path to check-lintro-tooling-bootstrap.sh (repo or tooling checkout)
+        required: false
+        type: string
+        default: ".lgtm-ci-tooling/scripts/ci/quality/check-lintro-tooling-bootstrap.sh"
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "block"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+      egress-preset:
+        description: >-
+          Named allowlist when allowed-endpoints is empty and egress-policy is
+          block (github-minimal, github-pages, github-tooling, docker, playwright, pypi,
+          rubygems, npm-publish, quality, sbom, scorecard)
+        required: false
+        type: string
+        default: "quality"
+      job-name:
+        description: "GitHub check name"
+        required: false
+        type: string
+        default: "Validate Lintro Version"
+
+jobs:
+  validate-lintro-version:
+    name: ${{ inputs.job-name }}
+    runs-on: ubuntu-latest
+    permissions:
+      # Checkout repository and lgtm-ci tooling
+      contents: read
+      # Authenticate to ghcr.io for lintro image access
+      packages: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Bootstrap lgtm-ci tooling when required scripts are missing
+        id: tooling-bootstrap
+        if: inputs.tooling-ref-fallback != ''
+        shell: bash
+        env:
+          BOOTSTRAP_SCRIPT: ${{ inputs.tooling-bootstrap-script }}
+        run: bash "$BOOTSTRAP_SCRIPT"
+
+      - name: Checkout lgtm-ci tooling (fallback)
+        if: >-
+          inputs.tooling-ref-fallback != '' &&
+          steps.tooling-bootstrap.outputs.needs-fallback == 'true'
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref-fallback }}
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Resolve lintro image reference
+        id: lintro-image
+        shell: bash
+        env:
+          INPUT_LINTRO_IMAGE: ${{ inputs.lintro-image }}
+        run: .lgtm-ci-tooling/scripts/ci/quality/resolve-lintro-image.sh
+
+      - name: Validate lintro version consistency
+        shell: bash
+        env:
+          LINTRO_IMAGE: ${{ steps.lintro-image.outputs.image }}
+          PYPROJECT: ${{ inputs.pyproject }}
+        run: .lgtm-ci-tooling/scripts/ci/quality/validate-lintro-version.sh

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+---
+name: Quality Check - Action Pinning Validation
+
+'on':
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - 'scripts/ci/actions/validate-action-pinning.sh'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - 'scripts/ci/actions/validate-action-pinning.sh'
+  merge_group:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: validate-action-pinning-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    uses: ./.github/workflows/reusable-validate-action-pinning.yml
+    with:
+      fail-on-error: true
+      verify-tags: true
+      audit-transitive: true
+      tooling-ref: ${{ github.sha }}
+      egress-policy: block
+      egress-preset: github-tooling
+    permissions:
+      contents: read

--- a/.github/workflows/validate-lintro-version.yml
+++ b/.github/workflows/validate-lintro-version.yml
@@ -10,7 +10,11 @@ name: Quality Check - Lintro Version Sync
       - 'pyproject.toml'
       - '.github/workflows/reusable-quality-lint.yml'
       - '.github/workflows/reusable-validate-lintro-version.yml'
+      - '.github/workflows/validate-lintro-version.yml'
       - '.github/actions/run-quality/action.yml'
+      - 'scripts/ci/quality/check-lintro-tooling-bootstrap.sh'
+      - 'scripts/ci/quality/resolve-lintro-image.sh'
+      - 'scripts/ci/quality/validate-lintro-version.sh'
   merge_group:
   push:
     branches: [main]
@@ -18,7 +22,11 @@ name: Quality Check - Lintro Version Sync
       - 'pyproject.toml'
       - '.github/workflows/reusable-quality-lint.yml'
       - '.github/workflows/reusable-validate-lintro-version.yml'
+      - '.github/workflows/validate-lintro-version.yml'
       - '.github/actions/run-quality/action.yml'
+      - 'scripts/ci/quality/check-lintro-tooling-bootstrap.sh'
+      - 'scripts/ci/quality/resolve-lintro-image.sh'
+      - 'scripts/ci/quality/validate-lintro-version.sh'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/validate-lintro-version.yml
+++ b/.github/workflows/validate-lintro-version.yml
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+---
+name: Quality Check - Lintro Version Sync
+
+'on':
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'pyproject.toml'
+      - '.github/workflows/reusable-quality-lint.yml'
+      - '.github/workflows/reusable-validate-lintro-version.yml'
+      - '.github/actions/run-quality/action.yml'
+  merge_group:
+  push:
+    branches: [main]
+    paths:
+      - 'pyproject.toml'
+      - '.github/workflows/reusable-quality-lint.yml'
+      - '.github/workflows/reusable-validate-lintro-version.yml'
+      - '.github/actions/run-quality/action.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: validate-lintro-version-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    uses: ./.github/workflows/reusable-validate-lintro-version.yml
+    with:
+      tooling-ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
+      tooling-ref-fallback: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+      tooling-bootstrap-script: scripts/ci/quality/check-lintro-tooling-bootstrap.sh
+    permissions:
+      # Checkout repository and lgtm-ci tooling
+      contents: read
+      # Authenticate to ghcr.io for lintro image validation
+      packages: read

--- a/scripts/ci/actions/validate-action-pinning.sh
+++ b/scripts/ci/actions/validate-action-pinning.sh
@@ -7,6 +7,8 @@
 #   INPUT_ALLOW_TAG_EXCEPTIONS - Comma-separated action names allowed to use tag refs
 #   INPUT_ALLOW_ORG_VERSIONS   - Deprecated alias for INPUT_ALLOW_TAG_EXCEPTIONS
 #   INPUT_SCAN_PATHS           - Space-separated paths to scan for workflow files
+#   INPUT_VERIFY_TAGS          - Verify Renovate version comments match pinned SHAs
+#   INPUT_AUDIT_TRANSITIVE     - Warn on mutable tag refs in nested composite actions
 
 set -euo pipefail
 
@@ -14,13 +16,16 @@ set -euo pipefail
 : "${INPUT_ALLOW_TAG_EXCEPTIONS:=}"
 : "${INPUT_ALLOW_ORG_VERSIONS:=}"
 : "${INPUT_SCAN_PATHS:=.github/workflows .github/actions}"
+: "${INPUT_VERIFY_TAGS:=false}"
+: "${INPUT_AUDIT_TRANSITIVE:=false}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
 # shellcheck source=../lib/actions.sh
 source "$SCRIPT_DIR/../lib/actions.sh"
 
-readonly VERSION_COMMENT_PATTERN='#[[:space:]]*v[0-9]+(\.[0-9]+)*'
+readonly VERSION_COMMENT_PATTERN='#[[:space:]]*v[0-9]+(\.[0-9]+)*([-.][a-zA-Z0-9.]+)*'
 readonly LGTM_CI_REPOSITORY_PATTERN='repository:[[:space:]]*['\''"]?lgtm-hq/lgtm-ci['\''"]?'
+readonly LGTM_CI_REPO_SLUG='lgtm-hq/lgtm-ci'
 readonly LGTM_CI_RELEASE_COMMIT_SHA='d3736367191ddaf56c41804d2dd5174732ed2d2b'
 
 # =============================================================================
@@ -129,11 +134,94 @@ extract_literal_ref() {
 	printf '%s' "$value"
 }
 
+normalize_sha() {
+	local sha="$1"
+	printf '%s' "$sha" | tr '[:upper:]' '[:lower:]'
+}
+
+extract_version_tag_from_line() {
+	local line="$1"
+	local tag=""
+
+	if [[ ! "$line" =~ $VERSION_COMMENT_PATTERN ]]; then
+		return 1
+	fi
+
+	tag="$(echo "$line" | sed -E 's/.*#[[:space:]]*(v[0-9]+(\.[0-9]+)*([-.][a-zA-Z0-9.]+)*).*/\1/')"
+	if [[ -z "$tag" ]]; then
+		return 1
+	fi
+
+	printf '%s' "$tag"
+}
+
+parse_action_repo() {
+	local action_name="$1"
+	local org repo subpath remainder
+
+	org="${action_name%%/*}"
+	remainder="${action_name#*/}"
+	repo="${remainder%%/*}"
+	subpath=""
+
+	if [[ "$remainder" == */* ]]; then
+		subpath="${remainder#*/}"
+	fi
+
+	printf '%s %s %s' "$org" "$repo" "$subpath"
+}
+
+cache_get() {
+	local key="$1"
+	local i
+
+	for i in "${!TAG_SHA_CACHE_KEYS[@]}"; do
+		if [[ "${TAG_SHA_CACHE_KEYS[i]}" == "$key" ]]; then
+			printf '%s' "${TAG_SHA_CACHE_VALUES[i]}"
+			return 0
+		fi
+	done
+	return 1
+}
+
+cache_set() {
+	local key="$1"
+	local value="$2"
+
+	TAG_SHA_CACHE_KEYS+=("$key")
+	TAG_SHA_CACHE_VALUES+=("$value")
+}
+
+transitive_audit_seen() {
+	local cache_key="$1"
+	local seen
+
+	if [[ ${#TRANSITIVE_AUDIT_KEYS[@]} -eq 0 ]]; then
+		return 1
+	fi
+
+	for seen in "${TRANSITIVE_AUDIT_KEYS[@]}"; do
+		if [[ "$seen" == "$cache_key" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
 # =============================================================================
 # Scan workflow files
 # =============================================================================
+TAG_SHA_CACHE_KEYS=()
+TAG_SHA_CACHE_VALUES=()
+RESOLVED_TAG_SHA=""
+TRANSITIVE_AUDIT_KEYS=()
+
 offender_count=0
 offender_details=()
+warn_count=0
+warn_details=()
+PIN_VERIFY_QUEUE=()
+TRANSITIVE_AUDIT_QUEUE=()
 
 record_offender() {
 	local file="$1"
@@ -141,6 +229,206 @@ record_offender() {
 	local detail="$3"
 	offender_count=$((offender_count + 1))
 	offender_details+=("  ${file}:${line_number}: ${detail}")
+}
+
+record_warning() {
+	local detail="$1"
+	warn_count=$((warn_count + 1))
+	warn_details+=("  ${detail}")
+}
+
+queue_pin_verification() {
+	local file="$1"
+	local line_number="$2"
+	local action_name="$3"
+	local pinned_sha="$4"
+	local line="$5"
+	local tag
+
+	if ! tag="$(extract_version_tag_from_line "$line")"; then
+		return 0
+	fi
+
+	PIN_VERIFY_QUEUE+=("${file}|${line_number}|${action_name}|${pinned_sha}|${tag}")
+}
+
+queue_transitive_audit() {
+	local action_name="$1"
+	local pinned_sha="$2"
+	local cache_key="${action_name}@${pinned_sha}"
+
+	if transitive_audit_seen "$cache_key"; then
+		return 0
+	fi
+
+	TRANSITIVE_AUDIT_KEYS+=("$cache_key")
+	TRANSITIVE_AUDIT_QUEUE+=("${action_name}|${pinned_sha}")
+}
+
+resolve_tag_to_sha() {
+	local org="$1"
+	local repo="$2"
+	local tag="$3"
+	local cache_key="${org}/${repo}@${tag}"
+	local sha
+
+	if sha="$(cache_get "$cache_key")"; then
+		RESOLVED_TAG_SHA="$sha"
+		return 0
+	fi
+
+	if ! sha="$(gh api "repos/${org}/${repo}/commits/${tag}" --jq '.sha' 2>/dev/null)"; then
+		RESOLVED_TAG_SHA=""
+		return 1
+	fi
+
+	if [[ -z "$sha" || "$sha" == "null" ]]; then
+		RESOLVED_TAG_SHA=""
+		return 1
+	fi
+
+	sha="$(normalize_sha "$sha")"
+	cache_set "$cache_key" "$sha"
+	RESOLVED_TAG_SHA="$sha"
+	return 0
+}
+
+verify_queued_pins() {
+	local entry file line_number action_name pinned_sha tag org repo _subpath resolved_sha
+
+	for entry in "${PIN_VERIFY_QUEUE[@]}"; do
+		IFS='|' read -r file line_number action_name pinned_sha tag <<<"$entry"
+		read -r org repo _subpath <<<"$(parse_action_repo "$action_name")"
+
+		if ! resolve_tag_to_sha "$org" "$repo" "$tag"; then
+			record_warning \
+				"${file}:${line_number}: ${action_name}@${pinned_sha} (could not resolve ${tag} via GitHub API)"
+			continue
+		fi
+
+		resolved_sha="$RESOLVED_TAG_SHA"
+
+		if [[ "$(normalize_sha "$pinned_sha")" != "$resolved_sha" ]]; then
+			record_offender "$file" "$line_number" \
+				"${action_name}@${pinned_sha} (pinned SHA does not match ${tag}; resolved ${resolved_sha})"
+		fi
+	done
+}
+
+fetch_action_yaml_content_at_path() {
+	local org="$1"
+	local repo="$2"
+	local sha="$3"
+	local api_path="$4"
+	local content
+
+	if ! content="$(gh api "repos/${org}/${repo}/contents/${api_path}?ref=${sha}" --jq '.content' 2>/dev/null)"; then
+		return 1
+	fi
+
+	if [[ -z "$content" || "$content" == "null" ]]; then
+		return 1
+	fi
+
+	printf '%s' "$content" | base64 -d
+}
+
+fetch_action_yaml_at_sha() {
+	local org="$1"
+	local repo="$2"
+	local sha="$3"
+	local subpath="$4"
+	local manifest_name manifest_path
+
+	for manifest_name in action.yml action.yaml; do
+		manifest_path="$manifest_name"
+		if [[ -n "$subpath" ]]; then
+			manifest_path="${subpath}/${manifest_name}"
+		fi
+
+		if fetch_action_yaml_content_at_path "$org" "$repo" "$sha" "$manifest_path"; then
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+is_reusable_workflow_ref() {
+	local subpath="$1"
+
+	[[ "$subpath" == *".github/workflows/"* ]] ||
+		[[ "$subpath" == *.yml ]] ||
+		[[ "$subpath" == *.yaml ]]
+}
+
+audit_nested_uses_line() {
+	local parent_action="$1"
+	local nested_line="$2"
+	local action_ref action_name version_ref
+
+	if ! [[ "$nested_line" =~ ^[[:space:]]*-?[[:space:]]*uses:[[:space:]]* ]]; then
+		return 0
+	fi
+
+	action_ref="$(echo "$nested_line" | sed -E 's/^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*//' | sed 's/#.*//' | sed 's/[[:space:]]*$//')"
+	action_ref="$(echo "$action_ref" | sed -E "s/^['\"]//;s/['\"]$//")"
+
+	if [[ -z "$action_ref" || "$action_ref" == ./* || "$action_ref" == docker://* ]]; then
+		return 0
+	fi
+
+	if contains_template_expression "$action_ref"; then
+		return 0
+	fi
+
+	if [[ "$action_ref" != *@* ]]; then
+		record_warning "${parent_action}: nested ${action_ref} (no version specified)"
+		return 0
+	fi
+
+	action_name="${action_ref%@*}"
+	version_ref="${action_ref##*@}"
+
+	if is_valid_sha "$version_ref"; then
+		return 0
+	fi
+
+	if is_tag_exception "$action_name"; then
+		return 0
+	fi
+
+	record_warning \
+		"${parent_action}: nested ${action_ref} uses mutable tag ref (upstream tag deletion risk)"
+}
+
+audit_transitive_dependencies() {
+	local entry action_name pinned_sha org repo subpath action_yaml line_number line
+
+	for entry in "${TRANSITIVE_AUDIT_QUEUE[@]}"; do
+		IFS='|' read -r action_name pinned_sha <<<"$entry"
+		read -r org repo subpath <<<"$(parse_action_repo "$action_name")"
+
+		if is_reusable_workflow_ref "$subpath"; then
+			continue
+		fi
+
+		if ! action_yaml="$(fetch_action_yaml_at_sha "$org" "$repo" "$pinned_sha" "$subpath")"; then
+			record_warning \
+				"${action_name}@${pinned_sha}: could not fetch composite action manifest for transitive audit"
+			continue
+		fi
+
+		if ! grep -qE 'using:[[:space:]]*("composite"|'\''composite'\''|composite)' <<<"$action_yaml"; then
+			continue
+		fi
+
+		line_number=0
+		while IFS= read -r line || [[ -n "$line" ]]; do
+			line_number=$((line_number + 1))
+			audit_nested_uses_line "${action_name}@${pinned_sha}" "$line"
+		done <<<"$action_yaml"
+	done
 }
 
 log_info "Scanning for action pinning policy violations..."
@@ -164,6 +452,7 @@ done
 if [[ ${#yaml_files[@]} -eq 0 ]]; then
 	log_warn "No workflow files found in scan paths"
 	set_github_output "offenders" "0"
+	set_github_output "warnings" "0"
 	exit 0
 fi
 
@@ -207,6 +496,13 @@ scan_uses_line() {
 			fi
 			record_offender "$file" "$line_number" \
 				"${action_ref} (SHA pin missing version comment; add \"${hint}\")"
+		else
+			if [[ "$INPUT_VERIFY_TAGS" == "true" ]] && has_renovate_version_comment "$line"; then
+				queue_pin_verification "$file" "$line_number" "$action_name" "$version_ref" "$line"
+			fi
+			if [[ "$INPUT_AUDIT_TRANSITIVE" == "true" ]]; then
+				queue_transitive_audit "$action_name" "$version_ref"
+			fi
 		fi
 		return 0
 	fi
@@ -231,6 +527,10 @@ scan_literal_sha_field() {
 	fi
 
 	if has_renovate_version_comment "$line"; then
+		if [[ "$INPUT_VERIFY_TAGS" == "true" ]]; then
+			# tooling-ref/ref SHAs always target the lgtm-ci repository itself.
+			queue_pin_verification "$file" "$line_number" "$LGTM_CI_REPO_SLUG" "$sha_ref" "$line"
+		fi
 		return 0
 	fi
 
@@ -273,10 +573,21 @@ for file in "${yaml_files[@]}"; do
 	scan_file "$file"
 done
 
+if [[ "$INPUT_VERIFY_TAGS" == "true" && ${#PIN_VERIFY_QUEUE[@]} -gt 0 ]]; then
+	log_info "Verifying ${#PIN_VERIFY_QUEUE[@]} Renovate version comment(s) against pinned SHAs..."
+	verify_queued_pins
+fi
+
+if [[ "$INPUT_AUDIT_TRANSITIVE" == "true" && ${#TRANSITIVE_AUDIT_QUEUE[@]} -gt 0 ]]; then
+	log_info "Auditing transitive action references in ${#TRANSITIVE_AUDIT_QUEUE[@]} composite action(s)..."
+	audit_transitive_dependencies
+fi
+
 # =============================================================================
 # Report results
 # =============================================================================
 set_github_output "offenders" "$offender_count"
+set_github_output "warnings" "$warn_count"
 
 if [[ $offender_count -gt 0 ]]; then
 	log_error "Found $offender_count action pinning violation(s):"
@@ -288,9 +599,17 @@ if [[ $offender_count -gt 0 ]]; then
 	log_info "Example uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4"
 	log_info "Example tooling-ref: '${LGTM_CI_RELEASE_COMMIT_SHA}' # v0.18.4"
 
-	if [[ "$INPUT_ENFORCE" == "true" ]]; then
-		exit 1
-	fi
-else
+elif [[ $warn_count -eq 0 ]]; then
 	log_success "All action references follow SHA pinning with Renovate version comments"
+fi
+
+if [[ $warn_count -gt 0 ]]; then
+	log_warn "Found $warn_count verification warning(s):"
+	for detail in "${warn_details[@]}"; do
+		echo "$detail" >&2
+	done
+fi
+
+if [[ $offender_count -gt 0 && "$INPUT_ENFORCE" == "true" ]]; then
+	exit 1
 fi

--- a/scripts/ci/maintenance/open-registry-health-issue.sh
+++ b/scripts/ci/maintenance/open-registry-health-issue.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Open a GitHub issue when registry health check fails
+#
+# Required environment variables:
+#   GH_TOKEN - GitHub token with issues: write
+#   GITHUB_REPOSITORY - Target repository (owner/name)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/log.sh
+source "$SCRIPT_DIR/../lib/log.sh"
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+	log_error "GH_TOKEN is required"
+	exit 1
+fi
+
+if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+	log_error "GITHUB_REPOSITORY is required"
+	exit 1
+fi
+
+readonly DEDUP_LABEL="registry-health-check"
+readonly GH_REPO="${GITHUB_REPOSITORY}"
+
+title="Registry health check: unreachable container image digest(s)"
+body="$(
+	cat <<EOF
+The scheduled registry health check found digest-pinned container images that no longer resolve.
+
+Workflow run: ${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-unknown}/actions/runs/${GITHUB_RUN_ID:-unknown}
+
+## Next steps
+
+1. Inspect the workflow logs for the failing image reference(s).
+2. Update the digest pin to a current manifest in the affected workflow or action file.
+3. Re-run the registry health check workflow to confirm recovery.
+EOF
+)"
+
+ensure_issue_label() {
+	local label="$1"
+	local color="$2"
+	local description="${3:-}"
+
+	if gh label view "$label" --repo "$GH_REPO" >/dev/null 2>&1; then
+		return 0
+	fi
+
+	if [[ -n "$description" ]]; then
+		gh label create "$label" \
+			--repo "$GH_REPO" \
+			--color "$color" \
+			--description "$description" 2>/dev/null || true
+	else
+		gh label create "$label" \
+			--repo "$GH_REPO" \
+			--color "$color" 2>/dev/null || true
+	fi
+
+	if gh label view "$label" --repo "$GH_REPO" >/dev/null 2>&1; then
+		return 0
+	fi
+
+	log_error "Failed to ensure issue label exists: $label"
+	exit 1
+}
+
+existing_count="$(gh issue list \
+	--repo "$GH_REPO" \
+	--label "$DEDUP_LABEL" \
+	--state open \
+	--json number \
+	--jq 'length' 2>/dev/null || true)"
+
+if [[ ! "$existing_count" =~ ^[0-9]+$ ]]; then
+	log_error "Could not check for existing registry health issues"
+	exit 1
+fi
+
+if [[ "$existing_count" -gt 0 ]]; then
+	log_info "Open registry health issue already exists; skipping duplicate creation"
+	exit 0
+fi
+
+ensure_issue_label "$DEDUP_LABEL" "1D76DB" "Auto-opened by the registry health check workflow"
+
+label_args=(--label "$DEDUP_LABEL")
+if [[ -n "${ISSUE_LABELS:-}" ]]; then
+	IFS=',' read -ra labels <<<"$ISSUE_LABELS"
+	for label in "${labels[@]}"; do
+		label="$(echo "$label" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+		if [[ -z "$label" || "$label" == "$DEDUP_LABEL" ]]; then
+			continue
+		fi
+		ensure_issue_label "$label" "ededed" ""
+		label_args+=(--label "$label")
+	done
+fi
+
+gh issue create \
+	--repo "$GH_REPO" \
+	--title "$title" \
+	--body "$body" \
+	"${label_args[@]}"
+
+log_success "Opened registry health issue"

--- a/scripts/ci/maintenance/registry-health-check.sh
+++ b/scripts/ci/maintenance/registry-health-check.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Verify digest-pinned container images still resolve in their registries
+#
+# Environment variables:
+#   INPUT_SCAN_PATHS - Space-separated paths to scan (default: .github)
+
+set -euo pipefail
+
+: "${INPUT_SCAN_PATHS:=.github}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/log.sh
+source "$SCRIPT_DIR/../lib/log.sh"
+
+readonly DIGEST_PATTERN='@sha256:[0-9a-fA-F]{64}'
+readonly MANIFEST_INSPECT_TIMEOUT_SECONDS="${MANIFEST_INSPECT_TIMEOUT_SECONDS:-30}"
+
+failure_count=0
+failure_details=()
+checked_images=()
+
+record_failure() {
+	local detail="$1"
+	failure_count=$((failure_count + 1))
+	failure_details+=("  ${detail}")
+}
+
+image_already_checked() {
+	local image="$1"
+	local seen
+
+	if [[ ${#checked_images[@]} -eq 0 ]]; then
+		return 1
+	fi
+
+	for seen in "${checked_images[@]}"; do
+		if [[ "$seen" == "$image" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+normalize_extracted_image() {
+	local image="$1"
+
+	image="${image#docker://}"
+	if [[ -z "$image" || ! "$image" =~ ${DIGEST_PATTERN}$ ]]; then
+		return 1
+	fi
+
+	printf '%s' "$image"
+}
+
+queue_image_check() {
+	local image="$1"
+
+	if image_already_checked "$image"; then
+		return 0
+	fi
+	checked_images+=("$image")
+}
+
+extract_images_from_file() {
+	local file="$1"
+	local match
+	local image
+
+	while IFS= read -r match; do
+		[[ -z "$match" ]] && continue
+		image="$(normalize_extracted_image "$match" || true)"
+		[[ -z "$image" ]] && continue
+		queue_image_check "$image"
+	done < <(
+		grep -oE "[A-Za-z0-9._:/-]+${DIGEST_PATTERN}" "$file" 2>/dev/null || true
+	)
+}
+
+log_info "Scanning for digest-pinned container images..."
+log_info "Scan paths: $INPUT_SCAN_PATHS"
+
+read -ra scan_paths <<<"$INPUT_SCAN_PATHS"
+for scan_path in "${scan_paths[@]}"; do
+	if [[ ! -e "$scan_path" ]]; then
+		log_warn "Scan path does not exist: $scan_path"
+		continue
+	fi
+
+	if [[ -f "$scan_path" ]]; then
+		extract_images_from_file "$scan_path"
+		continue
+	fi
+
+	while IFS= read -r -d '' file; do
+		extract_images_from_file "$file"
+	done < <(
+		find "$scan_path" -type f \( -name "*.yml" -o -name "*.yaml" \) -print0 2>/dev/null
+	)
+done
+
+if [[ ${#checked_images[@]} -eq 0 ]]; then
+	log_warn "No digest-pinned container images found"
+	exit 0
+fi
+
+log_info "Found ${#checked_images[@]} unique digest-pinned image(s) to verify"
+
+run_manifest_inspect() {
+	local image="$1"
+
+	if command -v timeout >/dev/null 2>&1; then
+		timeout "$MANIFEST_INSPECT_TIMEOUT_SECONDS" docker manifest inspect "$image"
+	else
+		docker manifest inspect "$image"
+	fi
+}
+
+verify_digest() {
+	local image="$1"
+	local attempt
+
+	for attempt in 1 2 3; do
+		if run_manifest_inspect "$image" >/dev/null 2>&1; then
+			return 0
+		fi
+		if [[ $attempt -lt 3 ]]; then
+			sleep 2
+		fi
+	done
+
+	return 1
+}
+
+for image in "${checked_images[@]}"; do
+	log_info "Checking ${image}"
+	if verify_digest "$image"; then
+		log_success "Digest resolves: ${image}"
+	else
+		record_failure "${image} (digest unreachable after 3 manifest inspect attempts)"
+	fi
+done
+
+if [[ $failure_count -gt 0 ]]; then
+	log_error "Found $failure_count unreachable digest pin(s):"
+	for detail in "${failure_details[@]}"; do
+		echo "$detail" >&2
+	done
+	exit 1
+fi
+
+log_success "All digest-pinned container images resolve in their registries"

--- a/scripts/ci/maintenance/registry-health-check.sh
+++ b/scripts/ci/maintenance/registry-health-check.sh
@@ -73,7 +73,8 @@ extract_images_from_file() {
 		[[ -z "$image" ]] && continue
 		queue_image_check "$image"
 	done < <(
-		grep -oE "[A-Za-z0-9._:/-]+${DIGEST_PATTERN}" "$file" 2>/dev/null || true
+		grep -vE '^[[:space:]]*#' "$file" 2>/dev/null |
+			grep -oE "[A-Za-z0-9._:/-]+${DIGEST_PATTERN}" 2>/dev/null || true
 	)
 }
 
@@ -146,6 +147,9 @@ if [[ $failure_count -gt 0 ]]; then
 	for detail in "${failure_details[@]}"; do
 		echo "$detail" >&2
 	done
+	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+		printf 'digest-failure=true\n' >>"$GITHUB_OUTPUT"
+	fi
 	exit 1
 fi
 

--- a/scripts/ci/quality/check-lintro-tooling-bootstrap.sh
+++ b/scripts/ci/quality/check-lintro-tooling-bootstrap.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Detect whether lgtm-ci tooling checkout needs a fallback ref
+#
+# Required environment variables:
+#   GITHUB_OUTPUT - GitHub Actions output file
+#
+# Optional environment variables:
+#   RESOLVE_SCRIPT - Path to resolve-lintro-image.sh in tooling checkout
+#   VALIDATE_SCRIPT - Path to validate-lintro-version.sh in tooling checkout
+
+set -euo pipefail
+
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/log.sh
+source "$SCRIPT_DIR/../lib/log.sh"
+# shellcheck source=../lib/github/output.sh
+source "$SCRIPT_DIR/../lib/github/output.sh"
+
+: "${RESOLVE_SCRIPT:=.lgtm-ci-tooling/scripts/ci/quality/resolve-lintro-image.sh}"
+: "${VALIDATE_SCRIPT:=.lgtm-ci-tooling/scripts/ci/quality/validate-lintro-version.sh}"
+
+if [[ -f "$RESOLVE_SCRIPT" && -f "$VALIDATE_SCRIPT" ]]; then
+	set_github_output "needs-fallback" "false"
+	log_info "Required lintro tooling scripts present at primary ref"
+	exit 0
+fi
+
+set_github_output "needs-fallback" "true"
+log_warn "Required tooling scripts missing at primary ref; bootstrapping from fallback"

--- a/scripts/ci/quality/resolve-lintro-image.sh
+++ b/scripts/ci/quality/resolve-lintro-image.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Resolve the canonical lintro image reference from repository CI files
+#
+# Reads digest-pinned ghcr.io/lgtm-hq/py-lintro references from the workflow and
+# composite action defaults that must stay in sync with pyproject.toml.
+#
+# Optional environment variables:
+#   INPUT_LINTRO_IMAGE   - Use this image instead of resolving from CI files
+#   LINTRO_IMAGE_SOURCES - Space-separated files to scan (default below)
+#   GITHUB_OUTPUT        - When set, writes image=<value> for workflow steps
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/log.sh
+source "$SCRIPT_DIR/../lib/log.sh"
+
+if [[ -n "${INPUT_LINTRO_IMAGE:-}" ]]; then
+	log_info "Using provided lintro image override"
+	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+		printf 'image=%s\n' "$INPUT_LINTRO_IMAGE" >>"$GITHUB_OUTPUT"
+	else
+		printf '%s' "$INPUT_LINTRO_IMAGE"
+	fi
+	exit 0
+fi
+
+readonly DIGEST_PATTERN='ghcr\.io/lgtm-hq/py-lintro@sha256:[0-9a-fA-F]{64}'
+readonly DEFAULT_SOURCES=(
+	".github/workflows/reusable-quality-lint.yml"
+	".github/actions/run-quality/action.yml"
+)
+
+extract_image_from_file() {
+	local file="$1"
+	local image=""
+
+	if [[ ! -f "$file" ]]; then
+		log_error "Lintro image source file not found: $file"
+		return 1
+	fi
+
+	image="$(awk -v pattern="$DIGEST_PATTERN" '
+		function emit() {
+			print substr($0, RSTART, RLENGTH)
+			exit
+		}
+		/^[[:space:]]*#/ {
+			next
+		}
+		/lintro-image:/ {
+			capture = 1
+			default_capture = 0
+			match($0, /^[[:space:]]*/)
+			lintro_indent = RLENGTH
+			if (match($0, pattern)) {
+				emit()
+			}
+			next
+		}
+		capture {
+			match($0, /^[[:space:]]*/)
+			if (RLENGTH <= lintro_indent && $0 ~ /^[[:space:]]*[a-z0-9-]+:/ && $0 !~ /lintro-image:/) {
+				capture = 0
+				default_capture = 0
+				next
+			}
+			if ($0 ~ /default:/) {
+				match($0, /^[[:space:]]*/)
+				default_indent = RLENGTH
+				if (match($0, pattern)) {
+					emit()
+				} else {
+					default_capture = 1
+				}
+				next
+			}
+			if (default_capture) {
+				match($0, /^[[:space:]]*/)
+				if (RLENGTH <= default_indent && $0 ~ /:/ && $0 !~ /^[[:space:]]*#/) {
+					default_capture = 0
+					next
+				}
+				if (match($0, pattern)) {
+					emit()
+				}
+			}
+		}
+	' "$file")"
+
+	if [[ -z "$image" ]]; then
+		log_error "No digest-pinned lintro image found in: $file"
+		return 1
+	fi
+
+	printf '%s' "$image"
+}
+
+sources=()
+if [[ -n "${LINTRO_IMAGE_SOURCES:-}" ]]; then
+	read -ra sources <<<"$LINTRO_IMAGE_SOURCES"
+else
+	sources=("${DEFAULT_SOURCES[@]}")
+fi
+
+if [[ ${#sources[@]} -eq 0 ]]; then
+	log_error "No lintro image sources specified in LINTRO_IMAGE_SOURCES"
+	exit 1
+fi
+
+canonical_image=""
+for source in "${sources[@]}"; do
+	image="$(extract_image_from_file "$source")" || exit 1
+	if [[ -z "$canonical_image" ]]; then
+		canonical_image="$image"
+	elif [[ "$canonical_image" != "$image" ]]; then
+		log_error "Lintro image definitions disagree between CI files"
+		log_error "Expected a single digest pin across: ${sources[*]}"
+		exit 1
+	fi
+done
+
+log_info "Resolved lintro image: $canonical_image"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	printf 'image=%s\n' "$canonical_image" >>"$GITHUB_OUTPUT"
+else
+	printf '%s' "$canonical_image"
+fi

--- a/scripts/ci/quality/resolve-lintro-image.sh
+++ b/scripts/ci/quality/resolve-lintro-image.sh
@@ -16,7 +16,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
 # shellcheck source=../lib/log.sh
 source "$SCRIPT_DIR/../lib/log.sh"
 
+readonly DIGEST_PATTERN='ghcr\.io/lgtm-hq/py-lintro@sha256:[0-9a-fA-F]{64}'
+
 if [[ -n "${INPUT_LINTRO_IMAGE:-}" ]]; then
+	if [[ ! "$INPUT_LINTRO_IMAGE" =~ ^${DIGEST_PATTERN}$ ]]; then
+		log_error "INPUT_LINTRO_IMAGE must be a digest-pinned ghcr.io/lgtm-hq/py-lintro reference"
+		exit 1
+	fi
 	log_info "Using provided lintro image override"
 	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
 		printf 'image=%s\n' "$INPUT_LINTRO_IMAGE" >>"$GITHUB_OUTPUT"
@@ -25,8 +31,6 @@ if [[ -n "${INPUT_LINTRO_IMAGE:-}" ]]; then
 	fi
 	exit 0
 fi
-
-readonly DIGEST_PATTERN='ghcr\.io/lgtm-hq/py-lintro@sha256:[0-9a-fA-F]{64}'
 readonly DEFAULT_SOURCES=(
 	".github/workflows/reusable-quality-lint.yml"
 	".github/actions/run-quality/action.yml"

--- a/tests/bats/integration/test_check_lintro_tooling_bootstrap.bats
+++ b/tests/bats/integration/test_check_lintro_tooling_bootstrap.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Integration tests for check-lintro-tooling-bootstrap script
+
+load "../../helpers/common"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/quality/check-lintro-tooling-bootstrap.sh"
+
+setup() {
+	setup_temp_dir
+	export LIB_DIR
+	export BATS_TEST_TMPDIR
+	export PROJECT_ROOT
+	export SCRIPT
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/github_output"
+	: >"$GITHUB_OUTPUT"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "check-lintro-tooling-bootstrap: reports no fallback when scripts exist" {
+	local root="${BATS_TEST_TMPDIR}/tooling"
+	mkdir -p "${root}/scripts/ci/quality"
+	touch "${root}/scripts/ci/quality/resolve-lintro-image.sh"
+	touch "${root}/scripts/ci/quality/validate-lintro-version.sh"
+
+	run bash -c '
+		export RESOLVE_SCRIPT="'"${root}"'/scripts/ci/quality/resolve-lintro-image.sh"
+		export VALIDATE_SCRIPT="'"${root}"'/scripts/ci/quality/validate-lintro-version.sh"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	run grep -F "needs-fallback=false" "$GITHUB_OUTPUT"
+	assert_success
+}
+
+@test "check-lintro-tooling-bootstrap: reports fallback when scripts are missing" {
+	run bash -c '
+		export RESOLVE_SCRIPT="'"${BATS_TEST_TMPDIR}"'/missing-resolve.sh"
+		export VALIDATE_SCRIPT="'"${BATS_TEST_TMPDIR}"'/missing-validate.sh"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	run grep -F "needs-fallback=true" "$GITHUB_OUTPUT"
+	assert_success
+}

--- a/tests/bats/integration/test_open_registry_health_issue.bats
+++ b/tests/bats/integration/test_open_registry_health_issue.bats
@@ -1,0 +1,238 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Integration tests for open-registry-health-issue maintenance script
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/maintenance/open-registry-health-issue.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+	export LIB_DIR
+	export BATS_TEST_TMPDIR
+	export PROJECT_ROOT
+	export SCRIPT
+	export GH_TOKEN=test-token
+	export GITHUB_REPOSITORY=lgtm-hq/lgtm-ci
+	export GITHUB_RUN_ID=12345
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+@test "open-registry-health-issue: opens issue when none exists" {
+	mkdir -p "${BATS_TEST_TMPDIR}/bin"
+	cat >"${BATS_TEST_TMPDIR}/bin/gh" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> '${BATS_TEST_TMPDIR}/mock_calls_gh'
+case "\$*" in
+	*label*view*registry-health-check*)
+		[[ -f '${BATS_TEST_TMPDIR}/mock_label_registry-health-check' ]] && exit 0
+		exit 1
+		;;
+	*label*create*registry-health-check*)
+		touch '${BATS_TEST_TMPDIR}/mock_label_registry-health-check'
+		exit 0
+		;;
+	*issue*list*)
+		echo "0"
+		exit 0
+		;;
+	*issue*create*)
+		echo "https://github.com/lgtm-hq/lgtm-ci/issues/99"
+		exit 0
+		;;
+	*)
+		exit 1
+		;;
+esac
+EOF
+	chmod +x "${BATS_TEST_TMPDIR}/bin/gh"
+	export PATH="${BATS_TEST_TMPDIR}/bin:${PATH}"
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	assert_output --partial "Opened registry health issue"
+	run grep -F "registry-health-check" "${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_success
+}
+
+@test "open-registry-health-issue: skips when an open issue already exists" {
+	mock_command_multi "gh" '
+		*issue*list*) echo "1";;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	assert_output --partial "Open registry health issue already exists"
+}
+
+@test "open-registry-health-issue: fails when duplicate check output is invalid" {
+	mock_command_multi "gh" '
+		*issue*list*) echo "warning: rate limit";;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_failure
+	assert_output --partial "Could not check for existing registry health issues"
+}
+
+@test "open-registry-health-issue: fails when GITHUB_REPOSITORY is unset" {
+	unset GITHUB_REPOSITORY
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_failure
+	assert_output --partial "GITHUB_REPOSITORY is required"
+}
+
+@test "open-registry-health-issue: creates issue in the configured repository" {
+	mkdir -p "${BATS_TEST_TMPDIR}/bin"
+	cat >"${BATS_TEST_TMPDIR}/bin/gh" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> '${BATS_TEST_TMPDIR}/mock_calls_gh'
+case "\$*" in
+	*label*view*registry-health-check*)
+		exit 0
+		;;
+	*issue*list*)
+		echo "0"
+		exit 0
+		;;
+	*issue*create*)
+		echo "https://github.com/lgtm-hq/lgtm-ci/issues/99"
+		exit 0
+		;;
+	*)
+		exit 1
+		;;
+esac
+EOF
+	chmod +x "${BATS_TEST_TMPDIR}/bin/gh"
+	export PATH="${BATS_TEST_TMPDIR}/bin:${PATH}"
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	run grep -F -- "--repo" "${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_success
+	run grep -F "lgtm-hq/lgtm-ci" "${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_success
+}
+
+@test "open-registry-health-issue: ensures ISSUE_LABELS exist before creation" {
+	mkdir -p "${BATS_TEST_TMPDIR}/bin"
+	cat >"${BATS_TEST_TMPDIR}/bin/gh" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> '${BATS_TEST_TMPDIR}/mock_calls_gh'
+label_state_dir='${BATS_TEST_TMPDIR}/mock_labels'
+mkdir -p "\$label_state_dir"
+case "\$*" in
+	*label*view*)
+		for label in registry-health-check ci maintenance; do
+			if [[ "\$*" == *"label view \$label"* ]]; then
+				[[ -f "\$label_state_dir/\$label" ]] && exit 0
+				exit 1
+			fi
+		done
+		exit 1
+		;;
+	*label*create*)
+		for label in registry-health-check ci maintenance; do
+			if [[ "\$*" == *"label create \$label"* ]]; then
+				touch "\$label_state_dir/\$label"
+				exit 0
+			fi
+		done
+		exit 0
+		;;
+	*issue*list*)
+		echo "0"
+		exit 0
+		;;
+	*issue*create*)
+		echo "https://github.com/lgtm-hq/lgtm-ci/issues/99"
+		exit 0
+		;;
+	*)
+		exit 1
+		;;
+esac
+EOF
+	chmod +x "${BATS_TEST_TMPDIR}/bin/gh"
+	export PATH="${BATS_TEST_TMPDIR}/bin:${PATH}"
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export ISSUE_LABELS="ci,maintenance"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	run grep -F "label create ci" "${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_success
+	run grep -F "label create maintenance" "${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_success
+}
+
+@test "open-registry-health-issue: tolerates concurrent dedup label creation" {
+	mkdir -p "${BATS_TEST_TMPDIR}/bin"
+	cat >"${BATS_TEST_TMPDIR}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "${MOCK_CALLS}"
+case "$*" in
+	*label*view*registry-health-check*)
+		if [[ -f "${MOCK_LABEL_EXISTS}" ]]; then
+			exit 0
+		fi
+		exit 1
+		;;
+	*label*create*registry-health-check*)
+		touch "${MOCK_LABEL_EXISTS}"
+		echo "label already exists" >&2
+		exit 1
+		;;
+	*issue*list*)
+		echo "0"
+		exit 0
+		;;
+	*issue*create*)
+		echo "https://github.com/lgtm-hq/lgtm-ci/issues/99"
+		exit 0
+		;;
+	*)
+		exit 1
+		;;
+esac
+EOF
+	chmod +x "${BATS_TEST_TMPDIR}/bin/gh"
+	export PATH="${BATS_TEST_TMPDIR}/bin:${PATH}"
+	export MOCK_CALLS="${BATS_TEST_TMPDIR}/mock_calls_gh"
+	export MOCK_LABEL_EXISTS="${BATS_TEST_TMPDIR}/mock_label_exists"
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export MOCK_CALLS="'"$MOCK_CALLS"'"
+		export MOCK_LABEL_EXISTS="'"$MOCK_LABEL_EXISTS"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+}

--- a/tests/bats/integration/test_registry_health_check.bats
+++ b/tests/bats/integration/test_registry_health_check.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Integration tests for registry-health-check maintenance script
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/maintenance/registry-health-check.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+	export LIB_DIR
+	export BATS_TEST_TMPDIR
+	export PROJECT_ROOT
+	export SCRIPT
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+@test "registry-health-check: passes when all digest pins resolve" {
+	local scan_dir="${BATS_TEST_TMPDIR}/scan"
+	mkdir -p "$scan_dir"
+	cat >"${scan_dir}/workflow.yml" <<'YAML'
+jobs:
+  quality:
+    env:
+      LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro@sha256:1ff3db35939283734b859c7c5d95be87fd8fd62734b3434e0437769d50d53578
+YAML
+
+	mock_command_multi "docker" '
+		*manifest*inspect*) exit 0;;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	assert_output --partial "All digest-pinned container images resolve"
+}
+
+@test "registry-health-check: fails when a digest pin is unreachable" {
+	local scan_dir="${BATS_TEST_TMPDIR}/scan"
+	mkdir -p "$scan_dir"
+	cat >"${scan_dir}/workflow.yml" <<'YAML'
+jobs:
+  quality:
+    env:
+      LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+YAML
+
+	mock_command_multi "docker" '
+		*manifest*inspect*) exit 1;;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_failure
+	assert_output --partial "digest unreachable after 3 manifest inspect attempts"
+}
+
+@test "registry-health-check: ignores markdown files in scan paths" {
+	local scan_dir="${BATS_TEST_TMPDIR}/scan"
+	mkdir -p "$scan_dir"
+	cat >"${scan_dir}/docs.md" <<'MD'
+Example only: ghcr.io/lgtm-hq/py-lintro@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+MD
+
+	mock_command_record "docker" "" 0
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	assert_output --partial "No digest-pinned container images found"
+	run test ! -s "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+}
+
+@test "registry-health-check: strips docker:// prefix before manifest inspect" {
+	local scan_dir="${BATS_TEST_TMPDIR}/scan"
+	mkdir -p "$scan_dir"
+	cat >"${scan_dir}/workflow.yml" <<'YAML'
+jobs:
+  container:
+    steps:
+      - uses: docker://ghcr.io/lgtm-hq/py-lintro@sha256:1ff3db35939283734b859c7c5d95be87fd8fd62734b3434e0437769d50d53578
+YAML
+
+	mock_command_multi "docker" '
+		*manifest*inspect*ghcr.io/lgtm-hq/py-lintro@sha256:1ff3db35939283734b859c7c5d95be87fd8fd62734b3434e0437769d50d53578*) exit 0;;
+		*manifest*inspect*) exit 1;;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	assert_output --partial "All digest-pinned container images resolve"
+}
+
+@test "registry-health-check: deduplicates repeated digest pins" {
+	local scan_dir="${BATS_TEST_TMPDIR}/scan"
+	mkdir -p "$scan_dir"
+	cat >"${scan_dir}/a.yml" <<'YAML'
+image: ghcr.io/lgtm-hq/py-lintro@sha256:1ff3db35939283734b859c7c5d95be87fd8fd62734b3434e0437769d50d53578
+YAML
+	cp "${scan_dir}/a.yml" "${scan_dir}/b.yml"
+
+	mock_command_record "docker" "" 0
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	run bash -c 'wc -l < "'"${BATS_TEST_TMPDIR}"'/mock_calls_docker" | tr -d " "'
+	assert_output "1"
+}

--- a/tests/bats/integration/test_registry_health_check.bats
+++ b/tests/bats/integration/test_registry_health_check.bats
@@ -114,6 +114,56 @@ YAML
 	assert_output --partial "All digest-pinned container images resolve"
 }
 
+@test "registry-health-check: ignores digest pins in YAML comment lines" {
+	local scan_dir="${BATS_TEST_TMPDIR}/scan"
+	mkdir -p "$scan_dir"
+	cat >"${scan_dir}/workflow.yml" <<'YAML'
+jobs:
+  quality:
+    env:
+      # LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+      LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro@sha256:1ff3db35939283734b859c7c5d95be87fd8fd62734b3434e0437769d50d53578
+YAML
+
+	mock_command_record "docker" "" 0
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	run bash -c 'wc -l < "'"${BATS_TEST_TMPDIR}"'/mock_calls_docker" | tr -d " "'
+	assert_output "1"
+}
+
+@test "registry-health-check: sets digest-failure output when pins are unreachable" {
+	local scan_dir="${BATS_TEST_TMPDIR}/scan"
+	mkdir -p "$scan_dir"
+	cat >"${scan_dir}/workflow.yml" <<'YAML'
+jobs:
+  quality:
+    env:
+      LINTRO_IMAGE: ghcr.io/lgtm-hq/py-lintro@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+YAML
+
+	mock_command_multi "docker" '
+		*manifest*inspect*) exit 1;;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		export GITHUB_OUTPUT="'"${BATS_TEST_TMPDIR}"'/github_output"
+		: >"$GITHUB_OUTPUT"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_failure
+	run grep -F "digest-failure=true" "${BATS_TEST_TMPDIR}/github_output"
+	assert_success
+}
+
 @test "registry-health-check: deduplicates repeated digest pins" {
 	local scan_dir="${BATS_TEST_TMPDIR}/scan"
 	mkdir -p "$scan_dir"

--- a/tests/bats/integration/test_resolve_lintro_image.bats
+++ b/tests/bats/integration/test_resolve_lintro_image.bats
@@ -53,6 +53,19 @@ write_source() {
 	assert_output --partial "Lintro image definitions disagree"
 }
 
+@test "resolve-lintro-image: rejects mutable INPUT_LINTRO_IMAGE override" {
+	run bash -c '
+		export INPUT_LINTRO_IMAGE="ghcr.io/lgtm-hq/py-lintro:latest"
+		export GITHUB_OUTPUT="'"${BATS_TEST_TMPDIR}"'/github_output"
+		: >"$GITHUB_OUTPUT"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_failure
+	assert_output --partial "must be a digest-pinned"
+	run test ! -s "${BATS_TEST_TMPDIR}/github_output"
+	assert_success
+}
+
 @test "resolve-lintro-image: uses INPUT_LINTRO_IMAGE override when provided" {
 	run bash -c '
 		export INPUT_LINTRO_IMAGE="'"$IMAGE"'"

--- a/tests/bats/integration/test_resolve_lintro_image.bats
+++ b/tests/bats/integration/test_resolve_lintro_image.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Integration tests for resolve-lintro-image script
+
+load "../../helpers/common"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/quality/resolve-lintro-image.sh"
+IMAGE="ghcr.io/lgtm-hq/py-lintro@sha256:1ff3db35939283734b859c7c5d95be87fd8fd62734b3434e0437769d50d53578"
+
+setup() {
+	setup_temp_dir
+	export LIB_DIR
+	export BATS_TEST_TMPDIR
+	export PROJECT_ROOT
+	export SCRIPT
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+write_source() {
+	local file="$1"
+	local image="$2"
+	mkdir -p "$(dirname "$file")"
+	printf 'lintro-image: %s\n' "$image" >"$file"
+}
+
+@test "resolve-lintro-image: resolves matching digest pins from CI files" {
+	local root="${BATS_TEST_TMPDIR}/repo"
+	write_source "${root}/.github/workflows/reusable-quality-lint.yml" "$IMAGE"
+	write_source "${root}/.github/actions/run-quality/action.yml" "$IMAGE"
+
+	run bash -c '
+		cd "'"$root"'"
+		bash "$SCRIPT"
+	'
+	assert_success
+	assert_output --partial "$IMAGE"
+}
+
+@test "resolve-lintro-image: fails when CI files disagree on digest pin" {
+	local root="${BATS_TEST_TMPDIR}/repo"
+	write_source "${root}/.github/workflows/reusable-quality-lint.yml" "$IMAGE"
+	write_source "${root}/.github/actions/run-quality/action.yml" \
+		"ghcr.io/lgtm-hq/py-lintro@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+	run bash -c '
+		cd "'"$root"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_failure
+	assert_output --partial "Lintro image definitions disagree"
+}
+
+@test "resolve-lintro-image: uses INPUT_LINTRO_IMAGE override when provided" {
+	run bash -c '
+		export INPUT_LINTRO_IMAGE="'"$IMAGE"'"
+		export GITHUB_OUTPUT="'"${BATS_TEST_TMPDIR}"'/github_output"
+		: >"$GITHUB_OUTPUT"
+		bash "$SCRIPT"
+	'
+	assert_success
+	run grep -F "image=${IMAGE}" "${BATS_TEST_TMPDIR}/github_output"
+	assert_success
+}
+
+@test "resolve-lintro-image: ignores commented stale digest before active default pin" {
+	local root="${BATS_TEST_TMPDIR}/repo"
+	local stale="ghcr.io/lgtm-hq/py-lintro@sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	mkdir -p "${root}/.github/workflows"
+	cat >"${root}/.github/workflows/reusable-quality-lint.yml" <<YAML
+# lintro-image: ${stale}
+lintro-image:
+  description: pinned image
+  default: "${IMAGE}"
+YAML
+	write_source "${root}/.github/actions/run-quality/action.yml" "$IMAGE"
+
+	run bash -c '
+		cd "'"$root"'"
+		bash "$SCRIPT"
+	'
+	assert_success
+	assert_output --partial "$IMAGE"
+	refute_output --partial "deadbeef"
+}
+
+@test "resolve-lintro-image: resolves digest from default under lintro-image block" {
+	local root="${BATS_TEST_TMPDIR}/repo"
+	mkdir -p "${root}/.github/workflows"
+	cat >"${root}/.github/workflows/reusable-quality-lint.yml" <<YAML
+lintro-image:
+  description: pinned image
+  default: "${IMAGE}"
+YAML
+	write_source "${root}/.github/actions/run-quality/action.yml" "$IMAGE"
+
+	run bash -c '
+		cd "'"$root"'"
+		bash "$SCRIPT"
+	'
+	assert_success
+	assert_output --partial "$IMAGE"
+}
+
+@test "resolve-lintro-image: resolves digest from block-scalar default value" {
+	local root="${BATS_TEST_TMPDIR}/repo"
+	mkdir -p "${root}/.github/workflows"
+	cat >"${root}/.github/workflows/reusable-quality-lint.yml" <<YAML
+lintro-image:
+  description: pinned image
+  default: >-
+    ${IMAGE}
+YAML
+	write_source "${root}/.github/actions/run-quality/action.yml" "$IMAGE"
+
+	run bash -c '
+		cd "'"$root"'"
+		bash "$SCRIPT"
+	'
+	assert_success
+	assert_output --partial "$IMAGE"
+}
+
+@test "resolve-lintro-image: fails when source file has no digest pin" {
+	local root="${BATS_TEST_TMPDIR}/repo"
+	mkdir -p "${root}/.github/workflows"
+	cat >"${root}/.github/workflows/reusable-quality-lint.yml" <<YAML
+lintro-image:
+  description: pinned image
+  default: "ghcr.io/lgtm-hq/py-lintro:latest"
+YAML
+	write_source "${root}/.github/actions/run-quality/action.yml" "$IMAGE"
+
+	run bash -c '
+		cd "'"$root"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_failure
+	assert_output --partial "No digest-pinned lintro image found"
+}
+
+@test "resolve-lintro-image: fails when LINTRO_IMAGE_SOURCES is whitespace only" {
+	local root="${BATS_TEST_TMPDIR}/repo"
+	write_source "${root}/.github/workflows/reusable-quality-lint.yml" "$IMAGE"
+	write_source "${root}/.github/actions/run-quality/action.yml" "$IMAGE"
+
+	run bash -c '
+		cd "'"$root"'"
+		export LINTRO_IMAGE_SOURCES="   "
+		bash "$SCRIPT" 2>&1
+	'
+	assert_failure
+	assert_output --partial "No lintro image sources specified in LINTRO_IMAGE_SOURCES"
+}

--- a/tests/bats/integration/test_validate_action_pinning_verify_tags.bats
+++ b/tests/bats/integration/test_validate_action_pinning_verify_tags.bats
@@ -1,0 +1,368 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Integration tests for SHA-to-tag verification in validate-action-pinning
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+load "../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/validate-action-pinning.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+	setup_github_env
+	export LIB_DIR
+	export BATS_TEST_TMPDIR
+	export PROJECT_ROOT
+	export SCRIPT
+}
+
+teardown() {
+	restore_path
+	teardown_github_env
+	teardown_temp_dir
+}
+
+create_workflow() {
+	local dir="$1"
+	local filename="$2"
+	local content="$3"
+	mkdir -p "$dir"
+	printf '%s\n' "$content" >"${dir}/${filename}"
+}
+
+@test "validate-action-pinning: verify-tags reuses tag resolution cache across duplicate pins" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+'
+
+	mkdir -p "${BATS_TEST_TMPDIR}/bin"
+	cat >"${BATS_TEST_TMPDIR}/bin/gh" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> '${BATS_TEST_TMPDIR}/mock_calls_gh'
+case "\$*" in
+	*repos/actions/checkout/commits/v4*)
+		echo "a5ac7e51b41094c92402da3b24376905380afc29"
+		exit 0
+		;;
+	*)
+		exit 1
+		;;
+esac
+EOF
+	chmod +x "${BATS_TEST_TMPDIR}/bin/gh"
+	export PATH="${BATS_TEST_TMPDIR}/bin:${PATH}"
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export INPUT_ENFORCE=true
+		export INPUT_VERIFY_TAGS=true
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	run bash -c 'grep -c "repos/actions/checkout/commits/v4" "'"${BATS_TEST_TMPDIR}"'/mock_calls_gh" || true'
+	assert_output "1"
+}
+
+@test "validate-action-pinning: verify-tags passes when comment tag resolves to pinned SHA" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+'
+
+	mock_command_multi "gh" '
+		*repos/actions/checkout/commits/v4*) echo "a5ac7e51b41094c92402da3b24376905380afc29";;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export INPUT_ENFORCE=true
+		export INPUT_VERIFY_TAGS=true
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	assert_output --partial "Verifying 1 Renovate version comment"
+}
+
+@test "validate-action-pinning: verify-tags warns when tag resolution returns null SHA" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+'
+
+	mock_command_multi "gh" '
+		*repos/actions/checkout/commits/v4*) echo "null";;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export INPUT_ENFORCE=true
+		export INPUT_VERIFY_TAGS=true
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	assert_output --partial "could not resolve v4 via GitHub API"
+	assert_output --partial "verification warning"
+	refute_output --partial "All action references follow SHA pinning"
+	refute_output --partial "action pinning violation"
+	assert_github_output "warnings" "1"
+}
+
+@test "validate-action-pinning: verify-tags fails when pinned SHA mismatches comment tag" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0000000000000000000000000000000000000001 # v4
+'
+
+	mock_command_multi "gh" '
+		*repos/actions/checkout/commits/v4*) echo "a5ac7e51b41094c92402da3b24376905380afc29";;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export INPUT_ENFORCE=true
+		export INPUT_VERIFY_TAGS=true
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_failure
+	assert_output --partial "pinned SHA does not match v4"
+}
+
+@test "validate-action-pinning: verify-tags resolves pre-release version comments" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.2.2-rc.1
+'
+
+	mock_command_multi "gh" '
+		*repos/actions/checkout/commits/v4.2.2-rc.1*) echo "a5ac7e51b41094c92402da3b24376905380afc29";;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export INPUT_ENFORCE=true
+		export INPUT_VERIFY_TAGS=true
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	assert_output --partial "Verifying 1 Renovate version comment"
+}
+
+@test "validate-action-pinning: audit-transitive skips reusable workflow refs" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v4
+'
+
+	mkdir -p "${BATS_TEST_TMPDIR}/bin"
+	cat >"${BATS_TEST_TMPDIR}/bin/gh" <<EOF
+#!/usr/bin/env bash
+echo "unexpected gh call: \$*" >&2
+exit 1
+EOF
+	chmod +x "${BATS_TEST_TMPDIR}/bin/gh"
+	export PATH="${BATS_TEST_TMPDIR}/bin:${PATH}"
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export INPUT_ENFORCE=true
+		export INPUT_AUDIT_TRANSITIVE=true
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	refute_output --partial "could not fetch composite action manifest"
+	refute_output --partial "unexpected gh call"
+	assert_github_output "warnings" "0"
+}
+
+@test "validate-action-pinning: audit-transitive skips when action content is unavailable" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: example/composite-action@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v1.0.0
+'
+
+	mock_command_multi "gh" '
+		*repos/example/composite-action/contents/action.yml?ref=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa*) echo "null";;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export INPUT_ENFORCE=true
+		export INPUT_AUDIT_TRANSITIVE=true
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	assert_output --partial "could not fetch composite action manifest for transitive audit"
+}
+
+@test "validate-action-pinning: audit-transitive falls back to action.yaml manifests" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: example/composite-action@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v1.0.0
+'
+
+	local encoded
+	encoded="$(printf '%s' '---
+runs:
+  using: composite
+  steps:
+    - uses: aquasecurity/setup-trivy@v0.2.2
+' | base64 | tr -d '\n')"
+
+	mock_command_multi "gh" "
+		*repos/example/composite-action/contents/action.yml?ref=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa*) exit 1;;
+		*repos/example/composite-action/contents/action.yaml?ref=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa*) echo '${encoded}';;
+		*) exit 1;;
+	"
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export INPUT_ENFORCE=true
+		export INPUT_AUDIT_TRANSITIVE=true
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	assert_output --partial "verification warning"
+}
+
+@test "validate-action-pinning: prints warnings before enforce exit when offenders exist" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: example/composite-action@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v1.0.0
+'
+
+	local encoded
+	encoded="$(printf '%s' '---
+runs:
+  using: composite
+  steps:
+    - uses: aquasecurity/setup-trivy@v0.2.2
+' | base64 | tr -d '\n')"
+
+	mock_command_multi "gh" "
+		*repos/example/composite-action/contents/action.yml?ref=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa*) echo '${encoded}';;
+		*) exit 1;;
+	"
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export INPUT_ENFORCE=true
+		export INPUT_AUDIT_TRANSITIVE=true
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_failure
+	assert_output --partial "action pinning violation"
+	assert_output --partial "verification warning"
+	assert_output --partial "aquasecurity/setup-trivy@v0.2.2"
+	assert_github_output "offenders" "1"
+	assert_github_output "warnings" "1"
+}
+
+@test "validate-action-pinning: audit-transitive warns on nested mutable tag refs" {
+	local scan_dir="${BATS_TEST_TMPDIR}/workflows"
+	create_workflow "$scan_dir" "ci.yml" '
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: example/composite-action@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # v1.0.0
+'
+
+	local encoded
+	encoded="$(printf '%s' '---
+runs:
+  using: composite
+  steps:
+    - uses: aquasecurity/setup-trivy@v0.2.2
+' | base64 | tr -d '\n')"
+
+	mock_command_multi "gh" "
+		*repos/example/composite-action/contents/action.yml?ref=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa*) echo '${encoded}';;
+		*) exit 1;;
+	"
+
+	run bash -c '
+		export PATH="'"$PATH"'"
+		export INPUT_ENFORCE=true
+		export INPUT_AUDIT_TRANSITIVE=true
+		export INPUT_SCAN_PATHS="'"$scan_dir"'"
+		bash "$SCRIPT" 2>&1
+	'
+	assert_success
+	assert_output --partial "verification warning"
+	assert_output --partial "aquasecurity/setup-trivy@v0.2.2"
+}

--- a/tests/bats/integration/test_version_drift_workflows.bats
+++ b/tests/bats/integration/test_version_drift_workflows.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for version-drift prevention workflows (#98)
+
+load "../../helpers/common"
+
+@test "validate-action-pinning workflow: calls reusable with verify-tags enabled" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/validate-action-pinning.yml"
+
+	run grep -E 'uses: \./\.github/workflows/reusable-validate-action-pinning\.yml' "$workflow"
+	assert_success
+	run grep -E 'verify-tags: true' "$workflow"
+	assert_success
+	run grep -E 'audit-transitive: true' "$workflow"
+	assert_success
+}
+
+@test "dependency-review workflow: calls reusable dependency review" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/dependency-review.yml"
+
+	run grep -E 'uses: \./\.github/workflows/reusable-dependency-review\.yml' "$workflow"
+	assert_success
+}
+
+@test "validate-lintro-version workflow: triggers on pyproject and lintro image paths" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/validate-lintro-version.yml"
+
+	run grep -F "pyproject.toml" "$workflow"
+	assert_success
+	run grep -F "reusable-quality-lint.yml" "$workflow"
+	assert_success
+	run grep -F "reusable-validate-lintro-version.yml" "$workflow"
+	assert_success
+}
+
+@test "validate-lintro-version workflow: runs on merge_group" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/validate-lintro-version.yml"
+
+	run grep -F "merge_group:" "$workflow"
+	assert_success
+}
+
+@test "validate-lintro-version workflow: bootstraps tooling from PR head when base lacks scripts" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/validate-lintro-version.yml"
+	local reusable="${PROJECT_ROOT}/.github/workflows/reusable-validate-lintro-version.yml"
+
+	run grep -F "tooling-ref-fallback:" "$workflow"
+	assert_success
+	run grep -F "pull_request.head.sha" "$workflow"
+	assert_success
+	run grep -F "tooling-ref-fallback:" "$reusable"
+	assert_success
+	run grep -F "BOOTSTRAP_SCRIPT:" "$reusable"
+	assert_success
+	run grep -F 'inputs.tooling-bootstrap-script' "$reusable"
+	assert_success
+	run grep -F "tooling-bootstrap-script:" "$workflow"
+	assert_success
+	if grep -qE 'run:[[:space:]]*[|>][-+]?' "$reusable"; then
+		fail "reusable workflow contains inline multiline run blocks"
+	fi
+}
+
+@test "registry-health-check workflow: runs on schedule and workflow_dispatch" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/registry-health-check.yml"
+
+	run grep -F "cron: '0 2 * * 1'" "$workflow"
+	assert_success
+	run grep -F "workflow_dispatch" "$workflow"
+	assert_success
+}
+
+@test "registry-health-check workflow: grants issues write for issue opening" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/registry-health-check.yml"
+
+	run grep -F "issues: write" "$workflow"
+	assert_success
+	run grep -F "open-issue-on-failure: true" "$workflow"
+	assert_success
+}
+
+@test "reusable-registry-health-check: scopes issue creation to follow-up job" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-registry-health-check.yml"
+
+	run grep -F "open-registry-health-issue:" "$workflow"
+	assert_success
+	run grep -E "if: failure\(\) && inputs\.open-issue-on-failure" "$workflow"
+	assert_success
+}
+
+@test "reusable-registry-health-check: hardens egress on issue follow-up job" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-registry-health-check.yml"
+
+	run awk '
+		/open-registry-health-issue:/ { in_job = 1 }
+		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /open-registry-health-issue:/ {
+			in_job = 0
+		}
+		in_job && /harden-runner/ { found = 1; exit }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+	run awk '
+		/open-registry-health-issue:/ { in_job = 1 }
+		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /open-registry-health-issue:/ {
+			in_job = 0
+		}
+		in_job && /egress-preset: github-minimal/ { found = 1; exit }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-registry-health-check: grants contents read to issue job checkout" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-registry-health-check.yml"
+
+	run awk '
+		/open-registry-health-issue:/ { in_job = 1; in_perms = 0 }
+		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /open-registry-health-issue:/ {
+			in_job = 0
+			in_perms = 0
+		}
+		in_job && /permissions:/ { in_perms = 1 }
+		in_perms && /contents: read/ { found = 1; exit }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+}

--- a/tests/bats/integration/test_version_drift_workflows.bats
+++ b/tests/bats/integration/test_version_drift_workflows.bats
@@ -31,6 +31,14 @@ load "../../helpers/common"
 	assert_success
 	run grep -F "reusable-validate-lintro-version.yml" "$workflow"
 	assert_success
+	run grep -F ".github/workflows/validate-lintro-version.yml" "$workflow"
+	assert_success
+	run grep -F "scripts/ci/quality/check-lintro-tooling-bootstrap.sh" "$workflow"
+	assert_success
+	run grep -F "scripts/ci/quality/resolve-lintro-image.sh" "$workflow"
+	assert_success
+	run grep -F "scripts/ci/quality/validate-lintro-version.sh" "$workflow"
+	assert_success
 }
 
 @test "validate-lintro-version workflow: runs on merge_group" {
@@ -84,7 +92,9 @@ load "../../helpers/common"
 
 	run grep -F "open-registry-health-issue:" "$workflow"
 	assert_success
-	run grep -E "if: failure\(\) && inputs\.open-issue-on-failure" "$workflow"
+	run grep -F "needs.registry-health.outputs.digest-failure == 'true'" "$workflow"
+	assert_success
+	run grep -F "digest-failure: \${{ steps.health.outputs.digest-failure }}" "$workflow"
 	assert_success
 }
 


### PR DESCRIPTION
## Summary

Implement multi-layered version-drift prevention for lgtm-ci: enforce action pinning in CI, verify Renovate SHA-to-tag comments via GitHub API, audit transitive composite-action references, add dependency review and scheduled registry health checks, and gate lintro version sync on PRs that touch CI image pins.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #98

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add version-drift prevention CI workflows and scripts for action pinning and registry health
> - Extends [`validate-action-pinning.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/303/files#diff-0ce4a2e993bff4ddd8efacb503d5c3b875d9b3b57b9927ea3f539a9a6aa6b191) to optionally verify Renovate version comments against pinned SHAs via the GitHub API and audit nested composite actions for mutable tag refs, emitting a new `warnings` output.
> - Adds a reusable registry health check workflow and [`registry-health-check.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/303/files#diff-db4195517b12428a0b1c92b733fc3cb55041205a57e257ffa8d6ea2673238882) that scans YAML files for digest-pinned container images, verifies each digest is reachable, and opens a deduplication-labeled GitHub issue on failure.
> - Adds a reusable lintro version validation workflow and [`resolve-lintro-image.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/303/files#diff-05999b09f1547996d325a6e8fa1094692be7ec8a3a2e1184f8df9f1ad617af80) that resolves the canonical `ghcr.io/lgtm-hq/py-lintro` digest pin and checks it matches `pyproject` configuration.
> - Wires all new functionality into trigger workflows for PRs, pushes to main, merge groups, and (for registry health) a weekly schedule.
> - Covers new scripts with Bats integration tests for bootstrap detection, issue creation deduplication, digest verification, image pin resolution, tag-to-SHA caching, and workflow wiring.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e73aa1e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflows for action-pin validation, dependency review, registry health checks, and lintro-version validation
  * New CI utilities to verify registry image digests, open a deduplicated issue on failures, resolve canonical lintro images, and check lint tooling bootstrap
  * Action-pinning validation gains optional tag-verification and transitive-audit modes and now exposes a warnings summary

* **Tests**
  * Added comprehensive integration tests covering registry checks, issue creation, lintro resolution, action-pinning verification, and workflow contract assertions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR implements a multi-layered version-drift prevention system: it extends the existing action-pinning validator with SHA↔tag verification (via GitHub API) and transitive composite-action auditing, adds a scheduled registry health check that verifies digest-pinned images are still reachable, introduces a lintro image version consistency check between `pyproject.toml` and CI files, and wires all new scripts into caller and reusable workflows with harden-runner egress controls.

- **`validate-action-pinning.sh`** gains a two-phase queue-then-flush design for tag resolution with a correct in-process cache (global `RESOLVED_TAG_SHA` avoids the subshell cache-miss trap) and a transitive audit that fetches composite action manifests at their pinned SHAs via the GitHub API.
- **`registry-health-check.sh` + `open-registry-health-issue.sh`** implement a scheduled weekly digest reachability scan with retry logic, label-based deduplication, and a two-job workflow structure so issue creation only fires when the health step itself fails.
- **`resolve-lintro-image.sh` + `validate-lintro-version.sh`** enforce that the digest pin in CI files matches the lintro version pinned in `pyproject.toml`, with a bootstrap fallback for PRs that introduce the scripts themselves.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the docker run hang risk in validate-lintro-version.sh.

The validate-lintro-version.sh script calls docker run without a timeout. 2>/dev/null hides all stderr and || true only handles a non-zero exit — neither prevents the step from blocking if the image pull stalls on a flaky network. A misconfigured or temporarily unavailable GHCR endpoint would cause the job to hang until the 6-hour GitHub Actions default, stalling any merge that touches lintro-related paths.

scripts/ci/quality/validate-lintro-version.sh — the docker run call needs a timeout guard before this workflow can be considered reliable for blocking PR merges.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/ci/quality/validate-lintro-version.sh | Runs `docker run` to extract lintro version but applies no timeout; a hung image pull blocks the job indefinitely. Version extraction regex picks the first three-part version string, which may match the Python interpreter version if the output format changes. |
| scripts/ci/actions/validate-action-pinning.sh | Adds verify-tags and audit-transitive modes. Cache correctly avoids subshells by using a RESOLVED_TAG_SHA global and calling cache_set in the parent shell. Two-phase queue-then-flush design is sound. |
| scripts/ci/maintenance/registry-health-check.sh | New script scans YAML files for digest-pinned container images and verifies each via docker manifest inspect with 3 retries and configurable timeout. Deduplication, comment-line skipping, and docker:// prefix stripping all look correct. |
| scripts/ci/maintenance/open-registry-health-issue.sh | ensure_issue_label handles concurrent creation correctly via check-create-recheck pattern. Pre-existing review threads cover the label deduplication concerns addressed in this version. |
| .github/workflows/reusable-validate-lintro-version.yml | Reusable workflow with proper sparse-checkout, fallback tooling-ref bootstrap logic, and GHCR login. Uses egress-preset quality — callers adding docker pull steps should verify the preset includes ghcr.io pull endpoints. |
| .github/workflows/reusable-registry-health-check.yml | Two-job structure with digest-failure job output gating the issue-creation job. Uses docker egress-preset for health job and github-minimal for issue job. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR / push to main] -->|.github/workflows/** changed| B[validate-action-pinning.yml]
    A -->|pyproject.toml or lintro scripts changed| C[validate-lintro-version.yml]
    A -->|any dependency change| D[dependency-review.yml]
    E[Schedule: Mon 02:00 UTC] --> F[registry-health-check.yml]
    B --> B1[reusable-validate-action-pinning.yml]
    B1 --> B2[validate-action-pinning.sh]
    B2 --> B3{verify-tags?}
    B3 -->|yes| B4[gh api: resolve tag to SHA]
    B3 -->|no| B5[Basic SHA pin check]
    B2 --> B6{audit-transitive?}
    B6 -->|yes| B7[gh api: fetch composite action YAML]
    C --> C1[reusable-validate-lintro-version.yml]
    C1 --> C2[check-lintro-tooling-bootstrap.sh]
    C2 -->|needs-fallback=false| C3[resolve-lintro-image.sh]
    C2 -->|needs-fallback=true| C4[Checkout tooling from head SHA] --> C3
    C3 --> C5[validate-lintro-version.sh: docker run lintro --version]
    F --> F1[reusable-registry-health-check.yml]
    F1 --> F2[registry-health-check.sh: docker manifest inspect]
    F2 -->|digest-failure=true| F3[open-registry-health-issue.sh]
    F2 -->|all OK| F4[Exit 0]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/ci/actions/validate-action-pinning.sh`, line 670-692 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/9ebbb8ad2b64315699aea6e2a0d379c47f3f8c8d/scripts/ci/actions/validate-action-pinning.sh#L670-L692)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Cache always misses — every tag triggers a fresh API call**

   `resolve_tag_to_sha` is only ever invoked via command substitution (`resolved_sha="$(resolve_tag_to_sha ...)"`) in `verify_queued_pins`. Command substitution forks a subshell that inherits a *copy* of `TAG_SHA_CACHE_KEYS`/`TAG_SHA_CACHE_VALUES`; any `cache_set` calls made inside that subshell are discarded when it exits. The parent shell's arrays are therefore never populated, so every entry in `PIN_VERIFY_QUEUE` — including repeated references to the same `(org, repo, tag)` tuple across multiple files — triggers a separate GitHub API call. In a repo with many uniformly-pinned actions, this can exhaust the `GITHUB_TOKEN` rate limit mid-run, causing the entire verify pass to silently fall back to warnings and produce a misleading "all OK" result.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Factions%2Fvalidate-action-pinning.sh%0ALine%3A%20670-692%0A%0AComment%3A%0A**Cache%20always%20misses%20%E2%80%94%20every%20tag%20triggers%20a%20fresh%20API%20call**%0A%0A%60resolve_tag_to_sha%60%20is%20only%20ever%20invoked%20via%20command%20substitution%20%28%60resolved_sha%3D%22%24%28resolve_tag_to_sha%20...%29%22%60%29%20in%20%60verify_queued_pins%60.%20Command%20substitution%20forks%20a%20subshell%20that%20inherits%20a%20*copy*%20of%20%60TAG_SHA_CACHE_KEYS%60%2F%60TAG_SHA_CACHE_VALUES%60%3B%20any%20%60cache_set%60%20calls%20made%20inside%20that%20subshell%20are%20discarded%20when%20it%20exits.%20The%20parent%20shell's%20arrays%20are%20therefore%20never%20populated%2C%20so%20every%20entry%20in%20%60PIN_VERIFY_QUEUE%60%20%E2%80%94%20including%20repeated%20references%20to%20the%20same%20%60%28org%2C%20repo%2C%20tag%29%60%20tuple%20across%20multiple%20files%20%E2%80%94%20triggers%20a%20separate%20GitHub%20API%20call.%20In%20a%20repo%20with%20many%20uniformly-pinned%20actions%2C%20this%20can%20exhaust%20the%20%60GITHUB_TOKEN%60%20rate%20limit%20mid-run%2C%20causing%20the%20entire%20verify%20pass%20to%20silently%20fall%20back%20to%20warnings%20and%20produce%20a%20misleading%20%22all%20OK%22%20result.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=303&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Factions%2Fvalidate-action-pinning.sh%0ALine%3A%20670-692%0A%0AComment%3A%0A**Cache%20always%20misses%20%E2%80%94%20every%20tag%20triggers%20a%20fresh%20API%20call**%0A%0A%60resolve_tag_to_sha%60%20is%20only%20ever%20invoked%20via%20command%20substitution%20%28%60resolved_sha%3D%22%24%28resolve_tag_to_sha%20...%29%22%60%29%20in%20%60verify_queued_pins%60.%20Command%20substitution%20forks%20a%20subshell%20that%20inherits%20a%20*copy*%20of%20%60TAG_SHA_CACHE_KEYS%60%2F%60TAG_SHA_CACHE_VALUES%60%3B%20any%20%60cache_set%60%20calls%20made%20inside%20that%20subshell%20are%20discarded%20when%20it%20exits.%20The%20parent%20shell's%20arrays%20are%20therefore%20never%20populated%2C%20so%20every%20entry%20in%20%60PIN_VERIFY_QUEUE%60%20%E2%80%94%20including%20repeated%20references%20to%20the%20same%20%60%28org%2C%20repo%2C%20tag%29%60%20tuple%20across%20multiple%20files%20%E2%80%94%20triggers%20a%20separate%20GitHub%20API%20call.%20In%20a%20repo%20with%20many%20uniformly-pinned%20actions%2C%20this%20can%20exhaust%20the%20%60GITHUB_TOKEN%60%20rate%20limit%20mid-run%2C%20causing%20the%20entire%20verify%20pass%20to%20silently%20fall%20back%20to%20warnings%20and%20produce%20a%20misleading%20%22all%20OK%22%20result.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=303&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F98-implement-comprehensive-version-drift-prevention%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F98-implement-comprehensive-version-drift-prevention%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Factions%2Fvalidate-action-pinning.sh%0ALine%3A%20670-692%0A%0AComment%3A%0A**Cache%20always%20misses%20%E2%80%94%20every%20tag%20triggers%20a%20fresh%20API%20call**%0A%0A%60resolve_tag_to_sha%60%20is%20only%20ever%20invoked%20via%20command%20substitution%20%28%60resolved_sha%3D%22%24%28resolve_tag_to_sha%20...%29%22%60%29%20in%20%60verify_queued_pins%60.%20Command%20substitution%20forks%20a%20subshell%20that%20inherits%20a%20*copy*%20of%20%60TAG_SHA_CACHE_KEYS%60%2F%60TAG_SHA_CACHE_VALUES%60%3B%20any%20%60cache_set%60%20calls%20made%20inside%20that%20subshell%20are%20discarded%20when%20it%20exits.%20The%20parent%20shell's%20arrays%20are%20therefore%20never%20populated%2C%20so%20every%20entry%20in%20%60PIN_VERIFY_QUEUE%60%20%E2%80%94%20including%20repeated%20references%20to%20the%20same%20%60%28org%2C%20repo%2C%20tag%29%60%20tuple%20across%20multiple%20files%20%E2%80%94%20triggers%20a%20separate%20GitHub%20API%20call.%20In%20a%20repo%20with%20many%20uniformly-pinned%20actions%2C%20this%20can%20exhaust%20the%20%60GITHUB_TOKEN%60%20rate%20limit%20mid-run%2C%20causing%20the%20entire%20verify%20pass%20to%20silently%20fall%20back%20to%20warnings%20and%20produce%20a%20misleading%20%22all%20OK%22%20result.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=303&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Fquality%2Fvalidate-lintro-version.sh%3A42%0A%60docker%20run%60%20is%20called%20without%20a%20timeout.%20If%20the%20GHCR%20image%20pull%20stalls%20due%20to%20a%20transient%20network%20hiccup%20%28or%20the%20egress%20preset%20blocks%20Docker%20pull%20endpoints%29%2C%20this%20step%20hangs%20silently%20%E2%80%94%20%602%3E%2Fdev%2Fnull%60%20hides%20all%20stderr%2C%20and%20%60%7C%7C%20true%60%20only%20handles%20non-zero%20exits%2C%20not%20indefinite%20blocking.%20The%20job%20then%20waits%20the%20full%206-hour%20GitHub%20Actions%20default%20before%20being%20cancelled.%0A%0A%60%60%60suggestion%0ADOCKER_VERSION%3D%24%28timeout%20%22%24%7BLINTRO_DOCKER_TIMEOUT%3A-60%7D%22%20docker%20run%20--rm%20%22%24LINTRO_IMAGE%22%20lintro%20--version%202%3E%2Fdev%2Fnull%20%7C%20grep%20-oE%20'%5B0-9%5D%2B%5C.%5B0-9%5D%2B%5C.%5B0-9%5D%2B'%20%7C%20head%20-1%20%7C%7C%20true%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Fquality%2Fvalidate-lintro-version.sh%3A42%0AThe%20pipeline%20extracts%20the%20first%20three-part%20version%20string%20found%20in%20the%20output%20of%20%60lintro%20--version%60.%20If%20the%20container%20emits%20a%20Python%20runtime%20version%20%28e.g.%2C%20%60Python%203.11.5%60%29%20on%20stdout%20before%20the%20tool's%20own%20version%20line%2C%20%60head%20-1%60%20will%20pick%20up%20the%20interpreter%20version%20instead%20of%20lintro's%2C%20producing%20a%20false%20mismatch%20against%20%60pyproject.toml%60%20on%20every%20run.%20Anchoring%20the%20pattern%20to%20a%20%60lintro%60%20prefix%20makes%20the%20intent%20explicit%20and%20robust%20to%20output-format%20changes.%0A%0A%60%60%60suggestion%0ADOCKER_VERSION%3D%24%28docker%20run%20--rm%20%22%24LINTRO_IMAGE%22%20lintro%20--version%202%3E%2Fdev%2Fnull%20%5C%0A%09%7C%20grep%20-oE%20'lintro%5B%5B%3Aspace%3A%5D%5D%2B%5B0-9%5D%2B%5C.%5B0-9%5D%2B%5C.%5B0-9%5D%2B'%20%5C%0A%09%7C%20grep%20-oE%20'%5B0-9%5D%2B%5C.%5B0-9%5D%2B%5C.%5B0-9%5D%2B'%20%5C%0A%09%7C%20head%20-1%20%7C%7C%20true%29%0A%60%60%60%0A%0A&pr=303&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Fquality%2Fvalidate-lintro-version.sh%3A42%0A%60docker%20run%60%20is%20called%20without%20a%20timeout.%20If%20the%20GHCR%20image%20pull%20stalls%20due%20to%20a%20transient%20network%20hiccup%20%28or%20the%20egress%20preset%20blocks%20Docker%20pull%20endpoints%29%2C%20this%20step%20hangs%20silently%20%E2%80%94%20%602%3E%2Fdev%2Fnull%60%20hides%20all%20stderr%2C%20and%20%60%7C%7C%20true%60%20only%20handles%20non-zero%20exits%2C%20not%20indefinite%20blocking.%20The%20job%20then%20waits%20the%20full%206-hour%20GitHub%20Actions%20default%20before%20being%20cancelled.%0A%0A%60%60%60suggestion%0ADOCKER_VERSION%3D%24%28timeout%20%22%24%7BLINTRO_DOCKER_TIMEOUT%3A-60%7D%22%20docker%20run%20--rm%20%22%24LINTRO_IMAGE%22%20lintro%20--version%202%3E%2Fdev%2Fnull%20%7C%20grep%20-oE%20'%5B0-9%5D%2B%5C.%5B0-9%5D%2B%5C.%5B0-9%5D%2B'%20%7C%20head%20-1%20%7C%7C%20true%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Fquality%2Fvalidate-lintro-version.sh%3A42%0AThe%20pipeline%20extracts%20the%20first%20three-part%20version%20string%20found%20in%20the%20output%20of%20%60lintro%20--version%60.%20If%20the%20container%20emits%20a%20Python%20runtime%20version%20%28e.g.%2C%20%60Python%203.11.5%60%29%20on%20stdout%20before%20the%20tool's%20own%20version%20line%2C%20%60head%20-1%60%20will%20pick%20up%20the%20interpreter%20version%20instead%20of%20lintro's%2C%20producing%20a%20false%20mismatch%20against%20%60pyproject.toml%60%20on%20every%20run.%20Anchoring%20the%20pattern%20to%20a%20%60lintro%60%20prefix%20makes%20the%20intent%20explicit%20and%20robust%20to%20output-format%20changes.%0A%0A%60%60%60suggestion%0ADOCKER_VERSION%3D%24%28docker%20run%20--rm%20%22%24LINTRO_IMAGE%22%20lintro%20--version%202%3E%2Fdev%2Fnull%20%5C%0A%09%7C%20grep%20-oE%20'lintro%5B%5B%3Aspace%3A%5D%5D%2B%5B0-9%5D%2B%5C.%5B0-9%5D%2B%5C.%5B0-9%5D%2B'%20%5C%0A%09%7C%20grep%20-oE%20'%5B0-9%5D%2B%5C.%5B0-9%5D%2B%5C.%5B0-9%5D%2B'%20%5C%0A%09%7C%20head%20-1%20%7C%7C%20true%29%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=303&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F98-implement-comprehensive-version-drift-prevention%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F98-implement-comprehensive-version-drift-prevention%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Fquality%2Fvalidate-lintro-version.sh%3A42%0A%60docker%20run%60%20is%20called%20without%20a%20timeout.%20If%20the%20GHCR%20image%20pull%20stalls%20due%20to%20a%20transient%20network%20hiccup%20%28or%20the%20egress%20preset%20blocks%20Docker%20pull%20endpoints%29%2C%20this%20step%20hangs%20silently%20%E2%80%94%20%602%3E%2Fdev%2Fnull%60%20hides%20all%20stderr%2C%20and%20%60%7C%7C%20true%60%20only%20handles%20non-zero%20exits%2C%20not%20indefinite%20blocking.%20The%20job%20then%20waits%20the%20full%206-hour%20GitHub%20Actions%20default%20before%20being%20cancelled.%0A%0A%60%60%60suggestion%0ADOCKER_VERSION%3D%24%28timeout%20%22%24%7BLINTRO_DOCKER_TIMEOUT%3A-60%7D%22%20docker%20run%20--rm%20%22%24LINTRO_IMAGE%22%20lintro%20--version%202%3E%2Fdev%2Fnull%20%7C%20grep%20-oE%20'%5B0-9%5D%2B%5C.%5B0-9%5D%2B%5C.%5B0-9%5D%2B'%20%7C%20head%20-1%20%7C%7C%20true%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Fquality%2Fvalidate-lintro-version.sh%3A42%0AThe%20pipeline%20extracts%20the%20first%20three-part%20version%20string%20found%20in%20the%20output%20of%20%60lintro%20--version%60.%20If%20the%20container%20emits%20a%20Python%20runtime%20version%20%28e.g.%2C%20%60Python%203.11.5%60%29%20on%20stdout%20before%20the%20tool's%20own%20version%20line%2C%20%60head%20-1%60%20will%20pick%20up%20the%20interpreter%20version%20instead%20of%20lintro's%2C%20producing%20a%20false%20mismatch%20against%20%60pyproject.toml%60%20on%20every%20run.%20Anchoring%20the%20pattern%20to%20a%20%60lintro%60%20prefix%20makes%20the%20intent%20explicit%20and%20robust%20to%20output-format%20changes.%0A%0A%60%60%60suggestion%0ADOCKER_VERSION%3D%24%28docker%20run%20--rm%20%22%24LINTRO_IMAGE%22%20lintro%20--version%202%3E%2Fdev%2Fnull%20%5C%0A%09%7C%20grep%20-oE%20'lintro%5B%5B%3Aspace%3A%5D%5D%2B%5B0-9%5D%2B%5C.%5B0-9%5D%2B%5C.%5B0-9%5D%2B'%20%5C%0A%09%7C%20grep%20-oE%20'%5B0-9%5D%2B%5C.%5B0-9%5D%2B%5C.%5B0-9%5D%2B'%20%5C%0A%09%7C%20head%20-1%20%7C%7C%20true%29%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=303&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (9): Last reviewed commit: ["fix(ci): tighten lintro version drift tr..."](https://github.com/lgtm-hq/lgtm-ci/commit/e73aa1e8bdcb1bab2b67418e3339994e4aa05cb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35999741)</sub>

<!-- /greptile_comment -->