### PR TITLE
feat(ci): add Cargo auto-tag support for reusable-release-auto-tag

### DIFF
--- a/.github/workflows/reusable-release-auto-tag.yml
+++ b/.github/workflows/reusable-release-auto-tag.yml
@@ -9,6 +9,24 @@ name: "Reusable: Release Auto Tag"
         required: false
         type: string
         default: ""
+      version-source:
+        description: >-
+          Version detection source: commit (default) reads chore(release): from
+          HEAD; cargo reads [package] or [workspace.package] from version-file
+        required: false
+        type: string
+        default: "commit"
+      version-file:
+        description: "Cargo.toml path when version-source is cargo"
+        required: false
+        type: string
+        default: "Cargo.toml"
+      skip-if-unchanged:
+        description: >-
+          Skip tagging when the resolved version matches the latest tag version
+        required: false
+        type: boolean
+        default: false
       tag-prefix:
         description: "Prefix for the release tag"
         required: false
@@ -198,21 +216,48 @@ jobs:
         shell: bash
         run: .lgtm-ci-tooling/scripts/ci/release/guard-release-commit.sh
 
-      - name: Extract version from commit
+      - name: Resolve version
         # yamllint disable-line rule:line-length
         if: steps.guard.outputs.is-release-commit == 'true' || inputs.version != ''
         id: version
         shell: bash
         env:
+          VERSION_SOURCE: >-
+            ${{ inputs.version != '' && 'commit' || inputs.version-source }}
+          VERSION_FILE: ${{ inputs.version-file }}
           COMMIT_MESSAGE: >-
             ${{ inputs.version != ''
                 && format('chore(release): version {0}', inputs.version)
                 || '' }}
-        run: .lgtm-ci-tooling/scripts/ci/release/extract-version-from-commit.sh
+        run: .lgtm-ci-tooling/scripts/ci/release/resolve-auto-tag-version.sh
+
+      - name: Detect previous tag version
+        if: >-
+          steps.version.outputs.found == 'true' &&
+          inputs.skip-if-unchanged
+        id: previous-version
+        shell: bash
+        env:
+          TAG_PREFIX: ${{ inputs.tag-prefix }}
+        run: .lgtm-ci-tooling/scripts/ci/release/detect-previous-tag-version.sh
+
+      - name: Check version unchanged
+        if: >-
+          steps.version.outputs.found == 'true' &&
+          inputs.skip-if-unchanged
+        id: unchanged
+        shell: bash
+        env:
+          CURRENT_VERSION: ${{ steps.version.outputs.version }}
+          PREVIOUS_VERSION: ${{ steps.previous-version.outputs.version }}
+        run: .lgtm-ci-tooling/scripts/ci/release/check-version-unchanged.sh
 
       - name: Configure git with app token
         # yamllint disable-line rule:line-length
-        if: steps.version.outputs.found == 'true'
+        if: >-
+          steps.version.outputs.found == 'true' &&
+          (inputs.skip-if-unchanged != true ||
+          steps.unchanged.outputs.should-tag == 'true')
         shell: bash
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -220,7 +265,10 @@ jobs:
         run: .lgtm-ci-tooling/scripts/ci/release/configure-git-remote.sh
 
       - name: Create release tag
-        if: steps.version.outputs.found == 'true'
+        if: >-
+          steps.version.outputs.found == 'true' &&
+          (inputs.skip-if-unchanged != true ||
+          steps.unchanged.outputs.should-tag == 'true')
         id: tag
         shell: bash
         env:
@@ -230,7 +278,11 @@ jobs:
         run: .lgtm-ci-tooling/scripts/ci/release/create-tag.sh
 
       - name: Create GitHub release
-        if: steps.version.outputs.found == 'true' && inputs.create-release
+        if: >-
+          steps.version.outputs.found == 'true' &&
+          (inputs.skip-if-unchanged != true ||
+          steps.unchanged.outputs.should-tag == 'true') &&
+          inputs.create-release
         id: github-release
         shell: bash
         env:
@@ -239,7 +291,10 @@ jobs:
         run: .lgtm-ci-tooling/scripts/ci/release/create-github-release.sh
 
       - name: Update floating tag
-        if: steps.version.outputs.found == 'true'
+        if: >-
+          steps.version.outputs.found == 'true' &&
+          (inputs.skip-if-unchanged != true ||
+          steps.unchanged.outputs.should-tag == 'true')
         shell: bash
         env:
           TAG: ${{ steps.tag.outputs.tag-name }}
@@ -248,7 +303,10 @@ jobs:
         run: .lgtm-ci-tooling/scripts/ci/release/update-floating-tag.sh
 
       - name: Release summary
-        if: steps.version.outputs.found == 'true'
+        if: >-
+          steps.version.outputs.found == 'true' &&
+          (inputs.skip-if-unchanged != true ||
+          steps.unchanged.outputs.should-tag == 'true')
         shell: bash
         env:
           SUMMARY_TYPE: release
@@ -259,10 +317,18 @@ jobs:
 
       - name: Skip summary
         # yamllint disable-line rule:line-length
-        if: always() && steps.version.outputs.found != 'true'
+        if: >-
+          always() &&
+          (
+            steps.version.outputs.found != 'true' ||
+            (inputs.skip-if-unchanged &&
+            steps.unchanged.outputs.should-tag == 'false')
+          )
         shell: bash
         env:
           IS_RELEASE: ${{ steps.guard.outputs.is-release-commit }}
+          VERSION_FOUND: ${{ steps.version.outputs.found }}
+          VERSION_UNCHANGED: ${{ steps.unchanged.outputs.unchanged }}
         run: .lgtm-ci-tooling/scripts/ci/release/write-skip-summary.sh
 
   report-release-failure:

--- a/.github/workflows/reusable-release-auto-tag.yml
+++ b/.github/workflows/reusable-release-auto-tag.yml
@@ -5,7 +5,9 @@ name: "Reusable: Release Auto Tag"
   workflow_call:
     inputs:
       version:
-        description: "Version override (e.g., 1.2.3). Leave empty for commit-based detection."
+        description: >-
+          Version override (e.g., 1.2.3). Leave empty to detect from the
+          configured version-source (commit or cargo).
         required: false
         type: string
         default: ""
@@ -250,6 +252,7 @@ jobs:
         env:
           CURRENT_VERSION: ${{ steps.version.outputs.version }}
           PREVIOUS_VERSION: ${{ steps.previous-version.outputs.version }}
