### PR TITLE
feat(ci): add per-language CodeQL build modes to reusable-codeql

### DIFF
--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -11,29 +11,35 @@ on:
         default: ""
       build-mode:
         description: >-
-          CodeQL build mode. Use none (default) for languages with
-          direct-source extraction (python, javascript-typescript, ruby, go,
-          etc.). Use autobuild for languages that require build observation
-          (c-cpp, csharp, java, etc.) or manual with explicit build steps.
-          Python does not support autobuild.
+          Default CodeQL build mode when language-build-modes omits a language:
+          none, autobuild, or manual
         required: false
         type: string
         default: "none"
+      language-build-modes:
+        description: >-
+          JSON object mapping language to build-mode (e.g.
+          {"rust":"autobuild","actions":"none"}). Each language runs in its own
+          matrix leg so mixed compiled/interpreted repos can scan without a
+          single global build-mode.
+        required: false
+        type: string
+        default: ""
       config-file:
         description: "Optional CodeQL config file path"
         required: false
         type: string
         default: ""
       category:
-        description: "SARIF category for results"
+        description: >-
+          SARIF category for results. When empty, each matrix leg uses
+          /language:<language>
         required: false
         type: string
         default: ""
 
       tooling-ref:
-        description: >-
-          Optional — pins egress composites only (no scripts/ci checkout).
-          Defaults to caller workflow SHA.
+        description: "Git ref for lgtm-ci tooling and composite actions"
         required: false
         type: string
         default: ""
@@ -72,12 +78,62 @@ on:
         default: "CodeQL"
 
 jobs:
