### PR TITLE
feat(ci): block-only Rust release builds with OS-aware harden-runner

### DIFF
--- a/.github/actions/harden-runner/action.yml
+++ b/.github/actions/harden-runner/action.yml
@@ -36,7 +36,7 @@ runs:
   using: "composite"
   steps:
     # Create agent state before harden-runner; uses sudo while disable-sudo is still off.
-    # Linux-only: /home/agent and sudo are unavailable on Windows/macOS runners.
+    # Linux-only: StepSecurity agent requires /home/agent (unavailable on Windows/macOS).
     # Call validate-runner-policy first and skip this action when enforce-egress is false.
     - name: Ensure agent state for post cleanup
       if: runner.os == 'Linux'

--- a/.github/actions/harden-runner/action.yml
+++ b/.github/actions/harden-runner/action.yml
@@ -36,7 +36,10 @@ runs:
   using: "composite"
   steps:
     # Create agent state before harden-runner; uses sudo while disable-sudo is still off.
+    # Linux-only: /home/agent and sudo are unavailable on Windows/macOS runners.
+    # Call validate-runner-policy first and skip this action when enforce-egress is false.
     - name: Ensure agent state for post cleanup
+      if: runner.os == 'Linux'
       shell: bash
       run: |
         sudo mkdir -p /home/agent

--- a/.github/actions/harden-runner/lib/egress/presets.sh
+++ b/.github/actions/harden-runner/lib/egress/presets.sh
@@ -196,9 +196,22 @@ egress_preset_endpoints() {
 		;;
 	rust-release)
 		# Rust cross-compile release builds (reusable-build-rust-binaries.yml).
-		# Extends quality with Ubuntu apt mirrors (musl-tools) and Sigstore attestation.
-		egress_preset_endpoints quality
+		# Minimal base: GitHub checkout/tooling, Rust/crates, cross Docker, apt, Sigstore.
+		egress_preset_endpoints github-minimal
 		printf '%s\n' \
+			raw.githubusercontent.com:443 \
+			static.rust-lang.org:443 \
+			sh.rustup.rs:443 \
+			crates.io:443 \
+			static.crates.io:443 \
+			index.crates.io:443 \
+			ghcr.io:443 \
+			pkg-containers.githubusercontent.com:443 \
+			docker.io:443 \
+			registry-1.docker.io:443 \
+			auth.docker.io:443 \
+			production.cloudflare.docker.com:443 \
+			production.cloudfront.docker.com:443 \
 			archive.ubuntu.com:80 \
 			azure.archive.ubuntu.com:80 \
 			security.ubuntu.com:80 \

--- a/.github/actions/harden-runner/lib/egress/presets.sh
+++ b/.github/actions/harden-runner/lib/egress/presets.sh
@@ -196,9 +196,12 @@ egress_preset_endpoints() {
 		;;
 	rust-release)
 		# Rust cross-compile release builds (reusable-build-rust-binaries.yml).
-		# Extends quality with Sigstore attestation endpoints for SLSA provenance.
+		# Extends quality with Ubuntu apt mirrors (musl-tools) and Sigstore attestation.
 		egress_preset_endpoints quality
 		printf '%s\n' \
+			archive.ubuntu.com:80 \
+			azure.archive.ubuntu.com:80 \
+			security.ubuntu.com:80 \
 			fulcio.sigstore.dev:443 \
 			rekor.sigstore.dev:443 \
 			timestamp.sigstore.dev:443 \

--- a/.github/actions/harden-runner/lib/egress/presets.sh
+++ b/.github/actions/harden-runner/lib/egress/presets.sh
@@ -194,6 +194,17 @@ egress_preset_endpoints() {
 			api.scorecard.dev:443 \
 			api.securityscorecards.dev:443
 		;;
+	rust-release)
+		# Rust cross-compile release builds (reusable-build-rust-binaries.yml).
+		# Extends quality with Sigstore attestation endpoints for SLSA provenance.
+		egress_preset_endpoints quality
+		printf '%s\n' \
+			fulcio.sigstore.dev:443 \
+			rekor.sigstore.dev:443 \
+			timestamp.sigstore.dev:443 \
+			tuf-repo-cdn.sigstore.dev:443 \
+			sigstore-tuf-root.storage.googleapis.com:443
+		;;
 	*)
 		echo "unknown egress preset: $preset" >&2
 		return 1

--- a/.github/actions/resolve-egress-allowlist/action.yml
+++ b/.github/actions/resolve-egress-allowlist/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: >-
       Named baseline allowlist for block policy (github-minimal, github-pages,
       github-tooling, docker, playwright, pypi, rubygems, npm-publish, quality,
-      sbom, scorecard)
+      rust-release, sbom, scorecard)
     required: false
     default: ""
   allowed-endpoints:

--- a/.github/actions/validate-runner-policy/action.yml
+++ b/.github/actions/validate-runner-policy/action.yml
@@ -1,0 +1,49 @@
+---
+name: "Validate runner policy"
+description: >-
+  Enforce tiered egress policy (strict, hardened, permissive) before
+  harden-runner. Outputs whether egress enforcement should run on this leg.
+author: "lgtm-hq"
+
+inputs:
+  tier:
+    description: "Policy tier: strict, hardened, or permissive"
+    required: true
+  egress-policy:
+    description: "Requested egress policy (block or audit; audit rejected except permissive advisory)"
+    required: true
+  runner-environment:
+    description: "Pass ${{ runner.environment }}"
+    required: true
+  runner-os:
+    description: "Pass ${{ runner.os }}"
+    required: true
+
+outputs:
+  enforce-egress:
+    description: "Whether harden-runner should be called on this leg (true or false)"
+    value: ${{ steps.policy.outputs['enforce-egress'] }}
+  effective-policy:
+    description: "Applied policy: block, audit, or none"
+    value: ${{ steps.policy.outputs['effective-policy'] }}
+  tier-warning:
+    description: "Non-empty when a leg runs without egress enforcement"
+    value: ${{ steps.policy.outputs['tier-warning'] }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate runner policy
+      id: policy
+      shell: bash
+      env:
+        TIER: ${{ inputs.tier }}
+        EGRESS_POLICY: ${{ inputs['egress-policy'] }}
+        RUNNER_ENVIRONMENT: ${{ inputs['runner-environment'] }}
+        RUNNER_OS: ${{ inputs['runner-os'] }}
+      run: >-
+        bash "${{ github.action_path }}/../../../scripts/ci/actions/validate-runner-policy.sh"
+
+branding:
+  icon: "shield"
+  color: "yellow"

--- a/.github/workflows/reusable-build-rust-binaries.yml
+++ b/.github/workflows/reusable-build-rust-binaries.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-path: SHA256SUMS
+          subject-path: SHA256SUMS-${{ matrix.target }}
 
       - name: Upload binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -222,6 +222,6 @@ jobs:
           path: |
             *.tar.gz
             *.zip
-            SHA256SUMS
+            SHA256SUMS-${{ matrix.target }}
           if-no-files-found: error
           retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/reusable-build-rust-binaries.yml
+++ b/.github/workflows/reusable-build-rust-binaries.yml
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: MIT
+---
+name: Reusable Rust Binary Build Workflow
+
+on:
+  workflow_call:
+    inputs:
+      tooling-ref:
+        description: "Git ref for lgtm-ci tooling and composite actions (SHA pin)"
+        required: true
+        type: string
+      packages:
+        description: "Comma-separated Cargo package names to build"
+        required: true
+        type: string
+      binary-names:
+        description: >-
+          Optional comma-separated binary names parallel to packages (defaults
+          via cargo metadata)
+        required: false
+        type: string
+        default: ""
+      targets:
+        description: >-
+          JSON matrix override (array of {target, cross, archive} objects).
+          Defaults to Linux musl + aarch64 gnu + Windows MSVC cross-compile.
+        required: false
+        type: string
+        default: ""
+      egress-policy:
+        description: "harden-runner egress policy (block only; audit rejected)"
+        required: false
+        type: string
+        default: "block"
+      egress-preset:
+        description: >-
+          Named allowlist when allowed-endpoints is empty and egress-policy is
+          block (rust-release recommended)
+        required: false
+        type: string
+        default: "rust-release"
+      allowed-endpoints:
+        description: "Additional allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      allowed-endpoints-mode:
+        description: "append merges preset with allowed-endpoints (deduped)"
+        required: false
+        type: string
+        default: "append"
+      build-script:
+        description: "Override path to build script"
+        required: false
+        type: string
+        default: ""
+      package-script:
+        description: "Override path to packaging script"
+        required: false
+        type: string
+        default: ""
+      artifact-prefix:
+        description: "Artifact name prefix (defaults to repository name)"
+        required: false
+        type: string
+        default: ""
+      retention-days:
+        description: "Days to retain build artifacts"
+        required: false
+        type: number
+        default: 7
+      runner-image:
+        description: "GitHub-hosted runner image (Linux only for strict tier)"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 45
+      version-file:
+        description: "Cargo.toml path for version reads"
+        required: false
+        type: string
+        default: "Cargo.toml"
+
+    outputs:
+      version:
+        description: "Cargo workspace version"
+        value: ${{ jobs.build.outputs.version }}
+
+jobs:
+  build:
+    name: "Rust binaries (${{ matrix.target }})"
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    concurrency:
+      group: rust-binaries-${{ github.ref_name }}
+      cancel-in-progress: false
+    strategy:
+      fail-fast: false
+      matrix:
+        include: >-
+          ${{
+            fromJson(
+              inputs.targets != '' && inputs.targets ||
+              '[
+                {"target":"x86_64-unknown-linux-musl","cross":false,"archive":"tar.gz"},
+                {"target":"aarch64-unknown-linux-gnu","cross":true,"archive":"tar.gz"},
+                {"target":"x86_64-pc-windows-msvc","cross":true,"archive":"zip"}
+              ]'
+            )
+          }}
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref }}
+          sparse-checkout: |
+            .github/actions/
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Validate runner policy
+        id: policy
+        uses: ./.lgtm-ci-tooling/.github/actions/validate-runner-policy
+        with:
+          tier: strict
+          egress-policy: ${{ inputs.egress-policy }}
+          runner-environment: ${{ runner.environment }}
+          runner-os: ${{ runner.os }}
+
+      - name: Resolve egress allowlist
+        id: egress
+        if: steps.policy.outputs['enforce-egress'] == 'true'
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+
+      - name: Harden runner
+        if: steps.policy.outputs['enforce-egress'] == 'true'
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+
+      - name: Setup Rust
+        uses: ./.lgtm-ci-tooling/.github/actions/setup-rust
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install musl toolchain
+        if: contains(matrix.target, 'musl')
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - name: Install cross
+        if: matrix.cross
+        shell: bash
+        run: cargo install cross --locked
+
+      - name: Build release binaries
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+          PACKAGES: ${{ inputs.packages }}
+          USE_CROSS: ${{ matrix.cross }}
+          RAW_SCRIPT_PATH: ${{ inputs.build-script }}
+          DEFAULT_SCRIPT_PATH: .lgtm-ci-tooling/scripts/ci/release/build-rust-binary.sh
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/run-caller-script.sh
+
+      - name: Read Cargo version
+        id: version
+        shell: bash
+        env:
+          VERSION_FILE: ${{ inputs.version-file }}
+        run: >-
+          .lgtm-ci-tooling/scripts/ci/release/read-cargo-version.sh
+
+      - name: Package release binaries
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TARGET: ${{ matrix.target }}
+          PACKAGES: ${{ inputs.packages }}
+          BINARY_NAMES: ${{ inputs.binary-names }}
+          ARCHIVE_FORMAT: ${{ matrix.archive }}
+          RAW_SCRIPT_PATH: ${{ inputs.package-script }}
+          DEFAULT_SCRIPT_PATH: .lgtm-ci-tooling/scripts/ci/release/package-rust-binary.sh
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/run-caller-script.sh
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: SHA256SUMS
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: >-
+            ${{ inputs.artifact-prefix != '' && inputs.artifact-prefix ||
+            github.event.repository.name }}-${{ matrix.target }}
+          path: |
+            *.tar.gz
+            *.zip
+            SHA256SUMS
+          if-no-files-found: error
+          retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/reusable-build-rust-binaries.yml
+++ b/.github/workflows/reusable-build-rust-binaries.yml
@@ -90,18 +90,21 @@ on:
         description: "Cargo workspace version"
         value: ${{ jobs.build.outputs.version }}
 
+concurrency:
+  group: rust-binaries-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   build:
     name: "Rust binaries (${{ matrix.target }})"
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
+      # Read repository contents for checkout and build
       contents: read
+      # OIDC + attestations for build provenance (Attest build provenance step)
       id-token: write
       attestations: write
-    concurrency:
-      group: rust-binaries-${{ github.ref_name }}
-      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reusable-build-rust-binaries.yml
+++ b/.github/workflows/reusable-build-rust-binaries.yml
@@ -102,8 +102,9 @@ jobs:
     permissions:
       # Read repository contents for checkout and build
       contents: read
-      # OIDC + attestations for build provenance (Attest build provenance step)
+      # OIDC token issuance for Sigstore authentication during attestation
       id-token: write