+          TAG_PREFIX: ${{ inputs.tag-prefix }}
         run: .lgtm-ci-tooling/scripts/ci/release/check-version-unchanged.sh
 
       - name: Configure git with app token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ci**: Cargo auto-tag support in `reusable-release-auto-tag` with
+  `version-source`, `version-file`, and `skip-if-unchanged` inputs (#307)
+
 ### Changed
 
 ### Deprecated

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -354,6 +354,35 @@ jobs:
     secrets: inherit
 ```
 
+**Cargo workspace auto-tag** (Rust monorepos that bump `Cargo.toml` on `main`):
+
+```yaml
+name: Release - Auto Tag
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - Cargo.toml
+
+jobs:
+  auto-tag:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@<sha>
+    permissions:
+      contents: write
+      actions: read
+      issues: write
+    with:
+      version-source: cargo
+      version-file: Cargo.toml
+      skip-if-unchanged: true
+      create-release: false
+    secrets: inherit
+```
+
+`guard-release-commit` skips non-`chore(release):` commits. `skip-if-unchanged`
+compares the Cargo version to the latest `tag-prefix` tag before creating a new tag.
+
 ## Publishing And Deployment
 
 ```yaml

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -380,8 +380,10 @@ jobs:
     secrets: inherit
 ```
 
-`guard-release-commit` skips non-`chore(release):` commits. `skip-if-unchanged`
-compares the Cargo version to the latest `tag-prefix` tag before creating a new tag.
+`guard-release-commit` skips non-`chore(release):` commits — version bumps must
+use a `chore(release):` subject or the job writes a skip summary without tagging.
+`skip-if-unchanged` compares the Cargo version to the latest `tag-prefix` tag
+before creating a new tag.
 
 ## Publishing And Deployment
 

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -431,11 +431,13 @@ from the commit subject.
 
 Flow when `version-source: cargo`:
 
-1. `guard-release-commit` — proceed only on `chore(release):` commits
-2. `read-cargo-version.sh` — read semver from `version-file`
-3. `detect-previous-tag-version.sh` — latest tag version when `skip-if-unchanged`
-4. `check-version-unchanged.sh` — skip tagging when versions match
-5. `create-tag.sh` — create and push the annotated tag
+1. `guard-release-commit` — common; proceed only on `chore(release):` commits
+2. `read-cargo-version.sh` — cargo-specific; read semver from `version-file`
+3. `detect-previous-tag-version.sh` — conditional (`skip-if-unchanged: true`);
+   read latest `tag-prefix` version
+4. `check-version-unchanged.sh` — conditional (`skip-if-unchanged: true`);
+   skip tagging when versions match
+5. `create-tag.sh` — common; create and push the annotated tag
 
 Callers should filter `on.push.paths` to the manifest (for example `Cargo.toml`)
 and set `create-release: false` when release assets are published separately.

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -413,6 +413,33 @@ fall back to a visible tracking key footer
 marker is retained for backward compatibility. Recurring failures add comments
 to the same open issue.
 
+### Cargo auto-tag contract
+
+`reusable-release-auto-tag.yml` supports Rust monorepos that tag from
+`Cargo.toml` workspace versions instead of parsing `chore(release): version`
+from the commit subject.
+
+<!-- markdownlint-disable MD013 MD060 -->
+
+| Input               | Default      | Purpose                                              |
+| ------------------- | ------------ | ---------------------------------------------------- |
+| `version-source`    | `commit`     | `commit` (default) or `cargo`                        |
+| `version-file`      | `Cargo.toml` | Manifest path for workspace/package version          |
+| `skip-if-unchanged` | `false`      | Skip when version matches the latest `tag-prefix` tag |
+
+<!-- markdownlint-enable MD013 MD060 -->
+
+Flow when `version-source: cargo`:
+
+1. `guard-release-commit` — proceed only on `chore(release):` commits
+2. `read-cargo-version.sh` — read semver from `version-file`
+3. `detect-previous-tag-version.sh` — latest tag version when `skip-if-unchanged`
+4. `check-version-unchanged.sh` — skip tagging when versions match
+5. `create-tag.sh` — create and push the annotated tag
+
+Callers should filter `on.push.paths` to the manifest (for example `Cargo.toml`)
+and set `create-release: false` when release assets are published separately.
+
 ## Egress presets
 
 Reusable workflows default to `egress-policy: block` and

--- a/scripts/ci/release/check-version-unchanged.sh
+++ b/scripts/ci/release/check-version-unchanged.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Compare current and previous versions for auto-tag skip logic
+#
+# Required environment variables:
+#   CURRENT_VERSION - Version to tag
+#
+# Optional environment variables:
+#   PREVIOUS_VERSION - Version from latest tag (empty when no prior tag)
+#
+# Outputs:
+#   unchanged  - true when versions match
+#   should-tag - false when tagging should be skipped
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+# shellcheck source=../lib/log.sh
+source "$LIB_DIR/log.sh"
+# shellcheck source=../lib/github.sh
+source "$LIB_DIR/github.sh"
+
+: "${CURRENT_VERSION:?CURRENT_VERSION is required}"
+: "${PREVIOUS_VERSION:=}"
+
+if [[ -z "$PREVIOUS_VERSION" ]]; then
+	log_info "No previous tag version; tagging $CURRENT_VERSION"
+	set_github_output "unchanged" "false"
+	set_github_output "should-tag" "true"
+	echo "unchanged=false"
+	echo "should-tag=true"
+	exit 0
+fi
+
+if [[ "$CURRENT_VERSION" == "$PREVIOUS_VERSION" ]]; then
+	log_info "Version unchanged: $CURRENT_VERSION"
+	set_github_output "unchanged" "true"
+	set_github_output "should-tag" "false"
+	echo "unchanged=true"
+	echo "should-tag=false"
+	exit 0
+fi
+
+log_info "Version changed: $PREVIOUS_VERSION -> $CURRENT_VERSION"
+set_github_output "unchanged" "false"
+set_github_output "should-tag" "true"
+echo "unchanged=false"
+echo "should-tag=true"

--- a/scripts/ci/release/check-version-unchanged.sh
+++ b/scripts/ci/release/check-version-unchanged.sh
@@ -7,6 +7,7 @@
 #
 # Optional environment variables:
 #   PREVIOUS_VERSION - Version from latest tag (empty when no prior tag)
+#   TAG_PREFIX       - Tag prefix for direct existence check (default: v)
 #
 # Outputs:
 #   unchanged  - true when versions match
@@ -21,14 +22,29 @@ LIB_DIR="$SCRIPT_DIR/../lib"
 source "$LIB_DIR/log.sh"
 # shellcheck source=../lib/github.sh
 source "$LIB_DIR/github.sh"
+# shellcheck source=../lib/git.sh
+source "$LIB_DIR/git.sh"
 
 : "${CURRENT_VERSION:?CURRENT_VERSION is required}"
 : "${PREVIOUS_VERSION:=}"
+: "${TAG_PREFIX:=v}"
+
+target_tag="${TAG_PREFIX}${CURRENT_VERSION}"
+if tag_exists "$target_tag"; then
+	log_info "Tag $target_tag already exists; skipping"
+	set_github_output "unchanged" "true"
+	set_github_output "should-tag" "false"
+	# Also echo to stdout for BATS test assertions
+	echo "unchanged=true"
+	echo "should-tag=false"
+	exit 0
+fi
 
 if [[ -z "$PREVIOUS_VERSION" ]]; then
 	log_info "No previous tag version; tagging $CURRENT_VERSION"
 	set_github_output "unchanged" "false"
 	set_github_output "should-tag" "true"
+	# Also echo to stdout for BATS test assertions
 	echo "unchanged=false"
 	echo "should-tag=true"
 	exit 0
@@ -38,6 +54,7 @@ if [[ "$CURRENT_VERSION" == "$PREVIOUS_VERSION" ]]; then
 	log_info "Version unchanged: $CURRENT_VERSION"
 	set_github_output "unchanged" "true"
 	set_github_output "should-tag" "false"
+	# Also echo to stdout for BATS test assertions
 	echo "unchanged=true"
 	echo "should-tag=false"
 	exit 0
@@ -46,5 +63,6 @@ fi
 log_info "Version changed: $PREVIOUS_VERSION -> $CURRENT_VERSION"
 set_github_output "unchanged" "false"
 set_github_output "should-tag" "true"
+# Also echo to stdout for BATS test assertions
 echo "unchanged=false"
 echo "should-tag=true"

--- a/scripts/ci/release/detect-previous-tag-version.sh
+++ b/scripts/ci/release/detect-previous-tag-version.sh
@@ -36,16 +36,6 @@ if [[ -z "$tag" ]]; then
 	exit 0
 fi
 
-if [[ "$tag" != "${TAG_PREFIX}"* ]]; then
-	log_error "Tag $tag does not start with prefix $TAG_PREFIX"
-	set_github_output "version" ""
-	set_github_output "found" "false"
-	# Also echo to stdout for BATS test assertions
-	echo "version="
-	echo "found=false"
-	exit 0
-fi
-
 version="${tag#"${TAG_PREFIX}"}"
 if [[ -z "$version" ]]; then
 	log_error "Tag $tag has empty version after removing prefix $TAG_PREFIX"
@@ -54,7 +44,7 @@ if [[ -z "$version" ]]; then
 	# Also echo to stdout for BATS test assertions
 	echo "version="
 	echo "found=false"
-	exit 0
+	exit 1
 fi
 
 log_info "Previous tag: $tag (version: $version)"

--- a/scripts/ci/release/detect-previous-tag-version.sh
+++ b/scripts/ci/release/detect-previous-tag-version.sh
@@ -30,14 +30,36 @@ if [[ -z "$tag" ]]; then
 	log_info "No tag found matching pattern: $pattern"
 	set_github_output "version" ""
 	set_github_output "found" "false"
+	# Also echo to stdout for BATS test assertions
+	echo "version="
+	echo "found=false"
+	exit 0
+fi
+
+if [[ "$tag" != "${TAG_PREFIX}"* ]]; then
+	log_error "Tag $tag does not start with prefix $TAG_PREFIX"
+	set_github_output "version" ""
+	set_github_output "found" "false"
+	# Also echo to stdout for BATS test assertions
 	echo "version="
 	echo "found=false"
 	exit 0
 fi
 
 version="${tag#"${TAG_PREFIX}"}"
+if [[ -z "$version" ]]; then
+	log_error "Tag $tag has empty version after removing prefix $TAG_PREFIX"
+	set_github_output "version" ""
+	set_github_output "found" "false"
+	# Also echo to stdout for BATS test assertions
+	echo "version="
+	echo "found=false"
+	exit 0
+fi
+
 log_info "Previous tag: $tag (version: $version)"
 set_github_output "version" "$version"
 set_github_output "found" "true"
+# Also echo to stdout for BATS test assertions
 echo "version=$version"
 echo "found=true"

--- a/scripts/ci/release/detect-previous-tag-version.sh
+++ b/scripts/ci/release/detect-previous-tag-version.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Detect the version from the latest reachable git tag
+#
+# Optional environment variables:
+#   TAG_PREFIX - Tag prefix to match and strip (default: v)
+#
+# Outputs:
+#   version - Version without tag prefix (e.g., 1.2.3)
+#   found   - true when a matching tag exists
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+# shellcheck source=../lib/log.sh
+source "$LIB_DIR/log.sh"
+# shellcheck source=../lib/github.sh
+source "$LIB_DIR/github.sh"
+# shellcheck source=../lib/git.sh
+source "$LIB_DIR/git.sh"
+
+: "${TAG_PREFIX:=v}"
+
+pattern="${TAG_PREFIX}*"
+tag="$(get_latest_tag "$pattern" || true)"
+
+if [[ -z "$tag" ]]; then
+	log_info "No tag found matching pattern: $pattern"
+	set_github_output "version" ""
+	set_github_output "found" "false"
+	echo "version="
+	echo "found=false"
+	exit 0
+fi
+
+version="${tag#"${TAG_PREFIX}"}"
+log_info "Previous tag: $tag (version: $version)"
+set_github_output "version" "$version"
+set_github_output "found" "true"
+echo "version=$version"
+echo "found=true"

--- a/scripts/ci/release/read-cargo-version.sh
+++ b/scripts/ci/release/read-cargo-version.sh
@@ -47,5 +47,6 @@ fi
 log_success "Cargo version: $version"
 set_github_output "version" "$version"
 set_github_output "found" "true"
+# Also echo to stdout for BATS test assertions
 echo "version=$version"
 echo "found=true"

--- a/scripts/ci/release/read-cargo-version.sh
+++ b/scripts/ci/release/read-cargo-version.sh
@@ -12,10 +12,14 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_DIR="$SCRIPT_DIR/../lib"
 
+# shellcheck source=../lib/log.sh
+source "$LIB_DIR/log.sh"
 # shellcheck source=../lib/cargo/version.sh
 source "$LIB_DIR/cargo/version.sh"
-# shellcheck source=../lib/github/output.sh
-source "$LIB_DIR/github/output.sh"
+# shellcheck source=../lib/github.sh
+source "$LIB_DIR/github.sh"
+# shellcheck source=../lib/release/version.sh
+source "$LIB_DIR/release/version.sh"
 
 VERSION_FILE="${VERSION_FILE:-Cargo.toml}"
 
@@ -27,9 +31,21 @@ fi
 version="$(parse_cargo_version "$VERSION_FILE" || true)"
 
 if [[ -z "$version" ]]; then
-	echo "version not found in $VERSION_FILE ([package] or [workspace.package])" >&2
+	log_error "version not found in $VERSION_FILE ([package] or [workspace.package])"
+	set_github_output "version" ""
+	set_github_output "found" "false"
 	exit 1
 fi
 
+if ! validate_semver "$version"; then
+	log_error "Cargo version is not valid semver: $version"
+	set_github_output "version" ""
+	set_github_output "found" "false"
+	exit 1
+fi
+
+log_success "Cargo version: $version"
 set_github_output "version" "$version"
-echo "Cargo version: $version"
+set_github_output "found" "true"
+echo "version=$version"
+echo "found=true"

--- a/scripts/ci/release/resolve-auto-tag-version.sh
+++ b/scripts/ci/release/resolve-auto-tag-version.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Resolve auto-tag version from commit message or Cargo.toml
+#
+# Required environment variables:
+#   VERSION_SOURCE - commit (default) or cargo
+#
+# Optional environment variables:
+#   VERSION_FILE   - Cargo manifest path when VERSION_SOURCE is cargo
+#   COMMIT_MESSAGE - Override commit subject for commit source
+#
+# Outputs: version, found (from the selected resolver)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+
+: "${VERSION_SOURCE:=commit}"
+
+case "$VERSION_SOURCE" in
+cargo)
+	exec "$SCRIPT_DIR/read-cargo-version.sh"
+	;;
+commit)
+	exec "$SCRIPT_DIR/extract-version-from-commit.sh"
+	;;
+*)
+	echo "Unknown VERSION_SOURCE: $VERSION_SOURCE (expected: commit or cargo)" >&2
+	exit 1
+	;;
+esac

--- a/scripts/ci/release/write-skip-summary.sh
+++ b/scripts/ci/release/write-skip-summary.sh
@@ -6,6 +6,8 @@
 #
 # Environment variables:
 #   IS_RELEASE - Whether the last commit was a release commit (default: 'false')
+#   VERSION_FOUND - Whether a version was resolved (default: 'false')
+#   VERSION_UNCHANGED - Whether version matches the latest tag (default: 'false')
 
 set -euo pipefail
 
@@ -17,11 +19,19 @@ LIB_DIR="$SCRIPT_DIR/../lib"
 source "$LIB_DIR/github.sh"
 
 : "${IS_RELEASE:=false}"
+: "${VERSION_FOUND:=false}"
+: "${VERSION_UNCHANGED:=false}"
 
 add_github_summary "## Auto Tag Summary"
 add_github_summary ""
-if [[ "$IS_RELEASE" != "true" ]]; then
-	add_github_summary "Skipped: last commit is not a release commit"
+if [[ "$VERSION_UNCHANGED" == "true" ]]; then
+	add_github_summary "Skipped: version unchanged since last tag"
+elif [[ "$VERSION_FOUND" != "true" ]]; then
+	if [[ "$IS_RELEASE" != "true" ]]; then
+		add_github_summary "Skipped: last commit is not a release commit"
+	else
+		add_github_summary "Skipped: version not found"
+	fi
 else
-	add_github_summary "Skipped: version not found or guard step failed"
+	add_github_summary "Skipped: auto-tag conditions not met"
 fi

--- a/scripts/ci/release/write-skip-summary.sh
+++ b/scripts/ci/release/write-skip-summary.sh
@@ -33,5 +33,5 @@ elif [[ "$VERSION_FOUND" != "true" ]]; then
 		add_github_summary "Skipped: version not found"
 	fi
 else
-	add_github_summary "Skipped: unexpected auto-tag skip state"
+	add_github_summary "Skipped: unexpected auto-tag skip state (IS_RELEASE=$IS_RELEASE, VERSION_FOUND=$VERSION_FOUND, VERSION_UNCHANGED=$VERSION_UNCHANGED)"
 fi

--- a/scripts/ci/release/write-skip-summary.sh
+++ b/scripts/ci/release/write-skip-summary.sh
@@ -32,4 +32,6 @@ elif [[ "$VERSION_FOUND" != "true" ]]; then
 	else
 		add_github_summary "Skipped: version not found"
 	fi
+else
+	add_github_summary "Skipped: unexpected auto-tag skip state"
 fi

--- a/scripts/ci/release/write-skip-summary.sh
+++ b/scripts/ci/release/write-skip-summary.sh
@@ -32,6 +32,4 @@ elif [[ "$VERSION_FOUND" != "true" ]]; then
 	else
 		add_github_summary "Skipped: version not found"
 	fi
-else
-	add_github_summary "Skipped: auto-tag conditions not met"
 fi

--- a/tests/bats/integration/test_check_version_unchanged.bats
+++ b/tests/bats/integration/test_check_version_unchanged.bats
@@ -9,6 +9,7 @@ load "../../helpers/github_env"
 setup() {
 	setup_temp_dir
 	setup_github_env
+	setup_mock_git_repo
 	export PROJECT_ROOT
 }
 
@@ -21,9 +22,11 @@ run_check() {
 	local current="$1"
 	local previous="${2:-}"
 	run bash -c "
+		cd '$MOCK_GIT_REPO'
 		export GITHUB_OUTPUT='$GITHUB_OUTPUT'
 		export CURRENT_VERSION='$current'
 		export PREVIOUS_VERSION='$previous'
+		export TAG_PREFIX='v'
 		'$PROJECT_ROOT/scripts/ci/release/check-version-unchanged.sh' 2>&1
 	"
 }
@@ -50,20 +53,12 @@ run_check() {
 }
 
 @test "check-version-unchanged: skips when target tag already exists" {
-	setup_mock_git_repo
 	(
 		cd "$MOCK_GIT_REPO"
 		git tag "v1.2.0"
 	)
 
-	run bash -c "
-		cd '$MOCK_GIT_REPO'
-		export GITHUB_OUTPUT='$GITHUB_OUTPUT'
-		export CURRENT_VERSION='1.2.0'
-		export PREVIOUS_VERSION='1.0.0'
-		export TAG_PREFIX='v'
-		'$PROJECT_ROOT/scripts/ci/release/check-version-unchanged.sh' 2>&1
-	"
+	run_check "1.2.0" "1.0.0"
 	assert_success
 	assert_line --partial "should-tag=false"
 	assert_line --partial "unchanged=true"

--- a/tests/bats/integration/test_check_version_unchanged.bats
+++ b/tests/bats/integration/test_check_version_unchanged.bats
@@ -3,6 +3,7 @@
 # Purpose: Integration tests for scripts/ci/release/check-version-unchanged.sh
 
 load "../../helpers/common"
+load "../../helpers/mocks"
 load "../../helpers/github_env"
 
 setup() {
@@ -46,4 +47,24 @@ run_check() {
 	assert_success
 	assert_line --partial "should-tag=true"
 	assert_line --partial "unchanged=false"
+}
+
+@test "check-version-unchanged: skips when target tag already exists" {
+	setup_mock_git_repo
+	(
+		cd "$MOCK_GIT_REPO"
+		git tag "v1.2.0"
+	)
+
+	run bash -c "
+		cd '$MOCK_GIT_REPO'
+		export GITHUB_OUTPUT='$GITHUB_OUTPUT'
+		export CURRENT_VERSION='1.2.0'
+		export PREVIOUS_VERSION='1.0.0'
+		export TAG_PREFIX='v'
+		'$PROJECT_ROOT/scripts/ci/release/check-version-unchanged.sh' 2>&1
+	"
+	assert_success
+	assert_line --partial "should-tag=false"
+	assert_line --partial "unchanged=true"
 }

--- a/tests/bats/integration/test_check_version_unchanged.bats
+++ b/tests/bats/integration/test_check_version_unchanged.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Integration tests for scripts/ci/release/check-version-unchanged.sh
+
+load "../../helpers/common"
+load "../../helpers/github_env"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+	export PROJECT_ROOT
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+run_check() {
+	local current="$1"
+	local previous="${2:-}"
+	run bash -c "
+		export GITHUB_OUTPUT='$GITHUB_OUTPUT'
+		export CURRENT_VERSION='$current'
+		export PREVIOUS_VERSION='$previous'
+		'$PROJECT_ROOT/scripts/ci/release/check-version-unchanged.sh' 2>&1
+	"
+}
+
+@test "check-version-unchanged: tags when no previous version exists" {
+	run_check "1.0.0"
+	assert_success
+	assert_line --partial "should-tag=true"
+	assert_line --partial "unchanged=false"
+}
+
+@test "check-version-unchanged: skips when versions match" {
+	run_check "1.0.0" "1.0.0"
+	assert_success
+	assert_line --partial "should-tag=false"
+	assert_line --partial "unchanged=true"
+}
+
+@test "check-version-unchanged: tags when versions differ" {
+	run_check "1.1.0" "1.0.0"
+	assert_success
+	assert_line --partial "should-tag=true"
+	assert_line --partial "unchanged=false"
+}

--- a/tests/bats/integration/test_detect_previous_tag_version.bats
+++ b/tests/bats/integration/test_detect_previous_tag_version.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Integration tests for scripts/ci/release/detect-previous-tag-version.sh
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+load "../../helpers/github_env"
+
+setup() {
+	setup_temp_dir
+	save_path
+	setup_github_env
+	export LIB_DIR
+	export BATS_TEST_TMPDIR
+	export PROJECT_ROOT
+}
+
+teardown() {
+	restore_path
+	teardown_github_env
+	teardown_temp_dir
+}
+
+run_detect() {
+	local tag_prefix="${1:-v}"
+	run bash -c "
+		cd '$MOCK_GIT_REPO'
+		export GITHUB_OUTPUT='$GITHUB_OUTPUT'
+		export TAG_PREFIX='$tag_prefix'
+		'$PROJECT_ROOT/scripts/ci/release/detect-previous-tag-version.sh' 2>&1
+	"
+}
+
+@test "detect-previous-tag-version: extracts version from latest tag" {
+	setup_mock_git_repo
+	(
+		cd "$MOCK_GIT_REPO"
+		git tag "v1.2.3"
+	)
+
+	run_detect
+	assert_success
+	assert_line --partial "version=1.2.3"
+	assert_line --partial "found=true"
+}
+
+@test "detect-previous-tag-version: reports not found when no tags exist" {
+	setup_mock_git_repo
+
+	run_detect
+	assert_success
+	assert_line --partial "found=false"
+}
+
+@test "detect-previous-tag-version: strips custom tag prefix" {
+	setup_mock_git_repo
+	(
+		cd "$MOCK_GIT_REPO"
+		git tag "release-2.0.0"
+	)
+
+	run_detect "release-"
+	assert_success
+	assert_line --partial "version=2.0.0"
+	assert_line --partial "found=true"
+}

--- a/tests/bats/integration/test_read_cargo_version.bats
+++ b/tests/bats/integration/test_read_cargo_version.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Integration tests for scripts/ci/release/read-cargo-version.sh
+
+load "../../helpers/common"
+load "../../helpers/github_env"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+	export PROJECT_ROOT
+	cd "$BATS_TEST_TMPDIR"
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+run_read() {
+	local version_file="${1:-Cargo.toml}"
+	run bash -c "
+		cd '$BATS_TEST_TMPDIR'
+		export GITHUB_OUTPUT='$GITHUB_OUTPUT'
+		export VERSION_FILE='$version_file'
+		'$PROJECT_ROOT/scripts/ci/release/read-cargo-version.sh' 2>&1
+	"
+}
+
+@test "read-cargo-version: reads workspace.package version" {
+	cat >Cargo.toml <<'EOF'
+[workspace.package]
+version = "0.4.2"
+EOF
+
+	run_read
+	assert_success
+	assert_line --partial "version=0.4.2"
+	assert_line --partial "found=true"
+}
+
+@test "read-cargo-version: fails when manifest is missing" {
+	run_read "missing.toml"
+	assert_failure
+}
+
+@test "read-cargo-version: fails when version is invalid semver" {
+	cat >Cargo.toml <<'EOF'
+[package]
+name = "demo"
+version = "not-semver"
+EOF
+
+	run_read
+	assert_failure
+}

--- a/tests/bats/integration/test_read_cargo_version.bats
+++ b/tests/bats/integration/test_read_cargo_version.bats
@@ -39,6 +39,19 @@ EOF
 	assert_line --partial "found=true"
 }
 
+@test "read-cargo-version: succeeds when package version is semver" {
+	cat >Cargo.toml <<'EOF'
+[package]
+name = "demo"
+version = "1.2.3"
+EOF
+
+	run_read
+	assert_success
+	assert_line --partial "version=1.2.3"
+	assert_line --partial "found=true"
+}
+
 @test "read-cargo-version: fails when manifest is missing" {
 	run_read "missing.toml"
 	assert_failure

--- a/tests/bats/integration/test_reusable_release_auto_tag_cargo.bats
+++ b/tests/bats/integration/test_reusable_release_auto_tag_cargo.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for Cargo auto-tag inputs in reusable-release-auto-tag
+
+load "../../helpers/common"
+
+@test "reusable-release-auto-tag: defines cargo version-source inputs" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-auto-tag.yml"
+
+	run grep -F "version-source:" "$workflow"
+	assert_success
+	run grep -F "version-file:" "$workflow"
+	assert_success
+	run grep -F "skip-if-unchanged:" "$workflow"
+	assert_success
+}
+
+@test "reusable-release-auto-tag: wires cargo version resolution scripts" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-auto-tag.yml"
+
+	run grep -F "resolve-auto-tag-version.sh" "$workflow"
+	assert_success
+	run grep -F "detect-previous-tag-version.sh" "$workflow"
+	assert_success
+	run grep -F "check-version-unchanged.sh" "$workflow"
+	assert_success
+}
+
+@test "reusable-release-auto-tag: guards release commit before version resolve" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-auto-tag.yml"
+
+	run awk '
+		/- name: Guard release commit/ { saw_guard = 1 }
+		saw_guard && /- name: Resolve version/ { saw_resolve = 1; exit }
+		END { exit !saw_resolve }
+	' "$workflow"
+	assert_success
+}


### PR DESCRIPTION
## Summary

Extend `reusable-release-auto-tag` with Cargo workspace tagging so Rust monorepos can replace inline `auto-tag-on-main.yml` scripts. Adds `version-source`, `version-file`, and `skip-if-unchanged` inputs plus release tooling for version resolution, previous-tag detection, and unchanged-version guards.

Implements lgtm-ci #307 §4 (Cargo release guard).

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. Default `version-source: commit` preserves existing caller behaviour.

## Closes

- Relates to #307

## Testing

- [x] BATS integration tests for new release scripts (`detect-previous-tag-version`, `check-version-unchanged`, `read-cargo-version`)
- [x] BATS contract tests for `reusable-release-auto-tag` cargo inputs and wiring
- [x] `uv run lintro chk` (full check)
- [x] Greptile and CodeRabbit pre-push review

## Quality Checks

- [x] `uv run lintro chk` — pass
- [x] BATS tests for changed scripts/workflows — pass
- [x] Signed semantic commits on `feat/307-cargo-release-guard`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Cargo version source and skip-if-unchanged support to reusable-release-auto-tag workflow
> - Adds `version-source` (default: `commit`), `version-file` (default: `Cargo.toml`), and `skip-if-unchanged` inputs to the [reusable-release-auto-tag workflow](https://github.com/lgtm-hq/lgtm-ci/pull/319/files#diff-9029c6ffc07d573f6df930a91ea59eded9a0f588356d5b11c902e070189aa298).
> - Adds [resolve-auto-tag-version.sh](https://github.com/lgtm-hq/lgtm-ci/pull/319/files#diff-5ce7a06544051a1e87fed8d45c432b64ab1bbb44a410c723ab5242e29ff1bb6a) as a dispatcher that delegates to either [read-cargo-version.sh](https://github.com/lgtm-hq/lgtm-ci/pull/319/files#diff-22fe5878a6ef24bfe8a03eb9782747224bbf00fa73ed282984c3a6539a1883d8) or the existing commit extractor based on `VERSION_SOURCE`.
> - Adds [detect-previous-tag-version.sh](https://github.com/lgtm-hq/lgtm-ci/pull/319/files#diff-1298b483c6d0f83dbc77839e207f5cf234f9ae88d38a9ad880186deb14efccfd) and [check-version-unchanged.sh](https://github.com/lgtm-hq/lgtm-ci/pull/319/files#diff-4dedec5b437e9f7b1738156e188c5d0068d866f70cb18299a92c0d697c12c7b2) to detect the latest tag and gate tagging when the version hasn't changed.
> - All tagging, release, and floating-tag steps are now gated on the `should-tag` output from the unchanged check when `skip-if-unchanged` is true.
> - Behavioral Change: `read-cargo-version.sh` now exits with failure and sets `found=false` when the version is missing or not valid semver, rather than continuing silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb00f0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cargo workspace auto-tagging for the reusable release workflow with selectable version source and an option to skip actions when the resolved version is unchanged.

* **Documentation**
  * New guidance and examples for configuring Cargo auto-tag behavior, inputs, and recommended workflow patterns.

* **Tests**
  * Added integration tests covering version resolution, previous-tag detection, unchanged-version skipping, and end-to-end Cargo auto-tag flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Extends `reusable-release-auto-tag` with Cargo workspace support by adding `version-source`, `version-file`, and `skip-if-unchanged` inputs and three new release scripts (`resolve-auto-tag-version.sh`, `detect-previous-tag-version.sh`, `check-version-unchanged.sh`). The `tag_exists` guard in `check-version-unchanged.sh` correctly handles the non-linear-history edge case raised in prior review.

- `resolve-auto-tag-version.sh` dispatches to the existing commit extractor or the new Cargo reader via `exec`, preserving the `version` override path cleanly.
- `skip-if-unchanged` logic gates all tagging/release steps on `should-tag == 'true'`; `write-skip-summary.sh` now distinguishes three skip reasons and adds a defensive fallback for unexpected states.
- BATS contract and integration tests cover the new scripts; `read-cargo-version.sh` error paths omit the stdout echoes that other scripts in the PR include for test assertion compatibility (minor inconsistency).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the new Cargo version-source path is correctly gated, default behavior is unchanged, and the tag_exists guard prevents duplicate-tag failures.

All tagging and release steps use consistent guard conditions, the tag_exists check in check-version-unchanged.sh addresses the non-linear history concern from prior review, and the skip/release summary paths are correctly wired with always() where needed. The two findings are diagnostic quality issues that don't affect the tagging decision itself.

check-version-unchanged.sh — the unchanged=true output label merges two distinct skip reasons, which may complicate future debugging of stuck release pipelines.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-release-auto-tag.yml | Adds version-source, version-file, and skip-if-unchanged inputs; wires three new release scripts; conditional guard logic for all release/tag steps is correct. |
| scripts/ci/release/check-version-unchanged.sh | Correctly gates tagging via tag_exists then version comparison; minor semantic issue: both 'tag already exists' and 'version matches' emit unchanged=true, producing the same (slightly misleading) skip summary message. |
| scripts/ci/release/detect-previous-tag-version.sh | Thin wrapper around get_latest_tag; correctly handles no-tag case; the ancestor-vs-highest-version concern from previous review is mitigated by the tag_exists check in check-version-unchanged.sh. |
| scripts/ci/release/read-cargo-version.sh | Adds semver validation and found output; error paths omit stdout echoes that all sibling scripts include for BATS assertions. |
| scripts/ci/release/resolve-auto-tag-version.sh | Clean dispatcher using exec; correctly forces version-source to commit when an explicit version override is passed; unknown source values produce a clear error. |
| scripts/ci/release/write-skip-summary.sh | Addresses previous review concern by adding a defensive else clause; correctly distinguishes non-release-commit, version-not-found, and version-unchanged skip paths. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[push to main] --> B[guard-release-commit]
    B -->|is-release-commit=false| Z1[Skip summary:\nnot a release commit]
    B -->|is-release-commit=true| C[resolve-auto-tag-version]
    C -->|version-source=commit| D[extract-version-from-commit.sh]
    C -->|version-source=cargo| E[read-cargo-version.sh]
    D -->|found=false| Z2[Skip summary:\nversion not found]
    E -->|found=false / exit 1| Z2
    D -->|found=true| F{skip-if-unchanged?}
    E -->|found=true| F
    F -->|false| G[configure-git + create-tag]
    F -->|true| H[detect-previous-tag-version]
    H --> I[check-version-unchanged\ntag_exists first, then compare]
    I -->|should-tag=false| Z3[Skip summary:\nversion unchanged / tag exists]
    I -->|should-tag=true| G
    G --> J[create-github-release?]
    J --> K[update-floating-tag]
    K --> L[Release summary]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Frelease%2Fcheck-version-unchanged.sh%3A32-41%0A**%60unchanged%3Dtrue%60%20semantics%20overloaded%20for%20two%20distinct%20conditions**%0A%0ABoth%20the%20%22target%20tag%20already%20exists%22%20branch%20%28line%2033%29%20and%20the%20%22versions%20match%22%20branch%20%28line%2053%29%20emit%20%60unchanged%3Dtrue%60.%20This%20collapses%20two%20different%20conditions%20into%20one%20output%3A%20%60write-skip-summary.sh%60%20reads%20%60VERSION_UNCHANGED%3Dtrue%60%20and%20always%20prints%20%22Skipped%3A%20version%20unchanged%20since%20last%20tag%22%2C%20even%20when%20the%20real%20reason%20is%20that%20the%20exact%20target%20tag%20already%20exists%20%28e.g.%2C%20after%20a%20partial%20run%20that%20created%20the%20tag%20but%20failed%20before%20completing%20the%20release%29.%20For%20operators%20debugging%20a%20stuck%20release%20pipeline%20the%20two%20situations%20have%20different%20remediation%20paths%2C%20so%20distinguishing%20them%20in%20the%20output%20would%20improve%20diagnostics.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Frelease%2Fread-cargo-version.sh%3A33-45%0A**Error%20paths%20don't%20echo%20%60found%3Dfalse%60%20to%20stdout%2C%20inconsistent%20with%20sibling%20scripts**%0A%0AThe%20success%20path%20echoes%20%60version%3D%60%20and%20%60found%3Dtrue%60%20to%20stdout%20for%20BATS%20assertions%20%28and%20the%20comment%20on%20line%2050%20acknowledges%20this%20pattern%29%2C%20but%20both%20error%20branches%20%28%60version%20not%20found%60%20and%20%60invalid%20semver%60%29%20call%20only%20%60set_github_output%60%20before%20exiting.%20All%20other%20scripts%20in%20this%20PR%20%E2%80%94%20%60detect-previous-tag-version.sh%60%2C%20%60check-version-unchanged.sh%60%2C%20and%20%60extract-version-from-commit.sh%60%20%E2%80%94%20echo%20%60found%3Dfalse%60%20in%20their%20error%20paths.%20If%20a%20future%20BATS%20test%20for%20these%20error%20cases%20asserts%20on%20stdout%20output%20%28matching%20the%20pattern%20in%20the%20other%20test%20files%29%2C%20it%20will%20see%20no%20matching%20line.%0A%0A%60%60%60suggestion%0Aif%20%5B%5B%20-z%20%22%24version%22%20%5D%5D%3B%20then%0A%09log_error%20%22version%20not%20found%20in%20%24VERSION_FILE%20%28%5Bpackage%5D%20or%20%5Bworkspace.package%5D%29%22%0A%09set_github_output%20%22version%22%20%22%22%0A%09set_github_output%20%22found%22%20%22false%22%0A%09%23%20Also%20echo%20to%20stdout%20for%20BATS%20test%20assertions%0A%09echo%20%22version%3D%22%0A%09echo%20%22found%3Dfalse%22%0A%09exit%201%0Afi%0A%0Aif%20!%20validate_semver%20%22%24version%22%3B%20then%0A%09log_error%20%22Cargo%20version%20is%20not%20valid%20semver%3A%20%24version%22%0A%09set_github_output%20%22version%22%20%22%22%0A%09set_github_output%20%22found%22%20%22false%22%0A%09%23%20Also%20echo%20to%20stdout%20for%20BATS%20test%20assertions%0A%09echo%20%22version%3D%22%0A%09echo%20%22found%3Dfalse%22%0A%09exit%201%0Afi%0A%60%60%60%0A%0A&pr=319&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Frelease%2Fcheck-version-unchanged.sh%3A32-41%0A**%60unchanged%3Dtrue%60%20semantics%20overloaded%20for%20two%20distinct%20conditions**%0A%0ABoth%20the%20%22target%20tag%20already%20exists%22%20branch%20%28line%2033%29%20and%20the%20%22versions%20match%22%20branch%20%28line%2053%29%20emit%20%60unchanged%3Dtrue%60.%20This%20collapses%20two%20different%20conditions%20into%20one%20output%3A%20%60write-skip-summary.sh%60%20reads%20%60VERSION_UNCHANGED%3Dtrue%60%20and%20always%20prints%20%22Skipped%3A%20version%20unchanged%20since%20last%20tag%22%2C%20even%20when%20the%20real%20reason%20is%20that%20the%20exact%20target%20tag%20already%20exists%20%28e.g.%2C%20after%20a%20partial%20run%20that%20created%20the%20tag%20but%20failed%20before%20completing%20the%20release%29.%20For%20operators%20debugging%20a%20stuck%20release%20pipeline%20the%20two%20situations%20have%20different%20remediation%20paths%2C%20so%20distinguishing%20them%20in%20the%20output%20would%20improve%20diagnostics.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Frelease%2Fread-cargo-version.sh%3A33-45%0A**Error%20paths%20don't%20echo%20%60found%3Dfalse%60%20to%20stdout%2C%20inconsistent%20with%20sibling%20scripts**%0A%0AThe%20success%20path%20echoes%20%60version%3D%60%20and%20%60found%3Dtrue%60%20to%20stdout%20for%20BATS%20assertions%20%28and%20the%20comment%20on%20line%2050%20acknowledges%20this%20pattern%29%2C%20but%20both%20error%20branches%20%28%60version%20not%20found%60%20and%20%60invalid%20semver%60%29%20call%20only%20%60set_github_output%60%20before%20exiting.%20All%20other%20scripts%20in%20this%20PR%20%E2%80%94%20%60detect-previous-tag-version.sh%60%2C%20%60check-version-unchanged.sh%60%2C%20and%20%60extract-version-from-commit.sh%60%20%E2%80%94%20echo%20%60found%3Dfalse%60%20in%20their%20error%20paths.%20If%20a%20future%20BATS%20test%20for%20these%20error%20cases%20asserts%20on%20stdout%20output%20%28matching%20the%20pattern%20in%20the%20other%20test%20files%29%2C%20it%20will%20see%20no%20matching%20line.%0A%0A%60%60%60suggestion%0Aif%20%5B%5B%20-z%20%22%24version%22%20%5D%5D%3B%20then%0A%09log_error%20%22version%20not%20found%20in%20%24VERSION_FILE%20%28%5Bpackage%5D%20or%20%5Bworkspace.package%5D%29%22%0A%09set_github_output%20%22version%22%20%22%22%0A%09set_github_output%20%22found%22%20%22false%22%0A%09%23%20Also%20echo%20to%20stdout%20for%20BATS%20test%20assertions%0A%09echo%20%22version%3D%22%0A%09echo%20%22found%3Dfalse%22%0A%09exit%201%0Afi%0A%0Aif%20!%20validate_semver%20%22%24version%22%3B%20then%0A%09log_error%20%22Cargo%20version%20is%20not%20valid%20semver%3A%20%24version%22%0A%09set_github_output%20%22version%22%20%22%22%0A%09set_github_output%20%22found%22%20%22false%22%0A%09%23%20Also%20echo%20to%20stdout%20for%20BATS%20test%20assertions%0A%09echo%20%22version%3D%22%0A%09echo%20%22found%3Dfalse%22%0A%09exit%201%0Afi%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=319&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F307-cargo-release-guard%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F307-cargo-release-guard%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Frelease%2Fcheck-version-unchanged.sh%3A32-41%0A**%60unchanged%3Dtrue%60%20semantics%20overloaded%20for%20two%20distinct%20conditions**%0A%0ABoth%20the%20%22target%20tag%20already%20exists%22%20branch%20%28line%2033%29%20and%20the%20%22versions%20match%22%20branch%20%28line%2053%29%20emit%20%60unchanged%3Dtrue%60.%20This%20collapses%20two%20different%20conditions%20into%20one%20output%3A%20%60write-skip-summary.sh%60%20reads%20%60VERSION_UNCHANGED%3Dtrue%60%20and%20always%20prints%20%22Skipped%3A%20version%20unchanged%20since%20last%20tag%22%2C%20even%20when%20the%20real%20reason%20is%20that%20the%20exact%20target%20tag%20already%20exists%20%28e.g.%2C%20after%20a%20partial%20run%20that%20created%20the%20tag%20but%20failed%20before%20completing%20the%20release%29.%20For%20operators%20debugging%20a%20stuck%20release%20pipeline%20the%20two%20situations%20have%20different%20remediation%20paths%2C%20so%20distinguishing%20them%20in%20the%20output%20would%20improve%20diagnostics.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Frelease%2Fread-cargo-version.sh%3A33-45%0A**Error%20paths%20don't%20echo%20%60found%3Dfalse%60%20to%20stdout%2C%20inconsistent%20with%20sibling%20scripts**%0A%0AThe%20success%20path%20echoes%20%60version%3D%60%20and%20%60found%3Dtrue%60%20to%20stdout%20for%20BATS%20assertions%20%28and%20the%20comment%20on%20line%2050%20acknowledges%20this%20pattern%29%2C%20but%20both%20error%20branches%20%28%60version%20not%20found%60%20and%20%60invalid%20semver%60%29%20call%20only%20%60set_github_output%60%20before%20exiting.%20All%20other%20scripts%20in%20this%20PR%20%E2%80%94%20%60detect-previous-tag-version.sh%60%2C%20%60check-version-unchanged.sh%60%2C%20and%20%60extract-version-from-commit.sh%60%20%E2%80%94%20echo%20%60found%3Dfalse%60%20in%20their%20error%20paths.%20If%20a%20future%20BATS%20test%20for%20these%20error%20cases%20asserts%20on%20stdout%20output%20%28matching%20the%20pattern%20in%20the%20other%20test%20files%29%2C%20it%20will%20see%20no%20matching%20line.%0A%0A%60%60%60suggestion%0Aif%20%5B%5B%20-z%20%22%24version%22%20%5D%5D%3B%20then%0A%09log_error%20%22version%20not%20found%20in%20%24VERSION_FILE%20%28%5Bpackage%5D%20or%20%5Bworkspace.package%5D%29%22%0A%09set_github_output%20%22version%22%20%22%22%0A%09set_github_output%20%22found%22%20%22false%22%0A%09%23%20Also%20echo%20to%20stdout%20for%20BATS%20test%20assertions%0A%09echo%20%22version%3D%22%0A%09echo%20%22found%3Dfalse%22%0A%09exit%201%0Afi%0A%0Aif%20!%20validate_semver%20%22%24version%22%3B%20then%0A%09log_error%20%22Cargo%20version%20is%20not%20valid%20semver%3A%20%24version%22%0A%09set_github_output%20%22version%22%20%22%22%0A%09set_github_output%20%22found%22%20%22false%22%0A%09%23%20Also%20echo%20to%20stdout%20for%20BATS%20test%20assertions%0A%09echo%20%22version%3D%22%0A%09echo%20%22found%3Dfalse%22%0A%09exit%201%0Afi%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=319&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): isolate auto-tag tests and hard..."](https://github.com/lgtm-hq/lgtm-ci/commit/cb00f0ece3a2ddff124df1068e54dd3460c18492) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36101323)</sub>

<!-- /greptile_comment -->