### PR TITLE
fix(release): sign release PR commits and request CODEOWNER review from release bot

### DIFF
--- a/.github/workflows/reusable-release-version-pr.yml
+++ b/.github/workflows/reusable-release-version-pr.yml
@@ -404,6 +404,7 @@ jobs:
         # yamllint disable-line rule:line-length
         if: >-
           steps.create-pr.outputs.pull-request-number != ''
+          && !cancelled()
         id: pr-author
         shell: bash
         env:
@@ -417,6 +418,7 @@ jobs:
         # yamllint disable-line rule:line-length
         if: >-
           steps.create-pr.outputs.pull-request-number != ''
+          && !cancelled()
         shell: bash
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/reusable-release-version-pr.yml
+++ b/.github/workflows/reusable-release-version-pr.yml
@@ -35,6 +35,11 @@ name: "Reusable: Release Version PR"
         required: false
         type: string
         default: "release-bump"
+      codeowners-path:
+        description: "Path to CODEOWNERS file"
+        required: false
+        type: string
+        default: ".github/CODEOWNERS"
       auto-merge:
         description: "Enable auto-merge (squash) on the created PR"
         required: false
@@ -405,7 +410,7 @@ jobs:
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
           PR_AUTHOR: lgtm-release-bot[bot]
           PR_AUTHOR_TYPE: Bot
-          CODEOWNERS_PATH: .github/CODEOWNERS
+          CODEOWNERS_PATH: ${{ inputs.codeowners-path }}
           REQUEST_CODEOWNER_REVIEW: "true"
         run: .lgtm-ci-tooling/scripts/ci/actions/assign-codeowner.sh
 

--- a/.github/workflows/reusable-release-version-pr.yml
+++ b/.github/workflows/reusable-release-version-pr.yml
@@ -339,6 +339,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ steps.app-token.outputs.token }}
+          sign-commits: true
           branch: >-
             ${{ inputs.release-branch-prefix }}${{ inputs.tag-prefix }}${{
             steps.version.outputs.next-version }}
@@ -393,6 +394,20 @@ jobs:
           sparse-checkout-cone-mode: true
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}
+
+      - name: Request CODEOWNER review
+        # yamllint disable-line rule:line-length
+        if: >-
+          steps.create-pr.outputs.pull-request-number != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+          PR_AUTHOR: lgtm-release-bot[bot]
+          PR_AUTHOR_TYPE: Bot
+          CODEOWNERS_PATH: .github/CODEOWNERS
+          REQUEST_CODEOWNER_REVIEW: "true"
+        run: .lgtm-ci-tooling/scripts/ci/actions/assign-codeowner.sh
 
       - name: Enable auto-merge
         # yamllint disable-line rule:line-length

--- a/.github/workflows/reusable-release-version-pr.yml
+++ b/.github/workflows/reusable-release-version-pr.yml
@@ -400,6 +400,19 @@ jobs:
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Get PR author
+        # yamllint disable-line rule:line-length
+        if: >-
+          steps.create-pr.outputs.pull-request-number != ''
+        id: pr-author
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+        run: |
+          author=$(gh pr view "$PR_NUMBER" --json author --jq '.author.login')
+          echo "author=${author}" >> "${GITHUB_OUTPUT}"
+
       - name: Request CODEOWNER review
         # yamllint disable-line rule:line-length
         if: >-
@@ -408,7 +421,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
-          PR_AUTHOR: lgtm-release-bot[bot]
+          PR_AUTHOR: ${{ steps.pr-author.outputs.author }}
           PR_AUTHOR_TYPE: Bot
           CODEOWNERS_PATH: ${{ inputs.codeowners-path }}
           REQUEST_CODEOWNER_REVIEW: "true"

--- a/scripts/ci/actions/assign-codeowner.sh
+++ b/scripts/ci/actions/assign-codeowner.sh
@@ -9,7 +9,9 @@
 #   CODEOWNERS_PATH - Path to CODEOWNERS file
 #
 # Optional environment variables:
-#   PR_AUTHOR_TYPE  - GitHub user type (e.g. "User", "Bot")
+#   PR_AUTHOR_TYPE           - GitHub user type (e.g. "User", "Bot")
+#   REQUEST_CODEOWNER_REVIEW - When "true", request review even on release-bump PRs
+#                              (used by the release workflow; pr-auto-assign omits this)
 
 set -euo pipefail
 
@@ -74,6 +76,9 @@ gh pr edit "$PR_NUMBER" --add-assignee "$selected"
 if [[ "${PR_AUTHOR_TYPE:-}" == "Bot" ]]; then
 	if [[ "$selected" == "$PR_AUTHOR" ]]; then
 		echo "Bot-authored PR detected, but selected CODEOWNER is the PR author ($selected); skipping review request"
+	elif [[ "${REQUEST_CODEOWNER_REVIEW:-}" != "true" ]] &&
+		gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' | grep -qx 'release-bump'; then
+		echo "Release-bump PR — review request handled by release workflow; skipping"
 	else
 		echo "Bot-authored PR detected, requesting review from $selected"
 		gh pr edit "$PR_NUMBER" --add-reviewer "$selected"

--- a/tests/bats/unit/actions/test_assign_codeowner.bats
+++ b/tests/bats/unit/actions/test_assign_codeowner.bats
@@ -1,0 +1,127 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/assign-codeowner.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+
+setup() {
+	setup_temp_dir
+	export SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/assign-codeowner.sh"
+	export GH_TOKEN="test-token"
+	export PR_NUMBER="42"
+	export PR_AUTHOR="some-bot[bot]"
+	export CODEOWNERS_PATH="${BATS_TEST_TMPDIR}/CODEOWNERS"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+_create_codeowners() {
+	cat >"$CODEOWNERS_PATH" <<'EOF'
+# Team entries are ignored
+* @lgtm-hq/maintainers
+
+# Individual owners
+* @alice
+* @bob
+EOF
+}
+
+_mock_gh() {
+	local labels="${1:-}"
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+	local calls_file="${BATS_TEST_TMPDIR}/mock_calls_gh"
+	: >"$calls_file"
+
+	cat >"${mock_bin}/gh" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> '${calls_file}'
+case "\$*" in
+	*pr\ view*labels*)
+		echo '${labels}'
+		;;
+	*pr\ edit*)
+		;;
+	*)
+		echo "unexpected gh call: \$*" >&2
+		exit 1
+		;;
+esac
+EOF
+	chmod +x "${mock_bin}/gh"
+	export PATH="${mock_bin}:$PATH"
+}
+
+@test "assign-codeowner: skips review request on release-bump PRs from pr-auto-assign" {
+	require_bash4
+	_create_codeowners
+	_mock_gh "release-bump"
+
+	run env PR_AUTHOR_TYPE=Bot "$MODERN_BASH" "$SCRIPT"
+
+	assert_success
+	assert_output --partial "Release-bump PR — review request handled by release workflow; skipping"
+	local calls="${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_file_contains "${calls}" "pr edit 42 --add-assignee"
+	refute_output --partial "requesting review from"
+	! grep -q -- '--add-reviewer' "$calls"
+}
+
+@test "assign-codeowner: requests review on release-bump PRs when REQUEST_CODEOWNER_REVIEW=true" {
+	require_bash4
+	_create_codeowners
+	_mock_gh "release-bump"
+
+	run env PR_AUTHOR_TYPE=Bot REQUEST_CODEOWNER_REVIEW=true "$MODERN_BASH" "$SCRIPT"
+
+	assert_success
+	assert_output --partial "Bot-authored PR detected, requesting review from"
+	local calls="${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_file_contains "${calls}" "pr edit 42 --add-assignee"
+	assert_file_contains "${calls}" "pr edit 42 --add-reviewer"
+}
+
+@test "assign-codeowner: requests review for bot PRs without release-bump label" {
+	require_bash4
+	_create_codeowners
+	_mock_gh ""
+
+	run env PR_AUTHOR_TYPE=Bot "$MODERN_BASH" "$SCRIPT"
+
+	assert_success
+	assert_output --partial "Bot-authored PR detected, requesting review from"
+	local calls="${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_file_contains "${calls}" "pr edit 42 --add-reviewer"
+}
+
+@test "assign-codeowner: assigns but does not request review for human-authored PRs" {
+	require_bash4
+	_create_codeowners
+	_mock_gh ""
+
+	run env PR_AUTHOR_TYPE=User "$MODERN_BASH" "$SCRIPT"
+
+	assert_success
+	assert_output --partial "Selected assignee:"
+	local calls="${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_file_contains "${calls}" "pr edit 42 --add-assignee"
+	! grep -q -- '--add-reviewer' "$calls"
+}
+
+@test "assign-codeowner: skips when CODEOWNERS has no individual owners" {
+	require_bash4
+	cat >"$CODEOWNERS_PATH" <<'EOF'
+* @lgtm-hq/maintainers
+EOF
+	_mock_gh ""
+
+	run env PR_AUTHOR_TYPE=Bot "$MODERN_BASH" "$SCRIPT"
+
+	assert_success
+	assert_output --partial "No valid individual CODEOWNERS found, skipping assignment"
+	local calls="${BATS_TEST_TMPDIR}/mock_calls_gh"
+	[[ ! -s "$calls" ]]
+}


