### PR TITLE
docs(ci): document CodeQL build-mode and action-only reusable contracts

### DIFF
--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -11,10 +11,11 @@ on:
         default: ""
       build-mode:
         description: >-
-          CodeQL build mode. Use none (default) for interpreted languages
-          (python, javascript-typescript, etc.). Use autobuild for compiled
-          languages (c-cpp, csharp, java, etc.) or manual with explicit build
-          steps. Python does not support autobuild.
+          CodeQL build mode. Use none (default) for languages with
+          direct-source extraction (python, javascript-typescript, ruby, go,
+          etc.). Use autobuild for languages that require build observation
+          (c-cpp, csharp, java, etc.) or manual with explicit build steps.
+          Python does not support autobuild.
         required: false
         type: string
         default: "none"

--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -10,7 +10,11 @@ on:
         type: string
         default: ""
       build-mode:
-        description: "CodeQL build mode: none or autobuild"
+        description: >-
+          CodeQL build mode. Use none (default) for interpreted languages
+          (python, javascript-typescript, etc.). Use autobuild for compiled
+          languages (c-cpp, csharp, java, etc.) or manual with explicit build
+          steps. Python does not support autobuild.
         required: false
         type: string
         default: "none"
@@ -26,7 +30,9 @@ on:
         default: ""
 
       tooling-ref:
-        description: "Git ref for lgtm-ci tooling and composite actions"
+        description: >-
+          Optional — pins egress composites only (no scripts/ci checkout).
+          Defaults to caller workflow SHA.
         required: false
         type: string
         default: ""

--- a/.github/workflows/reusable-dependency-review.yml
+++ b/.github/workflows/reusable-dependency-review.yml
@@ -21,7 +21,9 @@ on:
         default: ""
 
       tooling-ref:
-        description: "Git ref for lgtm-ci tooling and composite actions"
+        description: >-
+          Optional — pins egress composites only (no scripts/ci checkout).
+          Defaults to caller workflow SHA.
         required: false
         type: string
         default: ""

--- a/.github/workflows/reusable-pr-labeler.yml
+++ b/.github/workflows/reusable-pr-labeler.yml
@@ -23,7 +23,9 @@ name: Reusable PR Auto Label
         type: string
         default: "PR Labeler"
       tooling-ref:
-        description: "Git ref for lgtm-ci tooling and composite actions"
+        description: >-
+          Optional — pins egress composites only (no scripts/ci checkout).
+          Defaults to caller workflow SHA.
         required: false
         type: string
         default: ""

--- a/.github/workflows/reusable-release-auto-tag.yml
+++ b/.github/workflows/reusable-release-auto-tag.yml
@@ -332,6 +332,7 @@ jobs:
           IS_RELEASE: ${{ steps.guard.outputs.is-release-commit }}
           VERSION_FOUND: ${{ steps.version.outputs.found }}
           VERSION_UNCHANGED: ${{ steps.unchanged.outputs.unchanged }}
+          TAG_EXISTS: ${{ steps.unchanged.outputs.tag-exists }}
         run: .lgtm-ci-tooling/scripts/ci/release/write-skip-summary.sh
 
   report-release-failure:

--- a/.github/workflows/reusable-scorecards.yml
+++ b/.github/workflows/reusable-scorecards.yml
@@ -21,7 +21,9 @@ on:
         default: true
 
       tooling-ref:
-        description: "Git ref for lgtm-ci tooling and composite actions"
+        description: >-
+          Optional — pins egress composites only (no scripts/ci checkout).
+          Defaults to caller workflow SHA.
         required: false
         type: string
         default: ""

--- a/.github/workflows/reusable-semantic-pr-title.yml
+++ b/.github/workflows/reusable-semantic-pr-title.yml
@@ -47,7 +47,9 @@ on:
         type: string
         default: "semantic-pr-title"
       tooling-ref:
-        description: "Git ref to use when checking out lgtm-ci tooling scripts"
+        description: >-
+          Optional — pins egress composites and helper scripts under
+          scripts/ci/. Defaults to caller workflow SHA.
         required: false
         type: string
         default: ""

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -39,8 +39,15 @@ jobs:
       exit-code: ${{ needs.quality.outputs.exit-code }}
 ```
 
-Pass `tooling-ref` when testing an unreleased lgtm-ci branch. Production callers
-should pin the workflow ref to a commit SHA.
+Pass `tooling-ref` when testing an unreleased lgtm-ci branch on **script-backed**
+reusables (quality, test-*, validate-*, release-*, etc.). Production callers
+should pin the workflow ref to a commit SHA and pass the same ref as
+`tooling-ref` on script-backed workflows.
+
+**Action-only reusables** (labeler, dependency review, semantic PR title,
+CodeQL, Scorecard) do not run `scripts/ci/`; `tooling-ref` is optional and
+only pins egress composites. See
+[workflow-contract.md](workflow-contract.md#action-only-reusables).
 
 Consumers do **not** need to vendor `.github/actions/harden-runner` or
 `resolve-egress-allowlist` — reusables sparse-checkout lgtm-ci into
@@ -703,3 +710,52 @@ jobs:
       security-events: write
       id-token: write
 ```
