### PR TITLE
feat(release): surface reusable release workflow failures

### DIFF
--- a/.github/workflows/reusable-release-auto-tag.yml
+++ b/.github/workflows/reusable-release-auto-tag.yml
@@ -273,9 +273,13 @@ jobs:
       inputs.report-failures &&
       needs.auto-tag.result == 'failure'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
+      # Read workflow/job metadata to generate failure context
       actions: read
+      # Read repository context for issue body
       contents: read
+      # Create or update failure notification issues
       issues: write
 
     steps:

--- a/.github/workflows/reusable-release-auto-tag.yml
+++ b/.github/workflows/reusable-release-auto-tag.yml
@@ -69,6 +69,25 @@ name: "Reusable: Release Auto Tag"
         required: false
         type: number
         default: 20
+      report-failures:
+        description: >-
+          When true, open or update a deduplicated GitHub issue when the release
+          job fails on the target branch
+        required: false
+        type: boolean
+        default: true
+      failure-issue-labels:
+        description: Comma-separated labels for auto-opened release failure issues
+        required: false
+        type: string
+        default: "bug,ci,release,automation,infrastructure"
+      failure-target-branch:
+        description: >-
+          Branch name for failure notifications. Empty uses the repository default
+          branch.
+        required: false
+        type: string
+        default: ""
 
     secrets:
       RELEASE_APP_ID:
@@ -245,3 +264,65 @@ jobs:
         env:
           IS_RELEASE: ${{ steps.guard.outputs.is-release-commit }}
         run: .lgtm-ci-tooling/scripts/ci/release/write-skip-summary.sh
+
+  report-release-failure:
+    name: Report release automation failure
+    needs: [auto-tag]
+    if: >-
+      always() &&
+      inputs.report-failures &&
+      needs.auto-tag.result == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress-failure
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: github-minimal
+
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress-failure.outputs['allowed-endpoints'] }}
+
+      - name: Write failure trigger summary
+        shell: bash
+        env:
+          RELEASE_WORKFLOW_KEY: release-auto-tag
+          PRIMARY_JOB_FAILED: "true"
+        run: >-
+          .lgtm-ci-tooling/scripts/ci/release/report-release-failure.sh
+          write_trigger_summary
+
+      - name: Notify release failure
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_WORKFLOW_KEY: release-auto-tag
+          FAILURE_ISSUE_LABELS: ${{ inputs.failure-issue-labels }}
+          FAILURE_TARGET_BRANCH: ${{ inputs.failure-target-branch }}
+        run: >-
+          .lgtm-ci-tooling/scripts/ci/release/report-release-failure.sh
+          notify_failure

--- a/.github/workflows/reusable-release-version-pr.yml
+++ b/.github/workflows/reusable-release-version-pr.yml
@@ -106,6 +106,25 @@ name: "Reusable: Release Version PR"
         required: false
         type: string
         default: "github-tooling"
+      report-failures:
+        description: >-
+          When true, open or update a deduplicated GitHub issue when the release
+          job fails on the target branch
+        required: false
+        type: boolean
+        default: true
+      failure-issue-labels:
+        description: Comma-separated labels for auto-opened release failure issues
+        required: false
+        type: string
+        default: "bug,ci,release,automation,infrastructure"
+      failure-target-branch:
+        description: >-
+          Branch name for failure notifications. Empty uses the repository default
+          branch.
+        required: false
+        type: string
+        default: ""
 
     secrets:
       RELEASE_APP_ID:
@@ -461,3 +480,65 @@ jobs:
         # yamllint disable-line rule:line-length
         run: >-
           .lgtm-ci-tooling/scripts/ci/release/write-version-pr-summary.sh
+
+  report-release-failure:
+    name: Report release automation failure
+    needs: [version-pr]
+    if: >-
+      always() &&
+      inputs.report-failures &&
+      needs.version-pr.result == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress-failure
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: github-minimal
+
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress-failure.outputs['allowed-endpoints'] }}
+
+      - name: Write failure trigger summary
+        shell: bash
+        env:
+          RELEASE_WORKFLOW_KEY: release-version-pr
+          PRIMARY_JOB_FAILED: "true"
+        run: >-
+          .lgtm-ci-tooling/scripts/ci/release/report-release-failure.sh
+          write_trigger_summary
+
+      - name: Notify release failure
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_WORKFLOW_KEY: release-version-pr
+          FAILURE_ISSUE_LABELS: ${{ inputs.failure-issue-labels }}
+          FAILURE_TARGET_BRANCH: ${{ inputs.failure-target-branch }}
+        run: >-
+          .lgtm-ci-tooling/scripts/ci/release/report-release-failure.sh
+          notify_failure

--- a/.github/workflows/reusable-release-version-pr.yml
+++ b/.github/workflows/reusable-release-version-pr.yml
@@ -489,9 +489,13 @@ jobs:
       inputs.report-failures &&
       needs.version-pr.result == 'failure'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
+      # Read workflow/job metadata to generate failure context
       actions: read
+      # Read repository context for issue body
       contents: read
