### PR TITLE
chore(ci): egress resolver and GITHUB_OUTPUT hygiene

### DIFF
--- a/.github/actions/harden-runner/lib/egress.sh
+++ b/.github/actions/harden-runner/lib/egress.sh
@@ -48,18 +48,25 @@ egress_normalize_endpoint_lines() {
 	printf '%s' "${lines[*]}"
 }
 
-# Deduplicate host:port lines; preserve first-seen order (O(n) via awk).
-egress_dedupe_endpoint_lines() {
-	local raw="$1"
-	local normalized
+# Deduplicate normalized host:port lines; preserve first-seen order (O(n) via awk).
+_egress_dedupe_normalized_endpoint_lines() {
+	local normalized="$1"
 
-	normalized="$(egress_normalize_endpoint_lines "$raw")"
 	if [[ -z "$normalized" ]]; then
 		printf ''
 		return
 	fi
 
 	printf '%s' "$(awk '!seen[$0]++' <<<"$normalized")"
+}
+
+# Deduplicate host:port lines; preserve first-seen order (O(n) via awk).
+egress_dedupe_endpoint_lines() {
+	local raw="$1"
+	local normalized
+
+	normalized="$(egress_normalize_endpoint_lines "$raw")"
+	_egress_dedupe_normalized_endpoint_lines "$normalized"
 }
 
 # Merge multiple multiline endpoint lists (empty parts skipped), then dedupe.
@@ -74,7 +81,7 @@ egress_merge_endpoint_lines() {
 			combined="${combined}"$'\n'"${normalized}"
 		fi
 	done
-	egress_dedupe_endpoint_lines "$combined"
+	_egress_dedupe_normalized_endpoint_lines "$combined"
 }
 
 export -f egress_normalize_endpoint_lines egress_dedupe_endpoint_lines egress_merge_endpoint_lines

--- a/.github/actions/harden-runner/lib/egress.sh
+++ b/.github/actions/harden-runner/lib/egress.sh
@@ -48,42 +48,18 @@ egress_normalize_endpoint_lines() {
 	printf '%s' "${lines[*]}"
 }
 
-# Deduplicate host:port lines; preserve first-seen order (bash 3.2 compatible).
+# Deduplicate host:port lines; preserve first-seen order (O(n) via awk).
 egress_dedupe_endpoint_lines() {
 	local raw="$1"
-	local -a unique=()
-	local line existing found
+	local normalized
 
-	if [[ -z "${raw//[[:space:]]/}" ]]; then
+	normalized="$(egress_normalize_endpoint_lines "$raw")"
+	if [[ -z "$normalized" ]]; then
 		printf ''
 		return
 	fi
 
-	while IFS= read -r line || [[ -n "$line" ]]; do
-		line="${line#"${line%%[![:space:]]*}"}"
-		line="${line%"${line##*[![:space:]]}"}"
-		[[ -z "$line" ]] && continue
-		found=0
-		if ((${#unique[@]} > 0)); then
-			for existing in "${unique[@]}"; do
-				if [[ "$existing" == "$line" ]]; then
-					found=1
-					break
-				fi
-			done
-		fi
-		if [[ "$found" -eq 0 ]]; then
-			unique+=("$line")
-		fi
-	done <<<"$raw"
-
-	if ((${#unique[@]} == 0)); then
-		printf ''
-		return
-	fi
-
-	local IFS=$'\n'
-	printf '%s' "${unique[*]}"
+	printf '%s' "$(awk '!seen[$0]++' <<<"$normalized")"
 }
 
 # Merge multiple multiline endpoint lists (empty parts skipped), then dedupe.

--- a/.github/actions/harden-runner/lib/egress.sh
+++ b/.github/actions/harden-runner/lib/egress.sh
@@ -84,4 +84,5 @@ egress_merge_endpoint_lines() {
 	_egress_dedupe_normalized_endpoint_lines "$combined"
 }
 
+export -f _egress_dedupe_normalized_endpoint_lines
 export -f egress_normalize_endpoint_lines egress_dedupe_endpoint_lines egress_merge_endpoint_lines

--- a/.github/actions/harden-runner/lib/github/output.sh
+++ b/.github/actions/harden-runner/lib/github/output.sh
@@ -31,6 +31,7 @@ _validate_github_output_key() {
 		echo "${context}: invalid key '$key' (use alphanumerics, hyphens, underscores)" >&2
 		return 1
 	fi
+	return 0
 }
 
 # Validate a PATH entry before appending to GITHUB_PATH.
@@ -45,6 +46,7 @@ _validate_github_path_entry() {
 		echo "add_github_path: path contains invalid characters" >&2
 		return 1
 	fi
+	return 0
 }
 
 # Random multiline delimiter for GITHUB_OUTPUT / GITHUB_ENV (openssl with od fallback).
@@ -66,9 +68,9 @@ _github_write_multiline_entry() {
 
 	delimiter="$(_github_actions_multiline_delimiter)"
 	{
-		echo "$key<<$delimiter"
-		echo "$value"
-		echo "$delimiter"
+		printf '%s\n' "$key<<$delimiter"
+		printf '%s\n' "$value"
+		printf '%s\n' "$delimiter"
 	} >>"$file"
 }
 

--- a/.github/actions/harden-runner/lib/github/output.sh
+++ b/.github/actions/harden-runner/lib/github/output.sh
@@ -11,6 +11,72 @@
 readonly _LGTM_CI_GITHUB_OUTPUT_LOADED=1
 
 # =============================================================================
+# Internal validation and multiline helpers
+# =============================================================================
+
+# Validate GitHub Actions output/env key (alphanumerics, hyphens, underscores).
+_validate_github_output_key() {
+	local key="$1"
+	local context="${2:-set_github_output}"
+
+	if [[ -z "$key" ]]; then
+		echo "${context}: key must not be empty" >&2
+		return 1
+	fi
+	if [[ "$key" == *$'\n'* || "$key" == *$'\r'* ]]; then
+		echo "${context}: key contains invalid characters" >&2
+		return 1
+	fi
+	if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_-]*$ ]]; then
+		echo "${context}: invalid key '$key' (use alphanumerics, hyphens, underscores)" >&2
+		return 1
+	fi
+}
+
+# Validate a PATH entry before appending to GITHUB_PATH.
+_validate_github_path_entry() {
+	local path="$1"
+
+	if [[ -z "$path" ]]; then
+		echo "add_github_path: path must not be empty" >&2
+		return 1
+	fi
+	if [[ "$path" == *$'\n'* || "$path" == *$'\r'* ]]; then
+		echo "add_github_path: path contains invalid characters" >&2
+		return 1
+	fi
+	if [[ "$path" != /* ]]; then
+		echo "add_github_path: path must be absolute" >&2
+		return 1
+	fi
+}
+
+# Random multiline delimiter for GITHUB_OUTPUT / GITHUB_ENV (openssl with od fallback).
+_github_actions_multiline_delimiter() {
+	local suffix
+	suffix="$(
+		openssl rand -hex 16 2>/dev/null ||
+			od -An -N16 -tx1 /dev/urandom | tr -d ' \n'
+	)"
+	printf 'ghadelimiter_%s' "$suffix"
+}
+
+# Append a multiline key/value block to a GitHub Actions file.
+_github_write_multiline_entry() {
+	local file="$1"
+	local key="$2"
+	local value="$3"
+	local delimiter
+
+	delimiter="$(_github_actions_multiline_delimiter)"
+	{
+		echo "$key<<$delimiter"
+		echo "$value"
+		echo "$delimiter"
+	} >>"$file"
+}
+
+# =============================================================================
 # GitHub Actions output/environment helpers
 # =============================================================================
 
@@ -20,6 +86,9 @@ set_github_output() {
 	local key="$1"
 	local value="$2"
 	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+		if ! _validate_github_output_key "$key" "set_github_output"; then
+			return 1
+		fi
 		if [[ "$value" == *$'\n'* ]]; then
 			echo "set_github_output: value for '$key' contains newline; use set_github_output_multiline" >&2
 			return 1
@@ -34,18 +103,10 @@ set_github_output_multiline() {
 	local key="$1"
 	local value="$2"
 	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-		# Use unique delimiter to prevent content collision
-		# Separate declaration and assignment to avoid SC2155
-		local delimiter
-		delimiter="ghadelimiter_$(
-			openssl rand -hex 16 2>/dev/null ||
-				od -An -N16 -tx1 /dev/urandom | tr -d ' \n'
-		)"
-		{
-			echo "$key<<$delimiter"
-			echo "$value"
-			echo "$delimiter"
-		} >>"$GITHUB_OUTPUT"
+		if ! _validate_github_output_key "$key" "set_github_output_multiline"; then
+			return 1
+		fi
+		_github_write_multiline_entry "$GITHUB_OUTPUT" "$key" "$value"
 	fi
 }
 
@@ -55,17 +116,11 @@ set_github_env() {
 	local key="$1"
 	local value="$2"
 	if [[ -n "${GITHUB_ENV:-}" ]]; then
+		if ! _validate_github_output_key "$key" "set_github_env"; then
+			return 1
+		fi
 		if [[ "$value" == *$'\n'* ]]; then
-			local delimiter
-			delimiter="ghadelimiter_$(
-				openssl rand -hex 16 2>/dev/null ||
-					od -An -N16 -tx1 /dev/urandom | tr -d ' \n'
-			)"
-			{
-				echo "$key<<$delimiter"
-				echo "$value"
-				echo "$delimiter"
-			} >>"$GITHUB_ENV"
+			_github_write_multiline_entry "$GITHUB_ENV" "$key" "$value"
 		else
 			echo "$key=$value" >>"$GITHUB_ENV"
 		fi
@@ -76,8 +131,13 @@ set_github_env() {
 # Usage: add_github_path "/some/path"
 add_github_path() {
 	local path="$1"
-	if [[ -n "${GITHUB_PATH:-}" ]] && [[ -d "$path" ]]; then
-		echo "$path" >>"$GITHUB_PATH"
+	if [[ -n "${GITHUB_PATH:-}" ]]; then
+		if ! _validate_github_path_entry "$path"; then
+			return 1
+		fi
+		if [[ -d "$path" ]]; then
+			echo "$path" >>"$GITHUB_PATH"
+		fi
 	fi
 }
 
@@ -90,5 +150,7 @@ configure_git_ci_user() {
 # =============================================================================
 # Export functions
 # =============================================================================
+export -f _validate_github_output_key _validate_github_path_entry
+export -f _github_actions_multiline_delimiter _github_write_multiline_entry
 export -f set_github_output set_github_output_multiline set_github_env add_github_path
 export -f configure_git_ci_user

--- a/.github/actions/harden-runner/lib/github/output.sh
+++ b/.github/actions/harden-runner/lib/github/output.sh
@@ -45,10 +45,6 @@ _validate_github_path_entry() {
 		echo "add_github_path: path contains invalid characters" >&2
 		return 1
 	fi
-	if [[ "$path" != /* ]]; then
-		echo "add_github_path: path must be absolute" >&2
-		return 1
-	fi
 }
 
 # Random multiline delimiter for GITHUB_OUTPUT / GITHUB_ENV (openssl with od fallback).
@@ -134,6 +130,9 @@ add_github_path() {
 	if [[ -n "${GITHUB_PATH:-}" ]]; then
 		if ! _validate_github_path_entry "$path"; then
 			return 1
+		fi
+		if [[ "$path" != /* ]]; then
+			return 0
 		fi
 		if [[ -d "$path" ]]; then
 			echo "$path" >>"$GITHUB_PATH"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **ci**: replace O(n²) egress endpoint dedupe with an O(n) awk pass while
+  preserving first-seen order
+- **ci**: centralize `GITHUB_OUTPUT` / `GITHUB_ENV` multiline delimiter helpers
+  and validate output keys before writing
+- **ci**: reject newline injection in `add_github_path`; relative paths remain
+  silently ignored (legacy behavior)
+- **release**: external callers upgrading reusable release workflows must grant
+  `actions: read` and `issues: write` on the caller job when using the default
+  `report-failures: true`, or set `report-failures: false` to opt out
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- **release**: declare `local -a labels` in `collect_existing_issue_label_args`
+  to avoid leaking into global scope
 
 ### Security
 
@@ -41,6 +54,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **release**: deduplicate failure issues by title and visible tracking key
   instead of HTML comment search alone; fall back to tracking-key search when
   title search fails
+
+- **release**: `report-failures` defaults to `true`; external callers must grant
+  `actions: read` and `issues: write` on the caller job or pass
+  `report-failures: false`
 
 ## [0.34.1] - 2026-06-06
 

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -281,6 +281,12 @@ trigger context to the job step summary, then creates or updates a deduplicated
 GitHub issue with failed step details. Set `report-failures: false` to disable
 both actions. See [workflow-contract.md](workflow-contract.md) for inputs.
 
+`report-failures` defaults to `true`. GitHub rejects a reusable-workflow call at
+startup when the caller job does not grant every permission the reusable
+workflow declares. Grant at least `actions: read` and `issues: write` on the
+caller job, or pass `report-failures: false` when upgrading from a release that
+did not include failure reporting.
+
 Recommended caller `run-name` (reusable workflows cannot set this for you):
 
 ```yaml

--- a/scripts/ci/lib/egress.sh
+++ b/scripts/ci/lib/egress.sh
@@ -48,18 +48,25 @@ egress_normalize_endpoint_lines() {
 	printf '%s' "${lines[*]}"
 }
 
-# Deduplicate host:port lines; preserve first-seen order (O(n) via awk).
-egress_dedupe_endpoint_lines() {
-	local raw="$1"
-	local normalized
+# Deduplicate normalized host:port lines; preserve first-seen order (O(n) via awk).
+_egress_dedupe_normalized_endpoint_lines() {
+	local normalized="$1"
 
-	normalized="$(egress_normalize_endpoint_lines "$raw")"
 	if [[ -z "$normalized" ]]; then
 		printf ''
 		return
 	fi
 
 	printf '%s' "$(awk '!seen[$0]++' <<<"$normalized")"
+}
+
+# Deduplicate host:port lines; preserve first-seen order (O(n) via awk).
+egress_dedupe_endpoint_lines() {
+	local raw="$1"
+	local normalized
+
+	normalized="$(egress_normalize_endpoint_lines "$raw")"
+	_egress_dedupe_normalized_endpoint_lines "$normalized"
 }
 
 # Merge multiple multiline endpoint lists (empty parts skipped), then dedupe.
@@ -74,7 +81,7 @@ egress_merge_endpoint_lines() {
 			combined="${combined}"$'\n'"${normalized}"
 		fi
 	done
-	egress_dedupe_endpoint_lines "$combined"
+	_egress_dedupe_normalized_endpoint_lines "$combined"
 }
 
 export -f egress_normalize_endpoint_lines egress_dedupe_endpoint_lines egress_merge_endpoint_lines

--- a/scripts/ci/lib/egress.sh
+++ b/scripts/ci/lib/egress.sh
@@ -48,42 +48,18 @@ egress_normalize_endpoint_lines() {
 	printf '%s' "${lines[*]}"
 }
 
-# Deduplicate host:port lines; preserve first-seen order (bash 3.2 compatible).
+# Deduplicate host:port lines; preserve first-seen order (O(n) via awk).
 egress_dedupe_endpoint_lines() {
 	local raw="$1"
-	local -a unique=()
-	local line existing found
+	local normalized
 
-	if [[ -z "${raw//[[:space:]]/}" ]]; then
+	normalized="$(egress_normalize_endpoint_lines "$raw")"
+	if [[ -z "$normalized" ]]; then
 		printf ''
 		return
 	fi
 
-	while IFS= read -r line || [[ -n "$line" ]]; do
-		line="${line#"${line%%[![:space:]]*}"}"
-		line="${line%"${line##*[![:space:]]}"}"
-		[[ -z "$line" ]] && continue
-		found=0
-		if ((${#unique[@]} > 0)); then
-			for existing in "${unique[@]}"; do
-				if [[ "$existing" == "$line" ]]; then
-					found=1
-					break
-				fi
-			done
-		fi
-		if [[ "$found" -eq 0 ]]; then
-			unique+=("$line")
-		fi
-	done <<<"$raw"
-
-	if ((${#unique[@]} == 0)); then
-		printf ''
-		return
-	fi
-
-	local IFS=$'\n'
-	printf '%s' "${unique[*]}"
+	printf '%s' "$(awk '!seen[$0]++' <<<"$normalized")"
 }
 
 # Merge multiple multiline endpoint lists (empty parts skipped), then dedupe.

--- a/scripts/ci/lib/egress.sh
+++ b/scripts/ci/lib/egress.sh
@@ -84,4 +84,5 @@ egress_merge_endpoint_lines() {
 	_egress_dedupe_normalized_endpoint_lines "$combined"
 }
 
+export -f _egress_dedupe_normalized_endpoint_lines
 export -f egress_normalize_endpoint_lines egress_dedupe_endpoint_lines egress_merge_endpoint_lines

--- a/scripts/ci/lib/github/output.sh
+++ b/scripts/ci/lib/github/output.sh
@@ -31,6 +31,7 @@ _validate_github_output_key() {
 		echo "${context}: invalid key '$key' (use alphanumerics, hyphens, underscores)" >&2
 		return 1
 	fi
+	return 0
 }
 
 # Validate a PATH entry before appending to GITHUB_PATH.
@@ -45,6 +46,7 @@ _validate_github_path_entry() {
 		echo "add_github_path: path contains invalid characters" >&2
 		return 1
 	fi
+	return 0
 }
 
 # Random multiline delimiter for GITHUB_OUTPUT / GITHUB_ENV (openssl with od fallback).
@@ -66,9 +68,9 @@ _github_write_multiline_entry() {
 
 	delimiter="$(_github_actions_multiline_delimiter)"
 	{
-		echo "$key<<$delimiter"
-		echo "$value"
-		echo "$delimiter"
+		printf '%s\n' "$key<<$delimiter"
+		printf '%s\n' "$value"
+		printf '%s\n' "$delimiter"
 	} >>"$file"
 }
 

--- a/scripts/ci/lib/github/output.sh
+++ b/scripts/ci/lib/github/output.sh
@@ -11,6 +11,72 @@
 readonly _LGTM_CI_GITHUB_OUTPUT_LOADED=1
 
 # =============================================================================
+# Internal validation and multiline helpers
+# =============================================================================
+
+# Validate GitHub Actions output/env key (alphanumerics, hyphens, underscores).
+_validate_github_output_key() {
+	local key="$1"
+	local context="${2:-set_github_output}"
+
+	if [[ -z "$key" ]]; then
+		echo "${context}: key must not be empty" >&2
+		return 1
+	fi
+	if [[ "$key" == *$'\n'* || "$key" == *$'\r'* ]]; then
+		echo "${context}: key contains invalid characters" >&2
+		return 1
+	fi
+	if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_-]*$ ]]; then
+		echo "${context}: invalid key '$key' (use alphanumerics, hyphens, underscores)" >&2
+		return 1
+	fi
+}
+
+# Validate a PATH entry before appending to GITHUB_PATH.
+_validate_github_path_entry() {
+	local path="$1"
+
+	if [[ -z "$path" ]]; then
+		echo "add_github_path: path must not be empty" >&2
+		return 1
+	fi
+	if [[ "$path" == *$'\n'* || "$path" == *$'\r'* ]]; then
+		echo "add_github_path: path contains invalid characters" >&2
+		return 1
+	fi
+	if [[ "$path" != /* ]]; then
+		echo "add_github_path: path must be absolute" >&2
+		return 1
+	fi
+}
+
+# Random multiline delimiter for GITHUB_OUTPUT / GITHUB_ENV (openssl with od fallback).
+_github_actions_multiline_delimiter() {
+	local suffix
+	suffix="$(
+		openssl rand -hex 16 2>/dev/null ||
+			od -An -N16 -tx1 /dev/urandom | tr -d ' \n'
+	)"
+	printf 'ghadelimiter_%s' "$suffix"
+}
+
+# Append a multiline key/value block to a GitHub Actions file.
+_github_write_multiline_entry() {
+	local file="$1"
+	local key="$2"
+	local value="$3"
+	local delimiter
+
+	delimiter="$(_github_actions_multiline_delimiter)"
+	{
+		echo "$key<<$delimiter"
+		echo "$value"
+		echo "$delimiter"
+	} >>"$file"
+}
+
+# =============================================================================
 # GitHub Actions output/environment helpers
 # =============================================================================
 
@@ -20,6 +86,9 @@ set_github_output() {
 	local key="$1"
 	local value="$2"
 	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+		if ! _validate_github_output_key "$key" "set_github_output"; then
+			return 1
+		fi
 		if [[ "$value" == *$'\n'* ]]; then
 			echo "set_github_output: value for '$key' contains newline; use set_github_output_multiline" >&2
 			return 1
@@ -34,18 +103,10 @@ set_github_output_multiline() {
 	local key="$1"
 	local value="$2"
 	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-		# Use unique delimiter to prevent content collision
-		# Separate declaration and assignment to avoid SC2155
-		local delimiter
-		delimiter="ghadelimiter_$(
-			openssl rand -hex 16 2>/dev/null ||
-				od -An -N16 -tx1 /dev/urandom | tr -d ' \n'
-		)"
-		{
-			echo "$key<<$delimiter"
-			echo "$value"
-			echo "$delimiter"
-		} >>"$GITHUB_OUTPUT"
+		if ! _validate_github_output_key "$key" "set_github_output_multiline"; then
+			return 1
+		fi
+		_github_write_multiline_entry "$GITHUB_OUTPUT" "$key" "$value"
 	fi
 }
 
@@ -55,17 +116,11 @@ set_github_env() {
 	local key="$1"
 	local value="$2"
 	if [[ -n "${GITHUB_ENV:-}" ]]; then
+		if ! _validate_github_output_key "$key" "set_github_env"; then
+			return 1
+		fi
 		if [[ "$value" == *$'\n'* ]]; then
-			local delimiter
-			delimiter="ghadelimiter_$(
-				openssl rand -hex 16 2>/dev/null ||
-					od -An -N16 -tx1 /dev/urandom | tr -d ' \n'
-			)"
-			{
-				echo "$key<<$delimiter"
-				echo "$value"
-				echo "$delimiter"
-			} >>"$GITHUB_ENV"
+			_github_write_multiline_entry "$GITHUB_ENV" "$key" "$value"
 		else
 			echo "$key=$value" >>"$GITHUB_ENV"
 		fi
@@ -76,8 +131,13 @@ set_github_env() {
 # Usage: add_github_path "/some/path"
 add_github_path() {
 	local path="$1"
-	if [[ -n "${GITHUB_PATH:-}" ]] && [[ -d "$path" ]]; then
-		echo "$path" >>"$GITHUB_PATH"
+	if [[ -n "${GITHUB_PATH:-}" ]]; then
+		if ! _validate_github_path_entry "$path"; then
+			return 1
+		fi
+		if [[ -d "$path" ]]; then
+			echo "$path" >>"$GITHUB_PATH"
+		fi
 	fi
 }
 
@@ -90,5 +150,7 @@ configure_git_ci_user() {
 # =============================================================================
 # Export functions
 # =============================================================================
+export -f _validate_github_output_key _validate_github_path_entry
+export -f _github_actions_multiline_delimiter _github_write_multiline_entry
 export -f set_github_output set_github_output_multiline set_github_env add_github_path
 export -f configure_git_ci_user

--- a/scripts/ci/lib/github/output.sh
+++ b/scripts/ci/lib/github/output.sh
@@ -45,10 +45,6 @@ _validate_github_path_entry() {
 		echo "add_github_path: path contains invalid characters" >&2
 		return 1
 	fi
-	if [[ "$path" != /* ]]; then
-		echo "add_github_path: path must be absolute" >&2
-		return 1
-	fi
 }
 
 # Random multiline delimiter for GITHUB_OUTPUT / GITHUB_ENV (openssl with od fallback).
@@ -134,6 +130,9 @@ add_github_path() {
 	if [[ -n "${GITHUB_PATH:-}" ]]; then
 		if ! _validate_github_path_entry "$path"; then
 			return 1
+		fi
+		if [[ "$path" != /* ]]; then
+			return 0
 		fi
 		if [[ -d "$path" ]]; then
 			echo "$path" >>"$GITHUB_PATH"

--- a/scripts/ci/release/report-release-failure.sh
+++ b/scripts/ci/release/report-release-failure.sh
@@ -293,6 +293,7 @@ collect_existing_issue_label_args() {
 	local repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 
 	_label_args=()
+	local -a labels
 	IFS=',' read -ra labels <<<"$default_labels"
 	for label in "${labels[@]}"; do
 		label="$(echo "$label" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"

--- a/tests/bats/unit/lib/egress/test_egress_lib.bats
+++ b/tests/bats/unit/lib/egress/test_egress_lib.bats
@@ -42,3 +42,36 @@ EGRESS_LIB="${PROJECT_ROOT}/scripts/ci/lib/egress.sh"
 	assert_success
 	assert_output $'x:1\ny:2\nz:3'
 }
+
+@test "egress_dedupe_endpoint_lines: dedupes large lists preserving order" {
+	run bash -c "
+		source '$EGRESS_LIB'
+		input=\$(
+			for i in \$(seq 1 200); do
+				printf 'host%s:443\n' \"\$i\"
+			done
+			for i in \$(seq 10 10 200); do
+				printf 'host%s:443\n' \"\$i\"
+			done
+		)
+		result=\$(egress_dedupe_endpoint_lines \"\$input\")
+		printf '%s\n' \"\$result\" | wc -l | tr -d ' '
+		printf '%s\n' \"\$result\" | head -1
+		printf '%s\n' \"\$result\" | sed -n '10p'
+		printf '%s\n' \"\$result\" | tail -1
+	"
+	assert_success
+	assert_line --index 0 "200"
+	assert_line --index 1 "host1:443"
+	assert_line --index 2 "host10:443"
+	assert_line --index 3 "host200:443"
+}
+
+@test "egress_dedupe_endpoint_lines: skips blank lines before dedupe" {
+	run bash -c "
+		source '$EGRESS_LIB'
+		egress_dedupe_endpoint_lines \$'a:1\n\n  \n b:2\na:1\n'
+	"
+	assert_success
+	assert_output $'a:1\nb:2'
+}

--- a/tests/bats/unit/lib/egress/test_egress_lib.bats
+++ b/tests/bats/unit/lib/egress/test_egress_lib.bats
@@ -75,3 +75,19 @@ EGRESS_LIB="${PROJECT_ROOT}/scripts/ci/lib/egress.sh"
 	assert_success
 	assert_output $'a:1\nb:2'
 }
+
+@test "egress.sh: exported dedupe functions work in subprocess" {
+	run bash -c "
+		source '$EGRESS_LIB'
+		bash -c \"egress_dedupe_endpoint_lines \\\$'b:2\\\\na:1\\\\nb:2'\"
+	"
+	assert_success
+	assert_output $'b:2\na:1'
+
+	run bash -c "
+		source '$EGRESS_LIB'
+		bash -c \"egress_merge_endpoint_lines \\\$'x:1\\\\ny:2\\\\n' \\\$'y:2\\\\nz:3\\\\n'\"
+	"
+	assert_success
+	assert_output $'x:1\ny:2\nz:3'
+}

--- a/tests/bats/unit/lib/github/test_output.bats
+++ b/tests/bats/unit/lib/github/test_output.bats
@@ -151,6 +151,19 @@ line3"'
 	assert_output --partial "invalid key"
 }
 
+@test "set_github_output_multiline: preserves value starting with -n" {
+	run bash -c 'source "$LIB_DIR/github/output.sh" && set_github_output_multiline "payload" "-n
+second line
+third line"'
+	assert_success
+
+	run get_github_output "payload"
+	assert_success
+	assert_output $'-n
+second line
+third line'
+}
+
 # =============================================================================
 # set_github_env tests
 # =============================================================================
@@ -209,6 +222,19 @@ line2"'
 	run bash -c 'source "$LIB_DIR/github/output.sh" && set_github_env "bad key" "value"'
 	assert_failure
 	assert_output --partial "invalid key"
+}
+
+@test "set_github_env: preserves value starting with -n" {
+	run bash -c 'source "$LIB_DIR/github/output.sh" && set_github_env "PAYLOAD" "-n
+second line
+third line"'
+	assert_success
+
+	run get_github_env "PAYLOAD"
+	assert_success
+	assert_output $'-n
+second line
+third line'
 }
 
 # =============================================================================

--- a/tests/bats/unit/lib/github/test_output.bats
+++ b/tests/bats/unit/lib/github/test_output.bats
@@ -64,6 +64,24 @@ teardown() {
 	assert_success
 }
 
+@test "set_github_output: rejects empty key" {
+	run bash -c 'source "$LIB_DIR/github/output.sh" && set_github_output "" "value"'
+	assert_failure
+	assert_output --partial "key must not be empty"
+}
+
+@test "set_github_output: rejects invalid key characters" {
+	run bash -c 'source "$LIB_DIR/github/output.sh" && set_github_output "bad key" "value"'
+	assert_failure
+	assert_output --partial "invalid key"
+}
+
+@test "set_github_output: accepts hyphenated keys" {
+	run bash -c 'source "$LIB_DIR/github/output.sh" && set_github_output "tests-passed" "1"'
+	assert_success
+	assert_github_output "tests-passed" "1"
+}
+
 @test "set_github_output: multiple outputs append to file" {
 	run bash -c '
 		source "$LIB_DIR/github/output.sh"
@@ -127,6 +145,12 @@ line3"'
 	assert_success
 }
 
+@test "set_github_output_multiline: rejects invalid key" {
+	run bash -c 'source "$LIB_DIR/github/output.sh" && set_github_output_multiline "bad key" "value"'
+	assert_failure
+	assert_output --partial "invalid key"
+}
+
 # =============================================================================
 # set_github_env tests
 # =============================================================================
@@ -170,6 +194,23 @@ line3"'
 	assert_output "value2"
 }
 
+@test "set_github_env: multiline values use shared delimiter" {
+	run bash -c 'source "$LIB_DIR/github/output.sh" && set_github_env "MULTI" "line1
+line2"'
+	assert_success
+
+	run cat "$GITHUB_ENV"
+	assert_output --partial "ghadelimiter_"
+	assert_output --partial "line1"
+	assert_output --partial "line2"
+}
+
+@test "set_github_env: rejects invalid key" {
+	run bash -c 'source "$LIB_DIR/github/output.sh" && set_github_env "bad key" "value"'
+	assert_failure
+	assert_output --partial "invalid key"
+}
+
 # =============================================================================
 # add_github_path tests
 # =============================================================================
@@ -191,6 +232,24 @@ line3"'
 
 	run cat "$GITHUB_PATH"
 	refute_output --partial "/nonexistent/path"
+}
+
+@test "add_github_path: rejects relative paths" {
+	local test_dir="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$test_dir"
+
+	run bash -c "source \"\$LIB_DIR/github/output.sh\" && add_github_path \"bin\""
+	assert_failure
+	assert_output --partial "path must be absolute"
+
+	run cat "$GITHUB_PATH"
+	refute_output --partial "bin"
+}
+
+@test "add_github_path: rejects paths with newlines" {
+	run bash -c 'source "$LIB_DIR/github/output.sh" && add_github_path "$(printf %b "/tmp/evil\ninjection")"'
+	assert_failure
+	assert_output --partial "invalid characters"
 }
 
 @test "add_github_path: does nothing when GITHUB_PATH unset" {

--- a/tests/bats/unit/lib/github/test_output.bats
+++ b/tests/bats/unit/lib/github/test_output.bats
@@ -234,13 +234,12 @@ line2"'
 	refute_output --partial "/nonexistent/path"
 }
 
-@test "add_github_path: rejects relative paths" {
+@test "add_github_path: silently ignores relative paths" {
 	local test_dir="${BATS_TEST_TMPDIR}/bin"
 	mkdir -p "$test_dir"
 
 	run bash -c "source \"\$LIB_DIR/github/output.sh\" && add_github_path \"bin\""
-	assert_failure
-	assert_output --partial "path must be absolute"
+	assert_success
 
 	run cat "$GITHUB_PATH"
 	refute_output --partial "bin"

--- a/tests/helpers/github_env.bash
+++ b/tests/helpers/github_env.bash
@@ -127,7 +127,39 @@ get_github_env() {
 		return 1
 	fi
 
-	grep "^${key}=" "$GITHUB_ENV" | head -1 | cut -d= -f2-
+	# Handle simple key=value format
+	local value
+	value=$(grep "^${key}=" "$GITHUB_ENV" | head -1 | cut -d= -f2-)
+
+	if [[ -n "$value" ]]; then
+		echo "$value"
+		return 0
+	fi
+
+	# Handle multiline format: key<<DELIMITER ... DELIMITER
+	local in_multiline=0
+	local delimiter=""
+	local result=""
+
+	while IFS= read -r line; do
+		if [[ $in_multiline -eq 1 ]]; then
+			if [[ "$line" == "$delimiter" ]]; then
+				echo "$result"
+				return 0
+			else
+				if [[ -n "$result" ]]; then
+					result="${result}"$'\n'"${line}"
+				else
+					result="$line"
+				fi
+			fi
+		elif [[ "$line" =~ ^${key}\<\<(.+)$ ]]; then
+			in_multiline=1
+			delimiter="${BASH_REMATCH[1]}"
+		fi
+	done <"$GITHUB_ENV"
+
+	return 1
 }
 
 # Get paths added to GITHUB_PATH


### PR DESCRIPTION
## Summary

Harden the egress preset stack and GitHub Actions output helpers: O(n) endpoint dedupe, shared multiline delimiter helpers, output-key validation, and PATH injection guards. Syncs the harden-runner bundle and documents caller migration notes for reusable release workflows.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. `add_github_path` still silently ignores relative paths; newline injection in PATH entries is now rejected.

## Closes

- Closes #283
- Relates to #268

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add input validation and centralized helpers to GITHUB_OUTPUT and egress deduplication
> - Adds `_validate_github_output_key` and `_validate_github_path_entry` validators to [`output.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/316/files#diff-7ffb278bce1a25ae50001d59329c78ac541900d8e85ba6fdb73a4ff660d0b128); `set_github_output`, `set_github_env`, and `add_github_path` now reject invalid/empty keys and malformed paths before writing.
> - Centralizes multiline `GITHUB_OUTPUT`/`GITHUB_ENV` writing via a new `_github_write_multiline_entry` helper and a shared random-delimiter generator `_github_actions_multiline_delimiter`.
> - `add_github_path` now silently ignores relative paths and rejects inputs containing newlines or CR; only absolute, existing directories are appended.
> - Refactors egress deduplication in [`egress.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/316/files#diff-0bfcd07193b540a34b60663ed9ac53141e3a040906da1b48ffb90ae69550baf5) to use a new `_egress_dedupe_normalized_endpoint_lines` helper that deduplicates in O(n) via `awk` while preserving first-seen order.
> - Fixes a global scope leak in `collect_existing_issue_label_args` by declaring the `labels` array as `local`.
> - Behavioral Change: functions that previously wrote silently on invalid input now return nonzero and write nothing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bcbb7bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validates GitHub Actions output keys and PATH entries; centralizes multiline output/env writing; requires absolute existing paths.
  * Faster, order-preserving deduplication of normalized host:port lists and exported dedupe helpers.

* **Bug Fixes**
  * Scoped shell variable to prevent global leakage in issue-label collection.

* **Documentation**
  * Clarified `report-failures` default and caller permission requirements for reusable workflows.

* **Tests**
  * Added unit tests covering deduplication, multiline output/env behavior, path handling, and exported helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the CI helper layer across two parallel copies (`.github/actions/harden-runner/lib` and `scripts/ci/lib`): egress endpoint deduplication is refactored from an O(n²) bash-array loop to a single awk pass, `GITHUB_OUTPUT`/`GITHUB_ENV`/`GITHUB_PATH` writers gain key and path validation with descriptive errors, and multiline delimiter generation is extracted into a shared helper. A scoping bug for the `labels` array in `collect_existing_issue_label_args` is also fixed.

- **Egress dedupe** (`egress.sh`): `_egress_dedupe_normalized_endpoint_lines` replaces the bash for-loop with `awk '!seen[$0]++'`; `egress_merge_endpoint_lines` skips the now-redundant second normalization pass by calling the internal helper directly.
- **Output helpers** (`output.sh`): `_validate_github_output_key` rejects empty, control-character, and non-identifier keys before any file write; `add_github_path` now explicitly rejects newline-containing paths with a non-zero exit and silently no-ops for relative paths; `printf '%s\
'` replaces `echo` in `_github_write_multiline_entry`, closing the `-n`-prefix mis-interpretation hazard.
- **Test helper** (`github_env.bash`): `get_github_env` gains multiline HEREDOC parsing to mirror `get_github_output`; its return code now correctly signals 1 when a key is absent (was implicitly 0).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the refactoring preserves all existing semantics and the new validation logic is well-tested.

All functional changes are either pure refactors (awk replacing a bash loop with identical observable output) or additive hardening (validation that was previously absent). The awk dedupe correctly handles trailing newlines via command-substitution stripping. The printf-based multiline writer correctly closes the echo -n hazard. The local -a labels scoping fix is straightforward. No auth, data-loss, or correctness regressions were found.

No files require special attention, though callers of get_github_env that check $? should be reviewed for the return-code behavior change in the test helper.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/lib/egress.sh | Replaces O(n²) bash-array dedupe loop with an O(n) awk pass. egress_merge_endpoint_lines now calls _egress_dedupe_normalized_endpoint_lines directly, avoiding double-normalization. Logic is correct. |
| scripts/ci/lib/github/output.sh | Adds key/path validation and shared multiline delimiter helpers. printf-based multiline write fixes the echo -n hazard. add_github_path silently returns 0 for relative paths (documented as intentional). |
| scripts/ci/release/report-release-failure.sh | Adds local -a labels to correctly scope the array in collect_existing_issue_label_args, preventing global leakage. |
| tests/helpers/github_env.bash | get_github_env gains multiline support mirroring get_github_output. Return-code semantics change: old code always returned 0; new code returns 1 when the key is absent. |
| tests/bats/unit/lib/egress/test_egress_lib.bats | New tests cover large-list dedup order, blank-line skipping, and subprocess export propagation. |
| tests/bats/unit/lib/github/test_output.bats | Adds tests for key validation, hyphenated keys, newline-injection rejection, and -n-prefixed multiline values. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[egress_dedupe_endpoint_lines] -->|normalize raw| B[egress_normalize_endpoint_lines]
    B --> C[_egress_dedupe_normalized_endpoint_lines]
    C --> D[awk dedup pass]
    D --> E[deduplicated output]
    F[egress_merge_endpoint_lines] -->|normalize each part| B
    F -->|combined normalized string| C
    G[set_github_output] --> H{_validate_github_output_key}
    H -->|invalid| I[return 1 + stderr]
    H -->|valid single-line| J[echo key=value to GITHUB_OUTPUT]
    L[set_github_output_multiline] --> H
    H -->|valid| M[_github_write_multiline_entry]
    M --> N[_github_actions_multiline_delimiter]
    N --> O[printf heredoc block to file]
    P[set_github_env] --> H
    H -->|valid multiline| M
    H -->|valid single-line| Q[echo key=value to GITHUB_ENV]
    R[add_github_path] --> S{_validate_github_path_entry}
    S -->|empty or newline| I
    S -->|relative path| T[return 0 silent]
    S -->|absolute dir exists| U[echo path to GITHUB_PATH]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Atests%2Fhelpers%2Fgithub_env.bash%3A123-163%0A**Return-code%20semantics%20changed%20for%20missing%20keys**%0A%0AThe%20old%20%60get_github_env%60%20ended%20with%20the%20exit%20code%20of%20%60cut%60%20%28always%200%29%2C%20so%20callers%20that%20did%20%60if%20get_github_env%20%22missing_key%22%3B%20then%20%E2%80%A6%60%20would%20always%20enter%20the%20branch.%20The%20new%20implementation%20closes%20the%20loop%20with%20%60return%201%60%2C%20so%20the%20same%20construct%20now%20correctly%20signals%20absence%20%E2%80%94%20but%20any%20test%20that%20explicitly%20checks%20%60%24%3F%60%20or%20uses%20%60assert_success%60%20on%20a%20key%20that%20was%20never%20written%20will%20now%20fail%20rather%20than%20silently%20succeed.%20The%20new%20tests%20added%20in%20this%20PR%20all%20write%20before%20reading%2C%20so%20they're%20fine%2C%20but%20it's%20worth%20a%20quick%20scan%20of%20any%20test%20that%20calls%20%60run%20get_github_env%60%20on%20a%20key%20that%20might%20be%20absent.%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Fci%2Flib%2Fgithub%2Foutput.sh%3A30-33%0AThe%20error%20message%20says%20%22use%20alphanumerics%2C%20hyphens%2C%20underscores%22%20but%20the%20regex%20enforces%20an%20additional%20constraint%20not%20mentioned%3A%20the%20key%20must%20start%20with%20a%20letter%20or%20underscore%20%28%60%5BA-Za-z_%5D%60%29%2C%20so%20a%20key%20like%20%602fa-token%60%20would%20be%20rejected.%20If%20that%20restriction%20is%20intentional%2C%20the%20error%20message%20should%20call%20it%20out%20to%20avoid%20confusing%20callers%20who%20read%20the%20message%20and%20produce%20a%20key%20like%20%602-step%60%20that%20still%20fails.%0A%0A%60%60%60suggestion%0A%09if%20%5B%5B%20!%20%22%24key%22%20%3D~%20%5E%5BA-Za-z_%5D%5BA-Za-z0-9_-%5D*%24%20%5D%5D%3B%20then%0A%09%09echo%20%22%24%7Bcontext%7D%3A%20invalid%20key%20'%24key'%20%28must%20start%20with%20a%20letter%20or%20underscore%3B%20use%20alphanumerics%2C%20hyphens%2C%20underscores%29%22%20%3E%262%0A%09%09return%201%0A%09fi%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Factions%2Fharden-runner%2Flib%2Fgithub%2Foutput.sh%3A30-33%0ASame%20misleading%20error%20message%20as%20in%20%60scripts%2Fci%2Flib%2Fgithub%2Foutput.sh%60%20%E2%80%94%20the%20regex%20enforces%20a%20letter%2Funderscore%20leading%20character%20that%20isn't%20mentioned%20in%20the%20error%20text.%0A%0A%60%60%60suggestion%0A%09if%20%5B%5B%20!%20%22%24key%22%20%3D~%20%5E%5BA-Za-z_%5D%5BA-Za-z0-9_-%5D*%24%20%5D%5D%3B%20then%0A%09%09echo%20%22%24%7Bcontext%7D%3A%20invalid%20key%20'%24key'%20%28must%20start%20with%20a%20letter%20or%20underscore%3B%20use%20alphanumerics%2C%20hyphens%2C%20underscores%29%22%20%3E%262%0A%09%09return%201%0A%09fi%0A%60%60%60%0A%0A&pr=316&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Atests%2Fhelpers%2Fgithub_env.bash%3A123-163%0A**Return-code%20semantics%20changed%20for%20missing%20keys**%0A%0AThe%20old%20%60get_github_env%60%20ended%20with%20the%20exit%20code%20of%20%60cut%60%20%28always%200%29%2C%20so%20callers%20that%20did%20%60if%20get_github_env%20%22missing_key%22%3B%20then%20%E2%80%A6%60%20would%20always%20enter%20the%20branch.%20The%20new%20implementation%20closes%20the%20loop%20with%20%60return%201%60%2C%20so%20the%20same%20construct%20now%20correctly%20signals%20absence%20%E2%80%94%20but%20any%20test%20that%20explicitly%20checks%20%60%24%3F%60%20or%20uses%20%60assert_success%60%20on%20a%20key%20that%20was%20never%20written%20will%20now%20fail%20rather%20than%20silently%20succeed.%20The%20new%20tests%20added%20in%20this%20PR%20all%20write%20before%20reading%2C%20so%20they're%20fine%2C%20but%20it's%20worth%20a%20quick%20scan%20of%20any%20test%20that%20calls%20%60run%20get_github_env%60%20on%20a%20key%20that%20might%20be%20absent.%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Fci%2Flib%2Fgithub%2Foutput.sh%3A30-33%0AThe%20error%20message%20says%20%22use%20alphanumerics%2C%20hyphens%2C%20underscores%22%20but%20the%20regex%20enforces%20an%20additional%20constraint%20not%20mentioned%3A%20the%20key%20must%20start%20with%20a%20letter%20or%20underscore%20%28%60%5BA-Za-z_%5D%60%29%2C%20so%20a%20key%20like%20%602fa-token%60%20would%20be%20rejected.%20If%20that%20restriction%20is%20intentional%2C%20the%20error%20message%20should%20call%20it%20out%20to%20avoid%20confusing%20callers%20who%20read%20the%20message%20and%20produce%20a%20key%20like%20%602-step%60%20that%20still%20fails.%0A%0A%60%60%60suggestion%0A%09if%20%5B%5B%20!%20%22%24key%22%20%3D~%20%5E%5BA-Za-z_%5D%5BA-Za-z0-9_-%5D*%24%20%5D%5D%3B%20then%0A%09%09echo%20%22%24%7Bcontext%7D%3A%20invalid%20key%20'%24key'%20%28must%20start%20with%20a%20letter%20or%20underscore%3B%20use%20alphanumerics%2C%20hyphens%2C%20underscores%29%22%20%3E%262%0A%09%09return%201%0A%09fi%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Factions%2Fharden-runner%2Flib%2Fgithub%2Foutput.sh%3A30-33%0ASame%20misleading%20error%20message%20as%20in%20%60scripts%2Fci%2Flib%2Fgithub%2Foutput.sh%60%20%E2%80%94%20the%20regex%20enforces%20a%20letter%2Funderscore%20leading%20character%20that%20isn't%20mentioned%20in%20the%20error%20text.%0A%0A%60%60%60suggestion%0A%09if%20%5B%5B%20!%20%22%24key%22%20%3D~%20%5E%5BA-Za-z_%5D%5BA-Za-z0-9_-%5D*%24%20%5D%5D%3B%20then%0A%09%09echo%20%22%24%7Bcontext%7D%3A%20invalid%20key%20'%24key'%20%28must%20start%20with%20a%20letter%20or%20underscore%3B%20use%20alphanumerics%2C%20hyphens%2C%20underscores%29%22%20%3E%262%0A%09%09return%201%0A%09fi%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=316&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22chore%2F283-egress-resolver-and-github-output-hygiene%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2F283-egress-resolver-and-github-output-hygiene%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Atests%2Fhelpers%2Fgithub_env.bash%3A123-163%0A**Return-code%20semantics%20changed%20for%20missing%20keys**%0A%0AThe%20old%20%60get_github_env%60%20ended%20with%20the%20exit%20code%20of%20%60cut%60%20%28always%200%29%2C%20so%20callers%20that%20did%20%60if%20get_github_env%20%22missing_key%22%3B%20then%20%E2%80%A6%60%20would%20always%20enter%20the%20branch.%20The%20new%20implementation%20closes%20the%20loop%20with%20%60return%201%60%2C%20so%20the%20same%20construct%20now%20correctly%20signals%20absence%20%E2%80%94%20but%20any%20test%20that%20explicitly%20checks%20%60%24%3F%60%20or%20uses%20%60assert_success%60%20on%20a%20key%20that%20was%20never%20written%20will%20now%20fail%20rather%20than%20silently%20succeed.%20The%20new%20tests%20added%20in%20this%20PR%20all%20write%20before%20reading%2C%20so%20they're%20fine%2C%20but%20it's%20worth%20a%20quick%20scan%20of%20any%20test%20that%20calls%20%60run%20get_github_env%60%20on%20a%20key%20that%20might%20be%20absent.%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Fci%2Flib%2Fgithub%2Foutput.sh%3A30-33%0AThe%20error%20message%20says%20%22use%20alphanumerics%2C%20hyphens%2C%20underscores%22%20but%20the%20regex%20enforces%20an%20additional%20constraint%20not%20mentioned%3A%20the%20key%20must%20start%20with%20a%20letter%20or%20underscore%20%28%60%5BA-Za-z_%5D%60%29%2C%20so%20a%20key%20like%20%602fa-token%60%20would%20be%20rejected.%20If%20that%20restriction%20is%20intentional%2C%20the%20error%20message%20should%20call%20it%20out%20to%20avoid%20confusing%20callers%20who%20read%20the%20message%20and%20produce%20a%20key%20like%20%602-step%60%20that%20still%20fails.%0A%0A%60%60%60suggestion%0A%09if%20%5B%5B%20!%20%22%24key%22%20%3D~%20%5E%5BA-Za-z_%5D%5BA-Za-z0-9_-%5D*%24%20%5D%5D%3B%20then%0A%09%09echo%20%22%24%7Bcontext%7D%3A%20invalid%20key%20'%24key'%20%28must%20start%20with%20a%20letter%20or%20underscore%3B%20use%20alphanumerics%2C%20hyphens%2C%20underscores%29%22%20%3E%262%0A%09%09return%201%0A%09fi%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Factions%2Fharden-runner%2Flib%2Fgithub%2Foutput.sh%3A30-33%0ASame%20misleading%20error%20message%20as%20in%20%60scripts%2Fci%2Flib%2Fgithub%2Foutput.sh%60%20%E2%80%94%20the%20regex%20enforces%20a%20letter%2Funderscore%20leading%20character%20that%20isn't%20mentioned%20in%20the%20error%20text.%0A%0A%60%60%60suggestion%0A%09if%20%5B%5B%20!%20%22%24key%22%20%3D~%20%5E%5BA-Za-z_%5D%5BA-Za-z0-9_-%5D*%24%20%5D%5D%3B%20then%0A%09%09echo%20%22%24%7Bcontext%7D%3A%20invalid%20key%20'%24key'%20%28must%20start%20with%20a%20letter%20or%20underscore%3B%20use%20alphanumerics%2C%20hyphens%2C%20underscores%29%22%20%3E%262%0A%09%09return%201%0A%09fi%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=316&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(egress): export internal dedupe help..."](https://github.com/lgtm-hq/lgtm-ci/commit/bcbb7bc1651281e5718bf209ea942b7f7ad8bb1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36082341)</sub>

<!-- /greptile_comment -->