+
+### CodeQL build-mode
+
+`reusable-codeql.yml` defaults `build-mode` to `none`. Choose the mode from the
+language class — do **not** pass `build-mode: autobuild` for interpreted
+languages (legacy inline workflows often had a separate `codeql-action/autobuild`
+step; that maps to `autobuild` only for compiled languages).
+
+<!-- markdownlint-disable MD013 -->
+
+| Language class                          | `build-mode`              | Notes                                      |
+| --------------------------------------- | ------------------------- | ------------------------------------------ |
+| Python, JavaScript/TypeScript, Ruby, Go | `none` (default)          | Database built directly from source        |
+| C/C++, C#, Java, Kotlin, Swift, …       | `autobuild` or `manual`   | Requires build observation or custom steps |
+
+<!-- markdownlint-enable MD013 -->
+
+**Python-only caller** — omit `build-mode` or set `none` explicitly:
+
+```yaml
+jobs:
+  codeql:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@<sha>
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      languages: python
+      # build-mode defaults to none — do not use autobuild for Python
+```
+
+**Compiled-language caller** — use `autobuild` (or `manual` with your own build
+steps before `Analyze`):
+
+```yaml
+jobs:
+  codeql:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@<sha>
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      languages: java
+      build-mode: autobuild
+```
+
+See [CodeQL workflow configuration — build modes](https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options)
+and [workflow-contract.md](workflow-contract.md#action-only-reusables) for the
+action-only contract (`tooling-ref` optional).

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -24,6 +24,52 @@ Where applicable, workflows accept:
 
 <!-- markdownlint-enable MD013 -->
 
+`tooling-ref` is listed above for workflows that accept it. See
+[Action-only reusables](#action-only-reusables) for workflows where the input
+pins egress composites only (not `scripts/ci/`).
+
+## Action-only reusables
+
+Some reusables wrap a third-party GitHub Action for a single check. They do
+**not** run the full lgtm-ci script suite — only optional egress hardening
+composites from a sparse lgtm-ci checkout (`harden-runner`,
+`resolve-egress-allowlist`).
+
+<!-- markdownlint-disable MD013 -->
+
+| Reusable                             | Third-party action                         |
+| ------------------------------------ | ------------------------------------------ |
+| `reusable-pr-labeler.yml`            | `actions/labeler`                          |
+| `reusable-dependency-review.yml`     | `actions/dependency-review`                |
+| `reusable-semantic-pr-title.yml`     | `amannn/action-semantic-pull-request`      |
+| `reusable-codeql.yml`                | `github/codeql-action/*`                   |
+| `reusable-scorecards.yml`            | OpenSSF Scorecard action                   |
+
+<!-- markdownlint-enable MD013 -->
+
+For these workflows:
+
+- Pin the reusable `uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-*.yml@<sha>`
+  ref in production.
+- `tooling-ref` is **optional** and pins egress composites only — not CI
+  scripts. When omitted, reusables default to `github.workflow_sha` (the pinned
+  workflow SHA). Pass a matching `tooling-ref` only when testing unreleased
+  egress composite changes on a branch.
+- Do **not** assume `tooling-ref` pins the third-party action inside the
+  reusable; those actions are pinned by SHA inside the workflow YAML.
+
+`reusable-semantic-pr-title.yml` also sparse-checkouts `scripts/ci/` for small
+helper scripts (`prepare-semantic-pr-lists.sh`, `validate-pr-title-length.sh`).
+Pass `tooling-ref` when testing unreleased fixes to those helpers.
+
+Contrast with **script-backed reusables** (quality, test-*, validate-*,
+pr-auto-assign, release-*, publish-*, etc.) where callers **should** pass
+`tooling-ref` matching the workflow pin so `scripts/ci/` and composites stay
+aligned.
+
+See [reusable-workflows.md](reusable-workflows.md) (CodeQL build-mode) for
+interpreted-language scanning guidance.
+
 ## Migration: test summary publishing (#281)
 
 Breaking renames unify test/coverage PR comments behind **`publish-test-summary`**

--- a/scripts/ci/lib/git.sh
+++ b/scripts/ci/lib/git.sh
@@ -61,7 +61,8 @@ get_git_remote_url() {
 
 # Get the most recent reachable tag from HEAD matching a pattern
 # Note: Returns the tag closest to HEAD in commit history, not necessarily
-# the highest version number. Use get_tags for version-sorted list.
+# the highest version number. Use get_latest_reachable_tag for highest semver
+# among reachable tags, or get_tags for all tags version-sorted.
 get_latest_tag() {
 	local pattern="${1:-v*}"
 	git describe --tags --match "$pattern" --abbrev=0 2>/dev/null
@@ -71,6 +72,12 @@ get_latest_tag() {
 get_tags() {
 	local pattern="${1:-v*}"
 	git tag -l "$pattern" --sort=-v:refname 2>/dev/null
+}
+
+# Get the highest semver among tags reachable from HEAD matching a pattern
+get_latest_reachable_tag() {
+	local pattern="${1:-v*}"
+	git tag -l "$pattern" --sort=-v:refname --merged HEAD 2>/dev/null | head -1
 }
 
 # Check if a tag exists
@@ -85,4 +92,4 @@ tag_exists() {
 # =============================================================================
 export -f get_git_root get_current_branch get_commit_sha get_short_sha
 export -f is_git_repo is_git_clean get_git_remote_url
-export -f get_latest_tag get_tags tag_exists
+export -f get_latest_tag get_tags get_latest_reachable_tag tag_exists

--- a/scripts/ci/release/check-version-unchanged.sh
+++ b/scripts/ci/release/check-version-unchanged.sh
@@ -10,8 +10,9 @@
 #   TAG_PREFIX       - Tag prefix for direct existence check (default: v)
 #
 # Outputs:
-#   unchanged  - true when versions match
+#   unchanged  - true when versions match (not when the target tag already exists)
 #   should-tag - false when tagging should be skipped
+#   tag-exists - true when the target tag is already present
 
 set -euo pipefail
 
@@ -32,11 +33,13 @@ source "$LIB_DIR/git.sh"
 target_tag="${TAG_PREFIX}${CURRENT_VERSION}"
 if tag_exists "$target_tag"; then
 	log_info "Tag $target_tag already exists; skipping"
-	set_github_output "unchanged" "true"
+	set_github_output "unchanged" "false"
 	set_github_output "should-tag" "false"
+	set_github_output "tag-exists" "true"
 	# Also echo to stdout for BATS test assertions
-	echo "unchanged=true"
+	echo "unchanged=false"
 	echo "should-tag=false"
+	echo "tag-exists=true"
 	exit 0
 fi
 
@@ -44,9 +47,11 @@ if [[ -z "$PREVIOUS_VERSION" ]]; then
 	log_info "No previous tag version; tagging $CURRENT_VERSION"
 	set_github_output "unchanged" "false"
 	set_github_output "should-tag" "true"
+	set_github_output "tag-exists" "false"
 	# Also echo to stdout for BATS test assertions
 	echo "unchanged=false"
 	echo "should-tag=true"
+	echo "tag-exists=false"
 	exit 0
 fi
 
@@ -54,15 +59,19 @@ if [[ "$CURRENT_VERSION" == "$PREVIOUS_VERSION" ]]; then
 	log_info "Version unchanged: $CURRENT_VERSION"
 	set_github_output "unchanged" "true"
 	set_github_output "should-tag" "false"
+	set_github_output "tag-exists" "false"
 	# Also echo to stdout for BATS test assertions
 	echo "unchanged=true"
 	echo "should-tag=false"
+	echo "tag-exists=false"
 	exit 0
 fi
 
 log_info "Version changed: $PREVIOUS_VERSION -> $CURRENT_VERSION"
 set_github_output "unchanged" "false"
 set_github_output "should-tag" "true"
+set_github_output "tag-exists" "false"
 # Also echo to stdout for BATS test assertions
 echo "unchanged=false"
 echo "should-tag=true"
+echo "tag-exists=false"

--- a/scripts/ci/release/detect-previous-tag-version.sh
+++ b/scripts/ci/release/detect-previous-tag-version.sh
@@ -24,7 +24,7 @@ source "$LIB_DIR/git.sh"
 : "${TAG_PREFIX:=v}"
 
 pattern="${TAG_PREFIX}*"
-tag="$(get_latest_tag "$pattern" || true)"
+tag="$(get_tags "$pattern" | head -1 || true)"
 
 if [[ -z "$tag" ]]; then
 	log_info "No tag found matching pattern: $pattern"

--- a/scripts/ci/release/detect-previous-tag-version.sh
+++ b/scripts/ci/release/detect-previous-tag-version.sh
@@ -24,7 +24,7 @@ source "$LIB_DIR/git.sh"
 : "${TAG_PREFIX:=v}"
 
 pattern="${TAG_PREFIX}*"
-tag="$(get_tags "$pattern" | head -1 || true)"
+tag="$(get_latest_reachable_tag "$pattern" || true)"
 
 if [[ -z "$tag" ]]; then
 	log_info "No tag found matching pattern: $pattern"

--- a/scripts/ci/release/write-skip-summary.sh
+++ b/scripts/ci/release/write-skip-summary.sh
@@ -8,6 +8,7 @@
 #   IS_RELEASE - Whether the last commit was a release commit (default: 'false')
 #   VERSION_FOUND - Whether a version was resolved (default: 'false')
 #   VERSION_UNCHANGED - Whether version matches the latest tag (default: 'false')
+#   TAG_EXISTS        - Whether the target tag already exists (default: 'false')
 
 set -euo pipefail
 
@@ -21,10 +22,13 @@ source "$LIB_DIR/github.sh"
 : "${IS_RELEASE:=false}"
 : "${VERSION_FOUND:=false}"
 : "${VERSION_UNCHANGED:=false}"
+: "${TAG_EXISTS:=false}"
 
 add_github_summary "## Auto Tag Summary"
 add_github_summary ""
-if [[ "$VERSION_UNCHANGED" == "true" ]]; then
+if [[ "$TAG_EXISTS" == "true" ]]; then
+	add_github_summary "Skipped: tag already exists"
+elif [[ "$VERSION_UNCHANGED" == "true" ]]; then
 	add_github_summary "Skipped: version unchanged since last tag"
 elif [[ "$VERSION_FOUND" != "true" ]]; then
 	if [[ "$IS_RELEASE" != "true" ]]; then
@@ -33,5 +37,5 @@ elif [[ "$VERSION_FOUND" != "true" ]]; then
 		add_github_summary "Skipped: version not found"
 	fi
 else
-	add_github_summary "Skipped: unexpected auto-tag skip state (IS_RELEASE=$IS_RELEASE, VERSION_FOUND=$VERSION_FOUND, VERSION_UNCHANGED=$VERSION_UNCHANGED)"
+	add_github_summary "Skipped: unexpected auto-tag skip state (IS_RELEASE=$IS_RELEASE, VERSION_FOUND=$VERSION_FOUND, VERSION_UNCHANGED=$VERSION_UNCHANGED, TAG_EXISTS=$TAG_EXISTS)"
 fi

--- a/tests/bats/integration/test_check_version_unchanged.bats
+++ b/tests/bats/integration/test_check_version_unchanged.bats
@@ -61,5 +61,6 @@ run_check() {
 	run_check "1.2.0" "1.0.0"
 	assert_success
 	assert_line --partial "should-tag=false"
-	assert_line --partial "unchanged=true"
+	assert_line --partial "unchanged=false"
+	assert_line --partial "tag-exists=true"
 }

--- a/tests/bats/integration/test_detect_previous_tag_version.bats
+++ b/tests/bats/integration/test_detect_previous_tag_version.bats
@@ -64,3 +64,18 @@ run_detect() {
 	assert_line --partial "version=2.0.0"
 	assert_line --partial "found=true"
 }
+
+@test "detect-previous-tag-version: selects highest semver, not git describe order" {
+	setup_mock_git_repo
+	(
+		cd "$MOCK_GIT_REPO"
+		git tag "v1.0.0"
+		git tag "v1.2.0"
+		git tag "v1.2.1"
+	)
+
+	run_detect
+	assert_success
+	assert_line --partial "version=1.2.1"
+	assert_line --partial "found=true"
+}

--- a/tests/bats/integration/test_detect_previous_tag_version.bats
+++ b/tests/bats/integration/test_detect_previous_tag_version.bats
@@ -79,3 +79,22 @@ run_detect() {
 	assert_line --partial "version=1.2.1"
 	assert_line --partial "found=true"
 }
+
+@test "detect-previous-tag-version: ignores unreachable higher semver tags" {
+	setup_mock_git_repo
+	(
+		cd "$MOCK_GIT_REPO"
+		git tag "v1.2.1"
+		git checkout -q -b release/2.0
+		echo "release" >>README.md
+		git add README.md
+		git commit -q -m "Release prep"
+		git tag "v2.0.0-rc.1"
+		git checkout -q -
+	)
+
+	run_detect
+	assert_success
+	assert_line --partial "version=1.2.1"
+	assert_line --partial "found=true"
+}

--- a/tests/bats/integration/test_write_skip_summary.bats
+++ b/tests/bats/integration/test_write_skip_summary.bats
@@ -44,3 +44,31 @@ run_skip_summary() {
 	run cat "$GITHUB_STEP_SUMMARY"
 	assert_output --partial "Skipped: version unchanged since last tag"
 }
+
+@test "write-skip-summary: reports non-release commit when version not found" {
+	run_skip_summary "false" "false" "false" "false"
+	assert_success
+	run cat "$GITHUB_STEP_SUMMARY"
+	assert_output --partial "Skipped: last commit is not a release commit"
+}
+
+@test "write-skip-summary: reports version not found on release commit" {
+	run_skip_summary "false" "false" "false" "true"
+	assert_success
+	run cat "$GITHUB_STEP_SUMMARY"
+	assert_output --partial "Skipped: version not found"
+}
+
+@test "write-skip-summary: reports unexpected skip state" {
+	run_skip_summary "false" "false" "true" "true"
+	assert_success
+	run cat "$GITHUB_STEP_SUMMARY"
+	assert_output --partial "Skipped: unexpected auto-tag skip state"
+}
+
+@test "write-skip-summary: tag already exists takes precedence over version unchanged" {
+	run_skip_summary "true" "true" "true" "true"
+	assert_success
+	run cat "$GITHUB_STEP_SUMMARY"
+	assert_output --partial "Skipped: tag already exists"
+}

--- a/tests/bats/integration/test_write_skip_summary.bats
+++ b/tests/bats/integration/test_write_skip_summary.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Integration tests for scripts/ci/release/write-skip-summary.sh
+
+load "../../helpers/common"
+load "../../helpers/github_env"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+	export PROJECT_ROOT
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+run_skip_summary() {
+	local tag_exists="${1:-false}"
+	local version_unchanged="${2:-false}"
+	local version_found="${3:-true}"
+	local is_release="${4:-true}"
+	run bash -c "
+		export GITHUB_STEP_SUMMARY='$GITHUB_STEP_SUMMARY'
+		export TAG_EXISTS='$tag_exists'
+		export VERSION_UNCHANGED='$version_unchanged'
+		export VERSION_FOUND='$version_found'
+		export IS_RELEASE='$is_release'
+		'$PROJECT_ROOT/scripts/ci/release/write-skip-summary.sh' 2>&1
+	"
+}
+
+@test "write-skip-summary: reports tag already exists" {
+	run_skip_summary "true" "false" "true" "true"
+	assert_success
+	run cat "$GITHUB_STEP_SUMMARY"
+	assert_output --partial "Skipped: tag already exists"
+}
+
+@test "write-skip-summary: reports version unchanged" {
+	run_skip_summary "false" "true" "true" "true"
+	assert_success
+	run cat "$GITHUB_STEP_SUMMARY"
+	assert_output --partial "Skipped: version unchanged since last tag"
+}

--- a/tests/bats/unit/lib/test_git.bats
+++ b/tests/bats/unit/lib/test_git.bats
@@ -303,6 +303,34 @@ teardown() {
 }
 
 # =============================================================================
+# get_latest_reachable_tag tests
+# =============================================================================
+
+@test "get_latest_reachable_tag: returns highest semver among reachable tags" {
+	cd "$MOCK_GIT_REPO"
+	git tag v1.0.0
+	git tag v1.2.0
+	git tag v1.2.1
+	run bash -c 'source "$LIB_DIR/git.sh" && get_latest_reachable_tag "v*"'
+	assert_success
+	assert_output "v1.2.1"
+}
+
+@test "get_latest_reachable_tag: ignores unreachable higher semver tags" {
+	cd "$MOCK_GIT_REPO"
+	git tag v1.2.1
+	git checkout -q -b release/2.0
+	echo "release" >>README.md
+	git add README.md
+	git commit -q -m "Release prep"
+	git tag v2.0.0-rc.1
+	git checkout -q -
+	run bash -c 'source "$LIB_DIR/git.sh" && get_latest_reachable_tag "v*"'
+	assert_success
+	assert_output "v1.2.1"
+}
+
+# =============================================================================
 # tag_exists tests
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Document CodeQL `build-mode` selection for interpreted vs compiled languages and
clarify the action-only reusable contract (`tooling-ref` pins egress composites
only). Also fixes Cargo auto-tag skip semantics surfaced during review: tag-exists
no longer sets `unchanged=true`, baseline tag lookup uses semver order, and skip
summaries report the correct reason.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #209

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document CodeQL build-mode and action-only reusable workflow contracts in CI
> - Expands documentation in [`docs/reusable-workflows.md`](https://github.com/lgtm-hq/lgtm-ci/pull/321/files#diff-3065010f73cb977ea6196048bf72137713f96a721704c83feab3b5e53216f40b) and [`docs/workflow-contract.md`](https://github.com/lgtm-hq/lgtm-ci/pull/321/files#diff-516a439fe86a0212ef098570637d887a6ef2bb796c179416edee44bc92be0a5f) to clarify `tooling-ref` behavior, distinguish script-backed vs action-only reusables, and add CodeQL `build-mode` guidance by language class.
> - Updates `tooling-ref` input descriptions across reusable workflows to accurately reflect that action-only workflows only pin egress composites and default to the caller workflow SHA.
> - Adds `git.get_latest_reachable_tag` to [`scripts/ci/lib/git.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/321/files#diff-42890413b28d2cbda9fe32f5af6c52cc309c8fc95f6b69918b2f4eb8c67859d9), returning the highest semver tag reachable from HEAD rather than the nearest tag per `git describe`.
> - Updates [`scripts/ci/release/check-version-unchanged.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/321/files#diff-4dedec5b437e9f7b1738156e188c5d0068d866f70cb18299a92c0d697c12c7b2) to emit a `tag-exists` output and set `unchanged=false` when the target tag already exists, allowing callers to differentiate that case from a truly unchanged version.
> - Updates [`scripts/ci/release/detect-previous-tag-version.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/321/files#diff-1298b483c6d0f83dbc77839e207f5cf234f9ae88d38a9ad880186deb14efccfd) and [`scripts/ci/release/write-skip-summary.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/321/files#diff-31ee44210df9059b55ef3d32fc5bb2df33a342605df57aec84cc5ec67ec90a17) to use the new reachable-tag logic and surface tag-exists state in the GitHub step summary.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2194a47.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified workflow input descriptions for tooling-ref and build-mode across reusable workflows; added guidance and examples for action-only vs script-backed reusables and compiled-language build modes.

* **Bug Fixes**
  * Release tagging improved to detect existing tags and avoid duplicate tagging; added semver-aware previous-tag resolution and a new skip-state (tag exists) in auto-tag summaries.

* **Tests**
  * Added and expanded integration/unit tests covering release detection, skip-summary behavior, and tag-resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR documents CodeQL `build-mode` selection (interpreted vs. compiled languages) and the action-only reusable contract (`tooling-ref` pins egress composites only), and fixes three related bugs in the Cargo auto-tag `skip-if-unchanged` path.

- **`check-version-unchanged.sh`**: `tag-exists` is now a distinct output; when the target tag already exists the script emits `unchanged=false, tag-exists=true` instead of the misleading `unchanged=true`, and `write-skip-summary.sh` prioritises this new flag so the step summary correctly reads \"Skipped: tag already exists\" rather than \"Skipped: version unchanged since last tag\".
- **`detect-previous-tag-version.sh`**: Switches from `get_latest_tag` (nearest ancestor in commit graph) to the new `get_latest_reachable_tag` helper (`git tag --merged HEAD --sort=-v:refname`), which returns the highest semver reachable from HEAD and ignores pre-release tags on unmerged branches.
- **Tests**: `test_write_skip_summary.bats` is new and covers all five branches; unit and integration tests for `get_latest_reachable_tag` validate both semver ordering and cross-branch filtering.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are well-scoped bug fixes with full test coverage and documentation improvements only.

The auto-tag logic changes are isolated to the `skip-if-unchanged` path, gating conditions in the workflow are unchanged (all guard on `should-tag`), and the new `tag-exists` signal degrades gracefully to `false` when the step doesn't run. All five branches of `write-skip-summary.sh` are now tested, and the `get_latest_reachable_tag` switch is covered by both unit and integration tests including the cross-branch case.

No files require special attention. The three pre-existing test cases in `test_check_version_unchanged.bats` could gain `tag-exists=false` assertions to fully pin the new output contract, but this is non-blocking.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/release/check-version-unchanged.sh | Adds `tag-exists` output and correctly flips `unchanged` to `false` when the target tag already exists, fixing the misleading skip-reason that was previously reported. |
| scripts/ci/release/write-skip-summary.sh | Adds `TAG_EXISTS` branch with correct precedence over `VERSION_UNCHANGED`; defaults safely when the `unchanged` step did not run (empty string → false). |
| scripts/ci/lib/git.sh | Adds `get_latest_reachable_tag` using `git tag --merged HEAD`, correctly restricting to reachable tags and sorting by semver; exports the new function alongside existing ones. |
| scripts/ci/release/detect-previous-tag-version.sh | Switches from `get_latest_tag` (graph-proximity order) to `get_latest_reachable_tag` (semver-sorted, reachable-only), fixing the pre-release tag on a divergent branch issue surfaced in review. |
| .github/workflows/reusable-release-auto-tag.yml | Wires `TAG_EXISTS: ${{ steps.unchanged.outputs.tag-exists }}` into the Skip summary step env; all gating conditions on `should-tag` remain unchanged and correct. |
| tests/bats/integration/test_write_skip_summary.bats | New test file covering all 5 branches plus a precedence test (TAG_EXISTS over VERSION_UNCHANGED); fully addresses the previously-noted coverage gap. |
| tests/bats/integration/test_check_version_unchanged.bats | Updates existing tag-exists test to assert `unchanged=false` and `tag-exists=true`; existing tests for non-tag-exists paths do not assert `tag-exists=false` on the new output. |
| docs/reusable-workflows.md | Adds CodeQL build-mode table (correctly placing Go under `none`), action-only vs script-backed distinction, and worked examples for Python and Java callers. |
| docs/workflow-contract.md | New "Action-only reusables" section with table and per-workflow `tooling-ref` semantics is accurate and consistent with the YAML changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[check-version-unchanged.sh] -->|tag_exists target_tag?| B{Tag exists?}
    B -->|yes| C[unchanged=false\nshould-tag=false\ntag-exists=true]
    B -->|no| D{PREVIOUS_VERSION empty?}
    D -->|yes| E[unchanged=false\nshould-tag=true\ntag-exists=false]
    D -->|no| F{CURRENT == PREVIOUS?}
    F -->|yes| G[unchanged=true\nshould-tag=false\ntag-exists=false]
    F -->|no| H[unchanged=false\nshould-tag=true\ntag-exists=false]

    C --> W[write-skip-summary.sh]
    G --> W

    W -->|TAG_EXISTS==true| S1[Skipped: tag already exists]
    W -->|VERSION_UNCHANGED==true| S2[Skipped: version unchanged since last tag]
    W -->|VERSION_FOUND!=true, IS_RELEASE!=true| S3[Skipped: last commit is not a release commit]
    W -->|VERSION_FOUND!=true, IS_RELEASE==true| S4[Skipped: version not found]
    W -->|fallthrough| S5[Skipped: unexpected auto-tag skip state]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fbats%2Fintegration%2Ftest_check_version_unchanged.bats%3A34-53%0AThe%20three%20pre-existing%20test%20cases%20don't%20assert%20%60tag-exists%3Dfalse%60%20on%20the%20new%20output.%20If%20the%20script%20ever%20accidentally%20emits%20%60tag-exists%3Dtrue%60%20in%20these%20paths%2C%20the%20tests%20would%20still%20pass.%20Adding%20the%20assertion%20makes%20the%20output%20contract%20explicit.%0A%0A%60%60%60suggestion%0A%40test%20%22check-version-unchanged%3A%20tags%20when%20no%20previous%20version%20exists%22%20%7B%0A%09run_check%20%221.0.0%22%0A%09assert_success%0A%09assert_line%20--partial%20%22should-tag%3Dtrue%22%0A%09assert_line%20--partial%20%22unchanged%3Dfalse%22%0A%09assert_line%20--partial%20%22tag-exists%3Dfalse%22%0A%7D%0A%0A%40test%20%22check-version-unchanged%3A%20skips%20when%20versions%20match%22%20%7B%0A%09run_check%20%221.0.0%22%20%221.0.0%22%0A%09assert_success%0A%09assert_line%20--partial%20%22should-tag%3Dfalse%22%0A%09assert_line%20--partial%20%22unchanged%3Dtrue%22%0A%09assert_line%20--partial%20%22tag-exists%3Dfalse%22%0A%7D%0A%0A%40test%20%22check-version-unchanged%3A%20tags%20when%20versions%20differ%22%20%7B%0A%09run_check%20%221.1.0%22%20%221.0.0%22%0A%09assert_success%0A%09assert_line%20--partial%20%22should-tag%3Dtrue%22%0A%09assert_line%20--partial%20%22unchanged%3Dfalse%22%0A%09assert_line%20--partial%20%22tag-exists%3Dfalse%22%0A%7D%0A%60%60%60%0A%0A&pr=321&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fbats%2Fintegration%2Ftest_check_version_unchanged.bats%3A34-53%0AThe%20three%20pre-existing%20test%20cases%20don't%20assert%20%60tag-exists%3Dfalse%60%20on%20the%20new%20output.%20If%20the%20script%20ever%20accidentally%20emits%20%60tag-exists%3Dtrue%60%20in%20these%20paths%2C%20the%20tests%20would%20still%20pass.%20Adding%20the%20assertion%20makes%20the%20output%20contract%20explicit.%0A%0A%60%60%60suggestion%0A%40test%20%22check-version-unchanged%3A%20tags%20when%20no%20previous%20version%20exists%22%20%7B%0A%09run_check%20%221.0.0%22%0A%09assert_success%0A%09assert_line%20--partial%20%22should-tag%3Dtrue%22%0A%09assert_line%20--partial%20%22unchanged%3Dfalse%22%0A%09assert_line%20--partial%20%22tag-exists%3Dfalse%22%0A%7D%0A%0A%40test%20%22check-version-unchanged%3A%20skips%20when%20versions%20match%22%20%7B%0A%09run_check%20%221.0.0%22%20%221.0.0%22%0A%09assert_success%0A%09assert_line%20--partial%20%22should-tag%3Dfalse%22%0A%09assert_line%20--partial%20%22unchanged%3Dtrue%22%0A%09assert_line%20--partial%20%22tag-exists%3Dfalse%22%0A%7D%0A%0A%40test%20%22check-version-unchanged%3A%20tags%20when%20versions%20differ%22%20%7B%0A%09run_check%20%221.1.0%22%20%221.0.0%22%0A%09assert_success%0A%09assert_line%20--partial%20%22should-tag%3Dtrue%22%0A%09assert_line%20--partial%20%22unchanged%3Dfalse%22%0A%09assert_line%20--partial%20%22tag-exists%3Dfalse%22%0A%7D%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=321&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22docs%2F209-document-codeql-build-mode-action-only-contracts%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2F209-document-codeql-build-mode-action-only-contracts%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fbats%2Fintegration%2Ftest_check_version_unchanged.bats%3A34-53%0AThe%20three%20pre-existing%20test%20cases%20don't%20assert%20%60tag-exists%3Dfalse%60%20on%20the%20new%20output.%20If%20the%20script%20ever%20accidentally%20emits%20%60tag-exists%3Dtrue%60%20in%20these%20paths%2C%20the%20tests%20would%20still%20pass.%20Adding%20the%20assertion%20makes%20the%20output%20contract%20explicit.%0A%0A%60%60%60suggestion%0A%40test%20%22check-version-unchanged%3A%20tags%20when%20no%20previous%20version%20exists%22%20%7B%0A%09run_check%20%221.0.0%22%0A%09assert_success%0A%09assert_line%20--partial%20%22should-tag%3Dtrue%22%0A%09assert_line%20--partial%20%22unchanged%3Dfalse%22%0A%09assert_line%20--partial%20%22tag-exists%3Dfalse%22%0A%7D%0A%0A%40test%20%22check-version-unchanged%3A%20skips%20when%20versions%20match%22%20%7B%0A%09run_check%20%221.0.0%22%20%221.0.0%22%0A%09assert_success%0A%09assert_line%20--partial%20%22should-tag%3Dfalse%22%0A%09assert_line%20--partial%20%22unchanged%3Dtrue%22%0A%09assert_line%20--partial%20%22tag-exists%3Dfalse%22%0A%7D%0A%0A%40test%20%22check-version-unchanged%3A%20tags%20when%20versions%20differ%22%20%7B%0A%09run_check%20%221.1.0%22%20%221.0.0%22%0A%09assert_success%0A%09assert_line%20--partial%20%22should-tag%3Dtrue%22%0A%09assert_line%20--partial%20%22unchanged%3Dfalse%22%0A%09assert_line%20--partial%20%22tag-exists%3Dfalse%22%0A%7D%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=321&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(release): restrict tag baseline to r..."](https://github.com/lgtm-hq/lgtm-ci/commit/2194a47c68e9091060126594525a5948fd6c492c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36105046)</sub>

<!-- /greptile_comment -->