### PR DESCRIPTION
## Summary

Release PRs created by `lgtm-release-bot` show unsigned commits and often miss the CODEOWNER "requested your review" banner due to a race between the release workflow and `pr-auto-assign`. This PR signs release commits via the GitHub App token and requests CODEOWNER review deterministically from the release bot before `pr-auto-assign` can interfere.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. Downstream repos must repin lgtm-ci after release to pick up the workflow changes.

## Closes

- Closes #255

## Changes Made

- Add `sign-commits: true` to `peter-evans/create-pull-request` in `reusable-release-version-pr.yml`
- Add a **Request CODEOWNER review** step using the release app token (`REQUEST_CODEOWNER_REVIEW=true`)
- Skip duplicate `--add-reviewer` calls from `pr-auto-assign` on `release-bump` PRs in `assign-codeowner.sh`
- Add BATS tests for release-bump skip and forced review paths

## Testing

- [x] `uv run lintro fmt` and `uv run lintro chk` pass
- [x] BATS tests added in `tests/bats/unit/actions/test_assign_codeowner.bats`
- [ ] Manual verification on a test release PR (commit **Verified**, banner from `lgtm-release-bot[bot]`)

## Review Notes

- Greptile: 4/5 confidence, safe to merge
- CodeRabbit: 1 minor finding — consider making `PR_AUTHOR` a workflow input (deferred; out of issue scope)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sign release PR commits and request CODEOWNER review from release bot
> - Sets `sign-commits: true` in the `create-pull-request` step of [reusable-release-version-pr.yml](.github/workflows/reusable-release-version-pr.yml) so version-bump PR commits are signed.
> - After PR creation, queries the PR author via the GitHub CLI and calls [assign-codeowner.sh](scripts/ci/actions/assign-codeowner.sh) with `REQUEST_CODEOWNER_REVIEW=true` to request a review from the relevant CODEOWNER.
> - Adds a `codeowners-path` workflow input (default `.github/CODEOWNERS`) so callers can override the path.
> - Updates `assign-codeowner.sh` to skip requesting a review on bot-authored PRs labeled `release-bump` unless `REQUEST_CODEOWNER_REVIEW=true` is explicitly set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9da7522.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Commit signing enabled for version pull requests.
  * Configurable CODEOWNERS path for review requests.
  * Conditional CODEOWNER review requests: PR author detection plus opt-in behavior to skip requesting reviews on bot-created release-bump PRs.