+      # Publish build provenance attestations (Attest build provenance step)
       attestations: write
     strategy:
       fail-fast: false
@@ -179,7 +180,7 @@ jobs:
       - name: Install cross
         if: matrix.cross
         shell: bash
-        run: cargo install cross --locked
+        run: cargo install cross --locked --version 0.2.5
 
       - name: Build release binaries
         shell: bash
@@ -214,7 +215,9 @@ jobs:
       - name: Attest build provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-path: SHA256SUMS-${{ matrix.target }}
+          subject-path: |
+            *.tar.gz
+            *.zip
 
       - name: Upload binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/reusable-publish-rust-release.yml
+++ b/.github/workflows/reusable-publish-rust-release.yml
@@ -105,6 +105,9 @@ jobs:
       contents: read
     outputs:
       version: ${{ steps.version.outputs.version }}
+      artifact_prefix: >-
+        ${{ inputs.artifact-prefix != '' && inputs.artifact-prefix ||
+        github.event.repository.name }}
     concurrency:
       group: release-${{ github.ref_name }}
       cancel-in-progress: false
@@ -173,7 +176,9 @@ jobs:
     needs: verify-tag
     permissions:
       contents: read
+      # OIDC token issuance for Sigstore authentication during attestation
       id-token: write
+      # SLSA provenance attestations via nested reusable-build-rust-binaries.yml
       attestations: write
     uses: ./.github/workflows/reusable-build-rust-binaries.yml
     with:
@@ -181,9 +186,7 @@ jobs:
       packages: ${{ inputs.packages }}
       binary-names: ${{ inputs.binary-names }}
       targets: ${{ inputs.targets }}
-      artifact-prefix: >-
-        ${{ inputs.artifact-prefix != '' && inputs.artifact-prefix ||
-        github.event.repository.name }}
+      artifact-prefix: ${{ needs.verify-tag.outputs.artifact_prefix }}
       build-script: ${{ inputs.build-script }}
       package-script: ${{ inputs.package-script }}
       allowed-endpoints: ${{ inputs.allowed-endpoints }}
@@ -252,9 +255,7 @@ jobs:
       - name: Download binary artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: >-
-            ${{ inputs.artifact-prefix != '' && inputs.artifact-prefix ||
-            github.event.repository.name }}-*
+          pattern: ${{ needs.verify-tag.outputs.artifact_prefix }}-*
           merge-multiple: true
           path: dist
 

--- a/.github/workflows/reusable-publish-rust-release.yml
+++ b/.github/workflows/reusable-publish-rust-release.yml
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: MIT
+---
+name: Reusable Rust Release Publish Workflow
+
+on:
+  workflow_call:
+    inputs:
+      tooling-ref:
+        description: "Git ref for lgtm-ci tooling and composite actions (SHA pin)"
+        required: true
+        type: string
+      packages:
+        description: "Comma-separated Cargo package names to build"
+        required: true
+        type: string
+      binary-names:
+        description: >-
+          Optional comma-separated binary names parallel to packages
+        required: false
+        type: string
+        default: ""
+      targets:
+        description: "JSON matrix override for binary targets"
+        required: false
+        type: string
+        default: ""
+      artifact-prefix:
+        description: "Artifact name prefix (defaults to repository name)"
+        required: false
+        type: string
+        default: ""
+      version-file:
+        description: "Cargo.toml path for tag/version verification"
+        required: false
+        type: string
+        default: "Cargo.toml"
+      build-script:
+        description: "Override path to build script"
+        required: false
+        type: string
+        default: ""
+      package-script:
+        description: "Override path to packaging script"
+        required: false
+        type: string
+        default: ""
+      allowed-endpoints:
+        description: "Additional allowed endpoints for release jobs"
+        required: false
+        type: string
+        default: ""
+      allowed-endpoints-mode:
+        description: "append merges preset with allowed-endpoints"
+        required: false
+        type: string
+        default: "append"
+      tag-name:
+        description: "Release tag (defaults to github.ref_name)"
+        required: false
+        type: string
+        default: ""
+      generate-release-notes:
+        description: "Use GitHub auto-generated release notes"
+        required: false
+        type: boolean
+        default: true
+      draft:
+        description: "Create as draft release"
+        required: false
+        type: boolean
+        default: false
+      prerelease:
+        description: "Mark as prerelease"
+        required: false
+        type: boolean
+        default: false
+      runner-image:
+        description: "GitHub-hosted runner image for verify/release jobs"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+      timeout-minutes:
+        description: "Timeout for verify and release jobs"
+        required: false
+        type: number
+        default: 15
+
+    outputs:
+      release-url:
+        description: "URL of the created GitHub release"
+        value: ${{ jobs.github-release.outputs.release-url }}
+      release-id:
+        description: "ID of the created GitHub release"
+        value: ${{ jobs.github-release.outputs.release-id }}
+      version:
+        description: "Verified Cargo workspace version"
+        value: ${{ jobs.verify-tag.outputs.version }}
+
+jobs:
+  verify-tag:
+    name: Verify release tag
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    concurrency:
+      group: release-${{ github.ref_name }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref }}
+          sparse-checkout: |
+            .github/actions/
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Validate runner policy
+        id: policy
+        uses: ./.lgtm-ci-tooling/.github/actions/validate-runner-policy
+        with:
+          tier: strict
+          egress-policy: block
+          runner-environment: ${{ runner.environment }}
+          runner-os: ${{ runner.os }}
+
+      - name: Resolve egress allowlist
+        id: egress
+        if: steps.policy.outputs['enforce-egress'] == 'true'
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: block
+          egress-preset: github-minimal
+
+      - name: Harden runner
+        if: steps.policy.outputs['enforce-egress'] == 'true'
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: block
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+
+      - name: Read Cargo version
+        id: version
+        shell: bash
+        env:
+          VERSION_FILE: ${{ inputs.version-file }}
+        run: >-
+          .lgtm-ci-tooling/scripts/ci/release/read-cargo-version.sh
+
+      - name: Verify tag matches Cargo.toml
+        shell: bash
+        env:
+          TAG: >-
+            ${{ inputs.tag-name != '' && inputs.tag-name || github.ref_name }}
+          VERSION_FILE: ${{ inputs.version-file }}
+        run: >-
+          .lgtm-ci-tooling/scripts/ci/release/verify-rust-release-tag.sh
+
+  build-binaries:
+    name: Build release binaries
+    needs: verify-tag
+    uses: ./.github/workflows/reusable-build-rust-binaries.yml
+    with:
+      tooling-ref: ${{ inputs.tooling-ref }}
+      packages: ${{ inputs.packages }}
+      binary-names: ${{ inputs.binary-names }}
+      targets: ${{ inputs.targets }}
+      artifact-prefix: >-
+        ${{ inputs.artifact-prefix != '' && inputs.artifact-prefix ||
+        github.event.repository.name }}
+      build-script: ${{ inputs.build-script }}
+      package-script: ${{ inputs.package-script }}
+      allowed-endpoints: ${{ inputs.allowed-endpoints }}
+      allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+      version-file: ${{ inputs.version-file }}
+
+  github-release:
+    name: Create GitHub release
+    needs: [verify-tag, build-binaries]
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: write
+    concurrency:
+      group: release-${{ github.ref_name }}
+      cancel-in-progress: false
+    outputs:
+      release-url: ${{ steps.release.outputs.release-url }}
+      release-id: ${{ steps.release.outputs.release-id }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref }}
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+            .github/actions/validate-runner-policy
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Validate runner policy
+        id: policy
+        uses: ./.lgtm-ci-tooling/.github/actions/validate-runner-policy
+        with:
+          tier: strict
+          egress-policy: block
+          runner-environment: ${{ runner.environment }}
+          runner-os: ${{ runner.os }}
+
+      - name: Resolve egress allowlist
+        id: egress
+        if: steps.policy.outputs['enforce-egress'] == 'true'
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: block
+          egress-preset: github-tooling
+
+      - name: Harden runner
+        if: steps.policy.outputs['enforce-egress'] == 'true'
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: block
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+
+      - name: Download binary artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: >-
+            ${{ inputs.artifact-prefix != '' && inputs.artifact-prefix ||
+            github.event.repository.name }}-*
+          merge-multiple: true
+          path: dist
+
+      - name: Verify release assets exist
+        shell: bash
+        env:
+          FILES: "dist/*"
+          ARTIFACT_PATH: dist
+        run: >-
+          .lgtm-ci-tooling/scripts/ci/release/verify-release-assets.sh
+
+      - name: Create GitHub Release
+        id: release
+        shell: bash
+        env:
+          TAG: >-
+            ${{ inputs.tag-name != '' && inputs.tag-name || github.ref_name }}
+          TITLE: >-
+            ${{ inputs.tag-name != '' && inputs.tag-name || github.ref_name }}
+          GENERATE_NOTES: ${{ inputs.generate-release-notes }}
+          DRAFT: ${{ inputs.draft }}
+          PRERELEASE: ${{ inputs.prerelease }}
+          FILE_PATTERNS: "dist/*"
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          .lgtm-ci-tooling/scripts/ci/release/create-github-release.sh

--- a/.github/workflows/reusable-publish-rust-release.yml
+++ b/.github/workflows/reusable-publish-rust-release.yml
@@ -171,6 +171,10 @@ jobs:
   build-binaries:
     name: Build release binaries
     needs: verify-tag
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/reusable-build-rust-binaries.yml
     with:
       tooling-ref: ${{ inputs.tooling-ref }}
@@ -192,6 +196,7 @@ jobs:
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
+      # Create GitHub Release and upload release assets
       contents: write
     concurrency:
       group: release-${{ github.ref_name }}

--- a/.github/workflows/reusable-publish-rust-release.yml
+++ b/.github/workflows/reusable-publish-rust-release.yml
@@ -253,6 +253,16 @@ jobs:
           merge-multiple: true
           path: dist
 
