### PR TITLE
fix(release): grant caller permissions for report-release-failure job

### DIFF
--- a/.github/workflows/release-auto-tag.yml
+++ b/.github/workflows/release-auto-tag.yml
@@ -28,3 +28,5 @@ jobs:
       RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
     permissions:
       contents: write
+      actions: read
+      issues: write

--- a/.github/workflows/release-version-pr.yml
+++ b/.github/workflows/release-version-pr.yml
@@ -23,3 +23,5 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: read
+      issues: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **release**: grant caller permissions for `report-release-failure` follow-up
   jobs so release workflows validate at startup (#312)
+- **release**: deduplicate failure issues by title and visible tracking key
+  instead of HTML comment search alone
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **release**: grant caller permissions for `report-release-failure` follow-up
+  jobs so release workflows validate at startup (#312)
+
 ### Security
 
 ## [0.34.1] - 2026-06-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **release**: grant caller permissions for `report-release-failure` follow-up
   jobs so release workflows validate at startup (#312)
 - **release**: deduplicate failure issues by title and visible tracking key
-  instead of HTML comment search alone
+  instead of HTML comment search alone; fall back to tracking-key search when
+  title search fails
 
 ### Security
 

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -302,6 +302,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      actions: read
+      issues: write
     with:
       ecosystems: node,ruby,python
       skip-patterns: "^chore(release):"
@@ -312,6 +314,8 @@ jobs:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@<sha>
     permissions:
       contents: write
+      actions: read
+      issues: write
     with:
       create-release: false
     secrets: inherit

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -331,9 +331,12 @@ the workflow at startup.
 
 <!-- markdownlint-enable MD013 -->
 
-Failure issues deduplicate via a hidden HTML comment marker
-(`release-automation-failure:<workflow-key>:<branch>`). Recurring failures add
-comments to the same open issue.
+Failure issues deduplicate by deterministic issue title
+(`fix(release): release automation failed on <branch> (<workflow-key>)`), then
+fall back to a visible tracking key footer
+(`release-automation-failure:<workflow-key>:<branch>`). A hidden HTML comment
+marker is retained for backward compatibility. Recurring failures add comments
+to the same open issue.
 
 ## Egress presets
 

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -109,8 +109,9 @@ would worsen check-name readability) and to access matrix-specific artifacts.
 | Test / report publish | `contents: read`, `pull-requests: write`             | `reusable-publish-test-summary.yml`,         |
 |                       |                                                      | `reusable-publish-artifact-report.yml`       |
 | Publish to Pages      | `contents: read`, `pages: write`, `id-token: write`  | Separate publish job                         |
-| Release version       | `contents: write`, `pull-requests: write`            | `reusable-release-version-pr.yml`            |
-| Release auto-tag      | `contents: write`                                    | `reusable-release-auto-tag.yml`              |
+| Release version       | `contents: write`, `pull-requests: write`,           | `reusable-release-version-pr.yml`            |
+|                       | `actions: read`, `issues: write`                     |                                              |
+| Release auto-tag      | `contents: write`, `actions: read`, `issues: write`  | `reusable-release-auto-tag.yml`              |
 | Release failure issue | `actions: read`, `contents: read`, `issues: write`   | `report-release-failure` follow-up job       |
 | PyPI upload (OIDC)    | `contents: read`; `id-token` + `attestations: write` | `prepare-pypi-upload` + pypa step            |
 | PyPI build            | `contents: read`                                     | `reusable-build-python-dist.yml`             |
@@ -315,7 +316,10 @@ Do **not** use `.lgtm-ci-egress` sparse checkouts for the composite.
 Both release reusables include an optional `report-release-failure` follow-up job
 that runs when the primary job fails (`needs.<job>.result == 'failure'`). The
 job uses `egress-preset: github-minimal` (GitHub API only) and declares its own
-`issues: write` permission — callers do not need extra permissions.
+`actions: read`, `contents: read`, and `issues: write` permissions. Callers
+must grant at least `actions: read` and `issues: write` on the reusable-workflow
+call job (in addition to the primary release permissions above) or GitHub rejects
+the workflow at startup.
 
 <!-- markdownlint-disable MD013 -->
 

--- a/scripts/ci/release/report-release-failure.sh
+++ b/scripts/ci/release/report-release-failure.sh
@@ -76,6 +76,12 @@ issue_marker() {
 	echo "<!-- $(marker_key) -->"
 }
 
+failure_issue_title() {
+	local target_branch="${1:?target_branch is required}"
+	printf 'fix(release): release automation failed on %s (%s)' \
+		"$target_branch" "$(workflow_key)"
+}
+
 resolve_target_branch() {
 	if [[ -n "${FAILURE_TARGET_BRANCH:-}" ]]; then
 		echo "$FAILURE_TARGET_BRANCH"
@@ -162,18 +168,19 @@ failed_step_summary() {
 }
 
 render_failure_body() {
+	local target_branch="${1:?target_branch is required}"
 	local branch
 	local sha
 	local current_run_url
 	local upstream_url
 	local marker
-	local target_branch
+	local tracking_key
 	branch="$(release_branch)"
 	sha="$(release_sha)"
 	current_run_url="$(run_url)"
 	upstream_url="$(upstream_run_url)"
 	marker="$(issue_marker)"
-	target_branch="$(resolve_target_branch)"
+	tracking_key="$(marker_key)"
 
 	cat <<EOF
 $marker
@@ -220,21 +227,24 @@ $(failed_step_summary)
 ## Suggested Next Action
 
 Open the failed run, inspect the failed step logs, and either fix the release automation failure or close this issue with the run URL if the failure was transient.
+
+---
+**Tracking key:** \`${tracking_key}\`
 EOF
 }
 
-find_existing_issue() {
-	local search_key
+lookup_open_issue() {
+	local search_query="$1"
 	local issue_number
 	local search_output
 	local gh_stderr
-	search_key="$(marker_key)"
+
 	gh_stderr="$(mktemp)"
 	if ! search_output="$(gh issue list \
 		--repo "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}" \
 		--state open \
 		--limit 1 \
-		--search "\"${search_key}\"" \
+		--search "$search_query" \
 		--json number \
 		--jq '.[0].number // empty' 2>"$gh_stderr")"; then
 		log_error "Could not search for existing release failure issues: $(cat "$gh_stderr")"
@@ -245,6 +255,27 @@ find_existing_issue() {
 
 	issue_number="$search_output"
 	if [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+		echo "$issue_number"
+	fi
+}
+
+find_existing_issue() {
+	local target_branch="${1:?target_branch is required}"
+	local title
+	local search_key
+	local issue_number
+
+	title="$(failure_issue_title "$target_branch")"
+	issue_number="$(lookup_open_issue "\"${title}\" in:title")"
+	if [[ -n "$issue_number" ]]; then
+		echo "$issue_number"
+		return
+	fi
+
+	# Visible tracking keys are indexed; HTML comment markers may not be.
+	search_key="$(marker_key)"
+	issue_number="$(lookup_open_issue "\"${search_key}\"")"
+	if [[ -n "$issue_number" ]]; then
 		echo "$issue_number"
 	fi
 }
@@ -282,20 +313,28 @@ comment_on_failure_issue() {
 create_failure_issue() {
 	local body_file="$1"
 	local target_branch="$2"
+	local title
+	local issue_url
 	local label_args=()
+	title="$(failure_issue_title "$target_branch")"
 	collect_existing_issue_label_args label_args
 	if ((${#label_args[@]} > 0)); then
-		gh issue create \
+		if ! issue_url="$(gh issue create \
 			--repo "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}" \
-			--title "fix(release): release automation failed on ${target_branch}" \
+			--title "$title" \
 			--body-file "$body_file" \
-			"${label_args[@]}" >/dev/null
+			"${label_args[@]}")"; then
+			return 1
+		fi
 	else
-		gh issue create \
+		if ! issue_url="$(gh issue create \
 			--repo "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}" \
-			--title "fix(release): release automation failed on ${target_branch}" \
-			--body-file "$body_file" >/dev/null
+			--title "$title" \
+			--body-file "$body_file")"; then
+			return 1
+		fi
 	fi
+	log_success "Created release failure issue: ${issue_url}"
 }
 
 notify_failure() {
@@ -329,21 +368,21 @@ notify_failure() {
 
 	body_file="$(mktemp)"
 	trap 'rm -f "$body_file"' EXIT
-	render_failure_body >"$body_file"
+	render_failure_body "$target_branch" >"$body_file"
 
-	existing_issue="$(find_existing_issue)"
+	existing_issue="$(find_existing_issue "$target_branch")"
 	if [[ -n "$existing_issue" ]]; then
 		comment_on_failure_issue "$existing_issue" "$body_file"
 	else
 		# Brief pause reduces duplicate issues when concurrent runs fail together.
 		sleep 2
-		existing_issue="$(find_existing_issue)"
+		existing_issue="$(find_existing_issue "$target_branch")"
 		if [[ -n "$existing_issue" ]]; then
 			comment_on_failure_issue "$existing_issue" "$body_file"
 		elif create_failure_issue "$body_file" "$target_branch"; then
-			log_success "Created release failure issue"
+			:
 		else
-			existing_issue="$(find_existing_issue)"
+			existing_issue="$(find_existing_issue "$target_branch")"
 			if [[ -n "$existing_issue" ]]; then
 				comment_on_failure_issue "$existing_issue" "$body_file"
 			else

--- a/scripts/ci/release/report-release-failure.sh
+++ b/scripts/ci/release/report-release-failure.sh
@@ -67,13 +67,13 @@ workflow_key() {
 }
 
 marker_key() {
-	local branch
-	branch="$(release_branch)"
+	local branch="${1:-$(release_branch)}"
 	echo "release-automation-failure:$(workflow_key):${branch}"
 }
 
 issue_marker() {
-	echo "<!-- $(marker_key) -->"
+	local branch="${1:?branch is required}"
+	echo "<!-- $(marker_key "$branch") -->"
 }
 
 failure_issue_title() {
@@ -169,18 +169,16 @@ failed_step_summary() {
 
 render_failure_body() {
 	local target_branch="${1:?target_branch is required}"
-	local branch
 	local sha
 	local current_run_url
 	local upstream_url
 	local marker
 	local tracking_key
-	branch="$(release_branch)"
 	sha="$(release_sha)"
 	current_run_url="$(run_url)"
 	upstream_url="$(upstream_run_url)"
-	marker="$(issue_marker)"
-	tracking_key="$(marker_key)"
+	marker="$(issue_marker "$target_branch")"
+	tracking_key="$(marker_key "$target_branch")"
 
 	cat <<EOF
 $marker
@@ -194,7 +192,7 @@ Release automation failed on \`${target_branch}\`. This issue keeps post-merge r
 - **Workflow:** ${GITHUB_WORKFLOW:-unknown}
 - **Workflow key:** $(workflow_key)
 - **Event:** ${GITHUB_EVENT_NAME:-unknown}
-- **Branch:** ${branch}
+- **Branch:** ${target_branch}
 - **SHA:** ${sha}
 - **Actor:** ${GITHUB_ACTOR:-unknown}
 - **Run:** ${current_run_url}
@@ -247,9 +245,9 @@ lookup_open_issue() {
 		--search "$search_query" \
 		--json number \
 		--jq '.[0].number // empty' 2>"$gh_stderr")"; then
-		log_error "Could not search for existing release failure issues: $(cat "$gh_stderr")"
+		log_info "Release failure issue search failed: $(cat "$gh_stderr")"
 		rm -f "$gh_stderr"
-		exit 1
+		return 1
 	fi
 	rm -f "$gh_stderr"
 
@@ -257,6 +255,7 @@ lookup_open_issue() {
 	if [[ "$issue_number" =~ ^[0-9]+$ ]]; then
 		echo "$issue_number"
 	fi
+	return 0
 }
 
 find_existing_issue() {
@@ -266,17 +265,24 @@ find_existing_issue() {
 	local issue_number
 
 	title="$(failure_issue_title "$target_branch")"
-	issue_number="$(lookup_open_issue "\"${title}\" in:title")"
-	if [[ -n "$issue_number" ]]; then
-		echo "$issue_number"
-		return
+	if issue_number="$(lookup_open_issue "\"${title}\" in:title")"; then
+		if [[ -n "$issue_number" ]]; then
+			echo "$issue_number"
+			return
+		fi
+	else
+		log_info "Title search unavailable; falling back to tracking key"
 	fi
 
 	# Visible tracking keys are indexed; HTML comment markers may not be.
-	search_key="$(marker_key)"
-	issue_number="$(lookup_open_issue "\"${search_key}\"")"
-	if [[ -n "$issue_number" ]]; then
-		echo "$issue_number"
+	search_key="$(marker_key "$target_branch")"
+	if issue_number="$(lookup_open_issue "\"${search_key}\"")"; then
+		if [[ -n "$issue_number" ]]; then
+			echo "$issue_number"
+		fi
+	else
+		log_error "Could not search for existing release failure issues"
+		exit 1
 	fi
 }
 

--- a/tests/bats/integration/test_reusable_release_failure_report.bats
+++ b/tests/bats/integration/test_reusable_release_failure_report.bats
@@ -169,3 +169,40 @@ load "../../helpers/common"
 	run grep -F "notify_failure" "$auto_tag"
 	assert_success
 }
+
+@test "release-version-pr caller: grants permissions for report-release-failure job" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/release-version-pr.yml"
+
+	run awk '
+		/^  version-pr:/ { in_job = 1; in_perms = 0 }
+		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /version-pr:/ {
+			in_job = 0
+			in_perms = 0
+		}
+		in_job && /permissions:/ { in_perms = 1 }
+		in_perms && /contents: write/ { found_contents = 1 }
+		in_perms && /pull-requests: write/ { found_prs = 1 }
+		in_perms && /actions: read/ { found_actions = 1 }
+		in_perms && /issues: write/ { found_issues = 1 }
+		END { exit !(found_contents && found_prs && found_actions && found_issues) }
+	' "$workflow"
+	assert_success
+}
+
+@test "release-auto-tag caller: grants permissions for report-release-failure job" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/release-auto-tag.yml"
+
+	run awk '
+		/^  auto-tag:/ { in_job = 1; in_perms = 0 }
+		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /auto-tag:/ {
+			in_job = 0
+			in_perms = 0
+		}
+		in_job && /permissions:/ { in_perms = 1 }
+		in_perms && /contents: write/ { found_contents = 1 }
+		in_perms && /actions: read/ { found_actions = 1 }
+		in_perms && /issues: write/ { found_issues = 1 }
+		END { exit !(found_contents && found_actions && found_issues) }
+	' "$workflow"
+	assert_success
+}

--- a/tests/bats/unit/release/test_report_release_failure.bats
+++ b/tests/bats/unit/release/test_report_release_failure.bats
@@ -263,6 +263,43 @@ EOF
 	assert_output --partial "Created release failure issue: https://github.com/lgtm-hq/lgtm-ci/issues/88"
 }
 
+@test "report-release-failure: notify_failure falls back when title search fails" {
+	mkdir -p "${BATS_TEST_TMPDIR}/bin"
+	cat >"${BATS_TEST_TMPDIR}/bin/gh" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+	*repo*view*)
+		echo "main"
+		;;
+	*in:title*)
+		echo "title search rejected" >&2
+		exit 1
+		;;
+	*issue*list*)
+		echo "88"
+		exit 0
+		;;
+	*issue*comment*)
+		echo "commented"
+		exit 0
+		;;
+	*run*view*)
+		exit 0
+		;;
+	*)
+		exit 1
+		;;
+esac
+EOF
+	chmod +x "${BATS_TEST_TMPDIR}/bin/gh"
+	export PATH="${BATS_TEST_TMPDIR}/bin:${PATH}"
+
+	run bash "$SCRIPT" notify_failure
+	assert_success
+	assert_output --partial "Title search unavailable; falling back to tracking key"
+	assert_output --partial "Updated release failure issue #88"
+}
+
 @test "report-release-failure: notify_failure fails when issue search fails" {
 	mock_command_multi "gh" '
 		*issue*list*) echo "API rate limit exceeded" >&2; exit 1;;

--- a/tests/bats/unit/release/test_report_release_failure.bats
+++ b/tests/bats/unit/release/test_report_release_failure.bats
@@ -109,8 +109,67 @@ EOF
 
 	run bash "$SCRIPT" notify_failure
 	assert_success
-	assert_output --partial "Created release failure issue"
+	assert_output --partial "Created release failure issue: https://github.com/lgtm-hq/lgtm-ci/issues/42"
+	run grep -F 'in:title' "${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_success
 	run grep -F 'release-automation-failure:release-version-pr:main' "${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_success
+}
+
+@test "report-release-failure: notify_failure deduplicates by issue title" {
+	mock_command_multi "gh" '
+		*repo*view*) echo "main";;
+		*in:title*) echo "77";;
+		*issue*comment*) echo "commented";;
+		*run*view*) exit 0;;
+		*) exit 1;;
+	'
+
+	run bash "$SCRIPT" notify_failure
+	assert_success
+	assert_output --partial "Updated release failure issue #77"
+}
+
+@test "report-release-failure: notify_failure includes visible tracking key in issue body" {
+	mkdir -p "${BATS_TEST_TMPDIR}/bin"
+	cat >"${BATS_TEST_TMPDIR}/bin/gh" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+	*repo*view*)
+		echo "main"
+		;;
+	*issue*list*)
+		echo ""
+		;;
+	*label*view*)
+		exit 0
+		;;
+	*issue*create*)
+		while [[ \$# -gt 0 ]]; do
+			if [[ "\$1" == "--body-file" && -n "\${2:-}" ]]; then
+				cp "\$2" '${BATS_TEST_TMPDIR}/issue-body.md'
+			fi
+			shift
+		done
+		echo "https://github.com/lgtm-hq/lgtm-ci/issues/42"
+		exit 0
+		;;
+	*run*view*)
+		exit 0
+		;;
+	*)
+		exit 1
+		;;
+esac
+EOF
+	chmod +x "${BATS_TEST_TMPDIR}/bin/gh"
+	export PATH="${BATS_TEST_TMPDIR}/bin:${PATH}"
+
+	run bash "$SCRIPT" notify_failure
+	assert_success
+	[[ -f "${BATS_TEST_TMPDIR}/issue-body.md" ]]
+	run grep -F "**Tracking key:** \`release-automation-failure:release-version-pr:main\`" \
+		"${BATS_TEST_TMPDIR}/issue-body.md"
 	assert_success
 }
 
@@ -185,7 +244,7 @@ EOF
 
 	run bash "$SCRIPT" notify_failure
 	assert_success
-	assert_output --partial "Created release failure issue"
+	assert_output --partial "Created release failure issue: https://github.com/lgtm-hq/lgtm-ci/issues/55"
 }
 
 @test "report-release-failure: notify_failure skips missing labels" {
@@ -201,7 +260,7 @@ EOF
 	run bash "$SCRIPT" notify_failure
 	assert_success
 	assert_output --partial "Skipping missing issue label"
-	assert_output --partial "Created release failure issue"
+	assert_output --partial "Created release failure issue: https://github.com/lgtm-hq/lgtm-ci/issues/88"
 }
 
 @test "report-release-failure: notify_failure fails when issue search fails" {


### PR DESCRIPTION
## Summary

Fixes release workflow startup failures introduced by #311. The new
`report-release-failure` follow-up job requires `actions: read` and
`issues: write`, but the caller workflows did not grant them — GitHub rejected
both **Release: Create Version PR** and **Release: Auto Tag** at parse time with
`startup_failure`.

Also hardens failure issue deduplication: resolve `target_branch` once, search
by deterministic issue title first, fall back to a visible tracking-key footer,
and add caller permission contract tests so this class of bug is caught before
merge.

After merge, re-run **Release: Create Version PR** via `workflow_dispatch` to
open the pending release bump for #311.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #312
- Relates to #207
- Relates to #311

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Grant `actions: read` and `issues: write` permissions to release caller workflows for `report-release-failure`
> - Adds `actions: read` and `issues: write` permissions to the `release-auto-tag` and `release-version-pr` caller workflows so the `report-release-failure` downstream job can execute correctly.
> - Improves deduplication in [`report-release-failure.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/314/files#diff-954e44820bd45b6e3078efc218c9832cc908b87370690de6a6e837565ebdf541): failure issues are now matched first by a deterministic title (`fix(release): release automation failed on <branch> (<workflow-key>)`), with a fallback to the HTML-comment tracking key.
> - Issue bodies now include a visible `Tracking key` footer, and `create_failure_issue` logs the full issue URL on creation.
> - Updates docs and integration/unit tests to reflect the new permission requirements and deduplication behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11cb07f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deduplication of release failure issues using a consistent title and visible tracking key
  * Prevented workflow startup failures by enforcing required permissions for release reporting

* **Chores**
  * Added required permissions to release caller workflows
  * Made release failure reports include a visible tracking key and deterministic titles

* **Tests**
  * Added and expanded tests to validate permissions and failure-reporting/deduplication behavior

* **Documentation**
  * Updated workflow contract and examples to reflect permission and reporting requirements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes `startup_failure` in the two release caller workflows by granting the `actions: read` and `issues: write` permissions that the `report-release-failure` follow-up job requires. Accompanying script changes harden deduplication by searching for an existing issue by deterministic title first, falling back to the visible tracking-key footer, and propagating `create` errors instead of silently swallowing them.

- **Workflow permission grants** (`release-auto-tag.yml`, `release-version-pr.yml`): adds `actions: read` and `issues: write` to match what the reusable follow-up job declares, unblocking GitHub's startup validation.
- **Deduplication refactor** (`report-release-failure.sh`): `find_existing_issue` now performs a two-step search (title → tracking key); `lookup_open_issue` returns rather than calls `exit 1` on API failure, so the fallback is exercised instead of short-circuiting; `create_failure_issue` now captures and logs the created issue URL and propagates failure via `return 1`.
- **Tests and docs**: integration tests assert the permission grants are present; new unit tests cover title-deduplication, visible tracking-key body content, and the title-search-failure fallback path; `workflow-contract.md` and `reusable-workflows.md` are updated to reflect the new caller contract.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the permission grants are the minimal correct fix, and the deduplication logic is well-covered by the new unit and integration tests.

The workflow permission additions directly address the GitHub startup-validation rejection and are straightforward. The script refactor correctly converts exit 1 to return 1 in lookup_open_issue so the title-search fallback is actually reachable (the previously broken path), propagates create_failure_issue errors, and resolves target_branch once and passes it through rather than recomputing it. Both previous review concerns are addressed. The new tests exercise all three paths: title hit, title miss to tracking-key hit, and title-search API failure to tracking-key fallback.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-auto-tag.yml | Adds `actions: read` and `issues: write` to the caller job permissions — the targeted fix for the startup_failure regression. |
| .github/workflows/release-version-pr.yml | Adds `actions: read` and `issues: write` to the caller job permissions — mirrors the auto-tag fix. |
| scripts/ci/release/report-release-failure.sh | Refactors deduplication to two-step (title then tracking-key), fixes exit-vs-return in lookup_open_issue so the fallback path is reachable, propagates issue-creation errors, and adds a visible tracking-key footer to issue bodies. |
| tests/bats/unit/release/test_report_release_failure.bats | Adds tests for title deduplication, visible tracking-key presence in body, and title-search-failure fallback; updates expected log messages for the new issue-URL logging. |
| tests/bats/integration/test_reusable_release_failure_report.bats | Adds two awk-based contract tests that parse the caller workflow YAML and assert all required permissions are present. |
| docs/workflow-contract.md | Updates the permission table and the failure-reporting section to reflect the new caller contract and two-step deduplication strategy. |
| CHANGELOG.md | Adds changelog entries for the permission grant fix and deduplication hardening under the Unreleased > Fixed section. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[notify_failure called] --> B[resolve_target_branch]
    B --> C{branch == target_branch?}
    C -- No --> D[Skip: log & exit 0]
    C -- Yes --> E[render_failure_body]
    E --> F[find_existing_issue - attempt 1]
    F --> G[lookup_open_issue: title search]
    G -- success + number --> H[comment on existing issue]
    G -- success + empty --> I[lookup_open_issue: tracking-key search]
    G -- API error return 1 --> J[log: Title search unavailable]
    J --> I
    I -- success + number --> H
    I -- success + empty --> K[sleep 2]
    I -- API error return 1 --> L[log_error + exit 1]
    K --> M[find_existing_issue - attempt 2]
    M -- found --> H
    M -- empty --> N[create_failure_issue]
    N -- success --> O[log Created issue URL]
    N -- failure return 1 --> P[find_existing_issue - attempt 3]
    P -- found --> H
    P -- empty --> Q[log_error + exit 1]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(release): use target\_branch consiste..."](https://github.com/lgtm-hq/lgtm-ci/commit/11cb07f3c8d024bc9420f7dc9e6a481515f01cb4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36064293)</sub>

<!-- /greptile_comment -->