+      # Create or update failure notification issues
       issues: write
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **release**: optional failure reporting for `reusable-release-version-pr` and
+  `reusable-release-auto-tag` — step summary context plus deduplicated GitHub
+  issues when release jobs fail on the default branch (#207)
+
 ### Changed
 
 ### Deprecated

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -275,10 +275,11 @@ layout so the artifact root is browsable HTML.
 
 ## Release
 
-When release automation fails on the default branch, the reusable workflows open
-or update a deduplicated GitHub issue with failed step details and write a step
-summary in the follow-up `report-release-failure` job. Set `report-failures:
-false` to disable. See [workflow-contract.md](workflow-contract.md) for inputs.
+When release automation fails on the default branch, the follow-up
+`report-release-failure` job runs two steps in order: it first writes release
+trigger context to the job step summary, then creates or updates a deduplicated
+GitHub issue with failed step details. Set `report-failures: false` to disable
+both actions. See [workflow-contract.md](workflow-contract.md) for inputs.
 
 Recommended caller `run-name` (reusable workflows cannot set this for you):
 
@@ -288,6 +289,11 @@ run-name: >-
   Release version PR via ${{ github.event_name }} on ${{ github.ref_name }}
   @ ${{ github.sha }}
 ```
+
+Including `${{ github.event_name }}`, `${{ github.ref_name }}`, and
+`${{ github.sha }}` in the `run-name` makes it easier to triage failures: the
+workflow run list shows the triggering event, branch, and commit so you can
+quickly correlate a failed run with the code and event that started it.
 
 ```yaml
 jobs:

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -275,6 +275,20 @@ layout so the artifact root is browsable HTML.
 
 ## Release
 
+When release automation fails on the default branch, the reusable workflows open
+or update a deduplicated GitHub issue with failed step details and write a step
+summary in the follow-up `report-release-failure` job. Set `report-failures:
+false` to disable. See [workflow-contract.md](workflow-contract.md) for inputs.
+
+Recommended caller `run-name` (reusable workflows cannot set this for you):
+
+```yaml
+name: Release Version PR
+run-name: >-
+  Release version PR via ${{ github.event_name }} on ${{ github.ref_name }}
+  @ ${{ github.sha }}
+```
+
 ```yaml
 jobs:
   version-pr:

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -110,6 +110,8 @@ would worsen check-name readability) and to access matrix-specific artifacts.
 |                       |                                                      | `reusable-publish-artifact-report.yml`       |
 | Publish to Pages      | `contents: read`, `pages: write`, `id-token: write`  | Separate publish job                         |
 | Release version       | `contents: write`, `pull-requests: write`            | `reusable-release-version-pr.yml`            |
+| Release auto-tag      | `contents: write`                                    | `reusable-release-auto-tag.yml`              |
+| Release failure issue | `actions: read`, `contents: read`, `issues: write`   | `report-release-failure` follow-up job       |
 | PyPI upload (OIDC)    | `contents: read`; `id-token` + `attestations: write` | `prepare-pypi-upload` + pypa step            |
 | PyPI build            | `contents: read`                                     | `reusable-build-python-dist.yml`             |
 | GitHub Release assets | `contents: write`                                    | `reusable-github-release.yml`                |
@@ -307,6 +309,27 @@ step** because step-security's pre-hook runs before composite steps and cannot r
 `steps.resolve.outputs` from inside `harden-runner`.
 
 Do **not** use `.lgtm-ci-egress` sparse checkouts for the composite.
+
+### Release failure reporting
+
+Both release reusables include an optional `report-release-failure` follow-up job
+that runs when the primary job fails (`needs.<job>.result == 'failure'`). The
+job uses `egress-preset: github-minimal` (GitHub API only) and declares its own
+`issues: write` permission — callers do not need extra permissions.
+
+<!-- markdownlint-disable MD013 -->
+
+| Input                   | Default                                    | Purpose                                       |
+| ----------------------- | ------------------------------------------ | --------------------------------------------- |
+| `report-failures`       | `true`                                     | Opt out when the repo handles alerting itself |
+| `failure-issue-labels`  | `bug,ci,release,automation,infrastructure` | Labels on auto-opened failure issues          |
+| `failure-target-branch` | *(empty → repository default branch)*      | Branch filter for issue notifications         |
+
+<!-- markdownlint-enable MD013 -->
+
+Failure issues deduplicate via a hidden HTML comment marker
+(`release-automation-failure:<workflow-key>:<branch>`). Recurring failures add
+comments to the same open issue.
 
 ## Egress presets
 

--- a/scripts/ci/release/report-release-failure.sh
+++ b/scripts/ci/release/report-release-failure.sh
@@ -91,35 +91,6 @@ resolve_target_branch() {
 	echo "$default_branch"
 }
 
-ensure_issue_label() {
-	local label="$1"
-	local color="$2"
-	local description="${3:-}"
-	local repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
-
-	if gh label view "$label" --repo "$repo" >/dev/null 2>&1; then
-		return 0
-	fi
-
-	if [[ -n "$description" ]]; then
-		gh label create "$label" \
-			--repo "$repo" \
-			--color "$color" \
-			--description "$description" 2>/dev/null || true
-	else
-		gh label create "$label" \
-			--repo "$repo" \
-			--color "$color" 2>/dev/null || true
-	fi
-
-	if gh label view "$label" --repo "$repo" >/dev/null 2>&1; then
-		return 0
-	fi
-
-	log_error "Failed to ensure issue label exists: $label"
-	exit 1
-}
-
 write_trigger_summary() {
 	local branch
 	local sha
@@ -255,30 +226,69 @@ EOF
 find_existing_issue() {
 	local search_key
 	local issue_number
+	local search_output
 	search_key="$(marker_key)"
-	issue_number="$(gh issue list \
+	if ! search_output="$(gh issue list \
 		--repo "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}" \
 		--state open \
+		--limit 1 \
 		--search "\"${search_key}\"" \
 		--json number \
-		--jq '.[0].number // empty' 2>/dev/null || true)"
+		--jq '.[0].number // empty' 2>&1)"; then
+		log_error "Could not search for existing release failure issues: ${search_output}"
+		exit 1
+	fi
+
+	issue_number="$search_output"
 	if [[ "$issue_number" =~ ^[0-9]+$ ]]; then
 		echo "$issue_number"
 	fi
 }
 
-ensure_failure_issue_labels() {
+collect_existing_issue_label_args() {
+	local -n _label_args=$1
 	local default_labels="${FAILURE_ISSUE_LABELS:-bug,ci,release,automation,infrastructure}"
 	local label
+	local repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 
+	_label_args=()
 	IFS=',' read -ra labels <<<"$default_labels"
 	for label in "${labels[@]}"; do
 		label="$(echo "$label" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
 		if [[ -z "$label" ]]; then
 			continue
 		fi
-		ensure_issue_label "$label" "ededed" ""
+		if gh label view "$label" --repo "$repo" >/dev/null 2>&1; then
+			_label_args+=(--label "$label")
+		else
+			log_info "Skipping missing issue label '$label'"
+		fi
 	done
+}
+
+comment_on_failure_issue() {
+	local issue_number="$1"
+	gh issue comment "$issue_number" \
+		--repo "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}" \
+		--body-file "$body_file" >/dev/null
+	log_success "Updated release failure issue #${issue_number}"
+}
+
+create_failure_issue() {
+	local label_args=()
+	collect_existing_issue_label_args label_args
+	if ((${#label_args[@]} > 0)); then
+		gh issue create \
+			--repo "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}" \
+			--title "fix(release): release automation failed on ${target_branch}" \
+			--body-file "$body_file" \
+			"${label_args[@]}" >/dev/null
+	else
+		gh issue create \
+			--repo "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}" \
+			--title "fix(release): release automation failed on ${target_branch}" \
+			--body-file "$body_file" >/dev/null
+	fi
 }
 
 notify_failure() {
@@ -286,9 +296,6 @@ notify_failure() {
 	local target_branch
 	local body_file
 	local existing_issue
-	local label_args
-	local label
-	local default_labels
 
 	if [[ -z "${GH_TOKEN:-}" ]]; then
 		log_error "GH_TOKEN is required"
@@ -319,28 +326,24 @@ notify_failure() {
 
 	existing_issue="$(find_existing_issue)"
 	if [[ -n "$existing_issue" ]]; then
-		gh issue comment "$existing_issue" \
-			--repo "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}" \
-			--body-file "$body_file" >/dev/null
-		log_success "Updated release failure issue #${existing_issue}"
+		comment_on_failure_issue "$existing_issue"
 	else
-		ensure_failure_issue_labels
-		label_args=()
-		default_labels="${FAILURE_ISSUE_LABELS:-bug,ci,release,automation,infrastructure}"
-		IFS=',' read -ra labels <<<"$default_labels"
-		for label in "${labels[@]}"; do
-			label="$(echo "$label" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-			if [[ -z "$label" ]]; then
-				continue
+		# Brief pause reduces duplicate issues when concurrent runs fail together.
+		sleep 2
+		existing_issue="$(find_existing_issue)"
+		if [[ -n "$existing_issue" ]]; then
+			comment_on_failure_issue "$existing_issue"
+		elif create_failure_issue; then
+			log_success "Created release failure issue"
+		else
+			existing_issue="$(find_existing_issue)"
+			if [[ -n "$existing_issue" ]]; then
+				comment_on_failure_issue "$existing_issue"
+			else
+				log_error "Failed to create release failure issue"
+				exit 1
 			fi
-			label_args+=(--label "$label")
-		done
-		gh issue create \
-			--repo "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}" \
-			--title "fix(release): release automation failed on ${target_branch}" \
-			--body-file "$body_file" \
-			"${label_args[@]}" >/dev/null
-		log_success "Created release failure issue"
+		fi
 	fi
 
 	rm -f "$body_file"

--- a/scripts/ci/release/report-release-failure.sh
+++ b/scripts/ci/release/report-release-failure.sh
@@ -268,6 +268,7 @@ collect_existing_issue_label_args() {
 
 comment_on_failure_issue() {
 	local issue_number="$1"
+	local body_file="$2"
 	gh issue comment "$issue_number" \
 		--repo "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}" \
 		--body-file "$body_file" >/dev/null
@@ -275,6 +276,8 @@ comment_on_failure_issue() {
 }
 
 create_failure_issue() {
+	local body_file="$1"
+	local target_branch="$2"
 	local label_args=()
 	collect_existing_issue_label_args label_args
 	if ((${#label_args[@]} > 0)); then
@@ -326,19 +329,19 @@ notify_failure() {
 
 	existing_issue="$(find_existing_issue)"
 	if [[ -n "$existing_issue" ]]; then
-		comment_on_failure_issue "$existing_issue"
+		comment_on_failure_issue "$existing_issue" "$body_file"
 	else
 		# Brief pause reduces duplicate issues when concurrent runs fail together.
 		sleep 2
 		existing_issue="$(find_existing_issue)"
 		if [[ -n "$existing_issue" ]]; then
-			comment_on_failure_issue "$existing_issue"
-		elif create_failure_issue; then
+			comment_on_failure_issue "$existing_issue" "$body_file"
+		elif create_failure_issue "$body_file" "$target_branch"; then
 			log_success "Created release failure issue"
 		else
 			existing_issue="$(find_existing_issue)"
 			if [[ -n "$existing_issue" ]]; then
-				comment_on_failure_issue "$existing_issue"
+				comment_on_failure_issue "$existing_issue" "$body_file"
 			else
 				log_error "Failed to create release failure issue"
 				exit 1

--- a/scripts/ci/release/report-release-failure.sh
+++ b/scripts/ci/release/report-release-failure.sh
@@ -227,17 +227,21 @@ find_existing_issue() {
 	local search_key
 	local issue_number
 	local search_output
+	local gh_stderr
 	search_key="$(marker_key)"
+	gh_stderr="$(mktemp)"
 	if ! search_output="$(gh issue list \
 		--repo "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}" \
 		--state open \
 		--limit 1 \
 		--search "\"${search_key}\"" \
 		--json number \
-		--jq '.[0].number // empty' 2>&1)"; then
-		log_error "Could not search for existing release failure issues: ${search_output}"
+		--jq '.[0].number // empty' 2>"$gh_stderr")"; then
+		log_error "Could not search for existing release failure issues: $(cat "$gh_stderr")"
+		rm -f "$gh_stderr"
 		exit 1
 	fi
+	rm -f "$gh_stderr"
 
 	issue_number="$search_output"
 	if [[ "$issue_number" =~ ^[0-9]+$ ]]; then

--- a/scripts/ci/release/report-release-failure.sh
+++ b/scripts/ci/release/report-release-failure.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Surface reusable release workflow failures via step summary and issues
+#
+# Subcommands:
+#   write_trigger_summary — append release trigger context to $GITHUB_STEP_SUMMARY
+#   notify_failure        — create or comment on a deduplicated GitHub issue
+#
+# Required environment variables (notify_failure):
+#   GH_TOKEN            — GitHub token with issues: write
+#   GITHUB_REPOSITORY   — Target repository (owner/name)
+#   RELEASE_WORKFLOW_KEY — Stable workflow key for marker namespacing
+#                          (e.g. release-version-pr, release-auto-tag)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/log.sh
+source "$SCRIPT_DIR/../lib/log.sh"
+# shellcheck source=../lib/github/summary.sh
+source "$SCRIPT_DIR/../lib/github/summary.sh"
+
+usage() {
+	cat <<'EOF'
+Usage: report-release-failure.sh <subcommand>
+
+Subcommands:
+  write_trigger_summary  Write release trigger context to $GITHUB_STEP_SUMMARY
+  notify_failure         Create or update a deduplicated GitHub issue on target branch
+EOF
+}
+
+release_branch() {
+	if [[ "${GITHUB_EVENT_NAME:-}" == "workflow_run" ]]; then
+		echo "${UPSTREAM_HEAD_BRANCH:-${GITHUB_REF_NAME:-unknown}}"
+	else
+		echo "${GITHUB_REF_NAME:-unknown}"
+	fi
+}
+
+release_sha() {
+	if [[ -n "${CHECKOUT_SHA:-}" ]]; then
+		echo "$CHECKOUT_SHA"
+	elif [[ "${GITHUB_EVENT_NAME:-}" == "workflow_run" && -n "${UPSTREAM_HEAD_SHA:-}" ]]; then
+		echo "$UPSTREAM_HEAD_SHA"
+	else
+		echo "${GITHUB_SHA:-unknown}"
+	fi
+}
+
+run_url() {
+	echo "${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}/actions/runs/${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+}
+
+upstream_run_url() {
+	if [[ -n "${UPSTREAM_RUN_URL:-}" ]]; then
+		echo "$UPSTREAM_RUN_URL"
+	elif [[ -n "${UPSTREAM_RUN_ID:-}" ]]; then
+		echo "${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}/actions/runs/${UPSTREAM_RUN_ID}"
+	else
+		echo ""
+	fi
+}
+
+workflow_key() {
+	echo "${RELEASE_WORKFLOW_KEY:?RELEASE_WORKFLOW_KEY is required}"
+}
+
+marker_key() {
+	local branch
+	branch="$(release_branch)"
+	echo "release-automation-failure:$(workflow_key):${branch}"
+}
+
+issue_marker() {
+	echo "<!-- $(marker_key) -->"
+}
+
+resolve_target_branch() {
+	if [[ -n "${FAILURE_TARGET_BRANCH:-}" ]]; then
+		echo "$FAILURE_TARGET_BRANCH"
+		return
+	fi
+
+	local default_branch="main"
+	if [[ -n "${GH_TOKEN:-}" ]] && command -v gh >/dev/null 2>&1; then
+		default_branch="$(gh repo view "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}" \
+			--json defaultBranchRef \
+			--jq '.defaultBranchRef.name' 2>/dev/null || echo main)"
+	fi
+	echo "$default_branch"
+}
+
+ensure_issue_label() {
+	local label="$1"
+	local color="$2"
+	local description="${3:-}"
+	local repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+	if gh label view "$label" --repo "$repo" >/dev/null 2>&1; then
+		return 0
+	fi
+
+	if [[ -n "$description" ]]; then
+		gh label create "$label" \
+			--repo "$repo" \
+			--color "$color" \
+			--description "$description" 2>/dev/null || true
+	else
+		gh label create "$label" \
+			--repo "$repo" \
+			--color "$color" 2>/dev/null || true
+	fi
+
+	if gh label view "$label" --repo "$repo" >/dev/null 2>&1; then
+		return 0
+	fi
+
+	log_error "Failed to ensure issue label exists: $label"
+	exit 1
+}
+
+write_trigger_summary() {
+	local branch
+	local sha
+	local current_run_url
+	local upstream_url
+	local heading="## Release Automation Context"
+
+	if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
+		log_error "GITHUB_STEP_SUMMARY is required"
+		exit 1
+	fi
+
+	branch="$(release_branch)"
+	sha="$(release_sha)"
+	current_run_url="$(run_url)"
+	upstream_url="$(upstream_run_url)"
+
+	if [[ "${PRIMARY_JOB_FAILED:-false}" == "true" ]]; then
+		heading="## Release Automation Failure"
+	fi
+
+	add_github_summary "$heading"
+	add_github_summary ""
+	add_github_summary "- **Workflow:** ${GITHUB_WORKFLOW:-unknown}"
+	add_github_summary "- **Workflow key:** $(workflow_key)"
+	add_github_summary "- **Event:** ${GITHUB_EVENT_NAME:-unknown}"
+	add_github_summary "- **Branch:** ${branch}"
+	add_github_summary "- **Checkout SHA:** ${sha}"
+	add_github_summary "- **Actor:** ${GITHUB_ACTOR:-unknown}"
+	add_github_summary "- **Run:** ${current_run_url}"
+
+	if [[ "${GITHUB_EVENT_NAME:-}" == "workflow_run" ]]; then
+		add_github_summary ""
+		add_github_summary "### Upstream Workflow"
+		add_github_summary ""
+		add_github_summary "- **Workflow:** ${UPSTREAM_WORKFLOW_NAME:-unknown}"
+		add_github_summary "- **Run ID:** ${UPSTREAM_RUN_ID:-unknown}"
+		if [[ -n "$upstream_url" ]]; then
+			add_github_summary "- **Run:** ${upstream_url}"
+		fi
+		add_github_summary "- **Conclusion:** ${UPSTREAM_CONCLUSION:-unknown}"
+		add_github_summary "- **Head branch:** ${UPSTREAM_HEAD_BRANCH:-unknown}"
+		add_github_summary "- **Head SHA:** ${UPSTREAM_HEAD_SHA:-unknown}"
+	fi
+}
+
+failed_step_summary() {
+	if ! command -v gh >/dev/null 2>&1; then
+		echo "Failed job and step details unavailable because gh is not installed."
+		return
+	fi
+
+	local failed
+	# gh --jq receives this expression literally; shell variables inside it are jq variables.
+	# shellcheck disable=SC2016
+	failed=$(
+		gh run view "${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}" \
+			--repo "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}" \
+			--json jobs \
+			--jq '.jobs[] | select(.conclusion == "failure") | .name as $job | if ([.steps[]? | select(.conclusion == "failure")] | length) > 0 then .steps[]? | select(.conclusion == "failure") | "- **Job:** " + $job + "\n  **Step:** " + .name else "- **Job:** " + $job + "\n  **Step:** unavailable" end' \
+			2>/dev/null || true
+	)
+
+	if [[ -n "$failed" ]]; then
+		echo "$failed"
+	else
+		echo "Failed job and step details unavailable. See the run logs."
+	fi
+}
+
+render_failure_body() {
+	local branch
+	local sha
+	local current_run_url
+	local upstream_url
+	local marker
+	local target_branch
+	branch="$(release_branch)"
+	sha="$(release_sha)"
+	current_run_url="$(run_url)"
+	upstream_url="$(upstream_run_url)"
+	marker="$(issue_marker)"
+	target_branch="$(resolve_target_branch)"
+
+	cat <<EOF
+$marker
+
+## Summary
+
+Release automation failed on \`${target_branch}\`. This issue keeps post-merge release failures visible outside the Actions history.
+
+## Failure Context
+
+- **Workflow:** ${GITHUB_WORKFLOW:-unknown}
+- **Workflow key:** $(workflow_key)
+- **Event:** ${GITHUB_EVENT_NAME:-unknown}
+- **Branch:** ${branch}
+- **SHA:** ${sha}
+- **Actor:** ${GITHUB_ACTOR:-unknown}
+- **Run:** ${current_run_url}
+EOF
+
+	if [[ "${GITHUB_EVENT_NAME:-}" == "workflow_run" ]]; then
+		cat <<EOF
+
+## Upstream Workflow
+
+- **Workflow:** ${UPSTREAM_WORKFLOW_NAME:-unknown}
+- **Run ID:** ${UPSTREAM_RUN_ID:-unknown}
+EOF
+		if [[ -n "$upstream_url" ]]; then
+			echo "- **Run:** ${upstream_url}"
+		fi
+		cat <<EOF
+- **Conclusion:** ${UPSTREAM_CONCLUSION:-unknown}
+- **Head branch:** ${UPSTREAM_HEAD_BRANCH:-unknown}
+- **Head SHA:** ${UPSTREAM_HEAD_SHA:-unknown}
+EOF
+	fi
+
+	cat <<EOF
+
+## Failed Job or Step
+
+$(failed_step_summary)
+
+## Suggested Next Action
+
+Open the failed run, inspect the failed step logs, and either fix the release automation failure or close this issue with the run URL if the failure was transient.
+EOF
+}
+
+find_existing_issue() {
+	local search_key
+	local issue_number
+	search_key="$(marker_key)"
+	issue_number="$(gh issue list \
+		--repo "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}" \
+		--state open \
+		--search "\"${search_key}\"" \
+		--json number \
+		--jq '.[0].number // empty' 2>/dev/null || true)"
+	if [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+		echo "$issue_number"
+	fi
+}
+
+ensure_failure_issue_labels() {
+	local default_labels="${FAILURE_ISSUE_LABELS:-bug,ci,release,automation,infrastructure}"
+	local label
+
+	IFS=',' read -ra labels <<<"$default_labels"
+	for label in "${labels[@]}"; do
+		label="$(echo "$label" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+		if [[ -z "$label" ]]; then
+			continue
+		fi
+		ensure_issue_label "$label" "ededed" ""
+	done
+}
+
+notify_failure() {
+	local branch
+	local target_branch
+	local body_file
+	local existing_issue
+	local label_args
+	local label
+	local default_labels
+
+	if [[ -z "${GH_TOKEN:-}" ]]; then
+		log_error "GH_TOKEN is required"
+		exit 1
+	fi
+
+	if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+		log_error "GITHUB_REPOSITORY is required"
+		exit 1
+	fi
+
+	if ! command -v gh >/dev/null 2>&1; then
+		log_error "gh CLI is required to report release automation failures"
+		exit 1
+	fi
+
+	branch="$(release_branch)"
+	target_branch="$(resolve_target_branch)"
+
+	if [[ "$branch" != "$target_branch" ]]; then
+		log_info "Release failure notification skipped for branch '$branch' (target: '$target_branch')"
+		exit 0
+	fi
+
+	body_file="$(mktemp)"
+	trap 'rm -f "$body_file"' EXIT
+	render_failure_body >"$body_file"
+
+	existing_issue="$(find_existing_issue)"
+	if [[ -n "$existing_issue" ]]; then
+		gh issue comment "$existing_issue" \
+			--repo "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}" \
+			--body-file "$body_file" >/dev/null
+		log_success "Updated release failure issue #${existing_issue}"
+	else
+		ensure_failure_issue_labels
+		label_args=()
+		default_labels="${FAILURE_ISSUE_LABELS:-bug,ci,release,automation,infrastructure}"
+		IFS=',' read -ra labels <<<"$default_labels"
+		for label in "${labels[@]}"; do
+			label="$(echo "$label" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+			if [[ -z "$label" ]]; then
+				continue
+			fi
+			label_args+=(--label "$label")
+		done
+		gh issue create \
+			--repo "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}" \
+			--title "fix(release): release automation failed on ${target_branch}" \
+			--body-file "$body_file" \
+			"${label_args[@]}" >/dev/null
+		log_success "Created release failure issue"
+	fi
+
+	rm -f "$body_file"
+	trap - EXIT
+}
+
+case "${1:-}" in
+write_trigger_summary)
+	write_trigger_summary
+	;;
+notify_failure)
+	notify_failure
+	;;
+--help | -h)
+	usage
+	;;
+"")
+	log_error "Subcommand is required"
+	usage >&2
+	exit 1
+	;;
+*)
+	log_error "Unknown subcommand: $1"
+	usage >&2
+	exit 1
+	;;
+esac

--- a/tests/bats/integration/test_reusable_release_failure_report.bats
+++ b/tests/bats/integration/test_reusable_release_failure_report.bats
@@ -106,6 +106,10 @@ load "../../helpers/common"
 	assert_success
 	run grep -F "write_trigger_summary" "$version_pr"
 	assert_success
+	run grep -F "notify_failure" "$version_pr"
+	assert_success
+	run grep -F "write_trigger_summary" "$auto_tag"
+	assert_success
 	run grep -F "notify_failure" "$auto_tag"
 	assert_success
 }

--- a/tests/bats/integration/test_reusable_release_failure_report.bats
+++ b/tests/bats/integration/test_reusable_release_failure_report.bats
@@ -11,7 +11,7 @@ load "../../helpers/common"
 	assert_success
 	run grep -F "needs.version-pr.result == 'failure'" "$workflow"
 	assert_success
-	run grep -F "report-failures:" "$workflow"
+	run grep -F "inputs.report-failures" "$workflow"
 	assert_success
 	run grep -F "failure-issue-labels:" "$workflow"
 	assert_success

--- a/tests/bats/integration/test_reusable_release_failure_report.bats
+++ b/tests/bats/integration/test_reusable_release_failure_report.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for release failure reporting in reusable workflows
+
+load "../../helpers/common"
+
+@test "reusable-release-version-pr: defines report-release-failure follow-up job" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
+
+	run grep -F "report-release-failure:" "$workflow"
+	assert_success
+	run grep -F "needs.version-pr.result == 'failure'" "$workflow"
+	assert_success
+	run grep -F "report-failures:" "$workflow"
+	assert_success
+	run grep -F "failure-issue-labels:" "$workflow"
+	assert_success
+	run grep -F "failure-target-branch:" "$workflow"
+	assert_success
+}
+
+@test "reusable-release-auto-tag: defines report-release-failure follow-up job" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-auto-tag.yml"
+
+	run grep -F "report-release-failure:" "$workflow"
+	assert_success
+	run grep -F "needs.auto-tag.result == 'failure'" "$workflow"
+	assert_success
+	run grep -F "inputs.report-failures" "$workflow"
+	assert_success
+}
+
+@test "reusable-release-version-pr: hardens egress on failure follow-up job" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
+
+	run awk '
+		/report-release-failure:/ { in_job = 1 }
+		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /report-release-failure:/ {
+			in_job = 0
+		}
+		in_job && /harden-runner/ { found = 1; exit }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+	run awk '
+		/report-release-failure:/ { in_job = 1 }
+		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /report-release-failure:/ {
+			in_job = 0
+		}
+		in_job && /egress-preset: github-minimal/ { found = 1; exit }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-release-auto-tag: grants issues write to failure follow-up job" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-auto-tag.yml"
+
+	run awk '
+		/report-release-failure:/ { in_job = 1; in_perms = 0 }
+		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /report-release-failure:/ {
+			in_job = 0
+			in_perms = 0
+		}
+		in_job && /permissions:/ { in_perms = 1 }
+		in_perms && /issues: write/ { found = 1; exit }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+	run awk '
+		/report-release-failure:/ { in_job = 1; in_perms = 0 }
+		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /report-release-failure:/ {
+			in_job = 0
+			in_perms = 0
+		}
+		in_job && /permissions:/ { in_perms = 1 }
+		in_perms && /actions: read/ { found = 1; exit }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable release workflows: wire distinct workflow keys" {
+	local version_pr="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
+	local auto_tag="${PROJECT_ROOT}/.github/workflows/reusable-release-auto-tag.yml"
+
+	run awk '
+		/report-release-failure:/ { in_job = 1 }
+		in_job && /RELEASE_WORKFLOW_KEY: release-version-pr/ { found = 1; exit }
+		END { exit !found }
+	' "$version_pr"
+	assert_success
+	run awk '
+		/report-release-failure:/ { in_job = 1 }
+		in_job && /RELEASE_WORKFLOW_KEY: release-auto-tag/ { found = 1; exit }
+		END { exit !found }
+	' "$auto_tag"
+	assert_success
+}
+
+@test "reusable release workflows: call report-release-failure helper" {
+	local version_pr="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
+	local auto_tag="${PROJECT_ROOT}/.github/workflows/reusable-release-auto-tag.yml"
+
+	run grep -F "report-release-failure.sh" "$version_pr"
+	assert_success
+	run grep -F "write_trigger_summary" "$version_pr"
+	assert_success
+	run grep -F "notify_failure" "$auto_tag"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_release_failure_report.bats
+++ b/tests/bats/integration/test_reusable_release_failure_report.bats
@@ -28,6 +28,10 @@ load "../../helpers/common"
 	assert_success
 	run grep -F "inputs.report-failures" "$workflow"
 	assert_success
+	run grep -F "failure-issue-labels:" "$workflow"
+	assert_success
+	run grep -F "failure-target-branch:" "$workflow"
+	assert_success
 }
 
 @test "reusable-release-version-pr: hardens egress on failure follow-up job" {
@@ -48,6 +52,56 @@ load "../../helpers/common"
 			in_job = 0
 		}
 		in_job && /egress-preset: github-minimal/ { found = 1; exit }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-release-auto-tag: hardens egress on failure follow-up job" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-auto-tag.yml"
+
+	run awk '
+		/report-release-failure:/ { in_job = 1 }
+		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /report-release-failure:/ {
+			in_job = 0
+		}
+		in_job && /harden-runner/ { found = 1; exit }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+	run awk '
+		/report-release-failure:/ { in_job = 1 }
+		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /report-release-failure:/ {
+			in_job = 0
+		}
+		in_job && /egress-preset: github-minimal/ { found = 1; exit }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-release-version-pr: grants issues write to failure follow-up job" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
+
+	run awk '
+		/report-release-failure:/ { in_job = 1; in_perms = 0 }
+		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /report-release-failure:/ {
+			in_job = 0
+			in_perms = 0
+		}
+		in_job && /permissions:/ { in_perms = 1 }
+		in_perms && /issues: write/ { found = 1; exit }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+	run awk '
+		/report-release-failure:/ { in_job = 1; in_perms = 0 }
+		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /report-release-failure:/ {
+			in_job = 0
+			in_perms = 0
+		}
+		in_job && /permissions:/ { in_perms = 1 }
+		in_perms && /actions: read/ { found = 1; exit }
 		END { exit !found }
 	' "$workflow"
 	assert_success
@@ -107,6 +161,8 @@ load "../../helpers/common"
 	run grep -F "write_trigger_summary" "$version_pr"
 	assert_success
 	run grep -F "notify_failure" "$version_pr"
+	assert_success
+	run grep -F "report-release-failure.sh" "$auto_tag"
 	assert_success
 	run grep -F "write_trigger_summary" "$auto_tag"
 	assert_success

--- a/tests/bats/unit/release/test_report_release_failure.bats
+++ b/tests/bats/unit/release/test_report_release_failure.bats
@@ -154,6 +154,34 @@ EOF
 	assert_output --partial "Created release failure issue"
 }
 
+@test "report-release-failure: notify_failure skips missing labels" {
+	mock_command_multi "gh" '
+		*issue*list*) echo "";;
+		*label*view*bug*) exit 0;;
+		*label*view*) exit 1;;
+		*issue*create*) echo "https://github.com/lgtm-hq/lgtm-ci/issues/88";;
+		*run*view*) exit 0;;
+		*) exit 1;;
+	'
+
+	run bash "$SCRIPT" notify_failure
+	assert_success
+	assert_output --partial "Skipping missing issue label"
+	assert_output --partial "Created release failure issue"
+}
+
+@test "report-release-failure: notify_failure fails when issue search fails" {
+	mock_command_multi "gh" '
+		*issue*list*) echo "API rate limit exceeded" >&2; exit 1;;
+		*run*view*) exit 0;;
+		*) exit 1;;
+	'
+
+	run bash "$SCRIPT" notify_failure
+	assert_failure
+	assert_output --partial "Could not search for existing release failure issues"
+}
+
 @test "report-release-failure: notify_failure fails when GH_TOKEN is unset" {
 	unset GH_TOKEN
 

--- a/tests/bats/unit/release/test_report_release_failure.bats
+++ b/tests/bats/unit/release/test_report_release_failure.bats
@@ -128,6 +128,39 @@ EOF
 	assert_output --partial "Updated release failure issue #77"
 }
 
+@test "report-release-failure: notify_failure ignores gh stderr warnings on issue search" {
+	mkdir -p "${BATS_TEST_TMPDIR}/bin"
+	cat >"${BATS_TEST_TMPDIR}/bin/gh" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+	*repo*view*)
+		echo "main"
+		;;
+	*issue*list*)
+		echo "Warning: rate limit approaching" >&2
+		echo "77"
+		exit 0
+		;;
+	*issue*comment*)
+		echo "commented"
+		exit 0
+		;;
+	*run*view*)
+		exit 0
+		;;
+	*)
+		exit 1
+		;;
+esac
+EOF
+	chmod +x "${BATS_TEST_TMPDIR}/bin/gh"
+	export PATH="${BATS_TEST_TMPDIR}/bin:${PATH}"
+
+	run bash "$SCRIPT" notify_failure
+	assert_success
+	assert_output --partial "Updated release failure issue #77"
+}
+
 @test "report-release-failure: notify_failure skips non-target branch" {
 	export GITHUB_REF_NAME=feature/test
 	export FAILURE_TARGET_BRANCH=main

--- a/tests/bats/unit/release/test_report_release_failure.bats
+++ b/tests/bats/unit/release/test_report_release_failure.bats
@@ -159,8 +159,7 @@ EOF
 	run bash "$SCRIPT" notify_failure
 	assert_success
 	assert_output --partial "Updated release failure issue #77"
-	refute_output --partial "warning"
-	refute_output --partial "WARNING"
+	refute_output --partial "Warning:"
 }
 
 @test "report-release-failure: notify_failure skips non-target branch" {

--- a/tests/bats/unit/release/test_report_release_failure.bats
+++ b/tests/bats/unit/release/test_report_release_failure.bats
@@ -159,6 +159,8 @@ EOF
 	run bash "$SCRIPT" notify_failure
 	assert_success
 	assert_output --partial "Updated release failure issue #77"
+	refute_output --partial "warning"
+	refute_output --partial "WARNING"
 }
 
 @test "report-release-failure: notify_failure skips non-target branch" {

--- a/tests/bats/unit/release/test_report_release_failure.bats
+++ b/tests/bats/unit/release/test_report_release_failure.bats
@@ -1,0 +1,163 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/release/report-release-failure.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/release/report-release-failure.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+	export PROJECT_ROOT
+	export SCRIPT
+	export GH_TOKEN=test-token
+	export GITHUB_REPOSITORY=lgtm-hq/lgtm-ci
+	export GITHUB_RUN_ID=12345
+	export GITHUB_SHA=abc123def456
+	export GITHUB_REF_NAME=main
+	export GITHUB_EVENT_NAME=push
+	export GITHUB_WORKFLOW="Release Version PR"
+	export GITHUB_ACTOR=test-actor
+	export GITHUB_SERVER_URL=https://github.com
+	export RELEASE_WORKFLOW_KEY=release-version-pr
+	export GITHUB_STEP_SUMMARY="${BATS_TEST_TMPDIR}/step-summary.md"
+	: >"$GITHUB_STEP_SUMMARY"
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+@test "report-release-failure: passes bash syntax check" {
+	run bash -n "$SCRIPT"
+	assert_success
+}
+
+@test "report-release-failure: write_trigger_summary records push context" {
+	run bash "$SCRIPT" write_trigger_summary
+	assert_success
+	[[ -f "$GITHUB_STEP_SUMMARY" ]]
+	run grep -F "## Release Automation Context" "$GITHUB_STEP_SUMMARY"
+	assert_success
+	run grep -F "release-version-pr" "$GITHUB_STEP_SUMMARY"
+	assert_success
+	run grep -F "**Branch:** main" "$GITHUB_STEP_SUMMARY"
+	assert_success
+	run grep -F "abc123def456" "$GITHUB_STEP_SUMMARY"
+	assert_success
+}
+
+@test "report-release-failure: write_trigger_summary records workflow_run upstream context" {
+	export GITHUB_EVENT_NAME=workflow_run
+	export UPSTREAM_WORKFLOW_NAME="CI"
+	export UPSTREAM_RUN_ID=999
+	export UPSTREAM_CONCLUSION=success
+	export UPSTREAM_HEAD_BRANCH=main
+	export UPSTREAM_HEAD_SHA=deadbeef
+
+	run bash "$SCRIPT" write_trigger_summary
+	assert_success
+	run grep -F "### Upstream Workflow" "$GITHUB_STEP_SUMMARY"
+	assert_success
+	run grep -F "**Workflow:** CI" "$GITHUB_STEP_SUMMARY"
+	assert_success
+	run grep -F "**Run ID:** 999" "$GITHUB_STEP_SUMMARY"
+	assert_success
+}
+
+@test "report-release-failure: write_trigger_summary uses failure heading when primary job failed" {
+	export PRIMARY_JOB_FAILED=true
+
+	run bash "$SCRIPT" write_trigger_summary
+	assert_success
+	run grep -F "## Release Automation Failure" "$GITHUB_STEP_SUMMARY"
+	assert_success
+}
+
+@test "report-release-failure: notify_failure creates issue when none exists" {
+	mkdir -p "${BATS_TEST_TMPDIR}/bin"
+	cat >"${BATS_TEST_TMPDIR}/bin/gh" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> '${BATS_TEST_TMPDIR}/mock_calls_gh'
+case "\$*" in
+	*repo*view*)
+		echo "main"
+		;;
+	*issue*list*)
+		echo ""
+		;;
+	*label*view*)
+		exit 0
+		;;
+	*issue*create*)
+		echo "https://github.com/lgtm-hq/lgtm-ci/issues/42"
+		exit 0
+		;;
+	*run*view*)
+		exit 0
+		;;
+	*)
+		exit 1
+		;;
+esac
+EOF
+	chmod +x "${BATS_TEST_TMPDIR}/bin/gh"
+	export PATH="${BATS_TEST_TMPDIR}/bin:${PATH}"
+
+	run bash "$SCRIPT" notify_failure
+	assert_success
+	assert_output --partial "Created release failure issue"
+	run grep -F 'release-automation-failure:release-version-pr:main' "${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_success
+}
+
+@test "report-release-failure: notify_failure comments on existing issue" {
+	mock_command_multi "gh" '
+		*repo*view*) echo "main";;
+		*issue*list*) echo "77";;
+		*issue*comment*) echo "commented";;
+		*run*view*) exit 0;;
+		*) exit 1;;
+	'
+
+	run bash "$SCRIPT" notify_failure
+	assert_success
+	assert_output --partial "Updated release failure issue #77"
+}
+
+@test "report-release-failure: notify_failure skips non-target branch" {
+	export GITHUB_REF_NAME=feature/test
+	export FAILURE_TARGET_BRANCH=main
+
+	run bash "$SCRIPT" notify_failure
+	assert_success
+	assert_output --partial "Release failure notification skipped for branch 'feature/test'"
+}
+
+@test "report-release-failure: notify_failure respects FAILURE_TARGET_BRANCH override" {
+	export FAILURE_TARGET_BRANCH=develop
+	export GITHUB_REF_NAME=develop
+
+	mock_command_multi "gh" '
+		*issue*list*) echo "";;
+		*label*view*) exit 0;;
+		*issue*create*) echo "https://github.com/lgtm-hq/lgtm-ci/issues/55";;
+		*run*view*) exit 0;;
+		*) exit 1;;
+	'
+
+	run bash "$SCRIPT" notify_failure
+	assert_success
+	assert_output --partial "Created release failure issue"
+}
+
+@test "report-release-failure: notify_failure fails when GH_TOKEN is unset" {
+	unset GH_TOKEN
+
+	run bash "$SCRIPT" notify_failure
+	assert_failure
+	assert_output --partial "GH_TOKEN is required"
+}


### PR DESCRIPTION
## Summary

Add optional failure visibility to the reusable release workflows so consumers get step-summary context and a deduplicated GitHub issue when version-PR or auto-tag jobs fail on the default branch. Closes the operational gap from py-lintro#907 after the lgtm-ci migration.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #207
- Relates to lgtm-hq/py-lintro#907

## Changes Made

- Add `scripts/ci/release/report-release-failure.sh` with `write_trigger_summary` and `notify_failure` subcommands
- Add `report-release-failure` follow-up jobs to `reusable-release-version-pr.yml` and `reusable-release-auto-tag.yml`
- Expose optional inputs: `report-failures`, `failure-issue-labels`, `failure-target-branch`
- Deduplicate failures via quoted HTML comment markers and retry/recover logic for concurrent runs
- Attach only pre-existing issue labels to avoid recoloring repository labels on first run
- Add BATS unit and integration contract tests
- Document behavior in `docs/workflow-contract.md`, `docs/reusable-workflows.md`, and `CHANGELOG.md`

## Testing

- [x] BATS unit tests for `report-release-failure.sh`
- [x] BATS integration tests for reusable workflow contracts
- [x] `uv run lintro chk` (full suite)
- [x] `uv run lintro tst`

## Quality Checks

- [x] `uv run lintro fmt`
- [x] `uv run lintro chk`
- [x] Greptile review (addressed P2 findings)
- [x] CodeRabbit review (addressed major/trivial findings)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add failure reporting jobs to reusable release workflows
> - Adds a `report-release-failure` follow-up job to both [`reusable-release-auto-tag.yml`](https://github.com/lgtm-hq/lgtm-ci/pull/311/files#diff-9029c6ffc07d573f6df930a91ea59eded9a0f588356d5b11c902e070189aa298) and [`reusable-release-version-pr.yml`](https://github.com/lgtm-hq/lgtm-ci/pull/311/files#diff-d61fae79363325466e1f95221611b67147acc63cce67db555b10ac20d3efe4ec) that runs when the primary job fails.
> - The new job writes failure context (workflow, event, branch, actor, run URL) to the GitHub step summary and creates or updates a deduplicated GitHub issue using a hidden marker keyed by workflow and branch.
> - A new [`report-release-failure.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/311/files#diff-954e44820bd45b6e3078efc218c9832cc908b87370690de6a6e837565ebdf541) script implements the `write_trigger_summary` and `notify_failure` subcommands; it skips issue creation when the triggering branch does not match the target branch.
> - Three new `workflow_call` inputs are added to each workflow: `report-failures` (bool, default `true`), `failure-issue-labels`, and `failure-target-branch`.
> - Behavioral Change: both reusable release workflows now run an additional job on failure with `issues: write` permission, gated by the `report-failures` input.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8589de7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional release failure reporting: workflows can write step summaries and create/update deduplicated GitHub issues when release jobs fail, with configurable enable/disable, labels, and target-branch control.
  * Added a reusable failure-reporting helper script invoked by the follow-up job.

* **Documentation**
  * Updated docs describing failure-reporting behavior, inputs, permissions, and recommended run-name.

* **Tests**
  * Added integration and unit tests covering failure-reporting flows and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds optional release failure visibility to the two reusable release workflows (`reusable-release-auto-tag.yml` and `reusable-release-version-pr.yml`): when a primary job fails, a follow-up `report-release-failure` job writes step-summary context and opens or updates a deduplicated GitHub issue keyed by a hidden HTML comment marker.

- Adds `scripts/ci/release/report-release-failure.sh` with `write_trigger_summary` and `notify_failure` subcommands; `find_existing_issue` correctly separates stderr via `2>\"$gh_stderr\"` (the `2>&1` issue flagged in a prior review has been addressed), and the concurrency race is mitigated with a sleep+retry pattern.
- Exposes three optional inputs (`report-failures`, `failure-issue-labels`, `failure-target-branch`) with the follow-up job declaring its own scoped permissions (`actions: read`, `contents: read`, `issues: write`) and `egress-preset: github-minimal`.
- Includes BATS unit tests (including a regression test for the stderr-isolation fix) and integration contract tests, plus documentation updates in `docs/workflow-contract.md` and `docs/reusable-workflows.md`.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is additive, all new code paths are guarded by `report-failures: true`, and the only concern is a minor observability gap in logging.

All new code is behind an opt-in guard (`report-failures` input evaluated at the `if:` condition), so existing callers are unaffected even with the `true` default unless a release job actually fails. The deduplication logic is sound, stderr separation was fixed from the prior review cycle, temp-file cleanup uses traps correctly, and BATS coverage is thorough. The sole new finding is that `create_failure_issue` discards the created issue URL via `>/dev/null`, leaving the step log without a clickable link — a usability nit that does not affect correctness.

No files require special attention; `scripts/ci/release/report-release-failure.sh` is the most complex new file and was reviewed in detail.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/ci/release/report-release-failure.sh | New script implementing `write_trigger_summary` and `notify_failure` subcommands; correctly separates stderr in `find_existing_issue` (the previous `2>&1` issue is resolved), uses trap-based temp-file cleanup, and deduplicates via hidden HTML comment markers; newly created issue URL is silently dropped via `>/dev/null`. |
| .github/workflows/reusable-release-auto-tag.yml | Adds `report-release-failure` follow-up job with correct `always()`/`inputs.report-failures`/`needs.auto-tag.result == 'failure'` guard, scoped permissions (`actions: read`, `contents: read`, `issues: write`), and `egress-preset: github-minimal` hardening. |
| .github/workflows/reusable-release-version-pr.yml | Identical pattern to `reusable-release-auto-tag.yml`; correctly wires distinct `RELEASE_WORKFLOW_KEY: release-version-pr` and `needs.version-pr.result == 'failure'` guard. |
| tests/bats/unit/release/test_report_release_failure.bats | Comprehensive unit tests covering branch filtering, heading switching, label skipping, search failure propagation, and the previously-flagged stderr-isolation path; test for `notify_failure creates issue when none exists` incurs a real 2-second sleep through the anti-duplication pause. |
| tests/bats/integration/test_reusable_release_failure_report.bats | Contract tests verify the follow-up job is present in both workflows, egress hardening is applied, `issues: write` is declared, and distinct workflow keys are wired. |
| docs/workflow-contract.md | Documents the three new inputs, required permissions, and deduplication mechanism; accurately represents what the code does. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CW as Caller Workflow
    participant PJ as Primary Job<br/>(auto-tag / version-pr)
    participant RJ as report-release-failure job
    participant GHA as GitHub Actions API
    participant GHI as GitHub Issues API

    CW->>PJ: trigger
    PJ-->>RJ: "failure (needs.<job>.result == 'failure')"
    Note over RJ: runs only when<br/>inputs.report-failures == true

    RJ->>RJ: "write_trigger_summary<br/>(→ GITHUB_STEP_SUMMARY)"

    RJ->>GHA: gh run view (failed job/step details)
    GHA-->>RJ: JSON jobs

    RJ->>RJ: render_failure_body (marker + context)

    RJ->>GHI: gh issue list --search marker --state open
    GHI-->>RJ: existing issue number (or empty)

    alt existing issue found
        RJ->>GHI: "gh issue comment #N --body-file"
        GHI-->>RJ: ok
    else no existing issue
        RJ->>RJ: sleep 2s (anti-duplicate pause)
        RJ->>GHI: gh issue list (retry)
        GHI-->>RJ: still empty
        RJ->>GHI: gh issue create (with label verification)
        GHI-->>RJ: new issue URL
        alt creation race-lost
            RJ->>GHI: gh issue list (recover)
            GHI-->>RJ: concurrent issue number
            RJ->>GHI: "gh issue comment #N --body-file"
        end
    end

    RJ->>RJ: "branch != target-branch → skip silently"
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `scripts/ci/release/report-release-failure.sh`, line 584-641 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/bc7c47d153bed5633050def2fc08c787603c1346/scripts/ci/release/report-release-failure.sh#L584-L641)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`resolve_target_branch` called twice per `notify_failure` invocation**

   `notify_failure` calls `resolve_target_branch` directly for the branch-filter guard, then `render_failure_body` calls it again internally to populate the issue body. When `FAILURE_TARGET_BRANCH` is unset, both calls execute `gh repo view … --json defaultBranchRef`, resulting in two identical API round-trips per failure run. The fix is to resolve once and pass `target_branch` as a parameter to `render_failure_body`, or cache the result in an environment variable before calling `render_failure_body`.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Frelease%2Freport-release-failure.sh%0ALine%3A%20584-641%0A%0AComment%3A%0A**%60resolve_target_branch%60%20called%20twice%20per%20%60notify_failure%60%20invocation**%0A%0A%60notify_failure%60%20calls%20%60resolve_target_branch%60%20directly%20for%20the%20branch-filter%20guard%2C%20then%20%60render_failure_body%60%20calls%20it%20again%20internally%20to%20populate%20the%20issue%20body.%20When%20%60FAILURE_TARGET_BRANCH%60%20is%20unset%2C%20both%20calls%20execute%20%60gh%20repo%20view%20%E2%80%A6%20--json%20defaultBranchRef%60%2C%20resulting%20in%20two%20identical%20API%20round-trips%20per%20failure%20run.%20The%20fix%20is%20to%20resolve%20once%20and%20pass%20%60target_branch%60%20as%20a%20parameter%20to%20%60render_failure_body%60%2C%20or%20cache%20the%20result%20in%20an%20environment%20variable%20before%20calling%20%60render_failure_body%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=311&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Frelease%2Freport-release-failure.sh%0ALine%3A%20584-641%0A%0AComment%3A%0A**%60resolve_target_branch%60%20called%20twice%20per%20%60notify_failure%60%20invocation**%0A%0A%60notify_failure%60%20calls%20%60resolve_target_branch%60%20directly%20for%20the%20branch-filter%20guard%2C%20then%20%60render_failure_body%60%20calls%20it%20again%20internally%20to%20populate%20the%20issue%20body.%20When%20%60FAILURE_TARGET_BRANCH%60%20is%20unset%2C%20both%20calls%20execute%20%60gh%20repo%20view%20%E2%80%A6%20--json%20defaultBranchRef%60%2C%20resulting%20in%20two%20identical%20API%20round-trips%20per%20failure%20run.%20The%20fix%20is%20to%20resolve%20once%20and%20pass%20%60target_branch%60%20as%20a%20parameter%20to%20%60render_failure_body%60%2C%20or%20cache%20the%20result%20in%20an%20environment%20variable%20before%20calling%20%60render_failure_body%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=311&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F207-surface-reusable-release-workflow-failures%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F207-surface-reusable-release-workflow-failures%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Frelease%2Freport-release-failure.sh%0ALine%3A%20584-641%0A%0AComment%3A%0A**%60resolve_target_branch%60%20called%20twice%20per%20%60notify_failure%60%20invocation**%0A%0A%60notify_failure%60%20calls%20%60resolve_target_branch%60%20directly%20for%20the%20branch-filter%20guard%2C%20then%20%60render_failure_body%60%20calls%20it%20again%20internally%20to%20populate%20the%20issue%20body.%20When%20%60FAILURE_TARGET_BRANCH%60%20is%20unset%2C%20both%20calls%20execute%20%60gh%20repo%20view%20%E2%80%A6%20--json%20defaultBranchRef%60%2C%20resulting%20in%20two%20identical%20API%20round-trips%20per%20failure%20run.%20The%20fix%20is%20to%20resolve%20once%20and%20pass%20%60target_branch%60%20as%20a%20parameter%20to%20%60render_failure_body%60%2C%20or%20cache%20the%20result%20in%20an%20environment%20variable%20before%20calling%20%60render_failure_body%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=311&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `.github/workflows/reusable-release-auto-tag.yml`, line 9-15 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/bc7c47d153bed5633050def2fc08c787603c1346/.github/workflows/reusable-release-auto-tag.yml#L9-L15)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`report-failures` opt-out default may surprise existing consumers**

   The new input defaults to `true`, so every existing caller of this reusable workflow will start opening GitHub issues when a release job fails — without making any change to their caller workflow. Repositories that manage their own alerting (PagerDuty, Slack, etc.) or that tolerate transient release failures silently will begin accumulating unexpected issues. Defaulting to `false` and having consumers opt in would be safer for a new capability. The same concern applies to the identical default in `reusable-release-version-pr.yml`.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-release-auto-tag.yml%0ALine%3A%209-15%0A%0AComment%3A%0A**%60report-failures%60%20opt-out%20default%20may%20surprise%20existing%20consumers**%0A%0AThe%20new%20input%20defaults%20to%20%60true%60%2C%20so%20every%20existing%20caller%20of%20this%20reusable%20workflow%20will%20start%20opening%20GitHub%20issues%20when%20a%20release%20job%20fails%20%E2%80%94%20without%20making%20any%20change%20to%20their%20caller%20workflow.%20Repositories%20that%20manage%20their%20own%20alerting%20%28PagerDuty%2C%20Slack%2C%20etc.%29%20or%20that%20tolerate%20transient%20release%20failures%20silently%20will%20begin%20accumulating%20unexpected%20issues.%20Defaulting%20to%20%60false%60%20and%20having%20consumers%20opt%20in%20would%20be%20safer%20for%20a%20new%20capability.%20The%20same%20concern%20applies%20to%20the%20identical%20default%20in%20%60reusable-release-version-pr.yml%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=311&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-release-auto-tag.yml%0ALine%3A%209-15%0A%0AComment%3A%0A**%60report-failures%60%20opt-out%20default%20may%20surprise%20existing%20consumers**%0A%0AThe%20new%20input%20defaults%20to%20%60true%60%2C%20so%20every%20existing%20caller%20of%20this%20reusable%20workflow%20will%20start%20opening%20GitHub%20issues%20when%20a%20release%20job%20fails%20%E2%80%94%20without%20making%20any%20change%20to%20their%20caller%20workflow.%20Repositories%20that%20manage%20their%20own%20alerting%20%28PagerDuty%2C%20Slack%2C%20etc.%29%20or%20that%20tolerate%20transient%20release%20failures%20silently%20will%20begin%20accumulating%20unexpected%20issues.%20Defaulting%20to%20%60false%60%20and%20having%20consumers%20opt%20in%20would%20be%20safer%20for%20a%20new%20capability.%20The%20same%20concern%20applies%20to%20the%20identical%20default%20in%20%60reusable-release-version-pr.yml%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=311&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F207-surface-reusable-release-workflow-failures%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F207-surface-reusable-release-workflow-failures%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-release-auto-tag.yml%0ALine%3A%209-15%0A%0AComment%3A%0A**%60report-failures%60%20opt-out%20default%20may%20surprise%20existing%20consumers**%0A%0AThe%20new%20input%20defaults%20to%20%60true%60%2C%20so%20every%20existing%20caller%20of%20this%20reusable%20workflow%20will%20start%20opening%20GitHub%20issues%20when%20a%20release%20job%20fails%20%E2%80%94%20without%20making%20any%20change%20to%20their%20caller%20workflow.%20Repositories%20that%20manage%20their%20own%20alerting%20%28PagerDuty%2C%20Slack%2C%20etc.%29%20or%20that%20tolerate%20transient%20release%20failures%20silently%20will%20begin%20accumulating%20unexpected%20issues.%20Defaulting%20to%20%60false%60%20and%20having%20consumers%20opt%20in%20would%20be%20safer%20for%20a%20new%20capability.%20The%20same%20concern%20applies%20to%20the%20identical%20default%20in%20%60reusable-release-version-pr.yml%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=311&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Frelease%2Freport-release-failure.sh%3A575-592%0A**Issue%20URL%20silently%20discarded%20on%20creation**%0A%0ABoth%20%60gh%20issue%20create%60%20calls%20redirect%20stdout%20to%20%60%2Fdev%2Fnull%60%2C%20so%20the%20URL%20of%20the%20newly-created%20issue%20never%20appears%20in%20the%20workflow%20logs.%20Because%20%60log_success%20%22Created%20release%20failure%20issue%22%60%20is%20emitted%20by%20the%20caller%20in%20%60notify_failure%60%20without%20a%20URL%2C%20operators%20triaging%20a%20failed%20run%20have%20to%20navigate%20to%20the%20repo's%20issue%20list%20to%20find%20the%20ticket%20rather%20than%20clicking%20a%20direct%20link%20from%20the%20step%20output.%20Capturing%20and%20logging%20the%20URL%20%28e.g.%2C%20%60issue_url%3D%24%28gh%20issue%20create%20...%29%60%20%2B%20%60log_success%20%22%E2%80%A6%20%24%7Bissue_url%7D%22%60%29%20would%20remove%20that%20friction.%0A%0A&pr=311&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Frelease%2Freport-release-failure.sh%3A575-592%0A**Issue%20URL%20silently%20discarded%20on%20creation**%0A%0ABoth%20%60gh%20issue%20create%60%20calls%20redirect%20stdout%20to%20%60%2Fdev%2Fnull%60%2C%20so%20the%20URL%20of%20the%20newly-created%20issue%20never%20appears%20in%20the%20workflow%20logs.%20Because%20%60log_success%20%22Created%20release%20failure%20issue%22%60%20is%20emitted%20by%20the%20caller%20in%20%60notify_failure%60%20without%20a%20URL%2C%20operators%20triaging%20a%20failed%20run%20have%20to%20navigate%20to%20the%20repo's%20issue%20list%20to%20find%20the%20ticket%20rather%20than%20clicking%20a%20direct%20link%20from%20the%20step%20output.%20Capturing%20and%20logging%20the%20URL%20%28e.g.%2C%20%60issue_url%3D%24%28gh%20issue%20create%20...%29%60%20%2B%20%60log_success%20%22%E2%80%A6%20%24%7Bissue_url%7D%22%60%29%20would%20remove%20that%20friction.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=311&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F207-surface-reusable-release-workflow-failures%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F207-surface-reusable-release-workflow-failures%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Frelease%2Freport-release-failure.sh%3A575-592%0A**Issue%20URL%20silently%20discarded%20on%20creation**%0A%0ABoth%20%60gh%20issue%20create%60%20calls%20redirect%20stdout%20to%20%60%2Fdev%2Fnull%60%2C%20so%20the%20URL%20of%20the%20newly-created%20issue%20never%20appears%20in%20the%20workflow%20logs.%20Because%20%60log_success%20%22Created%20release%20failure%20issue%22%60%20is%20emitted%20by%20the%20caller%20in%20%60notify_failure%60%20without%20a%20URL%2C%20operators%20triaging%20a%20failed%20run%20have%20to%20navigate%20to%20the%20repo's%20issue%20list%20to%20find%20the%20ticket%20rather%20than%20clicking%20a%20direct%20link%20from%20the%20step%20output.%20Capturing%20and%20logging%20the%20URL%20%28e.g.%2C%20%60issue_url%3D%24%28gh%20issue%20create%20...%29%60%20%2B%20%60log_success%20%22%E2%80%A6%20%24%7Bissue_url%7D%22%60%29%20would%20remove%20that%20friction.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=311&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["test: match gh stderr leak assertion to ..."](https://github.com/lgtm-hq/lgtm-ci/commit/8589de744718c21789b280fb6b5a9fce8beb9b7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36059256)</sub>

<!-- /greptile_comment -->