+  setup:
+    name: Setup CodeQL matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+
+    steps:
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+            scripts/ci/actions/generate-codeql-matrix.sh
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+
+      - name: Generate CodeQL matrix
+        id: matrix
+        shell: bash
+        env:
+          LANGUAGES: ${{ inputs.languages }}
+          BUILD_MODE: ${{ inputs.build-mode }}
+          LANGUAGE_BUILD_MODES: ${{ inputs.language-build-modes }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/generate-codeql-matrix.sh
+
   codeql:
     name: ${{ inputs.job-name }}
+    needs: setup
     runs-on: ubuntu-latest
     permissions:
       contents: read
       security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
 
     steps:
       - name: Checkout repository
@@ -114,31 +170,34 @@ jobs:
           allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Initialize CodeQL
-        if: inputs.config-file == '' && inputs.languages != ''
+        if: inputs.config-file == '' && matrix.language != ''
         uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
-          languages: ${{ inputs.languages }}
-          build-mode: ${{ inputs.build-mode }}
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
 
       - name: Initialize CodeQL with auto-detected languages
-        if: inputs.config-file == '' && inputs.languages == ''
+        if: inputs.config-file == '' && matrix.language == ''
         uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
-          build-mode: ${{ inputs.build-mode }}
+          build-mode: ${{ matrix.build-mode }}
 
       - name: Initialize CodeQL with config
         if: inputs.config-file != ''
         uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
-          languages: ${{ inputs.languages }}
-          build-mode: ${{ inputs.build-mode }}
+          languages: ${{ matrix.language != '' && matrix.language || inputs.languages }}
+          build-mode: ${{ matrix.build-mode }}
           config-file: ${{ inputs.config-file }}
 
       - name: Autobuild
-        if: inputs.build-mode == 'autobuild'
+        if: matrix.build-mode == 'autobuild'
         uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
 
       - name: Analyze
         uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
-          category: ${{ inputs.category }}
+          category: >-
+            ${{ inputs.category != '' && inputs.category
+            || (matrix.language != '' && format('/language:{0}', matrix.language)
+            || '') }}

--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -97,7 +97,7 @@ jobs:
           sparse-checkout: |
             .github/actions/harden-runner
             .github/actions/resolve-egress-allowlist
-            scripts/ci/actions/generate-codeql-matrix.sh
+            scripts/ci/actions/
           sparse-checkout-cone-mode: true
           persist-credentials: false
 

--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -81,6 +81,8 @@ jobs:
   setup:
     name: Setup CodeQL matrix
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
 

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -756,6 +756,36 @@ jobs:
       build-mode: autobuild
 ```
 
+**Multi-language caller** — when languages need different build modes (for example
+Rust plus GitHub Actions), pass `language-build-modes` as a JSON object. The
+reusable runs one matrix leg per language so `init` receives the correct
+`build-mode` for each extractor (do **not** rely on a single global
+`build-mode` across mixed language classes):
+
+```yaml
+jobs:
+  codeql:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-codeql.yml@<sha>
+    permissions:
+      contents: read
+      security-events: write
+    with:
+      languages: rust,actions
+      language-build-modes: '{"rust":"autobuild","actions":"none"}'
+      egress-policy: block
+      allowed-endpoints-mode: append
+      allowed-endpoints: |
+        static.rust-lang.org:443
+        sh.rustup.rs:443
+        crates.io:443
+        static.crates.io:443
+        index.crates.io:443
+```
+
+When `category` is omitted, each matrix leg uploads SARIF under
+`/language:<language>`. Pass `category` explicitly to override all legs (for
+example `/language:all` on a single-language scan).
+
 See [CodeQL workflow configuration — build modes](https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options)
 and [workflow-contract.md](workflow-contract.md#action-only-reusables) for the
 action-only contract (`tooling-ref` optional).

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -45,8 +45,14 @@ should pin the workflow ref to a commit SHA and pass the same ref as
 `tooling-ref` on script-backed workflows.
 
 **Action-only reusables** (labeler, dependency review, semantic PR title,
-CodeQL, Scorecard) do not run `scripts/ci/`; `tooling-ref` is optional and
-only pins egress composites. See
+CodeQL, Scorecard) do not run the full `scripts/ci/` suite in their analysis
+jobs; `tooling-ref` is optional and primarily pins egress composites.
+**`reusable-codeql.yml`** is an exception when callers pass `languages` or
+`language-build-modes`: its setup job sparse-checkouts
+`scripts/ci/actions/generate-codeql-matrix.sh` to build per-language matrix
+legs. Each leg still uses `github/codeql-action/*` with the resolved
+`build-mode` — not caller repo scripts. Pass `tooling-ref` when testing
+unreleased matrix-generator changes. See
 [workflow-contract.md](workflow-contract.md#action-only-reusables).
 
 Consumers do **not** need to vendor `.github/actions/harden-runner` or
@@ -786,6 +792,11 @@ When `category` is omitted, each matrix leg uploads SARIF under
 `/language:<language>`. Pass `category` explicitly to override all legs (for
 example `/language:all` on a single-language scan).
 
+Pin the workflow `uses:` ref to a commit SHA in production. `tooling-ref` is
+optional for egress composites only on single-language scans; for multi-language
+callers, pass a matching `tooling-ref` when testing unreleased
+`generate-codeql-matrix.sh` changes so the setup job and analysis legs stay
+aligned.
+
 See [CodeQL workflow configuration — build modes](https://docs.github.com/en/code-security/reference/code-scanning/workflow-configuration-options)
-and [workflow-contract.md](workflow-contract.md#action-only-reusables) for the
-action-only contract (`tooling-ref` optional).
+and [workflow-contract.md](workflow-contract.md#action-only-reusables).

--- a/scripts/ci/actions/generate-codeql-matrix.sh
+++ b/scripts/ci/actions/generate-codeql-matrix.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Generate a GitHub Actions matrix for per-language CodeQL build modes.
+
+set -euo pipefail
+
+: "${LANGUAGES:=}"
+: "${BUILD_MODE:=none}"
+: "${LANGUAGE_BUILD_MODES:=}"
+
+python3 - <<'PY'
+import json
+import os
+import sys
+
+github_output = os.environ.get("GITHUB_OUTPUT")
+if not github_output:
+    print("GITHUB_OUTPUT is required", file=sys.stderr)
+    sys.exit(1)
+
+raw_languages = os.environ.get("LANGUAGES", "").strip()
+default_build_mode = os.environ.get("BUILD_MODE", "none").strip() or "none"
+raw_build_modes = os.environ.get("LANGUAGE_BUILD_MODES", "").strip()
+
+per_language_modes: dict[str, str] = {}
+if raw_build_modes:
+    try:
+        parsed = json.loads(raw_build_modes)
+    except json.JSONDecodeError as exc:
+        print(f"LANGUAGE_BUILD_MODES must be valid JSON: {exc}", file=sys.stderr)
+        sys.exit(1)
+    if not isinstance(parsed, dict):
+        print("LANGUAGE_BUILD_MODES must be a JSON object", file=sys.stderr)
+        sys.exit(1)
+    for language, mode in parsed.items():
+        if not isinstance(language, str) or not language.strip():
+            print("LANGUAGE_BUILD_MODES keys must be non-empty strings", file=sys.stderr)
+            sys.exit(1)
+        if not isinstance(mode, str) or not mode.strip():
+            print(
+                f"LANGUAGE_BUILD_MODES[{language!r}] must be a non-empty string",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        per_language_modes[language.strip()] = mode.strip()
+
+valid_modes = {"none", "autobuild", "manual"}
+
+def resolve_mode(language: str) -> str:
+    mode = per_language_modes.get(language, default_build_mode)
+    if mode not in valid_modes:
+        print(
+            f"Invalid build-mode {mode!r} for language {language!r}; "
+            f"expected one of {sorted(valid_modes)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return mode
+
+if raw_languages:
+    languages = list(
+        dict.fromkeys(
+            language.strip()
+            for language in raw_languages.split(",")
+            if language.strip()
+        )
+    )
+    if not languages:
+        print("LANGUAGES must list at least one language when non-empty", file=sys.stderr)
+        sys.exit(1)
+    matrix = {
+        "include": [
+            {"language": language, "build-mode": resolve_mode(language)}
+            for language in languages
+        ]
+    }
+else:
+    if default_build_mode not in valid_modes:
+        print(
+            f"Invalid BUILD_MODE {default_build_mode!r}; "
+            f"expected one of {sorted(valid_modes)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    matrix = {"include": [{"language": "", "build-mode": default_build_mode}]}
+
+with open(github_output, "a", encoding="utf-8") as output:
+    output.write(f"matrix={json.dumps(matrix, separators=(',', ':'))}\n")
+
+if raw_languages:
+    summary = ", ".join(
+        f"{entry['language']}:{entry['build-mode']}" for entry in matrix["include"]
+    )
+else:
+    summary = f"auto-detect:{default_build_mode}"
+print(f"CodeQL matrix: {summary}")
+PY

--- a/scripts/ci/actions/generate-codeql-matrix.sh
+++ b/scripts/ci/actions/generate-codeql-matrix.sh
@@ -22,8 +22,14 @@ raw_languages = os.environ.get("LANGUAGES", "").strip()
 default_build_mode = os.environ.get("BUILD_MODE", "none").strip() or "none"
 raw_build_modes = os.environ.get("LANGUAGE_BUILD_MODES", "").strip()
 
-per_language_modes: dict[str, str] = {}
-if raw_build_modes:
+valid_modes = {"none", "autobuild", "manual"}
+
+
+def parse_build_modes(allowed_languages: set[str] | None) -> dict[str, str]:
+    per_language_modes: dict[str, str] = {}
+    if not raw_build_modes:
+        return per_language_modes
+
     try:
         parsed = json.loads(raw_build_modes)
     except json.JSONDecodeError as exc:
@@ -32,6 +38,7 @@ if raw_build_modes:
     if not isinstance(parsed, dict):
         print("LANGUAGE_BUILD_MODES must be a JSON object", file=sys.stderr)
         sys.exit(1)
+
     for language, mode in parsed.items():
         if not isinstance(language, str) or not language.strip():
             print("LANGUAGE_BUILD_MODES keys must be non-empty strings", file=sys.stderr)
@@ -42,9 +49,19 @@ if raw_build_modes:
                 file=sys.stderr,
             )
             sys.exit(1)
-        per_language_modes[language.strip()] = mode.strip()
 
-valid_modes = {"none", "autobuild", "manual"}
+        language_key = language.strip()
+        if allowed_languages is not None and language_key not in allowed_languages:
+            print(
+                f"LANGUAGE_BUILD_MODES contains unknown language {language_key!r}; "
+                f"expected one of {sorted(allowed_languages)}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        per_language_modes[language_key] = mode.strip()
+
+    return per_language_modes
 
 def resolve_mode(language: str) -> str:
     mode = per_language_modes.get(language, default_build_mode)
@@ -68,6 +85,9 @@ if raw_languages:
     if not languages:
         print("LANGUAGES must list at least one language when non-empty", file=sys.stderr)
         sys.exit(1)
+
+    per_language_modes = parse_build_modes(set(languages))
+
     matrix = {
         "include": [
             {"language": language, "build-mode": resolve_mode(language)}

--- a/scripts/ci/actions/generate-codeql-matrix.sh
+++ b/scripts/ci/actions/generate-codeql-matrix.sh
@@ -75,6 +75,13 @@ if raw_languages:
         ]
     }
 else:
+    if raw_build_modes:
+        print(
+            "LANGUAGE_BUILD_MODES requires LANGUAGES; "
+            "per-language build modes cannot be applied during auto-detect",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     if default_build_mode not in valid_modes:
         print(
             f"Invalid BUILD_MODE {default_build_mode!r}; "

--- a/tests/bats/unit/actions/test_generate_codeql_matrix.bats
+++ b/tests/bats/unit/actions/test_generate_codeql_matrix.bats
@@ -109,3 +109,25 @@ teardown() {
 	assert_failure
 	assert_output --partial "Invalid build-mode"
 }
+
+@test "generate-codeql-matrix: rejects invalid mode in language-build-modes" {
+	run env \
+		LANGUAGES=rust \
+		BUILD_MODE=none \
+		LANGUAGE_BUILD_MODES='{"rust":"invalid"}' \
+		bash "$SCRIPT"
+
+	assert_failure
+	assert_output --partial "Invalid build-mode 'invalid' for language 'rust'"
+}
+
+@test "generate-codeql-matrix: rejects language-build-modes without languages" {
+	run env \
+		LANGUAGES="" \
+		BUILD_MODE=none \
+		LANGUAGE_BUILD_MODES='{"rust":"autobuild"}' \
+		bash "$SCRIPT"
+
+	assert_failure
+	assert_output --partial "LANGUAGE_BUILD_MODES requires LANGUAGES"
+}

--- a/tests/bats/unit/actions/test_generate_codeql_matrix.bats
+++ b/tests/bats/unit/actions/test_generate_codeql_matrix.bats
@@ -131,3 +131,14 @@ teardown() {
 	assert_failure
 	assert_output --partial "LANGUAGE_BUILD_MODES requires LANGUAGES"
 }
+
+@test "generate-codeql-matrix: rejects override keys outside LANGUAGES" {
+	run env \
+		LANGUAGES=rust \
+		BUILD_MODE=none \
+		LANGUAGE_BUILD_MODES='{"ruts":"autobuild"}' \
+		bash "$SCRIPT"
+
+	assert_failure
+	assert_output --partial "LANGUAGE_BUILD_MODES contains unknown language 'ruts'"
+}

--- a/tests/bats/unit/actions/test_generate_codeql_matrix.bats
+++ b/tests/bats/unit/actions/test_generate_codeql_matrix.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/generate-codeql-matrix.sh
+
+load "../../../helpers/common"
+
+setup() {
+	setup_temp_dir
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/github_output"
+	touch "$GITHUB_OUTPUT"
+	export SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/generate-codeql-matrix.sh"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "generate-codeql-matrix: single language uses default build-mode" {
+	run env LANGUAGES=python BUILD_MODE=none LANGUAGE_BUILD_MODES="" \
+		bash "$SCRIPT"
+
+	assert_success
+	assert_output --partial "CodeQL matrix: python:none"
+	assert_file_contains "$GITHUB_OUTPUT" \
+		'matrix=\{"include":\[\{"language":"python","build-mode":"none"\}\]\}'
+}
+
+@test "generate-codeql-matrix: comma-separated languages share default build-mode" {
+	run env LANGUAGES="java, kotlin" BUILD_MODE=autobuild LANGUAGE_BUILD_MODES="" \
+		bash "$SCRIPT"
+
+	assert_success
+	assert_output --partial "java:autobuild, kotlin:autobuild"
+	assert_file_contains "$GITHUB_OUTPUT" '"language":"java","build-mode":"autobuild"'
+	assert_file_contains "$GITHUB_OUTPUT" '"language":"kotlin","build-mode":"autobuild"'
+}
+
+@test "generate-codeql-matrix: language-build-modes overrides per language" {
+	run env \
+		LANGUAGES="rust,actions" \
+		BUILD_MODE=none \
+		LANGUAGE_BUILD_MODES='{"rust":"autobuild","actions":"none"}' \
+		bash "$SCRIPT"
+
+	assert_success
+	assert_output --partial "rust:autobuild, actions:none"
+	assert_file_contains "$GITHUB_OUTPUT" '"language":"rust","build-mode":"autobuild"'
+	assert_file_contains "$GITHUB_OUTPUT" '"language":"actions","build-mode":"none"'
+}
+
+@test "generate-codeql-matrix: partial language-build-modes falls back to default" {
+	run env \
+		LANGUAGES="rust,actions" \
+		BUILD_MODE=none \
+		LANGUAGE_BUILD_MODES='{"rust":"autobuild"}' \
+		bash "$SCRIPT"
+
+	assert_success
+	assert_file_contains "$GITHUB_OUTPUT" '"language":"rust","build-mode":"autobuild"'
+	assert_file_contains "$GITHUB_OUTPUT" '"language":"actions","build-mode":"none"'
+}
+
+@test "generate-codeql-matrix: empty languages emits auto-detect leg" {
+	run env LANGUAGES="" BUILD_MODE=none LANGUAGE_BUILD_MODES="" \
+		bash "$SCRIPT"
+
+	assert_success
+	assert_output --partial "CodeQL matrix: auto-detect:none"
+	assert_file_contains "$GITHUB_OUTPUT" \
+		'matrix=\{"include":\[\{"language":"","build-mode":"none"\}\]\}'
+}
+
+@test "generate-codeql-matrix: deduplicates languages" {
+	run env LANGUAGES="python,python,go" BUILD_MODE=none LANGUAGE_BUILD_MODES="" \
+		bash "$SCRIPT"
+
+	assert_success
+	assert_output --partial "CodeQL matrix: python:none, go:none"
+	assert_file_contains "$GITHUB_OUTPUT" \
+		'matrix=\{"include":\[\{"language":"python","build-mode":"none"\},\{"language":"go","build-mode":"none"\}\]\}'
+}
+
+@test "generate-codeql-matrix: fails without GITHUB_OUTPUT" {
+	run env -u GITHUB_OUTPUT LANGUAGES=python \
+		bash "$SCRIPT"
+
+	assert_failure
+	assert_output --partial "GITHUB_OUTPUT is required"
+}
+
+@test "generate-codeql-matrix: rejects invalid language-build-modes JSON" {
+	run env \
+		LANGUAGES=rust \
+		BUILD_MODE=none \
+		LANGUAGE_BUILD_MODES='not-json' \
+		bash "$SCRIPT"
+
+	assert_failure
+	assert_output --partial "LANGUAGE_BUILD_MODES must be valid JSON"
+}
+
+@test "generate-codeql-matrix: rejects invalid build-mode" {
+	run env \
+		LANGUAGES=python \
+		BUILD_MODE=invalid \
+		LANGUAGE_BUILD_MODES="" \
+		bash "$SCRIPT"
+
+	assert_failure
+	assert_output --partial "Invalid build-mode"
+}


### PR DESCRIPTION
## Summary

Implements issue #307 §1: `reusable-codeql` now supports per-language `build-mode`
via a `language-build-modes` JSON input and an internal matrix (one CodeQL leg per
language). Mixed repos such as Rust + GitHub Actions can scan without a single
global `build-mode` or inline init/autobuild/analyze steps.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None for existing single-language callers. Multi-language callers that previously
passed one `build-mode` for all languages should migrate to `language-build-modes`
when languages need different modes.

## Closes

- Relates to #307

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add per-language CodeQL build modes to reusable-codeql workflow
> - Adds a `setup` job to [reusable-codeql.yml](.github/workflows/reusable-codeql.yml) that runs [generate-codeql-matrix.sh](scripts/ci/actions/generate-codeql-matrix.sh) to produce a per-language matrix, then the `codeql` job fans out one leg per language with its resolved `build-mode`.
> - Adds a new `language-build-modes` workflow input accepting a JSON object (e.g. `{"go": "autobuild", "python": "none"}`) to override `build-mode` per language; languages not specified fall back to the global `build-mode` input.
> - When `category` is not set, SARIF uploads default to `/language:<language>` per matrix leg instead of a single upload.
> - The matrix generator validates all inputs (valid modes, JSON shape, override keys must be in `languages`) and is covered by a Bats test suite in [test_generate_codeql_matrix.bats](tests/bats/unit/actions/test_generate_codeql_matrix.bats).
> - Behavioral Change: callers relying on a single SARIF upload with no `category` set will now get per-language categorized uploads when `languages` or `language-build-modes` is provided.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 692a4b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Robust multi-language CodeQL matrix generation with per-language build-mode resolution and a dedicated setup step feeding the analysis job
  * Per-language SARIF categorization applied automatically when no category is supplied

* **Documentation**
  * Clarified behavior for build-mode, category, and tooling-ref; guidance for multi-language callers and pinning refs

* **Tests**
  * Added comprehensive unit tests for matrix generation, validation, and error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds per-language CodeQL build-mode support to `reusable-codeql.yml` by introducing a `setup` job that runs `generate-codeql-matrix.sh` to produce a per-language matrix, then running the `codeql` job as a matrix strategy with one leg per language.

- Adds `language-build-modes` JSON input and a `setup` job that validates inputs and emits a GitHub Actions matrix via an embedded Python script with solid error handling.
- Converts the `codeql` job to a matrix strategy (`fail-fast: false`), using `matrix.language` and `matrix.build-mode` instead of workflow-level inputs, with auto-detected SARIF categories per leg.
- Adds bats unit tests for the matrix generator and updates documentation with a multi-language caller example.
</details>

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is: converting the `codeql` job to a matrix strategy changes the GitHub check name for every existing caller, but the Breaking Changes section incorrectly states there is no impact on single-language callers.

The matrix strategy on the `codeql` job causes GitHub to append matrix variable values to the job name, so the check name changes from `CodeQL` to `CodeQL (python, none)` (or the caller's language and mode). This affects all callers — single-language and multi-language alike — and any branch protection rule or required-status-check keyed on the previous check name silently stops being satisfied after this change. The logic is otherwise well-structured with solid input validation, but the check-name breakage is a real regression for callers relying on stable check names.

`.github/workflows/reusable-codeql.yml` — the matrix strategy on the `codeql` job and its impact on GitHub check names needs to be resolved before merging.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-codeql.yml | Adds a `setup` job that generates a per-language matrix and converts `codeql` to a matrix job; the matrix strategy changes GitHub check names for all existing callers, which is not documented in Breaking Changes. |
| scripts/ci/actions/generate-codeql-matrix.sh | New script that embeds a Python 3 heredoc to validate inputs and emit a CodeQL matrix JSON; solid validation but `BUILD_MODE` is not validated when all languages have explicit `LANGUAGE_BUILD_MODES` overrides. |
| tests/bats/unit/actions/test_generate_codeql_matrix.bats | New bats unit tests covering valid paths, deduplication, partial overrides, auto-detect, and all major error cases for the matrix generator script. |
| docs/reusable-workflows.md | Documentation update that adds a multi-language caller example, clarifies `language-build-modes` semantics, and corrects `tooling-ref` guidance for the new setup job. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Caller Workflow
    participant Setup as setup job
    participant Script as generate-codeql-matrix.sh
    participant GHOUT as GITHUB_OUTPUT
    participant CodeQL as codeql job (matrix)

    Caller->>Setup: trigger with languages, build-mode, language-build-modes
    Setup->>Script: bash (env: LANGUAGES, BUILD_MODE, LANGUAGE_BUILD_MODES)
    Script->>Script: validate inputs, deduplicate languages
    Script->>GHOUT: matrix JSON with per-language build-mode entries
    Setup-->>CodeQL: outputs.matrix
    CodeQL->>CodeQL: "leg 1 - language=rust, build-mode=autobuild"
    CodeQL->>CodeQL: "leg 2 - language=actions, build-mode=none"
    CodeQL-->>Caller: "SARIF uploaded per /language:<language>"
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Freusable-codeql.yml%3A128-138%0A**Matrix%20strategy%20changes%20the%20GitHub%20check%20name%20for%20all%20callers**%0A%0AWhen%20a%20job%20has%20%60name%3A%20%24%7B%7B%20inputs.job-name%20%7D%7D%60%20and%20a%20%60strategy.matrix%60%2C%20GitHub%20Actions%20appends%20the%20matrix%20variable%20values%20in%20parentheses%2C%20producing%20check%20names%20like%20%60CodeQL%20%28python%2C%20none%29%60%20or%20%60CodeQL%20%28rust%2C%20autobuild%29%60%20instead%20of%20%60CodeQL%60.%20This%20happens%20even%20for%20single-entry%20matrices.%0A%0AAny%20caller%20with%20a%20branch%20protection%20rule%20requiring%20the%20%60CodeQL%60%20check%20%28the%20default%20%60job-name%60%29%20will%20silently%20break%20after%20this%20change%20%E2%80%94%20their%20required%20status%20check%20no%20longer%20exists.%20The%20PR's%20Breaking%20Changes%20section%20claims%20this%20is%20non-breaking%20for%20single-language%20callers%2C%20but%20the%20rename%20affects%20all%20callers%20regardless%20of%20how%20many%20languages%20they%20scan.%0A%0ATo%20make%20the%20check%20name%20predictable%20and%20stable%2C%20include%20the%20language%20in%20the%20explicit%20%60name%3A%60%20field%20so%20GitHub%20does%20not%20append%20extra%20context%2C%20for%20example%3A%20%60name%3A%20%24%7B%7B%20format%28'%7B0%7D%20%28%7B1%7D%29'%2C%20inputs.job-name%2C%20matrix.language%29%20%7D%7D%60.%20Callers%20who%20need%20a%20fixed%20check%20name%20can%20also%20add%20a%20dedicated%20%60name%60%20key%20to%20the%20matrix%20entries%20%28GitHub%20uses%20the%20matrix%20%60name%60%20key%20as-is%20without%20appending%20other%20values%29.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Factions%2Fgenerate-codeql-matrix.sh%3A97-112%0A**%60BUILD_MODE%60%20not%20validated%20when%20all%20languages%20have%20explicit%20overrides**%0A%0AWhen%20%60LANGUAGES%60%20is%20non-empty%20and%20%60LANGUAGE_BUILD_MODES%60%20provides%20an%20override%20for%20every%20language%20in%20the%20list%2C%20%60default_build_mode%60%20is%20never%20passed%20to%20%60resolve_mode%60%2C%20so%20its%20value%20is%20never%20checked%20against%20%60valid_modes%60.%20For%20example%2C%20%60LANGUAGES%3Drust%20BUILD_MODE%3Dinvalid%20LANGUAGE_BUILD_MODES%3D'%7B%22rust%22%3A%22autobuild%22%7D'%60%20succeeds%20silently.%20The%20validation%20in%20the%20%60else%60%20branch%20%28auto-detect%20path%29%20does%20not%20cover%20this%20case.%20Consider%20validating%20%60default_build_mode%60%20early%2C%20before%20the%20%60if%20raw_languages%3A%60%20branch%2C%20so%20an%20invalid%20default%20is%20always%20caught%20regardless%20of%20whether%20it%20is%20actually%20used.%0A%0A&pr=323&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Freusable-codeql.yml%3A128-138%0A**Matrix%20strategy%20changes%20the%20GitHub%20check%20name%20for%20all%20callers**%0A%0AWhen%20a%20job%20has%20%60name%3A%20%24%7B%7B%20inputs.job-name%20%7D%7D%60%20and%20a%20%60strategy.matrix%60%2C%20GitHub%20Actions%20appends%20the%20matrix%20variable%20values%20in%20parentheses%2C%20producing%20check%20names%20like%20%60CodeQL%20%28python%2C%20none%29%60%20or%20%60CodeQL%20%28rust%2C%20autobuild%29%60%20instead%20of%20%60CodeQL%60.%20This%20happens%20even%20for%20single-entry%20matrices.%0A%0AAny%20caller%20with%20a%20branch%20protection%20rule%20requiring%20the%20%60CodeQL%60%20check%20%28the%20default%20%60job-name%60%29%20will%20silently%20break%20after%20this%20change%20%E2%80%94%20their%20required%20status%20check%20no%20longer%20exists.%20The%20PR's%20Breaking%20Changes%20section%20claims%20this%20is%20non-breaking%20for%20single-language%20callers%2C%20but%20the%20rename%20affects%20all%20callers%20regardless%20of%20how%20many%20languages%20they%20scan.%0A%0ATo%20make%20the%20check%20name%20predictable%20and%20stable%2C%20include%20the%20language%20in%20the%20explicit%20%60name%3A%60%20field%20so%20GitHub%20does%20not%20append%20extra%20context%2C%20for%20example%3A%20%60name%3A%20%24%7B%7B%20format%28'%7B0%7D%20%28%7B1%7D%29'%2C%20inputs.job-name%2C%20matrix.language%29%20%7D%7D%60.%20Callers%20who%20need%20a%20fixed%20check%20name%20can%20also%20add%20a%20dedicated%20%60name%60%20key%20to%20the%20matrix%20entries%20%28GitHub%20uses%20the%20matrix%20%60name%60%20key%20as-is%20without%20appending%20other%20values%29.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Factions%2Fgenerate-codeql-matrix.sh%3A97-112%0A**%60BUILD_MODE%60%20not%20validated%20when%20all%20languages%20have%20explicit%20overrides**%0A%0AWhen%20%60LANGUAGES%60%20is%20non-empty%20and%20%60LANGUAGE_BUILD_MODES%60%20provides%20an%20override%20for%20every%20language%20in%20the%20list%2C%20%60default_build_mode%60%20is%20never%20passed%20to%20%60resolve_mode%60%2C%20so%20its%20value%20is%20never%20checked%20against%20%60valid_modes%60.%20For%20example%2C%20%60LANGUAGES%3Drust%20BUILD_MODE%3Dinvalid%20LANGUAGE_BUILD_MODES%3D'%7B%22rust%22%3A%22autobuild%22%7D'%60%20succeeds%20silently.%20The%20validation%20in%20the%20%60else%60%20branch%20%28auto-detect%20path%29%20does%20not%20cover%20this%20case.%20Consider%20validating%20%60default_build_mode%60%20early%2C%20before%20the%20%60if%20raw_languages%3A%60%20branch%2C%20so%20an%20invalid%20default%20is%20always%20caught%20regardless%20of%20whether%20it%20is%20actually%20used.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=323&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F307-per-language-codeql-build-modes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F307-per-language-codeql-build-modes%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Freusable-codeql.yml%3A128-138%0A**Matrix%20strategy%20changes%20the%20GitHub%20check%20name%20for%20all%20callers**%0A%0AWhen%20a%20job%20has%20%60name%3A%20%24%7B%7B%20inputs.job-name%20%7D%7D%60%20and%20a%20%60strategy.matrix%60%2C%20GitHub%20Actions%20appends%20the%20matrix%20variable%20values%20in%20parentheses%2C%20producing%20check%20names%20like%20%60CodeQL%20%28python%2C%20none%29%60%20or%20%60CodeQL%20%28rust%2C%20autobuild%29%60%20instead%20of%20%60CodeQL%60.%20This%20happens%20even%20for%20single-entry%20matrices.%0A%0AAny%20caller%20with%20a%20branch%20protection%20rule%20requiring%20the%20%60CodeQL%60%20check%20%28the%20default%20%60job-name%60%29%20will%20silently%20break%20after%20this%20change%20%E2%80%94%20their%20required%20status%20check%20no%20longer%20exists.%20The%20PR's%20Breaking%20Changes%20section%20claims%20this%20is%20non-breaking%20for%20single-language%20callers%2C%20but%20the%20rename%20affects%20all%20callers%20regardless%20of%20how%20many%20languages%20they%20scan.%0A%0ATo%20make%20the%20check%20name%20predictable%20and%20stable%2C%20include%20the%20language%20in%20the%20explicit%20%60name%3A%60%20field%20so%20GitHub%20does%20not%20append%20extra%20context%2C%20for%20example%3A%20%60name%3A%20%24%7B%7B%20format%28'%7B0%7D%20%28%7B1%7D%29'%2C%20inputs.job-name%2C%20matrix.language%29%20%7D%7D%60.%20Callers%20who%20need%20a%20fixed%20check%20name%20can%20also%20add%20a%20dedicated%20%60name%60%20key%20to%20the%20matrix%20entries%20%28GitHub%20uses%20the%20matrix%20%60name%60%20key%20as-is%20without%20appending%20other%20values%29.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Factions%2Fgenerate-codeql-matrix.sh%3A97-112%0A**%60BUILD_MODE%60%20not%20validated%20when%20all%20languages%20have%20explicit%20overrides**%0A%0AWhen%20%60LANGUAGES%60%20is%20non-empty%20and%20%60LANGUAGE_BUILD_MODES%60%20provides%20an%20override%20for%20every%20language%20in%20the%20list%2C%20%60default_build_mode%60%20is%20never%20passed%20to%20%60resolve_mode%60%2C%20so%20its%20value%20is%20never%20checked%20against%20%60valid_modes%60.%20For%20example%2C%20%60LANGUAGES%3Drust%20BUILD_MODE%3Dinvalid%20LANGUAGE_BUILD_MODES%3D'%7B%22rust%22%3A%22autobuild%22%7D'%60%20succeeds%20silently.%20The%20validation%20in%20the%20%60else%60%20branch%20%28auto-detect%20path%29%20does%20not%20cover%20this%20case.%20Consider%20validating%20%60default_build_mode%60%20early%2C%20before%20the%20%60if%20raw_languages%3A%60%20branch%2C%20so%20an%20invalid%20default%20is%20always%20caught%20regardless%20of%20whether%20it%20is%20actually%20used.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=323&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["docs: clarify CodeQL action-only scripts..."](https://github.com/lgtm-hq/lgtm-ci/commit/692a4b378057a64c458bd74a4d480e348aac88fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36144908)</sub>

<!-- /greptile_comment -->