* **Tests**
  * Added comprehensive tests covering CODEOWNER review assignment across bot/human and labeled/unlabeled PR scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related issues with bot-authored release PRs: unsigned commits and a race condition that caused CODEOWNER review requests to be missed. It adds `sign-commits: true` to `peter-evans/create-pull-request` and introduces an explicit "Request CODEOWNER review" step driven by the release app token, while teaching `assign-codeowner.sh` to skip the duplicate request when `pr-auto-assign` fires on `release-bump` PRs.

- **`reusable-release-version-pr.yml`**: Adds `sign-commits: true`, a new `codeowners-path` workflow input, and two new steps (`Get PR author` + `Request CODEOWNER review`) that both gate on `!cancelled()` to stay resilient against the `if: always()` "Restore tooling" step.
- **`assign-codeowner.sh`**: New `elif` branch skips `--add-reviewer` when `REQUEST_CODEOWNER_REVIEW` is unset and the PR carries the `release-bump` label, preventing double requests from `pr-auto-assign`.
- **`test_assign_codeowner.bats`**: Five new BATS tests cover bot/human authorship, `release-bump` skip logic, forced-review override, and the empty-CODEOWNERS guard.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new steps are correctly gated with !cancelled() and the skip logic in assign-codeowner.sh is sound.

Both new workflow steps use !cancelled() rather than the implicit success() guard, so they run even if the always()-gated Restore Tooling step fails after a successful PR creation. The elif skip in assign-codeowner.sh short-circuits cleanly under set -euo pipefail, the BATS tests cover the key paths, and sign-commits: true is a straightforward addition compatible with the pinned v8 action.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-release-version-pr.yml | Adds sign-commits, codeowners-path input, and two new post-PR steps; both new steps correctly use !cancelled() to avoid the implicit success() guard added by the always() Restore-tooling step. |
| scripts/ci/actions/assign-codeowner.sh | Adds elif branch that skips --add-reviewer on release-bump PRs unless REQUEST_CODEOWNER_REVIEW=true; logic and short-circuit evaluation under set -euo pipefail are correct. |
| tests/bats/unit/actions/test_assign_codeowner.bats | Five BATS tests covering the new skip/request paths; mock covers all gh call sites; one test mixes raw bash assertions with BATS-style assertions (minor consistency issue). |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant RW as Release Workflow
    participant CPR as create-pull-request
    participant GH as GitHub API
    participant ACS as assign-codeowner.sh
    participant PAA as pr-auto-assign

    RW->>CPR: create PR (sign-commits: true)
    CPR->>GH: "open PR with labels=[release-bump]"
    GH-->>CPR: pull-request-number
    CPR-->>RW: outputs.pull-request-number

    RW->>GH: gh pr view (get author login)
    GH-->>RW: "author = lgtm-release-bot[bot]"

    RW->>ACS: "REQUEST_CODEOWNER_REVIEW=true"
    ACS->>GH: gh pr edit --add-assignee alice
    Note over ACS: REQUEST_CODEOWNER_REVIEW=true, skip elif go to else
    ACS->>GH: gh pr edit --add-reviewer alice

    GH-->>PAA: PR opened event triggers pr-auto-assign
    PAA->>ACS: (no REQUEST_CODEOWNER_REVIEW)
    ACS->>GH: gh pr view --json labels
    GH-->>ACS: "labels=[release-bump]"
    Note over ACS: release-bump detected and REQUEST_CODEOWNER_REVIEW unset, skip --add-reviewer
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(ci): run CODEOWNER review steps when..."](https://github.com/lgtm-hq/lgtm-ci/commit/9da752251c1da9ab652ab0ec67add4936b758e27) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36024917)</sub>

<!-- /greptile_comment -->