+      - name: Aggregate checksum manifests
+        shell: bash
+        run: |
+          shopt -s nullglob
+          manifests=(dist/SHA256SUMS-*)
+          if [[ ${#manifests[@]} -gt 0 ]]; then
+            cat "${manifests[@]}" >dist/SHA256SUMS
+            rm -f "${manifests[@]}"
+          fi
+
       - name: Verify release assets exist
         shell: bash
         env:

--- a/.github/workflows/reusable-publish-rust-release.yml
+++ b/.github/workflows/reusable-publish-rust-release.yml
@@ -255,13 +255,10 @@ jobs:
 
       - name: Aggregate checksum manifests
         shell: bash
-        run: |
-          shopt -s nullglob
-          manifests=(dist/SHA256SUMS-*)
-          if [[ ${#manifests[@]} -gt 0 ]]; then
-            cat "${manifests[@]}" >dist/SHA256SUMS
-            rm -f "${manifests[@]}"
-          fi
+        env:
+          ARTIFACT_PATH: dist
+        run: >-
+          .lgtm-ci-tooling/scripts/ci/release/aggregate-rust-release-checksums.sh
 
       - name: Verify release assets exist
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ci**: `validate-runner-policy` composite with `strict`, `hardened`, and
+  `permissive` tiers (#313)
+- **ci**: `rust-release` egress preset for cross-compile release builds (#313)
+- **ci**: `reusable-build-rust-binaries` and `reusable-publish-rust-release`
+  workflows with Linux-only strict tier (#313)
+- **release**: `build-rust-binary.sh`, `package-rust-binary.sh`, and Cargo tag
+  verification scripts (#313)
+
 ### Changed
+
+- **ci**: `harden-runner` Linux pre-step guarded with `runner.os == 'Linux'` (#313)
+- **ci**: release reusables use `validate-runner-policy` before conditional
+  harden-runner (#313)
 
 - **ci**: replace O(n²) egress endpoint dedupe with an O(n) awk pass while
   preserving first-seen order
@@ -27,10 +39,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **ci**: `setup-rust-nextest.sh` passes `--force` when reinstalling mismatched
+  crate versions (#307, #313)
 - **release**: declare `local -a labels` in `collect_existing_issue_label_args`
   to avoid leaking into global scope
 
 ### Security
+
+- **ci**: `validate-runner-policy` rejects `egress-policy: audit` on `strict` and
+  `hardened` tiers; release reusables default to block-only (#313)
 
 ## [0.35.0] - 2026-06-07
 

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -264,6 +264,33 @@ jobs:
 
 Outputs: `pages-coverage-artifact-name`, `pages-coverage-uploaded` (`true`/`false`).
 
+### Rust release (cross-compile from Linux)
+
+Use `reusable-publish-rust-release.yml` on tag pushes for block-only binary
+builds and GitHub release creation. The orchestrator verifies the tag against
+`Cargo.toml`, calls `reusable-build-rust-binaries.yml` (strict tier,
+`rust-release` egress preset), and uploads all matrix artifacts to a release.
+
+```yaml
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  release:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-rust-release.yml@<sha>
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    with:
+      tooling-ref: "<sha>"
+      packages: "my-cli,my-server"
+```
+
+See [workflow-contract.md](workflow-contract.md#rust-release-contract) for artifact
+naming, default target matrix, and runner policy tiers.
+
 **`pages-coverage-upload-on` (v1):** Same gating semantics as the Node reusable
 (see table above). `push-main` is a literal selector meaning push events to
 `refs/heads/main`; it is not a Git ref alias. The `(v1)` suffix denotes the

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -311,6 +311,81 @@ step** because step-security's pre-hook runs before composite steps and cannot r
 
 Do **not** use `.lgtm-ci-egress` sparse checkouts for the composite.
 
+### Runner policy tiers {#runner-policy-tiers}
+
+Reusable workflows that support multi-platform or release builds declare a **tier**
+via `validate-runner-policy` before `resolve-egress-allowlist` and `harden-runner`.
+Consumers cannot override the tier — it is baked into the reusable contract.
+
+<!-- markdownlint-disable MD013 MD060 -->
+
+| Tier         | `block` on GH Linux | `block` on GH Win/macOS | `block` on self-hosted | `audit` (any) |
+| ------------ | ------------------- | ----------------------- | ---------------------- | ------------- |
+| `strict`     | Enforce             | Hard fail               | Enforce                | Hard fail     |
+| `hardened`   | Enforce             | Skip + warn             | Enforce                | Hard fail     |
+| `permissive` | Enforce (advisory)  | Skip + log              | Skip + log             | Skip          |
+
+**Egress capabilities** ([StepSecurity harden-runner](https://github.com/step-security/harden-runner)):
+
+| Runner type                  | `egress-policy: block` |
+| ---------------------------- | ---------------------- |
+| GitHub-hosted Linux          | Supported              |
+| GitHub-hosted Windows/macOS  | Audit only today       |
+| Self-hosted (agent in image) | Supported on any OS    |
+
+<!-- markdownlint-enable MD013 MD060 -->
+
+New reusables call `validate-runner-policy` first, then conditionally run
+`resolve-egress-allowlist` and `harden-runner` when `enforce-egress` is `true`.
+The `harden-runner` composite Linux pre-step is guarded with
+`if: runner.os == 'Linux'`.
+
+**Usage guidance:**
+
+- `strict` — Rust CLI releases, Node/Python CI, Docker builds (Linux-only matrices)
+- `hardened` — Native desktop verification (Tauri, Electron), weekly native test legs
+- `permissive` — Exotic builds (iOS/Xcode, Android signing); document justification
+  in the workflow YAML
+
+```yaml
+- name: Validate runner policy
+  id: policy
+  uses: ./.lgtm-ci-tooling/.github/actions/validate-runner-policy
+  with:
+    tier: hardened
+    egress-policy: block
+    runner-environment: ${{ runner.environment }}
+    runner-os: ${{ runner.os }}
+
+- name: Harden runner
+  if: steps.policy.outputs['enforce-egress'] == 'true'
+  uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+  # ...
+```
+
+### Rust release contract
+
+`reusable-build-rust-binaries.yml` (tier `strict`) cross-compiles from Linux
+runners under block mode. `reusable-publish-rust-release.yml` orchestrates
+tag verification → binary build → GitHub release.
+
+**Default target matrix (v1):** `x86_64-unknown-linux-musl`,
+`aarch64-unknown-linux-gnu` (via `cross`), `x86_64-pc-windows-msvc` (via `cross`).
+Darwin targets are excluded from the default matrix; pass a JSON `targets` override
+for unsigned macOS binaries.
+
+**Artifact naming:** `{artifact-prefix}-{target}` per matrix leg. Each artifact
+contains `{package}-{version}-{target}.tar.gz` or `.zip` with the binary at the
+archive root (`cargo-binstall` compatible) plus a `SHA256SUMS` manifest.
+
+```yaml
+release:
+  uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-rust-release.yml@<sha>
+  with:
+    tooling-ref: "<sha>"
+    packages: "my-cli,my-server"
+```
+
 ### Release failure reporting
 
 Both release reusables include an optional `report-release-failure` follow-up job
@@ -364,6 +439,7 @@ Use `append` to keep lgtm-ci defaults and add project-specific hosts. Empty
 | `rubygems`       | RubyGems publish                                                     |
 | `npm-publish`    | npm publish + Sigstore attestation                                   |
 | `quality`        | Docker `lintro chk` (default on quality lint)                        |
+| `rust-release`   | Rust cross-compile releases (`reusable-build-rust-binaries.yml`)     |
 | `sbom`           | SBOM, Grype scan, Sigstore attestation                               |
 | `scorecard`      | OpenSSF Scorecard (`reusable-scorecards.yml`)                        |
 
@@ -390,6 +466,15 @@ allowed-endpoints: >
 ```
 
 ### Rust
+
+For release builds, prefer the preset:
+
+```yaml
+egress-policy: block
+egress-preset: rust-release
+```
+
+For workspace build/test only:
 
 ```yaml
 egress-policy: block

--- a/scripts/ci/actions/validate-runner-policy.sh
+++ b/scripts/ci/actions/validate-runner-policy.sh
@@ -30,6 +30,20 @@ _fail() {
 	exit 1
 }
 
+case "$RUNNER_ENVIRONMENT" in
+github-hosted | self-hosted) ;;
+*)
+	_fail "validate-runner-policy: invalid RUNNER_ENVIRONMENT '$RUNNER_ENVIRONMENT' (expected github-hosted or self-hosted)"
+	;;
+esac
+
+case "$RUNNER_OS" in
+Linux | Windows | macOS) ;;
+*)
+	_fail "validate-runner-policy: invalid RUNNER_OS '$RUNNER_OS' (expected Linux, Windows, or macOS)"
+	;;
+esac
+
 _can_enforce_block() {
 	if [[ "$RUNNER_OS" == "Linux" ]]; then
 		return 0

--- a/scripts/ci/actions/validate-runner-policy.sh
+++ b/scripts/ci/actions/validate-runner-policy.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Validate runner security policy tier before harden-runner
+#
+# Required environment variables:
+#   TIER                strict, hardened, or permissive
+#   EGRESS_POLICY       block or audit
+#   RUNNER_ENVIRONMENT  github-hosted or self-hosted
+#   RUNNER_OS           Linux, Windows, or macOS
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+# shellcheck source=../lib/github/output.sh
+source "$LIB_DIR/github/output.sh"
+
+: "${TIER:?TIER is required}"
+: "${EGRESS_POLICY:?EGRESS_POLICY is required}"
+: "${RUNNER_ENVIRONMENT:?RUNNER_ENVIRONMENT is required}"
+: "${RUNNER_OS:?RUNNER_OS is required}"
+
+_tier_warning=""
+_effective_policy="none"
+_enforce_egress="false"
+
+_fail() {
+	echo "$1" >&2
+	exit 1
+}
+
+_can_enforce_block() {
+	if [[ "$RUNNER_OS" == "Linux" ]]; then
+		return 0
+	fi
+	if [[ "$RUNNER_ENVIRONMENT" == "self-hosted" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+case "$TIER" in
+strict | hardened | permissive) ;;
+*)
+	_fail "validate-runner-policy: unknown tier '$TIER' (expected strict, hardened, or permissive)"
+	;;
+esac
+
+case "$EGRESS_POLICY" in
+block | audit) ;;
+*)
+	_fail "validate-runner-policy: unknown egress-policy '$EGRESS_POLICY' (expected block or audit)"
+	;;
+esac
+
+if [[ "$EGRESS_POLICY" == "audit" ]]; then
+	if [[ "$TIER" == "permissive" ]]; then
+		_tier_warning="permissive tier: audit-only egress is not enforced (advisory only)"
+		_effective_policy="none"
+		_enforce_egress="false"
+		echo "::warning::$_tier_warning"
+	else
+		_fail "validate-runner-policy: egress-policy 'audit' is not permitted (org requires block). Use egress-policy: block or choose permissive tier only for exotic builds with documented justification."
+	fi
+elif _can_enforce_block; then
+	case "$TIER" in
+	strict | hardened)
+		_effective_policy="block"
+		_enforce_egress="true"
+		;;
+	permissive)
+		if [[ "$RUNNER_ENVIRONMENT" == "self-hosted" ]]; then
+			_tier_warning="permissive tier: egress enforcement skipped on self-hosted runner (advisory only)"
+			_effective_policy="none"
+			_enforce_egress="false"
+			echo "::warning::$_tier_warning"
+		else
+			_tier_warning="permissive tier: egress enforced on GitHub-hosted Linux (advisory — document justification in workflow)"
+			_effective_policy="block"
+			_enforce_egress="true"
+			echo "::notice::$_tier_warning"
+		fi
+		;;
+	esac
+else
+	case "$TIER" in
+	strict)
+		_fail "validate-runner-policy: strict tier requires block-mode egress on all legs, but GitHub-hosted $RUNNER_OS runners cannot enforce egress today. Use Linux runners, self-hosted runners with the StepSecurity agent, or a hardened/permissive tier for native platform builds. See docs/workflow-contract.md#runner-policy-tiers."
+		;;
+	hardened)
+		_tier_warning="hardened tier: GitHub-hosted $RUNNER_OS cannot enforce egress — harden-runner skipped (Linux legs still enforced)"
+		_effective_policy="none"
+		_enforce_egress="false"
+		echo "::warning::$_tier_warning"
+		;;
+	permissive)
+		_tier_warning="permissive tier: GitHub-hosted $RUNNER_OS — egress enforcement skipped (advisory only)"
+		_effective_policy="none"
+		_enforce_egress="false"
+		echo "::notice::$_tier_warning"
+		;;
+	esac
+fi
+
+set_github_output "enforce-egress" "$_enforce_egress"
+set_github_output "effective-policy" "$_effective_policy"
+set_github_output "tier-warning" "$_tier_warning"
+
+if [[ -n "$_tier_warning" && -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+	{
+		echo "### Runner policy"
+		echo ""
+		echo "- **Tier:** \`$TIER\`"
+		echo "- **Runner:** \`$RUNNER_OS\` / \`$RUNNER_ENVIRONMENT\`"
+		echo "- **Effective policy:** \`$_effective_policy\`"
+		echo "- **Enforce egress:** \`$_enforce_egress\`"
+		echo ""
+		echo "> $_tier_warning"
+	} >>"$GITHUB_STEP_SUMMARY"
+fi

--- a/scripts/ci/lib/cargo/version.sh
+++ b/scripts/ci/lib/cargo/version.sh
@@ -18,9 +18,18 @@ parse_cargo_version() {
 		return 1
 	fi
 
-	awk -F'"' '
+	local version
+	version="$(
+		awk -F'"' '
 /^\[package\]/ || /^\[workspace\.package\]/ { in_pkg = 1 }
 /^\[/ && !/^\[package\]/ && !/^\[workspace\.package\]/ { in_pkg = 0 }
-in_pkg && /^version[[:space:]]*=/ { print $2; exit }
+in_pkg && /^[[:space:]]*version[[:space:]]*=/ { print $2; exit }
 ' "$file"
+	)"
+
+	if [[ -z "$version" ]]; then
+		return 1
+	fi
+
+	printf '%s\n' "$version"
 }

--- a/scripts/ci/lib/cargo/version.sh
+++ b/scripts/ci/lib/cargo/version.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Parse Cargo.toml workspace or package version fields
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/version.sh"
+#   parse_cargo_version "Cargo.toml"
+
+[[ -n "${_LGTM_CI_CARGO_VERSION_LOADED:-}" ]] && return 0
+readonly _LGTM_CI_CARGO_VERSION_LOADED=1
+
+# Parse version from [package] or [workspace.package] in a Cargo manifest.
+# Prints version on stdout; returns 1 when not found or file missing.
+parse_cargo_version() {
+	local file="${1:?cargo manifest path required}"
+
+	if [[ ! -f "$file" ]]; then
+		return 1
+	fi
+
+	awk -F'"' '
+/^\[package\]/ || /^\[workspace\.package\]/ { in_pkg = 1 }
+/^\[/ && !/^\[package\]/ && !/^\[workspace\.package\]/ { in_pkg = 0 }
+in_pkg && /^version[[:space:]]*=/ { print $2; exit }
+' "$file"
+}

--- a/scripts/ci/lib/egress/presets.sh
+++ b/scripts/ci/lib/egress/presets.sh
@@ -196,9 +196,22 @@ egress_preset_endpoints() {
 		;;
 	rust-release)
 		# Rust cross-compile release builds (reusable-build-rust-binaries.yml).
-		# Extends quality with Ubuntu apt mirrors (musl-tools) and Sigstore attestation.
-		egress_preset_endpoints quality
+		# Minimal base: GitHub checkout/tooling, Rust/crates, cross Docker, apt, Sigstore.
+		egress_preset_endpoints github-minimal
 		printf '%s\n' \
+			raw.githubusercontent.com:443 \
+			static.rust-lang.org:443 \
+			sh.rustup.rs:443 \
+			crates.io:443 \
+			static.crates.io:443 \
+			index.crates.io:443 \
+			ghcr.io:443 \
+			pkg-containers.githubusercontent.com:443 \
+			docker.io:443 \
+			registry-1.docker.io:443 \
+			auth.docker.io:443 \
+			production.cloudflare.docker.com:443 \
+			production.cloudfront.docker.com:443 \
 			archive.ubuntu.com:80 \
 			azure.archive.ubuntu.com:80 \
 			security.ubuntu.com:80 \

--- a/scripts/ci/lib/egress/presets.sh
+++ b/scripts/ci/lib/egress/presets.sh
@@ -196,9 +196,12 @@ egress_preset_endpoints() {
 		;;
 	rust-release)
 		# Rust cross-compile release builds (reusable-build-rust-binaries.yml).
-		# Extends quality with Sigstore attestation endpoints for SLSA provenance.
+		# Extends quality with Ubuntu apt mirrors (musl-tools) and Sigstore attestation.
 		egress_preset_endpoints quality
 		printf '%s\n' \
+			archive.ubuntu.com:80 \
+			azure.archive.ubuntu.com:80 \
+			security.ubuntu.com:80 \
 			fulcio.sigstore.dev:443 \
 			rekor.sigstore.dev:443 \
 			timestamp.sigstore.dev:443 \

--- a/scripts/ci/lib/egress/presets.sh
+++ b/scripts/ci/lib/egress/presets.sh
@@ -194,6 +194,17 @@ egress_preset_endpoints() {
 			api.scorecard.dev:443 \
 			api.securityscorecards.dev:443
 		;;
+	rust-release)
+		# Rust cross-compile release builds (reusable-build-rust-binaries.yml).
+		# Extends quality with Sigstore attestation endpoints for SLSA provenance.
+		egress_preset_endpoints quality
+		printf '%s\n' \
+			fulcio.sigstore.dev:443 \
+			rekor.sigstore.dev:443 \
+			timestamp.sigstore.dev:443 \
+			tuf-repo-cdn.sigstore.dev:443 \
+			sigstore-tuf-root.storage.googleapis.com:443
+		;;
 	*)
 		echo "unknown egress preset: $preset" >&2
 		return 1

--- a/scripts/ci/release/aggregate-rust-release-checksums.sh
+++ b/scripts/ci/release/aggregate-rust-release-checksums.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Merge per-target SHA256SUMS-* files into a single SHA256SUMS manifest
+#
+# Usage:
+#   ARTIFACT_PATH=dist scripts/ci/release/aggregate-rust-release-checksums.sh
+
+set -euo pipefail
+
+ARTIFACT_PATH="${ARTIFACT_PATH:-dist}"
+
+if [[ ! -d "$ARTIFACT_PATH" ]]; then
+	echo "Artifact path not found: $ARTIFACT_PATH" >&2
+	exit 1
+fi
+
+shopt -s nullglob
+manifests=("$ARTIFACT_PATH"/SHA256SUMS-*)
+
+if [[ ${#manifests[@]} -eq 0 ]]; then
+	echo "No per-target checksum manifests found in $ARTIFACT_PATH" >&2
+	exit 1
+fi
+
+cat "${manifests[@]}" >"$ARTIFACT_PATH/SHA256SUMS"
+rm -f "${manifests[@]}"
+echo "Aggregated ${#manifests[@]} checksum manifest(s) into $ARTIFACT_PATH/SHA256SUMS"

--- a/scripts/ci/release/build-rust-binary.sh
+++ b/scripts/ci/release/build-rust-binary.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Build release binaries for a Rust target (cargo or cross)
+#
+# Usage:
+#   TARGET=x86_64-unknown-linux-gnu PACKAGES=cli,server \
+#     scripts/ci/release/build-rust-binary.sh
+
+set -euo pipefail
+
+TARGET="${TARGET:-}"
+PACKAGES="${PACKAGES:-}"
+
+if [[ -z "$TARGET" || -z "$PACKAGES" ]]; then
+	echo "TARGET and PACKAGES are required" >&2
+	exit 1
+fi
+
+BUILD_CMD="cargo"
+if [[ "${USE_CROSS:-}" == "true" ]]; then
+	BUILD_CMD="cross"
+fi
+
+IFS=',' read -r -a package_list <<<"$PACKAGES"
+for package in "${package_list[@]}"; do
+	package="${package// /}"
+	[[ -z "$package" ]] && continue
+	echo "Building $package with $BUILD_CMD for target $TARGET"
+	$BUILD_CMD build --release --target "$TARGET" -p "$package"
+done

--- a/scripts/ci/release/build-rust-binary.sh
+++ b/scripts/ci/release/build-rust-binary.sh
@@ -16,15 +16,15 @@ if [[ -z "$TARGET" || -z "$PACKAGES" ]]; then
 	exit 1
 fi
 
-BUILD_CMD="cargo"
+BUILD_CMD=(cargo)
 if [[ "${USE_CROSS:-}" == "true" ]]; then
-	BUILD_CMD="cross"
+	BUILD_CMD=(cross)
 fi
 
 IFS=',' read -r -a package_list <<<"$PACKAGES"
 for package in "${package_list[@]}"; do
 	package="${package// /}"
 	[[ -z "$package" ]] && continue
-	echo "Building $package with $BUILD_CMD for target $TARGET"
-	$BUILD_CMD build --release --target "$TARGET" -p "$package"
+	echo "Building $package with ${BUILD_CMD[*]} for target $TARGET"
+	"${BUILD_CMD[@]}" build --release --target "$TARGET" -p "$package"
 done

--- a/scripts/ci/release/package-rust-binary.sh
+++ b/scripts/ci/release/package-rust-binary.sh
@@ -83,7 +83,9 @@ for package in "${package_list[@]}"; do
 		archive="${archive_base}.zip"
 	else
 		cp "$bin_path" "$staging/${bin_name}"
-		tar czf "${archive_base}.tar.gz" "$staging"
+		(
+			cd "$staging" && tar czf "../${archive_base}.tar.gz" "${bin_name}"
+		)
 		archive="${archive_base}.tar.gz"
 	fi
 

--- a/scripts/ci/release/package-rust-binary.sh
+++ b/scripts/ci/release/package-rust-binary.sh
@@ -51,7 +51,10 @@ index=0
 
 for package in "${package_list[@]}"; do
 	package="${package// /}"
-	[[ -z "$package" ]] && continue
+	if [[ -z "$package" ]]; then
+		index=$((index + 1))
+		continue
+	fi
 
 	bin_name="$(_resolve_binary_name "$package" "$index")"
 	if [[ -z "$bin_name" ]]; then

--- a/scripts/ci/release/package-rust-binary.sh
+++ b/scripts/ci/release/package-rust-binary.sh
@@ -56,6 +56,9 @@ _exe_suffix() {
 
 IFS=',' read -r -a package_list <<<"$PACKAGES"
 checksums=()
+# Index tracks position in package_list so BINARY_NAMES lookups use the same
+# comma-separated index N in both PACKAGES and BINARY_NAMES; empty entries still
+# advance index to preserve that parallel alignment.
 index=0
 
 for package in "${package_list[@]}"; do

--- a/scripts/ci/release/package-rust-binary.sh
+++ b/scripts/ci/release/package-rust-binary.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Package Rust release binaries per package with SHA256SUMS manifest
+#
+# Usage:
+#   VERSION=1.0.0 TARGET=x86_64-unknown-linux-gnu PACKAGES=cli,server \
+#     ARCHIVE_FORMAT=tar.gz scripts/ci/release/package-rust-binary.sh
+#
+# Optional:
+#   BINARY_NAMES  Comma-separated binary names parallel to PACKAGES (defaults via cargo metadata)
+
+set -euo pipefail
+
+VERSION="${VERSION:-}"
+TARGET="${TARGET:-}"
+PACKAGES="${PACKAGES:-}"
+ARCHIVE_FORMAT="${ARCHIVE_FORMAT:-tar.gz}"
+BINARY_NAMES="${BINARY_NAMES:-}"
+
+if [[ -z "$VERSION" || -z "$TARGET" || -z "$PACKAGES" ]]; then
+	echo "VERSION, TARGET, and PACKAGES are required" >&2
+	exit 1
+fi
+
+if [[ "$ARCHIVE_FORMAT" != "tar.gz" && "$ARCHIVE_FORMAT" != "zip" ]]; then
+	echo "ARCHIVE_FORMAT must be tar.gz or zip" >&2
+	exit 1
+fi
+
+_resolve_binary_name() {
+	local package="$1"
+	local index="$2"
+
+	if [[ -n "$BINARY_NAMES" ]]; then
+		IFS=',' read -r -a name_list <<<"$BINARY_NAMES"
+		if [[ -n "${name_list[$index]:-}" ]]; then
+			echo "${name_list[$index]// /}"
+			return 0
+		fi
+	fi
+
+	cargo metadata --format-version=1 --no-deps |
+		jq -r --arg pkg "$package" \
+			'.packages[] | select(.name == $pkg) | .targets[] | select(.kind[] == "bin") | .name' |
+		head -1
+}
+
+IFS=',' read -r -a package_list <<<"$PACKAGES"
+checksums=()
+index=0
+
+for package in "${package_list[@]}"; do
+	package="${package// /}"
+	[[ -z "$package" ]] && continue
+
+	bin_name="$(_resolve_binary_name "$package" "$index")"
+	if [[ -z "$bin_name" ]]; then
+		echo "Could not resolve binary name for package $package" >&2
+		exit 1
+	fi
+
+	if [[ "$ARCHIVE_FORMAT" == "zip" ]]; then
+		bin_path="target/${TARGET}/release/${bin_name}.exe"
+	else
+		bin_path="target/${TARGET}/release/${bin_name}"
+	fi
+
+	if [[ ! -f "$bin_path" ]]; then
+		echo "Required binary not found: $bin_path" >&2
+		exit 1
+	fi
+
+	archive_base="${package}-${VERSION}-${TARGET}"
+	staging="${archive_base}"
+	rm -rf "$staging"
+	mkdir -p "$staging"
+
+	if [[ "$ARCHIVE_FORMAT" == "zip" ]]; then
+		cp "$bin_path" "$staging/${bin_name}.exe"
+		(
+			cd "$staging" && zip -q "../${archive_base}.zip" .
+		)
+		archive="${archive_base}.zip"
+	else
+		cp "$bin_path" "$staging/${bin_name}"
+		tar czf "${archive_base}.tar.gz" "$staging"
+		archive="${archive_base}.tar.gz"
+	fi
+
+	rm -rf "$staging"
+	digest="$(sha256sum "$archive" | awk '{print $1}')"
+	checksums+=("$digest  $archive")
+	echo "Packaged $archive"
+	index=$((index + 1))
+done
+
+if [[ ${#checksums[@]} -eq 0 ]]; then
+	echo "No packages packaged" >&2
+	exit 1
+fi
+
+printf '%s\n' "${checksums[@]}" >SHA256SUMS
+echo "Wrote SHA256SUMS"

--- a/scripts/ci/release/package-rust-binary.sh
+++ b/scripts/ci/release/package-rust-binary.sh
@@ -78,7 +78,7 @@ for package in "${package_list[@]}"; do
 	if [[ "$ARCHIVE_FORMAT" == "zip" ]]; then
 		cp "$bin_path" "$staging/${bin_name}.exe"
 		(
-			cd "$staging" && zip -q "../${archive_base}.zip" .
+			cd "$staging" && zip -q "../${archive_base}.zip" "${bin_name}.exe"
 		)
 		archive="${archive_base}.zip"
 	else
@@ -99,5 +99,6 @@ if [[ ${#checksums[@]} -eq 0 ]]; then
 	exit 1
 fi
 
-printf '%s\n' "${checksums[@]}" >SHA256SUMS
-echo "Wrote SHA256SUMS"
+checksums_file="SHA256SUMS-${TARGET}"
+printf '%s\n' "${checksums[@]}" >"$checksums_file"
+echo "Wrote $checksums_file"

--- a/scripts/ci/release/package-rust-binary.sh
+++ b/scripts/ci/release/package-rust-binary.sh
@@ -41,8 +41,17 @@ _resolve_binary_name() {
 
 	cargo metadata --format-version=1 --no-deps |
 		jq -r --arg pkg "$package" \
-			'.packages[] | select(.name == $pkg) | .targets[] | select(.kind[] == "bin") | .name' |
-		head -1
+			'.packages[]
+			| select(.name == $pkg)
+			| [.targets[] | select(.kind[] == "bin") | .name][0] // empty'
+}
+
+_exe_suffix() {
+	if [[ "$TARGET" == *windows* ]]; then
+		echo ".exe"
+	else
+		echo ""
+	fi
 }
 
 IFS=',' read -r -a package_list <<<"$PACKAGES"
@@ -62,11 +71,9 @@ for package in "${package_list[@]}"; do
 		exit 1
 	fi
 
-	if [[ "$ARCHIVE_FORMAT" == "zip" ]]; then
-		bin_path="target/${TARGET}/release/${bin_name}.exe"
-	else
-		bin_path="target/${TARGET}/release/${bin_name}"
-	fi
+	exe_suffix="$(_exe_suffix)"
+	bin_file="${bin_name}${exe_suffix}"
+	bin_path="target/${TARGET}/release/${bin_file}"
 
 	if [[ ! -f "$bin_path" ]]; then
 		echo "Required binary not found: $bin_path" >&2
@@ -79,15 +86,15 @@ for package in "${package_list[@]}"; do
 	mkdir -p "$staging"
 
 	if [[ "$ARCHIVE_FORMAT" == "zip" ]]; then
-		cp "$bin_path" "$staging/${bin_name}.exe"
+		cp "$bin_path" "$staging/${bin_file}"
 		(
-			cd "$staging" && zip -q "../${archive_base}.zip" "${bin_name}.exe"
+			cd "$staging" && zip -q "../${archive_base}.zip" "${bin_file}"
 		)
 		archive="${archive_base}.zip"
 	else
-		cp "$bin_path" "$staging/${bin_name}"
+		cp "$bin_path" "$staging/${bin_file}"
 		(
-			cd "$staging" && tar czf "../${archive_base}.tar.gz" "${bin_name}"
+			cd "$staging" && tar czf "../${archive_base}.tar.gz" "${bin_file}"
 		)
 		archive="${archive_base}.tar.gz"
 	fi

--- a/scripts/ci/release/read-cargo-version.sh
+++ b/scripts/ci/release/read-cargo-version.sh
@@ -12,6 +12,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_DIR="$SCRIPT_DIR/../lib"
 
+# shellcheck source=../lib/cargo/version.sh
+source "$LIB_DIR/cargo/version.sh"
 # shellcheck source=../lib/github/output.sh
 source "$LIB_DIR/github/output.sh"
 
@@ -22,13 +24,7 @@ if [[ ! -f "$VERSION_FILE" ]]; then
 	exit 1
 fi
 
-version="$(
-	awk -F'"' '
-/^\[package\]/ || /^\[workspace\.package\]/ { in_pkg = 1 }
-/^\[/ && !/^\[package\]/ && !/^\[workspace\.package\]/ { in_pkg = 0 }
-in_pkg && /^version[[:space:]]*=/ { print $2; exit }
-' "$VERSION_FILE"
-)"
+version="$(parse_cargo_version "$VERSION_FILE")"
 
 if [[ -z "$version" ]]; then
 	echo "version not found in $VERSION_FILE ([package] or [workspace.package])" >&2

--- a/scripts/ci/release/read-cargo-version.sh
+++ b/scripts/ci/release/read-cargo-version.sh
@@ -24,7 +24,7 @@ if [[ ! -f "$VERSION_FILE" ]]; then
 	exit 1
 fi
 
-version="$(parse_cargo_version "$VERSION_FILE")"
+version="$(parse_cargo_version "$VERSION_FILE" || true)"
 
 if [[ -z "$version" ]]; then
 	echo "version not found in $VERSION_FILE ([package] or [workspace.package])" >&2

--- a/scripts/ci/release/read-cargo-version.sh
+++ b/scripts/ci/release/read-cargo-version.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Read workspace or package version from Cargo.toml
+#
+# Usage:
+#   VERSION_FILE=Cargo.toml scripts/ci/release/read-cargo-version.sh
+#
+# Writes version to GITHUB_OUTPUT when set.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+# shellcheck source=../lib/github/output.sh
+source "$LIB_DIR/github/output.sh"
+
+VERSION_FILE="${VERSION_FILE:-Cargo.toml}"
+
+if [[ ! -f "$VERSION_FILE" ]]; then
+	echo "Cargo manifest not found: $VERSION_FILE" >&2
+	exit 1
+fi
+
+version="$(
+	awk -F'"' '
+/^\[package\]/ || /^\[workspace\.package\]/ { in_pkg = 1 }
+/^\[/ && !/^\[package\]/ && !/^\[workspace\.package\]/ { in_pkg = 0 }
+in_pkg && /^version[[:space:]]*=/ { print $2; exit }
+' "$VERSION_FILE"
+)"
+
+if [[ -z "$version" ]]; then
+	echo "version not found in $VERSION_FILE ([package] or [workspace.package])" >&2
+	exit 1
+fi
+
+set_github_output "version" "$version"
+echo "Cargo version: $version"

--- a/scripts/ci/release/verify-rust-release-tag.sh
+++ b/scripts/ci/release/verify-rust-release-tag.sh
@@ -7,6 +7,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/cargo/version.sh
+source "$SCRIPT_DIR/../lib/cargo/version.sh"
+
 TAG="${TAG:-${GITHUB_REF_NAME:-}}"
 VERSION_FILE="${VERSION_FILE:-Cargo.toml}"
 
@@ -20,13 +24,7 @@ if [[ ! -f "$VERSION_FILE" ]]; then
 	exit 1
 fi
 
-cargo_version="$(
-	awk -F'"' '
-/^\[package\]/ || /^\[workspace\.package\]/ { in_pkg = 1 }
-/^\[/ && !/^\[package\]/ && !/^\[workspace\.package\]/ { in_pkg = 0 }
-in_pkg && /^version[[:space:]]*=/ { print $2; exit }
-' "$VERSION_FILE"
-)"
+cargo_version="$(parse_cargo_version "$VERSION_FILE")"
 
 if [[ -z "$cargo_version" ]]; then
 	echo "version not found in $VERSION_FILE" >&2

--- a/scripts/ci/release/verify-rust-release-tag.sh
+++ b/scripts/ci/release/verify-rust-release-tag.sh
@@ -24,7 +24,7 @@ if [[ ! -f "$VERSION_FILE" ]]; then
 	exit 1
 fi
 
-cargo_version="$(parse_cargo_version "$VERSION_FILE")"
+cargo_version="$(parse_cargo_version "$VERSION_FILE" || true)"
 
 if [[ -z "$cargo_version" ]]; then
 	echo "version not found in $VERSION_FILE" >&2

--- a/scripts/ci/release/verify-rust-release-tag.sh
+++ b/scripts/ci/release/verify-rust-release-tag.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Verify git tag matches Cargo.toml workspace version
+#
+# Usage:
+#   TAG=v1.0.0 VERSION_FILE=Cargo.toml scripts/ci/release/verify-rust-release-tag.sh
+
+set -euo pipefail
+
+TAG="${TAG:-${GITHUB_REF_NAME:-}}"
+VERSION_FILE="${VERSION_FILE:-Cargo.toml}"
+
+if [[ -z "$TAG" ]]; then
+	echo "TAG is required" >&2
+	exit 1
+fi
+
+if [[ ! -f "$VERSION_FILE" ]]; then
+	echo "Cargo manifest not found: $VERSION_FILE" >&2
+	exit 1
+fi
+
+cargo_version="$(
+	awk -F'"' '
+/^\[package\]/ || /^\[workspace\.package\]/ { in_pkg = 1 }
+/^\[/ && !/^\[package\]/ && !/^\[workspace\.package\]/ { in_pkg = 0 }
+in_pkg && /^version[[:space:]]*=/ { print $2; exit }
+' "$VERSION_FILE"
+)"
+
+if [[ -z "$cargo_version" ]]; then
+	echo "version not found in $VERSION_FILE" >&2
+	exit 1
+fi
+
+expected="v${cargo_version}"
+if [[ "$TAG" != "$expected" ]]; then
+	echo "Tag mismatch: $TAG != Cargo.toml $expected" >&2
+	exit 1
+fi
+
+echo "Tag $TAG matches Cargo.toml version $cargo_version"

--- a/scripts/ci/testing/rust/setup-rust-nextest.sh
+++ b/scripts/ci/testing/rust/setup-rust-nextest.sh
@@ -23,13 +23,16 @@ _install_cargo_crate() {
 	if command -v cargo-binstall >/dev/null 2>&1; then
 		cargo binstall "$crate" \
 			--version "$version" \
+			--force \
 			--no-confirm ||
 			cargo install "$crate" \
 				--locked \
+				--force \
 				--version "$version"
 	else
 		cargo install "$crate" \
 			--locked \
+			--force \
 			--version "$version"
 	fi
 }

--- a/scripts/ci/testing/rust/setup-rust-nextest.sh
+++ b/scripts/ci/testing/rust/setup-rust-nextest.sh
@@ -14,6 +14,7 @@ _install_cargo_crate() {
 
 	if command -v "$crate" >/dev/null 2>&1; then
 		if "$crate" --version 2>/dev/null | grep -qE "^${crate} ${version}(\$| )"; then
+			echo "${crate} ${version} already installed, skipping"
 			return 0
 		fi
 		echo "Found ${crate} but not pinned ${version}; reinstalling..."

--- a/tests/bats/integration/test_reusable_build_rust_binaries.bats
+++ b/tests/bats/integration/test_reusable_build_rust_binaries.bats
@@ -40,7 +40,7 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-build-rust-binaries.yml"
 @test "reusable-build-rust-binaries: uploads artifact with target suffix" {
 	run grep -F '${{ matrix.target }}' "$WORKFLOW"
 	assert_success
-	run grep -F 'SHA256SUMS' "$WORKFLOW"
+	run grep -F 'SHA256SUMS-${{ matrix.target }}' "$WORKFLOW"
 	assert_success
 }
 

--- a/tests/bats/integration/test_reusable_build_rust_binaries.bats
+++ b/tests/bats/integration/test_reusable_build_rust_binaries.bats
@@ -45,6 +45,19 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-build-rust-binaries.yml"
 }
 
 @test "reusable-build-rust-binaries: workflow-level concurrency uses ref name" {
-	run awk '/^concurrency:$/,/^jobs:/ { print }' "$WORKFLOW" | grep -F 'rust-binaries-${{ github.ref_name }}'
+	run bash -c "awk '/^concurrency:\$/,/^jobs:/ { print }' '$WORKFLOW' | grep -F 'rust-binaries-\${{ github.ref_name }}'"
+	assert_success
+}
+
+@test "reusable-build-rust-binaries: attests release archives not checksum manifests" {
+	run awk '/subject-path:/{show=1;next} show&&/^        [a-z]/{exit} show{print}' "$WORKFLOW"
+	assert_success
+	assert_output --partial '*.tar.gz'
+	assert_output --partial '*.zip'
+	refute_output --partial 'SHA256SUMS'
+}
+
+@test "reusable-build-rust-binaries: pins cross install version" {
+	run grep -F 'cargo install cross --locked --version 0.2.5' "$WORKFLOW"
 	assert_success
 }

--- a/tests/bats/integration/test_reusable_build_rust_binaries.bats
+++ b/tests/bats/integration/test_reusable_build_rust_binaries.bats
@@ -44,7 +44,7 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-build-rust-binaries.yml"
 	assert_success
 }
 
-@test "reusable-build-rust-binaries: concurrency group uses ref name" {
-	run grep -F 'rust-binaries-${{ github.ref_name }}' "$WORKFLOW"
+@test "reusable-build-rust-binaries: workflow-level concurrency uses ref name" {
+	run awk '/^concurrency:$/,/^jobs:/ { print }' "$WORKFLOW" | grep -F 'rust-binaries-${{ github.ref_name }}'
 	assert_success
 }

--- a/tests/bats/integration/test_reusable_build_rust_binaries.bats
+++ b/tests/bats/integration/test_reusable_build_rust_binaries.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-build-rust-binaries workflow
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-build-rust-binaries.yml"
+
+@test "reusable-build-rust-binaries: declares strict tier via validate-runner-policy" {
+	run grep -F 'tier: strict' "$WORKFLOW"
+	assert_success
+	run grep -F 'validate-runner-policy' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-build-rust-binaries: egress-preset defaults to rust-release" {
+	run awk '/^      egress-preset:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: "rust-release"'
+}
+
+@test "reusable-build-rust-binaries: timeout-minutes defaults to 45" {
+	run awk '/^      timeout-minutes:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: 45'
+}
+
+@test "reusable-build-rust-binaries: policy before conditional harden-runner" {
+	run awk '
+		/- name: Validate runner policy/ { policy = 1 }
+		policy && /- name: Resolve egress allowlist/ { resolve = 1 }
+		resolve && /if: steps\.policy\.outputs\[\x27enforce-egress\x27\] == \x27true\x27/ { found = 1 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-build-rust-binaries: uploads artifact with target suffix" {
+	run grep -F '${{ matrix.target }}' "$WORKFLOW"
+	assert_success
+	run grep -F 'SHA256SUMS' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-build-rust-binaries: concurrency group uses ref name" {
+	run grep -F 'rust-binaries-${{ github.ref_name }}' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_publish_rust_release.bats
+++ b/tests/bats/integration/test_reusable_publish_rust_release.bats
@@ -29,7 +29,12 @@ BUILD_WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-build-rust-binaries.y
 @test "reusable-publish-rust-release: downloads artifacts by prefix pattern" {
 	run grep -F 'merge-multiple: true' "$WORKFLOW"
 	assert_success
-	run grep -F 'pattern:' "$WORKFLOW"
+	run grep -F 'needs.verify-tag.outputs.artifact_prefix' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-publish-rust-release: verify-tag exposes artifact_prefix output" {
+	run grep -F 'artifact_prefix:' "$WORKFLOW"
 	assert_success
 }
 

--- a/tests/bats/integration/test_reusable_publish_rust_release.bats
+++ b/tests/bats/integration/test_reusable_publish_rust_release.bats
@@ -41,7 +41,7 @@ BUILD_WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-build-rust-binaries.y
 @test "reusable-publish-rust-release: aggregates per-target checksum manifests" {
 	run grep -F 'Aggregate checksum manifests' "$WORKFLOW"
 	assert_success
-	run grep -F 'SHA256SUMS-*' "$WORKFLOW"
+	run grep -F 'aggregate-rust-release-checksums.sh' "$WORKFLOW"
 	assert_success
 }
 

--- a/tests/bats/integration/test_reusable_publish_rust_release.bats
+++ b/tests/bats/integration/test_reusable_publish_rust_release.bats
@@ -38,6 +38,13 @@ BUILD_WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-build-rust-binaries.y
 	assert_success
 }
 
+@test "reusable-publish-rust-release: aggregates per-target checksum manifests" {
+	run grep -F 'Aggregate checksum manifests' "$WORKFLOW"
+	assert_success
+	run grep -F 'SHA256SUMS-*' "$WORKFLOW"
+	assert_success
+}
+
 @test "reusable-build-rust-binaries workflow file exists for nested call" {
 	[[ -f "$BUILD_WORKFLOW" ]]
 }

--- a/tests/bats/integration/test_reusable_publish_rust_release.bats
+++ b/tests/bats/integration/test_reusable_publish_rust_release.bats
@@ -48,3 +48,8 @@ BUILD_WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-build-rust-binaries.y
 @test "reusable-build-rust-binaries workflow file exists for nested call" {
 	[[ -f "$BUILD_WORKFLOW" ]]
 }
+
+@test "reusable-publish-rust-release: build-binaries grants attestation permissions" {
+	run grep -F 'attestations: write' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_publish_rust_release.bats
+++ b/tests/bats/integration/test_reusable_publish_rust_release.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-publish-rust-release orchestrator
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-publish-rust-release.yml"
+BUILD_WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-build-rust-binaries.yml"
+
+@test "reusable-publish-rust-release: orchestrates verify, build, and release jobs" {
+	run grep -F 'verify-tag:' "$WORKFLOW"
+	assert_success
+	run grep -F 'build-binaries:' "$WORKFLOW"
+	assert_success
+	run grep -F 'github-release:' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-publish-rust-release: calls reusable-build-rust-binaries" {
+	run grep -F 'reusable-build-rust-binaries.yml' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-publish-rust-release: verifies tag against Cargo.toml" {
+	run grep -F 'verify-rust-release-tag.sh' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-publish-rust-release: downloads artifacts by prefix pattern" {
+	run grep -F 'merge-multiple: true' "$WORKFLOW"
+	assert_success
+	run grep -F 'pattern:' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-publish-rust-release: release concurrency group" {
+	run grep -F 'release-${{ github.ref_name }}' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-build-rust-binaries workflow file exists for nested call" {
+	[[ -f "$BUILD_WORKFLOW" ]]
+}

--- a/tests/bats/unit/actions/test_harden_runner_bundle.bats
+++ b/tests/bats/unit/actions/test_harden_runner_bundle.bats
@@ -44,3 +44,20 @@ teardown() {
 	run grep -E '^docker\.io:443$' "$output_file"
 	assert_success
 }
+
+@test "sync-harden-runner-bundle: bundle resolver resolves rust-release preset" {
+	run bash "$SYNC"
+	assert_success
+	output_file="$(mktemp)"
+	run env \
+		EGRESS_POLICY=block \
+		EGRESS_PRESET=rust-release \
+		ALLOWED_ENDPOINTS="" \
+		GITHUB_OUTPUT="$output_file" \
+		bash "$BUNDLE_RESOLVE"
+	assert_success
+	run grep -E '^fulcio\.sigstore\.dev:443$' "$output_file"
+	assert_success
+	run grep -E '^crates\.io:443$' "$output_file"
+	assert_success
+}

--- a/tests/bats/unit/actions/test_harden_runner_platform.bats
+++ b/tests/bats/unit/actions/test_harden_runner_platform.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Platform guard tests for harden-runner composite pre-step
+
+load "../../../helpers/common"
+
+ACTION="${PROJECT_ROOT}/.github/actions/harden-runner/action.yml"
+
+@test "harden-runner: agent pre-step is guarded for Linux only" {
+	run awk '
+		/- name: Ensure agent state for post cleanup/ { found = 1 }
+		found && /^      if: runner\.os == .Linux./ { linux_guard = 1; exit }
+		END { exit !linux_guard }
+	' "$ACTION"
+	assert_success
+}
+
+@test "harden-runner: pre-step still uses /home/agent path on Linux" {
+	run grep -F '/home/agent' "$ACTION"
+	assert_success
+}
+
+@test "harden-runner: documents validate-runner-policy prerequisite" {
+	run grep -F 'validate-runner-policy' "$ACTION"
+	assert_success
+}

--- a/tests/bats/unit/actions/test_validate_runner_policy.bats
+++ b/tests/bats/unit/actions/test_validate_runner_policy.bats
@@ -128,3 +128,31 @@ _run_policy() {
 	assert_failure
 	assert_output --partial "unknown tier"
 }
+
+@test "validate-runner-policy: rejects unknown egress-policy" {
+	_run_policy strict invalid github-hosted Linux
+	assert_failure
+	assert_output --partial "unknown egress-policy"
+}
+
+@test "validate-runner-policy: rejects invalid RUNNER_ENVIRONMENT" {
+	run env \
+		TIER=strict \
+		EGRESS_POLICY=block \
+		RUNNER_ENVIRONMENT=invalid \
+		RUNNER_OS=Linux \
+		bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "invalid RUNNER_ENVIRONMENT"
+}
+
+@test "validate-runner-policy: rejects invalid RUNNER_OS" {
+	run env \
+		TIER=strict \
+		EGRESS_POLICY=block \
+		RUNNER_ENVIRONMENT=github-hosted \
+		RUNNER_OS=FreeBSD \
+		bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "invalid RUNNER_OS"
+}

--- a/tests/bats/unit/actions/test_validate_runner_policy.bats
+++ b/tests/bats/unit/actions/test_validate_runner_policy.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for validate-runner-policy tier × runner combinations
+
+load "../../../helpers/common"
+load "../../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/validate-runner-policy.sh"
+
+setup() {
+	setup_github_env
+}
+
+teardown() {
+	teardown_github_env
+}
+
+_run_policy() {
+	local tier="$1"
+	local egress="$2"
+	local environment="$3"
+	local os="$4"
+	run env \
+		TIER="$tier" \
+		EGRESS_POLICY="$egress" \
+		RUNNER_ENVIRONMENT="$environment" \
+		RUNNER_OS="$os" \
+		bash "$SCRIPT"
+}
+
+@test "strict: block on GitHub-hosted Linux enforces egress" {
+	_run_policy strict block github-hosted Linux
+	assert_success
+	run get_github_output "enforce-egress"
+	assert_output "true"
+	run get_github_output "effective-policy"
+	assert_output "block"
+	run get_github_output "tier-warning"
+	assert_output ""
+}
+
+@test "strict: block on GitHub-hosted Windows fails with remediation" {
+	_run_policy strict block github-hosted Windows
+	assert_failure
+	assert_output --partial "strict tier requires block-mode egress"
+	assert_output --partial "GitHub-hosted Windows"
+}
+
+@test "strict: block on GitHub-hosted macOS fails" {
+	_run_policy strict block github-hosted macOS
+	assert_failure
+	assert_output --partial "GitHub-hosted macOS"
+}
+
+@test "strict: block on self-hosted macOS enforces egress" {
+	_run_policy strict block self-hosted macOS
+	assert_success
+	run get_github_output "enforce-egress"
+	assert_output "true"
+}
+
+@test "strict: audit rejected on all runners" {
+	_run_policy strict audit github-hosted Linux
+	assert_failure
+	assert_output --partial "audit' is not permitted"
+}
+
+@test "hardened: block on GitHub-hosted Windows skips with warning" {
+	_run_policy hardened block github-hosted Windows
+	assert_success
+	run get_github_output "enforce-egress"
+	assert_output "false"
+	run get_github_output "effective-policy"
+	assert_output "none"
+	run get_github_output "tier-warning"
+	assert_output --partial "hardened tier"
+}
+
+@test "hardened: block on GitHub-hosted Linux enforces egress" {
+	_run_policy hardened block github-hosted Linux
+	assert_success
+	run get_github_output "enforce-egress"
+	assert_output "true"
+}
+
+@test "hardened: audit rejected" {
+	_run_policy hardened audit github-hosted Linux
+	assert_failure
+	assert_output --partial "audit' is not permitted"
+}
+
+@test "permissive: audit skips enforcement with advisory" {
+	_run_policy permissive audit github-hosted Linux
+	assert_success
+	run get_github_output "enforce-egress"
+	assert_output "false"
+	run get_github_output "tier-warning"
+	assert_output --partial "permissive tier"
+}
+
+@test "permissive: block on GitHub-hosted Windows skips" {
+	_run_policy permissive block github-hosted Windows
+	assert_success
+	run get_github_output "enforce-egress"
+	assert_output "false"
+}
+
+@test "permissive: block on self-hosted Linux skips with advisory" {
+	_run_policy permissive block self-hosted Linux
+	assert_success
+	run get_github_output "enforce-egress"
+	assert_output "false"
+	run get_github_output "tier-warning"
+	assert_output --partial "self-hosted"
+}
+
+@test "permissive: block on GitHub-hosted Linux enforces with advisory" {
+	_run_policy permissive block github-hosted Linux
+	assert_success
+	run get_github_output "enforce-egress"
+	assert_output "true"
+	run get_github_output "effective-policy"
+	assert_output "block"
+}
+
+@test "validate-runner-policy: rejects unknown tier" {
+	_run_policy invalid block github-hosted Linux
+	assert_failure
+	assert_output --partial "unknown tier"
+}

--- a/tests/bats/unit/lib/cargo/test_version.bats
+++ b/tests/bats/unit/lib/cargo/test_version.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/lib/cargo/version.sh
+
+load "../../../../helpers/common"
+
+LIB="${PROJECT_ROOT}/scripts/ci/lib/cargo/version.sh"
+
+setup() {
+	setup_temp_dir
+	cd "$BATS_TEST_TMPDIR"
+	# shellcheck source=/dev/null
+	source "$LIB"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "parse_cargo_version: reads indented workspace.package version" {
+	cat >Cargo.toml <<'EOF'
+[workspace.package]
+  version = "1.2.3"
+EOF
+
+	run parse_cargo_version Cargo.toml
+	assert_success
+	assert_output "1.2.3"
+}
+
+@test "parse_cargo_version: returns failure when version key is absent" {
+	cat >Cargo.toml <<'EOF'
+[package]
+name = "demo"
+EOF
+
+	run parse_cargo_version Cargo.toml
+	assert_failure
+}
+
+@test "parse_cargo_version: returns failure when manifest is missing" {
+	run parse_cargo_version missing.toml
+	assert_failure
+}

--- a/tests/bats/unit/lib/egress/test_presets.bats
+++ b/tests/bats/unit/lib/egress/test_presets.bats
@@ -113,6 +113,14 @@ PRESETS="${PROJECT_ROOT}/scripts/ci/lib/egress/presets.sh"
 	assert_output --partial 'tuf-repo-cdn.sigstore.dev:443'
 }
 
+@test "egress preset rust-release includes Ubuntu apt mirrors for musl-tools" {
+	run bash -c "source '$PRESETS' && egress_preset_endpoints rust-release"
+	assert_success
+	assert_output --partial 'archive.ubuntu.com:80'
+	assert_output --partial 'azure.archive.ubuntu.com:80'
+	assert_output --partial 'security.ubuntu.com:80'
+}
+
 @test "egress preset pypi includes artifact pipeline host" {
 	run bash -c "source '$PRESETS' && egress_preset_endpoints pypi"
 	assert_success

--- a/tests/bats/unit/lib/egress/test_presets.bats
+++ b/tests/bats/unit/lib/egress/test_presets.bats
@@ -103,7 +103,7 @@ PRESETS="${PROJECT_ROOT}/scripts/ci/lib/egress/presets.sh"
 	assert_output --partial 'pipelines.actions.githubusercontent.com:443'
 }
 
-@test "egress preset rust-release extends quality with Sigstore hosts" {
+@test "egress preset rust-release includes Rust Docker and Sigstore hosts" {
 	run bash -c "source '$PRESETS' && egress_preset_endpoints rust-release"
 	assert_success
 	assert_output --partial 'crates.io:443'
@@ -111,6 +111,13 @@ PRESETS="${PROJECT_ROOT}/scripts/ci/lib/egress/presets.sh"
 	assert_output --partial 'fulcio.sigstore.dev:443'
 	assert_output --partial 'rekor.sigstore.dev:443'
 	assert_output --partial 'tuf-repo-cdn.sigstore.dev:443'
+}
+
+@test "egress preset rust-release excludes unrelated quality-only hosts" {
+	run bash -c "source '$PRESETS' && egress_preset_endpoints rust-release"
+	assert_success
+	refute_output --partial 'pypi.org:443'
+	refute_output --partial 'semgrep.dev:443'
 }
 
 @test "egress preset rust-release includes Ubuntu apt mirrors for musl-tools" {

--- a/tests/bats/unit/lib/egress/test_presets.bats
+++ b/tests/bats/unit/lib/egress/test_presets.bats
@@ -103,6 +103,16 @@ PRESETS="${PROJECT_ROOT}/scripts/ci/lib/egress/presets.sh"
 	assert_output --partial 'pipelines.actions.githubusercontent.com:443'
 }
 
+@test "egress preset rust-release extends quality with Sigstore hosts" {
+	run bash -c "source '$PRESETS' && egress_preset_endpoints rust-release"
+	assert_success
+	assert_output --partial 'crates.io:443'
+	assert_output --partial 'docker.io:443'
+	assert_output --partial 'fulcio.sigstore.dev:443'
+	assert_output --partial 'rekor.sigstore.dev:443'
+	assert_output --partial 'tuf-repo-cdn.sigstore.dev:443'
+}
+
 @test "egress preset pypi includes artifact pipeline host" {
 	run bash -c "source '$PRESETS' && egress_preset_endpoints pypi"
 	assert_success
@@ -126,6 +136,7 @@ PRESETS="${PROJECT_ROOT}/scripts/ci/lib/egress/presets.sh"
 		rubygems
 		npm-publish
 		quality
+		rust-release
 		sbom
 		scorecard
 	)

--- a/tests/bats/unit/release/test_aggregate_rust_release_checksums.bats
+++ b/tests/bats/unit/release/test_aggregate_rust_release_checksums.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for aggregate-rust-release-checksums.sh
+
+load "../../../helpers/common"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/release/aggregate-rust-release-checksums.sh"
+
+setup() {
+	setup_temp_dir
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "aggregate-rust-release-checksums: merges per-target manifests" {
+	mkdir -p "$BATS_TEST_TMPDIR/dist"
+	printf 'aaa  a.tar.gz\n' >"$BATS_TEST_TMPDIR/dist/SHA256SUMS-x86_64-unknown-linux-musl"
+	printf 'bbb  b.zip\n' >"$BATS_TEST_TMPDIR/dist/SHA256SUMS-x86_64-pc-windows-msvc"
+
+	run env ARTIFACT_PATH="$BATS_TEST_TMPDIR/dist" bash "$SCRIPT"
+	assert_success
+
+	[[ -f "$BATS_TEST_TMPDIR/dist/SHA256SUMS" ]]
+	[[ ! -f "$BATS_TEST_TMPDIR/dist/SHA256SUMS-x86_64-unknown-linux-musl" ]]
+	[[ ! -f "$BATS_TEST_TMPDIR/dist/SHA256SUMS-x86_64-pc-windows-msvc" ]]
+	run grep -c . "$BATS_TEST_TMPDIR/dist/SHA256SUMS"
+	assert_success
+	assert_equal 2 "$output"
+}
+
+@test "aggregate-rust-release-checksums: fails when no manifests exist" {
+	mkdir -p "$BATS_TEST_TMPDIR/dist"
+	run env ARTIFACT_PATH="$BATS_TEST_TMPDIR/dist" bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "No per-target checksum manifests"
+}

--- a/tests/bats/unit/release/test_package_rust_binary.bats
+++ b/tests/bats/unit/release/test_package_rust_binary.bats
@@ -80,6 +80,25 @@ teardown() {
 	[[ ! -f wrong-name-3.0.0-${target}.tar.gz ]]
 }
 
+@test "package-rust-binary: uses TARGET not ARCHIVE_FORMAT for Windows exe suffix" {
+	local target="x86_64-pc-windows-msvc"
+	mkdir -p "target/${target}/release"
+	printf 'MZ' >"target/${target}/release/myapp.exe"
+
+	run env \
+		VERSION=4.0.0 \
+		TARGET="$target" \
+		PACKAGES=myapp \
+		BINARY_NAMES=myapp \
+		ARCHIVE_FORMAT=tar.gz \
+		bash "$SCRIPT"
+	assert_success
+
+	run tar -tzf "myapp-4.0.0-${target}.tar.gz"
+	assert_success
+	assert_output --partial 'myapp.exe'
+}
+
 @test "package-rust-binary: passes bash syntax check" {
 	run bash -n "$SCRIPT"
 	assert_success

--- a/tests/bats/unit/release/test_package_rust_binary.bats
+++ b/tests/bats/unit/release/test_package_rust_binary.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/release/package-rust-binary.sh
+
+load "../../../helpers/common"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/release/package-rust-binary.sh"
+
+setup() {
+	setup_temp_dir
+	cd "$BATS_TEST_TMPDIR"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "package-rust-binary: zip archive contains the Windows executable" {
+	local target="x86_64-pc-windows-msvc"
+	mkdir -p "target/${target}/release"
+	printf 'MZ' >"target/${target}/release/myapp.exe"
+
+	run env \
+		VERSION=1.2.3 \
+		TARGET="$target" \
+		PACKAGES=myapp \
+		BINARY_NAMES=myapp \
+		ARCHIVE_FORMAT=zip \
+		bash "$SCRIPT"
+	assert_success
+
+	[[ -f myapp-1.2.3-${target}.zip ]]
+	run unzip -l "myapp-1.2.3-${target}.zip"
+	assert_success
+	assert_output --partial 'myapp.exe'
+}
+
+@test "package-rust-binary: writes per-target SHA256SUMS manifest" {
+	local target="x86_64-unknown-linux-musl"
+	mkdir -p "target/${target}/release"
+	printf 'elf' >"target/${target}/release/myapp"
+
+	run env \
+		VERSION=2.0.0 \
+		TARGET="$target" \
+		PACKAGES=myapp \
+		BINARY_NAMES=myapp \
+		ARCHIVE_FORMAT=tar.gz \
+		bash "$SCRIPT"
+	assert_success
+
+	[[ -f "SHA256SUMS-${target}" ]]
+	run grep -F 'myapp-2.0.0-'"${target}"'.tar.gz' "SHA256SUMS-${target}"
+	assert_success
+}
+
+@test "package-rust-binary: passes bash syntax check" {
+	run bash -n "$SCRIPT"
+	assert_success
+}

--- a/tests/bats/unit/release/test_package_rust_binary.bats
+++ b/tests/bats/unit/release/test_package_rust_binary.bats
@@ -52,6 +52,12 @@ teardown() {
 	[[ -f "SHA256SUMS-${target}" ]]
 	run grep -F 'myapp-2.0.0-'"${target}"'.tar.gz' "SHA256SUMS-${target}"
 	assert_success
+	run tar -tzf "myapp-2.0.0-${target}.tar.gz"
+	assert_success
+	assert_output --partial 'myapp'
+	run bash -c 'tar -tzf "myapp-2.0.0-'"${target}"'.tar.gz" | grep -c / || true'
+	assert_success
+	assert_equal 0 "$output"
 }
 
 @test "package-rust-binary: passes bash syntax check" {

--- a/tests/bats/unit/release/test_package_rust_binary.bats
+++ b/tests/bats/unit/release/test_package_rust_binary.bats
@@ -60,6 +60,26 @@ teardown() {
 	assert_equal 0 "$output"
 }
 
+@test "package-rust-binary: skips empty package entries without shifting binary names" {
+	local target="x86_64-unknown-linux-musl"
+	mkdir -p "target/${target}/release"
+	printf 'elf' >"target/${target}/release/cli-bin"
+	printf 'elf' >"target/${target}/release/server-bin"
+
+	run env \
+		VERSION=3.0.0 \
+		TARGET="$target" \
+		PACKAGES='cli,,server' \
+		BINARY_NAMES='cli-bin,wrong-name,server-bin' \
+		ARCHIVE_FORMAT=tar.gz \
+		bash "$SCRIPT"
+	assert_success
+
+	[[ -f cli-3.0.0-${target}.tar.gz ]]
+	[[ -f server-3.0.0-${target}.tar.gz ]]
+	[[ ! -f wrong-name-3.0.0-${target}.tar.gz ]]
+}
+
 @test "package-rust-binary: passes bash syntax check" {
 	run bash -n "$SCRIPT"
 	assert_success


### PR DESCRIPTION
## Summary

Introduce tiered runner policy enforcement (`validate-runner-policy`), harden
`harden-runner` for non-Linux runners, and ship reusable workflows for
Linux-only cross-compiled Rust binary releases with SLSA provenance.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

`validate-runner-policy` rejects `egress-policy: audit` on `strict` and
`hardened` tiers. Release reusables default to block-only egress. Consumers
using audit on non-permissive tiers must migrate to `block` or document
`permissive` tier justification.

## Closes

- Closes #313
- Relates to #307
- Relates to #69

## Testing

- [x] BATS unit tests for `validate-runner-policy` tier × runner matrix
- [x] BATS unit tests for `package-rust-binary.sh` zip/tar packaging
- [x] BATS integration contract tests for new reusable workflows
- [x] `uv run lintro chk` (zero issues)
- [x] `uv run lintro tst`

## Quality Checks

- [x] Lint/format (`uv run lintro fmt` + `uv run lintro chk`)
- [x] Tests (`uv run lintro tst`)
- [x] Greptile pre-push review
- [x] CodeRabbit pre-push review

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add reusable Rust release CI workflows with block-only egress enforcement
> - Adds two reusable workflows: [`reusable-build-rust-binaries.yml`](https://github.com/lgtm-hq/lgtm-ci/pull/317/files#diff-06df47fbd5bdae5bd0a7599cef5209e0cbcac7f02d1636c60dfc8b6da5d509f9) builds and packages Rust binaries with per-target checksums and SLSA attestations; [`reusable-publish-rust-release.yml`](https://github.com/lgtm-hq/lgtm-ci/pull/317/files#diff-cacdff04073428719f82a3d0ad6ea2eca4c4ab9a04e0bfd2d015f68408f15ccd) orchestrates tag verification, builds, checksum aggregation, and GitHub Release creation.
> - Adds a [`validate-runner-policy`](https://github.com/lgtm-hq/lgtm-ci/pull/317/files#diff-fe72246da3b9aa731a558e45a9e7047b8ee76bc5a1195e6bd620db2f09d2ed40) composite action and backing [script](https://github.com/lgtm-hq/lgtm-ci/pull/317/files#diff-2d90993fb3c11d555cc808883436af842058375eba673c4f598e345a5ed408c9) that gates harden-runner usage by tier (`strict`, `hardened`, `permissive`); `audit` mode is rejected on strict/hardened tiers and strict tier fails when egress block cannot be enforced.
> - Adds a `rust-release` egress preset covering Rust toolchain, crates.io, container registries (ghcr.io, docker.io), Ubuntu APT mirrors, and Sigstore endpoints (fulcio, rekor, TUF).
> - Adds release scripts for building (`build-rust-binary.sh`), packaging into archives with checksums (`package-rust-binary.sh`), aggregating per-target manifests (`aggregate-rust-release-checksums.sh`), and verifying tag-to-Cargo-version parity.
> - Fixes the harden-runner pre-step that creates `/home/agent` to run only on Linux runners.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb591e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reusable build and publish workflows for Rust releases, CI helpers for building/packaging/attesting/checksum/version/tag verification, a validate-runner-policy composite for tiered egress enforcement, a new rust-release egress preset, and a Linux-only guard for the runner hardening pre-step.

* **Tests**
  * New integration and unit tests covering workflows, policy validation, egress presets, packaging, and checksum aggregation.

* **Documentation**
  * Updated docs describing reusable Rust release workflows, runner policy tiers, and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR ships tiered runner policy enforcement (`validate-runner-policy`), a `rust-release` egress preset, and two reusable workflows for block-only Rust release builds with SLSA provenance. It also guards the `harden-runner` Linux pre-step with `if: runner.os == 'Linux'` and fixes `setup-rust-nextest.sh` to pass `--force` when reinstalling a mismatched crate version.

- **`validate-runner-policy`** composite + shell script enforce strict/hardened/permissive tier semantics — `audit` rejected on strict/hardened, Windows/macOS GitHub-hosted hard-fails on strict, skips with warning on hardened, and all new reusable workflows gate `harden-runner` behind `enforce-egress == 'true'`.
- **`reusable-build-rust-binaries.yml`** cross-compiles Linux musl, Linux aarch64, and Windows MSVC targets from a single `ubuntu-24.04` runner under `block` egress with the new `rust-release` preset (Ubuntu apt mirrors, Docker registries, crates.io, Sigstore); attestation now covers the `.tar.gz`/`.zip` archives directly.
- **`reusable-publish-rust-release.yml`** orchestrates tag verification → binary builds → checksum aggregation → GitHub release with `contents: write` scoped only to the release job.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; all issues from the previous review round have been addressed and the new code is logically correct with good test coverage.

The policy logic in validate-runner-policy.sh correctly handles all tier × runner × egress-policy combinations. The egress preset, workflow ordering, attestation subjects, cross version pin, and empty-package index alignment are all correct. Minor style issues have no runtime impact.

No files require special attention. The harden-runner/action.yml inner step intentionally relies on callers using validate-runner-policy rather than self-guarding, which is consistent with the design but worth reviewing if the action is ever consumed without the policy gate.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/harden-runner/action.yml | Adds `if: runner.os == 'Linux'` guard to the `/home/agent` pre-step; the inner `step-security/harden-runner` step itself has no equivalent platform guard (intentional design relying on callers using `validate-runner-policy`) |
| .github/actions/validate-runner-policy/action.yml | New composite action delegating to `validate-runner-policy.sh`; exposes `enforce-egress`, `effective-policy`, and `tier-warning` outputs cleanly |
| scripts/ci/actions/validate-runner-policy.sh | Correct tier × runner logic; strict/hardened audit rejection, hardened Windows/macOS skip-with-warning, and permissive advisory paths all handled correctly with clear error messages |
| scripts/ci/release/package-rust-binary.sh | Empty-entry index alignment fix is correct; `name_list` not declared `local -a` inside `_resolve_binary_name` (global scope leak, harmless today) |
| scripts/ci/lib/cargo/version.sh | awk uses `\.` (matches any char in ERE) for the dot in `[workspace.package]`; functionally correct for real Cargo.toml but `[.]` would be more precise |
| .github/workflows/reusable-build-rust-binaries.yml | Policy → egress-resolve → harden-runner chain correctly ordered and conditionally gated; `cross` pinned to 0.2.5, attestation covers archives not checksum manifests, Ubuntu apt mirrors included in preset |
| .github/workflows/reusable-publish-rust-release.yml | Orchestrates verify-tag → build-binaries → github-release with proper needs chains; shared concurrency group intentional (prevents duplicate releases); permissions scoped per job |
| .github/actions/harden-runner/lib/egress/presets.sh | New `rust-release` preset adds Ubuntu apt mirrors, Docker registries, crates.io endpoints, and Sigstore hosts — addresses previous apt-get block issue |
| scripts/ci/release/verify-rust-release-tag.sh | Enforces `v`-prefixed tag convention; consistent with workflow docs showing `tags: ["v*"]`; clear error message on mismatch |
| scripts/ci/testing/rust/setup-rust-nextest.sh | Adds `--force` to cargo binstall/install for version-mismatch reinstalls; early-return for exact-match case prevents unnecessary force-installs |

</details>

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fci%2Frelease%2Fpackage-rust-binary.sh%3A34-36%0A%60name_list%60%20is%20assigned%20via%20%60read%20-r%20-a%60%20without%20a%20%60local%20-a%60%20declaration%2C%20so%20it%20leaks%20into%20the%20global%20script%20scope.%20Every%20invocation%20of%20%60_resolve_binary_name%60%20re-initialises%20it%20correctly%20in%20the%20current%20code%2C%20but%20any%20future%20code%20that%20reads%20%60name_list%60%20outside%20the%20function%20would%20see%20the%20last%20value%20set%20during%20the%20loop.%0A%0A%60%60%60suggestion%0A%09if%20%5B%5B%20-n%20%22%24BINARY_NAMES%22%20%5D%5D%3B%20then%0A%09%09local%20-a%20name_list%0A%09%09IFS%3D'%2C'%20read%20-r%20-a%20name_list%20%3C%3C%3C%22%24BINARY_NAMES%22%0A%09%09if%20%5B%5B%20-n%20%22%24%7Bname_list%5B%24index%5D%3A-%7D%22%20%5D%5D%3B%20then%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Fci%2Flib%2Fcargo%2Fversion.sh%3A24-25%0AThe%20awk%20uses%20%60%5C.%60%20%28ERE%3A%20matches%20any%20character%29%20for%20the%20dot%20in%20%60%5Bworkspace.package%5D%60.%20A%20section%20name%20like%20%60%5BworkspaceXpackage%5D%60%20would%20incorrectly%20keep%20%60in_pkg%20%3D%201%60.%20Using%20%60%5B.%5D%60%20makes%20the%20literal-dot%20intent%20unambiguous.%0A%0A%60%60%60suggestion%0A%2F%5E%5C%5Bpackage%5C%5D%2F%20%7C%7C%20%2F%5E%5C%5Bworkspace%5B.%5D%5Bp%5Dackage%5C%5D%2F%20%7B%20in_pkg%20%3D%201%20%7D%0A%2F%5E%5C%5B%2F%20%26%26%20!%2F%5E%5C%5Bpackage%5C%5D%2F%20%26%26%20!%2F%5E%5C%5Bworkspace%5B.%5D%5Bp%5Dackage%5C%5D%2F%20%7B%20in_pkg%20%3D%200%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Factions%2Fharden-runner%2Faction.yml%3A48-56%0A**%60step-security%2Fharden-runner%60%20step%20itself%20is%20not%20platform-guarded**%0A%0AThe%20new%20%60if%3A%20runner.os%20%3D%3D%20'Linux'%60%20guard%20protects%20the%20pre-step%20that%20creates%20%60%2Fhome%2Fagent%60%2C%20but%20the%20inner%20%60step-security%2Fharden-runner%60%20action%20still%20executes%20unconditionally.%20If%20the%20composite%20is%20ever%20called%20directly%20on%20a%20GitHub-hosted%20Windows%20or%20macOS%20runner%20with%20%60egress-policy%3A%20block%60%20%28bypassing%20%60validate-runner-policy%60%29%2C%20the%20StepSecurity%20agent%20would%20run%20but%20cannot%20enforce%20network%20blocking%20on%20those%20platforms.%20The%20design%20intent%20is%20that%20callers%20must%20gate%20this%20composite%20via%20%60validate-runner-policy%60%2C%20so%20this%20is%20a%20defense-in-depth%20gap%20rather%20than%20a%20bug%20in%20the%20new%20workflows.%20Consider%20adding%20%60if%3A%20runner.os%20%3D%3D%20'Linux'%20%7C%7C%20runner.environment%20%3D%3D%20'self-hosted'%60%20to%20the%20Harden%20Runner%20step%20as%20a%20self-contained%20safety%20net.%0A%0A&pr=317&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fci%2Frelease%2Fpackage-rust-binary.sh%3A34-36%0A%60name_list%60%20is%20assigned%20via%20%60read%20-r%20-a%60%20without%20a%20%60local%20-a%60%20declaration%2C%20so%20it%20leaks%20into%20the%20global%20script%20scope.%20Every%20invocation%20of%20%60_resolve_binary_name%60%20re-initialises%20it%20correctly%20in%20the%20current%20code%2C%20but%20any%20future%20code%20that%20reads%20%60name_list%60%20outside%20the%20function%20would%20see%20the%20last%20value%20set%20during%20the%20loop.%0A%0A%60%60%60suggestion%0A%09if%20%5B%5B%20-n%20%22%24BINARY_NAMES%22%20%5D%5D%3B%20then%0A%09%09local%20-a%20name_list%0A%09%09IFS%3D'%2C'%20read%20-r%20-a%20name_list%20%3C%3C%3C%22%24BINARY_NAMES%22%0A%09%09if%20%5B%5B%20-n%20%22%24%7Bname_list%5B%24index%5D%3A-%7D%22%20%5D%5D%3B%20then%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Fci%2Flib%2Fcargo%2Fversion.sh%3A24-25%0AThe%20awk%20uses%20%60%5C.%60%20%28ERE%3A%20matches%20any%20character%29%20for%20the%20dot%20in%20%60%5Bworkspace.package%5D%60.%20A%20section%20name%20like%20%60%5BworkspaceXpackage%5D%60%20would%20incorrectly%20keep%20%60in_pkg%20%3D%201%60.%20Using%20%60%5B.%5D%60%20makes%20the%20literal-dot%20intent%20unambiguous.%0A%0A%60%60%60suggestion%0A%2F%5E%5C%5Bpackage%5C%5D%2F%20%7C%7C%20%2F%5E%5C%5Bworkspace%5B.%5D%5Bp%5Dackage%5C%5D%2F%20%7B%20in_pkg%20%3D%201%20%7D%0A%2F%5E%5C%5B%2F%20%26%26%20!%2F%5E%5C%5Bpackage%5C%5D%2F%20%26%26%20!%2F%5E%5C%5Bworkspace%5B.%5D%5Bp%5Dackage%5C%5D%2F%20%7B%20in_pkg%20%3D%200%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Factions%2Fharden-runner%2Faction.yml%3A48-56%0A**%60step-security%2Fharden-runner%60%20step%20itself%20is%20not%20platform-guarded**%0A%0AThe%20new%20%60if%3A%20runner.os%20%3D%3D%20'Linux'%60%20guard%20protects%20the%20pre-step%20that%20creates%20%60%2Fhome%2Fagent%60%2C%20but%20the%20inner%20%60step-security%2Fharden-runner%60%20action%20still%20executes%20unconditionally.%20If%20the%20composite%20is%20ever%20called%20directly%20on%20a%20GitHub-hosted%20Windows%20or%20macOS%20runner%20with%20%60egress-policy%3A%20block%60%20%28bypassing%20%60validate-runner-policy%60%29%2C%20the%20StepSecurity%20agent%20would%20run%20but%20cannot%20enforce%20network%20blocking%20on%20those%20platforms.%20The%20design%20intent%20is%20that%20callers%20must%20gate%20this%20composite%20via%20%60validate-runner-policy%60%2C%20so%20this%20is%20a%20defense-in-depth%20gap%20rather%20than%20a%20bug%20in%20the%20new%20workflows.%20Consider%20adding%20%60if%3A%20runner.os%20%3D%3D%20'Linux'%20%7C%7C%20runner.environment%20%3D%3D%20'self-hosted'%60%20to%20the%20Harden%20Runner%20step%20as%20a%20self-contained%20safety%20net.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=317&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F313-block-only-rust-release-builds-os-aware-harden-runner%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F313-block-only-rust-release-builds-os-aware-harden-runner%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fci%2Frelease%2Fpackage-rust-binary.sh%3A34-36%0A%60name_list%60%20is%20assigned%20via%20%60read%20-r%20-a%60%20without%20a%20%60local%20-a%60%20declaration%2C%20so%20it%20leaks%20into%20the%20global%20script%20scope.%20Every%20invocation%20of%20%60_resolve_binary_name%60%20re-initialises%20it%20correctly%20in%20the%20current%20code%2C%20but%20any%20future%20code%20that%20reads%20%60name_list%60%20outside%20the%20function%20would%20see%20the%20last%20value%20set%20during%20the%20loop.%0A%0A%60%60%60suggestion%0A%09if%20%5B%5B%20-n%20%22%24BINARY_NAMES%22%20%5D%5D%3B%20then%0A%09%09local%20-a%20name_list%0A%09%09IFS%3D'%2C'%20read%20-r%20-a%20name_list%20%3C%3C%3C%22%24BINARY_NAMES%22%0A%09%09if%20%5B%5B%20-n%20%22%24%7Bname_list%5B%24index%5D%3A-%7D%22%20%5D%5D%3B%20then%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Fci%2Flib%2Fcargo%2Fversion.sh%3A24-25%0AThe%20awk%20uses%20%60%5C.%60%20%28ERE%3A%20matches%20any%20character%29%20for%20the%20dot%20in%20%60%5Bworkspace.package%5D%60.%20A%20section%20name%20like%20%60%5BworkspaceXpackage%5D%60%20would%20incorrectly%20keep%20%60in_pkg%20%3D%201%60.%20Using%20%60%5B.%5D%60%20makes%20the%20literal-dot%20intent%20unambiguous.%0A%0A%60%60%60suggestion%0A%2F%5E%5C%5Bpackage%5C%5D%2F%20%7C%7C%20%2F%5E%5C%5Bworkspace%5B.%5D%5Bp%5Dackage%5C%5D%2F%20%7B%20in_pkg%20%3D%201%20%7D%0A%2F%5E%5C%5B%2F%20%26%26%20!%2F%5E%5C%5Bpackage%5C%5D%2F%20%26%26%20!%2F%5E%5C%5Bworkspace%5B.%5D%5Bp%5Dackage%5C%5D%2F%20%7B%20in_pkg%20%3D%200%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0A.github%2Factions%2Fharden-runner%2Faction.yml%3A48-56%0A**%60step-security%2Fharden-runner%60%20step%20itself%20is%20not%20platform-guarded**%0A%0AThe%20new%20%60if%3A%20runner.os%20%3D%3D%20'Linux'%60%20guard%20protects%20the%20pre-step%20that%20creates%20%60%2Fhome%2Fagent%60%2C%20but%20the%20inner%20%60step-security%2Fharden-runner%60%20action%20still%20executes%20unconditionally.%20If%20the%20composite%20is%20ever%20called%20directly%20on%20a%20GitHub-hosted%20Windows%20or%20macOS%20runner%20with%20%60egress-policy%3A%20block%60%20%28bypassing%20%60validate-runner-policy%60%29%2C%20the%20StepSecurity%20agent%20would%20run%20but%20cannot%20enforce%20network%20blocking%20on%20those%20platforms.%20The%20design%20intent%20is%20that%20callers%20must%20gate%20this%20composite%20via%20%60validate-runner-policy%60%2C%20so%20this%20is%20a%20defense-in-depth%20gap%20rather%20than%20a%20bug%20in%20the%20new%20workflows.%20Consider%20adding%20%60if%3A%20runner.os%20%3D%3D%20'Linux'%20%7C%7C%20runner.environment%20%3D%3D%20'self-hosted'%60%20to%20the%20Harden%20Runner%20step%20as%20a%20self-contained%20safety%20net.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=317&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["fix(ci): address review feedback on rust..."](https://github.com/lgtm-hq/lgtm-ci/commit/cb591e1c5550cbc911ee39d911447aaa87023f0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36089483)</sub>

<!-- /greptile_comment -->