### PR TITLE
feat(ci): add reusable-security-audit for lintro osv-scanner audits

### DIFF
--- a/.github/workflows/reusable-publish-security-audit-comment.yml
+++ b/.github/workflows/reusable-publish-security-audit-comment.yml
@@ -1,0 +1,140 @@
+---
+name: Reusable Publish Security Audit Comment Workflow
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: "Artifact name uploaded by reusable-security-audit"
+        required: false
+        type: string
+        default: "security-audit-comment"
+      comment-file:
+        description: "PR comment file path inside the downloaded artifact"
+        required: false
+        type: string
+        default: "security-audit-comment.txt"
+      comment-marker:
+        description: "Upsert marker for the security audit PR comment"
+        required: false
+        type: string
+        default: "security-audit-report"
+      job-name:
+        description: "Display name for the PR comment publish job"
+        required: false
+        type: string
+        default: "Publish security audit comment"
+      missing-artifact-warning:
+        description: "Warning message when artifact download fails"
+        required: false
+        type: string
+        default: "Security audit comment artifact not found — upstream may have failed"
+      tooling-ref:
+        description: "Git ref to use when checking out lgtm-ci tooling scripts"
+        required: false
+        type: string
+        default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "block"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
+      egress-preset:
+        description: >-
+          Named allowlist when allowed-endpoints is empty and egress-policy is
+          block (github-minimal, github-pages, github-tooling, docker, playwright, pypi,
+          rubygems, npm-publish, quality, sbom, scorecard)
+        required: false
+        type: string
+        default: "github-minimal"
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 10
+
+jobs:
+  publish-security-audit-comment:
+    name: ${{ inputs.job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+            .github/actions/post-pr-comment
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+
+      - name: Download comment artifact
+        id: download
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: ${{ inputs.artifact-name }}
+
+      - name: Warn on missing artifact
+        if: steps.download.outcome != 'success'
+        shell: bash
+        env:
+          MISSING_ARTIFACT_WARNING: ${{ inputs.missing-artifact-warning }}
+        run: echo "::warning::${MISSING_ARTIFACT_WARNING}"
+
+      - name: Publish security audit comment
+        if: steps.download.outcome == 'success'
+        uses: ./.lgtm-ci-tooling/.github/actions/post-pr-comment
+        with:
+          file: ${{ inputs.comment-file }}
+          marker: ${{ inputs.comment-marker }}

--- a/.github/workflows/reusable-publish-security-audit-comment.yml
+++ b/.github/workflows/reusable-publish-security-audit-comment.yml
@@ -79,6 +79,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       contents: read
+      # Post/update security audit PR comments via post-pr-comment
       pull-requests: write
 
     steps:

--- a/.github/workflows/reusable-security-audit.yml
+++ b/.github/workflows/reusable-security-audit.yml
@@ -184,7 +184,8 @@ jobs:
         env:
           WORKSPACE: ${{ github.workspace }}/${{ inputs.working-directory }}
           COMMENT_FILE: ${{ inputs.comment-file }}
-        run: bash "${{ github.workspace }}/${{ inputs.audit-script }}"
+          AUDIT_SCRIPT: ${{ inputs.audit-script }}
+        run: bash "$GITHUB_WORKSPACE/$AUDIT_SCRIPT"
 
       - name: Upload comment artifact
         if: >-
@@ -192,7 +193,7 @@ jobs:
           && inputs.publish-pr-comment
           && github.event_name == 'pull_request'
         # Pinned to SHA for supply chain security
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.working-directory }}/${{ inputs.comment-file }}
@@ -201,7 +202,9 @@ jobs:
       - name: Fail on vulnerabilities
         if: steps.audit.outcome == 'failure'
         shell: bash
-        run: bash "${{ github.workspace }}/${{ inputs.fail-script }}"
+        env:
+          FAIL_SCRIPT: ${{ inputs.fail-script }}
+        run: bash "$GITHUB_WORKSPACE/$FAIL_SCRIPT"
 
   publish-pr-comment:
     name: ${{ inputs.publish-job-name }}

--- a/.github/workflows/reusable-security-audit.yml
+++ b/.github/workflows/reusable-security-audit.yml
@@ -1,0 +1,274 @@
+---
+name: Reusable Security Audit Workflow
+
+on:
+  workflow_call:
+    inputs:
+      job-name:
+        description: "GitHub check run name for the audit job"
+        required: false
+        type: string
+        default: "Security Audit"
+      publish-job-name:
+        description: "Display name for the PR comment publish job"
+        required: false
+        type: string
+        default: "Publish security audit comment"
+      lintro-image:
+        description: "Pinned ghcr.io/lgtm-hq/py-lintro image (digest strongly recommended)"
+        required: false
+        type: string
+        # yamllint disable-line rule:line-length
+        default: "ghcr.io/lgtm-hq/py-lintro@sha256:1ff3db35939283734b859c7c5d95be87fd8fd62734b3434e0437769d50d53578"
+      audit-script:
+        description: >-
+          Path to security audit script (repo checkout or tooling checkout).
+          Defaults to tooling run-lintro-audit.sh.
+        required: false
+        type: string
+        default: ".lgtm-ci-tooling/scripts/ci/security/run-lintro-audit.sh"
+      fail-script:
+        description: "Path to explicit fail step script after continue-on-error audit"
+        required: false
+        type: string
+        default: ".lgtm-ci-tooling/scripts/ci/security/fail-audit.sh"
+      working-directory:
+        description: "Working directory for the audit scan"
+        required: false
+        type: string
+        default: "."
+      comment-file:
+        description: "PR comment artifact path relative to working-directory"
+        required: false
+        type: string
+        default: "security-audit-comment.txt"
+      artifact-name:
+        description: "Uploaded artifact name for the PR comment file"
+        required: false
+        type: string
+        default: "security-audit-comment"
+      comment-marker:
+        description: "Upsert marker for the security audit PR comment"
+        required: false
+        type: string
+        default: "security-audit-report"
+      publish-pr-comment:
+        description: "Upload comment artifact and run publish-pr-comment job on pull_request"
+        required: false
+        type: boolean
+        default: true
+      tooling-ref:
+        description: "Git ref to use when checking out lgtm-ci tooling scripts"
+        required: false
+        type: string
+        default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "block"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
+      egress-preset:
+        description: >-
+          Named allowlist when allowed-endpoints is empty and egress-policy is
+          block (github-minimal, github-pages, github-tooling, docker, playwright, pypi,
+          rubygems, npm-publish, quality, sbom, scorecard)
+        required: false
+        type: string
+        default: "quality"
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Job timeout in minutes for the audit job"
+        required: false
+        type: number
+        default: 15
+
+    outputs:
+      exit-code:
+        description: "Exit code from the security audit script"
+        value: ${{ jobs.security-audit.outputs.exit-code }}
+      has-vulns:
+        description: "Whether vulnerabilities were found"
+        value: ${{ jobs.security-audit.outputs.has-vulns }}
+      audit-failed:
+        description: "Whether the audit tool/scan failed"
+        value: ${{ jobs.security-audit.outputs.audit-failed }}
+      status:
+        description: "passed or failed"
+        value: ${{ jobs.security-audit.outputs.status }}
+
+jobs:
+  security-audit:
+    name: ${{ inputs.job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      exit-code: ${{ steps.audit.outputs.exit-code }}
+      has-vulns: ${{ steps.audit.outputs.has-vulns }}
+      audit-failed: ${{ steps.audit.outputs.audit-failed }}
+      status: ${{ steps.audit.outputs.status }}
+
+    env:
+      LINTRO_IMAGE: ${{ inputs.lintro-image }}
+
+    steps:
+      - name: Checkout repository
+        # Pinned to SHA for supply chain security
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+            .github/actions/post-pr-comment
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Run security audit
+        id: audit
+        continue-on-error: true
+        shell: bash
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          WORKSPACE: ${{ github.workspace }}/${{ inputs.working-directory }}
+          COMMENT_FILE: ${{ inputs.comment-file }}
+        run: bash "${{ github.workspace }}/${{ inputs.audit-script }}"
+
+      - name: Upload comment artifact
+        if: >-
+          always()
+          && inputs.publish-pr-comment
+          && github.event_name == 'pull_request'
+        # Pinned to SHA for supply chain security
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ inputs.working-directory }}/${{ inputs.comment-file }}
+          if-no-files-found: error
+
+      - name: Fail on vulnerabilities
+        if: steps.audit.outcome == 'failure'
+        shell: bash
+        run: bash "${{ github.workspace }}/${{ inputs.fail-script }}"
+
+  publish-pr-comment:
+    name: ${{ inputs.publish-job-name }}
+    needs: security-audit
+    if: >-
+      always()
+      && inputs.publish-pr-comment
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.fork == false
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+            .github/actions/post-pr-comment
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+
+      - name: Download comment artifact
+        id: download
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: ${{ inputs.artifact-name }}
+
+      - name: Warn on missing artifact
+        if: steps.download.outcome != 'success'
+        shell: bash
+        run: echo "::warning::Security audit comment artifact not found — upstream may have failed"
+
+      - name: Publish security audit comment
+        if: steps.download.outcome == 'success'
+        uses: ./.lgtm-ci-tooling/.github/actions/post-pr-comment
+        with:
+          file: ${{ inputs.comment-file }}
+          marker: ${{ inputs.comment-marker }}

--- a/.github/workflows/reusable-security-audit.yml
+++ b/.github/workflows/reusable-security-audit.yml
@@ -9,11 +9,6 @@ on:
         required: false
         type: string
         default: "Security Audit"
-      publish-job-name:
-        description: "Display name for the PR comment publish job"
-        required: false
-        type: string
-        default: "Publish security audit comment"
       lintro-image:
         description: "Pinned ghcr.io/lgtm-hq/py-lintro image (digest strongly recommended)"
         required: false
@@ -47,13 +42,8 @@ on:
         required: false
         type: string
         default: "security-audit-comment"
-      comment-marker:
-        description: "Upsert marker for the security audit PR comment"
-        required: false
-        type: string
-        default: "security-audit-report"
-      publish-pr-comment:
-        description: "Upload comment artifact and run publish-pr-comment job on pull_request"
+      upload-comment-artifact:
+        description: "Upload comment artifact on pull_request for downstream publish job"
         required: false
         type: boolean
         default: true
@@ -148,7 +138,6 @@ jobs:
           sparse-checkout: |
             .github/actions/harden-runner
             .github/actions/resolve-egress-allowlist
-            .github/actions/post-pr-comment
             scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
@@ -190,10 +179,10 @@ jobs:
       - name: Upload comment artifact
         if: >-
           always()
-          && inputs.publish-pr-comment
+          && inputs.upload-comment-artifact
           && github.event_name == 'pull_request'
         # Pinned to SHA for supply chain security
-        uses: actions/upload-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.working-directory }}/${{ inputs.comment-file }}
@@ -205,73 +194,3 @@ jobs:
         env:
           FAIL_SCRIPT: ${{ inputs.fail-script }}
         run: bash "$GITHUB_WORKSPACE/$FAIL_SCRIPT"
-
-  publish-pr-comment:
-    name: ${{ inputs.publish-job-name }}
-    needs: security-audit
-    if: >-
-      always()
-      && inputs.publish-pr-comment
-      && github.event_name == 'pull_request'
-      && github.event.pull_request.head.repo.fork == false
-    runs-on: ${{ inputs.runner-image }}
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      pull-requests: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Checkout lgtm-ci tooling
-        # yamllint disable-line rule:line-length
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            .github/actions/post-pr-comment
-            scripts/ci/
-          sparse-checkout-cone-mode: true
-          persist-credentials: false
-
-      - name: Resolve egress allowlist
-        id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
-          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
-
-      - name: Download comment artifact
-        id: download
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        continue-on-error: true
-        with:
-          name: ${{ inputs.artifact-name }}
-
-      - name: Warn on missing artifact
-        if: steps.download.outcome != 'success'
-        shell: bash
-        run: echo "::warning::Security audit comment artifact not found — upstream may have failed"
-
-      - name: Publish security audit comment
-        if: steps.download.outcome == 'success'
-        uses: ./.lgtm-ci-tooling/.github/actions/post-pr-comment
-        with:
-          file: ${{ inputs.comment-file }}
-          marker: ${{ inputs.comment-marker }}

--- a/.github/workflows/reusable-security-audit.yml
+++ b/.github/workflows/reusable-security-audit.yml
@@ -186,7 +186,7 @@ jobs:
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.working-directory }}/${{ inputs.comment-file }}
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Fail on vulnerabilities
         if: steps.audit.outcome == 'failure'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **workflows**: add `reusable-security-audit` for lintro/osv-scanner Docker audits
+  with PR comment publish (#307)
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **workflows**: add `reusable-security-audit` for lintro/osv-scanner Docker audits
+- **workflows**: add `reusable-security-audit` and
+  `reusable-publish-security-audit-comment` for lintro/osv-scanner Docker audits
   with PR comment publish (#307)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ steps:
 | `reusable-validate.yml`                | Generic repo validation script runner        |
 | `reusable-codeql.yml`                  | CodeQL security analysis                     |
 | `reusable-dependency-review.yml`       | Dependency review gate                       |
+| `reusable-security-audit.yml`          | lintro/osv-scanner audit + PR comment        |
 | `reusable-scorecards.yml`              | OpenSSF Scorecard analysis                   |
 | `reusable-semantic-pr-title.yml`       | Conventional PR title validation + comments  |
 | `reusable-validate-action-pinning.yml` | GitHub Action SHA pinning validation         |

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ steps:
 
 ### Reusable Workflows
 
-<!-- markdownlint-disable MD013 -- workflow catalog table; descriptions exceed default line length -->
+<!-- markdownlint-disable MD013 MD060 -- workflow catalog table; long workflow names exceed column width -->
 
 | Workflow                               | Description                                  |
 | -------------------------------------- | -------------------------------------------- |
@@ -198,7 +198,8 @@ steps:
 | `reusable-validate.yml`                | Generic repo validation script runner        |
 | `reusable-codeql.yml`                  | CodeQL security analysis                     |
 | `reusable-dependency-review.yml`       | Dependency review gate                       |
-| `reusable-security-audit.yml`          | lintro/osv-scanner audit + PR comment        |
+| `reusable-security-audit.yml`          | lintro/osv-scanner audit + comment artifact    |
+| `reusable-publish-security-audit-comment.yml` | Publish security audit PR comment     |
 | `reusable-scorecards.yml`              | OpenSSF Scorecard analysis                   |
 | `reusable-semantic-pr-title.yml`       | Conventional PR title validation + comments  |
 | `reusable-validate-action-pinning.yml` | GitHub Action SHA pinning validation         |

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -657,19 +657,24 @@ reusable job.
 ### Security audit (lintro + osv-scanner)
 
 `reusable-security-audit.yml` runs osv-scanner via the pinned py-lintro Docker
-image, uploads a comment artifact on pull requests, and optionally posts a
-marker-based PR comment. The audit step uses `continue-on-error` with an explicit
-fail step so comment generation still runs when vulnerabilities are found.
+image and uploads a comment artifact on pull requests. The audit step uses
+`continue-on-error` with an explicit fail step so comment generation still runs
+when vulnerabilities are found.
+
+Post the marker-based PR comment from a separate caller job using
+`reusable-publish-security-audit-comment.yml` (same split pattern as quality
+lint + publish-quality-summary). The audit reusable requires only
+`contents: read` and `packages: read`.
 
 Add `merge_group:` to the caller workflow when using merge queue (audit runs;
-PR comment upload/post remains `pull_request`-only).
+artifact upload and PR comment publish remain `pull_request`-only).
 
-| Input                | Default           | Notes                                      |
-| -------------------- | ----------------- | ------------------------------------------ |
-| `lintro-image`       | pinned py-lintro  | Override when adopting a newer lintro pin  |
-| `audit-script`       | tooling default   | Rarely needed — override for custom scans  |
-| `publish-pr-comment` | `true`            | Set `false` for push/schedule check-only   |
-| `comment-marker`     | `security-audit-report` | Upsert identity for PR comments      |
+| Input                    | Default                 | Notes                                      |
+| ------------------------ | ----------------------- | ------------------------------------------ |
+| `lintro-image`           | pinned py-lintro        | Override when adopting a newer lintro pin  |
+| `audit-script`           | tooling default         | Rarely needed — override for custom scans  |
+| `upload-comment-artifact`| `true`                  | Set `false` for push/schedule check-only   |
+| `comment-marker`         | `security-audit-report` | Used by publish reusable                   |
 
 ```yaml
 'on':
@@ -687,16 +692,28 @@ jobs:
     permissions:
       contents: read
       packages: read
-      pull-requests: write
     with:
       tooling-ref: "<sha>"
       job-name: "🔐 Security Audit"
       lintro-image: ghcr.io/lgtm-hq/py-lintro@sha256:...
-      publish-pr-comment: ${{ github.event_name == 'pull_request' }}
+      upload-comment-artifact: ${{ github.event_name == 'pull_request' }}
+
+  publish-security-audit-comment:
+    needs: security-audit
+    if: >-
+      !cancelled()
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.fork == false
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-security-audit-comment.yml@<sha>
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      tooling-ref: "<sha>"
 ```
 
-For push/schedule workflows, pass `publish-pr-comment: false` and omit
-`pull-requests: write`.
+For push/schedule workflows, omit the publish job and pass
+`upload-comment-artifact: false`.
 
 ```yaml
 jobs:

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -654,6 +654,50 @@ Callers must grant `pull-requests: write` when `post-failure-comment` is enabled
 sufficient. Workflow root `permissions: {}` otherwise strips PR access from the
 reusable job.
 
+### Security audit (lintro + osv-scanner)
+
+`reusable-security-audit.yml` runs osv-scanner via the pinned py-lintro Docker
+image, uploads a comment artifact on pull requests, and optionally posts a
+marker-based PR comment. The audit step uses `continue-on-error` with an explicit
+fail step so comment generation still runs when vulnerabilities are found.
+
+Add `merge_group:` to the caller workflow when using merge queue (audit runs;
+PR comment upload/post remains `pull_request`-only).
+
+| Input                | Default           | Notes                                      |
+| -------------------- | ----------------- | ------------------------------------------ |
+| `lintro-image`       | pinned py-lintro  | Override when adopting a newer lintro pin  |
+| `audit-script`       | tooling default   | Rarely needed — override for custom scans  |
+| `publish-pr-comment` | `true`            | Set `false` for push/schedule check-only   |
+| `comment-marker`     | `security-audit-report` | Upsert identity for PR comments      |
+
+```yaml
+'on':
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '30 5 * * 1'
+
+jobs:
+  security-audit:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-security-audit.yml@<sha>
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: write
+    with:
+      tooling-ref: "<sha>"
+      job-name: "🔐 Security Audit"
+      lintro-image: ghcr.io/lgtm-hq/py-lintro@sha256:...
+      publish-pr-comment: ${{ github.event_name == 'pull_request' }}
+```
+
+For push/schedule workflows, pass `publish-pr-comment: false` and omit
+`pull-requests: write`.
+
 ```yaml
 jobs:
   semantic-title:

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -767,8 +767,8 @@ found.
 | --------------------- | ---------------------------------------------------- | ----------------------------------------------- |
 | `lintro-image`        | pinned `ghcr.io/lgtm-hq/py-lintro` digest            | Same contract as `reusable-quality-lint`        |
 | `audit-script`        | `.lgtm-ci-tooling/scripts/ci/security/run-lintro-audit.sh` | Repo-local override supported             |
-| `publish-pr-comment`  | `true`                                               | Built-in publish job; set `false` for check-only |
-| `comment-marker`      | `security-audit-report`                              | Upsert marker for `post-pr-comment`             |
+| `upload-comment-artifact` | `true`                                           | Set `false` for push/schedule check-only          |
+| `comment-marker`      | `security-audit-report`                              | Input on publish reusable                         |
 | `egress-preset`       | `quality`                                            | Includes `api.osv.dev` and `api.deps.dev`       |
 
 <!-- markdownlint-enable MD013 MD060 -->
@@ -776,11 +776,12 @@ found.
 Caller `on:` triggers are consumer-owned. Add `merge_group:` alongside
 `pull_request:` when using merge queue — the audit job runs on both; PR comments
 upload/post only on `pull_request`. Scheduled or push callers should set
-`publish-pr-comment: false` (or accept skipped publish jobs).
+`upload-comment-artifact: false` and omit the publish reusable caller job.
 
-Grant `packages: read` on the audit job (Docker pull from ghcr.io). Grant
-`pull-requests: write` on the reusable root when `publish-pr-comment: true`
-(the built-in publish job inherits reusable permissions).
+Grant `packages: read` on the audit job (Docker pull from ghcr.io). Call
+`reusable-publish-security-audit-comment.yml` from the caller when PR comments
+are required; that publish reusable declares `pull-requests: write`. The audit
+reusable itself requires only `contents: read` and `packages: read`.
 
 Outputs: `exit-code`, `has-vulns`, `audit-failed`, `status`.
 

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -752,6 +752,38 @@ tooling checkout need egress for `codeload.github.com`, `astral.sh`, and
 events. Do not invoke it from plain `push` workflows unless you accept the job
 being skipped.
 
+## Security audit (osv-scanner)
+
+`reusable-security-audit.yml` centralizes the lintro Docker + osv-scanner audit
+pattern used by Rust monorepos. The audit job runs
+`scripts/ci/security/run-lintro-audit.sh` (override with `audit-script`), uploads
+a PR comment artifact on `pull_request`, and uses `continue-on-error` plus an
+explicit fail step so comment generation still runs when vulnerabilities are
+found.
+
+<!-- markdownlint-disable MD013 MD060 -- wide input reference table -->
+
+| Input                 | Default                                              | Notes                                           |
+| --------------------- | ---------------------------------------------------- | ----------------------------------------------- |
+| `lintro-image`        | pinned `ghcr.io/lgtm-hq/py-lintro` digest            | Same contract as `reusable-quality-lint`        |
+| `audit-script`        | `.lgtm-ci-tooling/scripts/ci/security/run-lintro-audit.sh` | Repo-local override supported             |
+| `publish-pr-comment`  | `true`                                               | Built-in publish job; set `false` for check-only |
+| `comment-marker`      | `security-audit-report`                              | Upsert marker for `post-pr-comment`             |
+| `egress-preset`       | `quality`                                            | Includes `api.osv.dev` and `api.deps.dev`       |
+
+<!-- markdownlint-enable MD013 MD060 -->
+
+Caller `on:` triggers are consumer-owned. Add `merge_group:` alongside
+`pull_request:` when using merge queue — the audit job runs on both; PR comments
+upload/post only on `pull_request`. Scheduled or push callers should set
+`publish-pr-comment: false` (or accept skipped publish jobs).
+
+Grant `packages: read` on the audit job (Docker pull from ghcr.io). Grant
+`pull-requests: write` on the reusable root when `publish-pr-comment: true`
+(the built-in publish job inherits reusable permissions).
+
+Outputs: `exit-code`, `has-vulns`, `audit-failed`, `status`.
+
 ## Merge queue (`merge_group`)
 
 Callers using GitHub merge queue can add `merge_group:` triggers to thin
@@ -762,6 +794,7 @@ caller workflows alongside `pull_request:`.
 | `reusable-codeql.yml`                  | Safe to run — no PR context required           |
 | `reusable-validate-action-pinning.yml` | Safe to run — no PR context required           |
 | `reusable-dependency-review.yml`       | Runs on `merge_group` (same as PR)             |
+| `reusable-security-audit.yml`          | Audit on `merge_group`; PR comment on PR only  |
 | `reusable-semantic-pr-title.yml`       | Skips on `merge_group` — title validated on PR |
 
 Semantic title validation is intentionally skipped in the merge queue because

--- a/scripts/ci/security/fail-audit.sh
+++ b/scripts/ci/security/fail-audit.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Fail the CI job when the security audit found vulnerabilities or errors.
+#
+# Usage:
+#   bash scripts/ci/security/fail-audit.sh
+
+set -euo pipefail
+
+echo "::error::Security audit found vulnerabilities or failed. Review the PR comment and CI logs."
+exit 1

--- a/scripts/ci/security/format-security-comment.py
+++ b/scripts/ci/security/format-security-comment.py
@@ -29,7 +29,10 @@ def _escape_md_cell(value: str) -> str:
 
 def _read_suppressions_from_toml() -> list[dict[str, object]]:
     """Read suppression entries from .osv-scanner.toml as a fallback."""
-    import tomllib
+    try:
+        import tomllib
+    except ImportError:
+        return []
 
     toml_path = Path(".osv-scanner.toml")
     if not toml_path.exists():
@@ -71,7 +74,7 @@ def format_comment(json_path: str) -> str | None:
         return None
 
     try:
-        content = path.read_text()
+        content = path.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as e:
         print(f"Failed to read {path}: {e}", file=sys.stderr)
         return None

--- a/scripts/ci/security/format-security-comment.py
+++ b/scripts/ci/security/format-security-comment.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import sys
+from datetime import date
 from pathlib import Path
 
 
@@ -40,7 +41,6 @@ def _read_suppressions_from_toml() -> list[dict[str, object]]:
     try:
         with toml_path.open("rb") as f:
             data = tomllib.load(f)
-        from datetime import date
 
         def _valid_ignore_until(entry: dict[str, object]) -> bool:
             ignore_until = entry.get("ignoreUntil")

--- a/scripts/ci/security/format-security-comment.py
+++ b/scripts/ci/security/format-security-comment.py
@@ -42,13 +42,17 @@ def _read_suppressions_from_toml() -> list[dict[str, object]]:
             data = tomllib.load(f)
         from datetime import date
 
+        def _valid_ignore_until(entry: dict[str, object]) -> bool:
+            ignore_until = entry.get("ignoreUntil")
+            return ignore_until is None or isinstance(ignore_until, date)
+
         return [
             entry
             for entry in data.get("IgnoredVulns", [])
             if isinstance(entry, dict)
             and isinstance(entry.get("id"), str)
             and entry["id"].strip()
-            and isinstance(entry.get("ignoreUntil"), date)
+            and _valid_ignore_until(entry)
         ]
     except (tomllib.TOMLDecodeError, OSError) as e:
         print(f"Warning: failed to parse {toml_path}: {e}", file=sys.stderr)

--- a/scripts/ci/security/format-security-comment.py
+++ b/scripts/ci/security/format-security-comment.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Format lintro osv_scanner JSON output as a security PR comment.
+
+Reads lintro JSON output (from --output-format json) and extracts the
+osv_scanner result to produce a markdown PR comment body with a
+vulnerability table and suppression status table.
+
+Usage:
+    python3 scripts/ci/security/format-security-comment.py osv-results.json
+
+Exit codes:
+    0 - Success (markdown printed to stdout)
+    1 - Invalid arguments or missing file
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def _escape_md_cell(value: str) -> str:
+    """Escape a string for safe use inside a Markdown table cell."""
+    escaped = value.replace("|", "\\|").replace("`", "\\`")
+    return escaped.replace("\n", " ").replace("\r", "")
+
+
+def _read_suppressions_from_toml() -> list[dict[str, object]]:
+    """Read suppression entries from .osv-scanner.toml as a fallback."""
+    import tomllib
+
+    toml_path = Path(".osv-scanner.toml")
+    if not toml_path.exists():
+        return []
+    try:
+        with toml_path.open("rb") as f:
+            data = tomllib.load(f)
+        from datetime import date
+
+        return [
+            entry
+            for entry in data.get("IgnoredVulns", [])
+            if isinstance(entry, dict)
+            and isinstance(entry.get("id"), str)
+            and entry["id"].strip()
+            and isinstance(entry.get("ignoreUntil"), date)
+        ]
+    except (tomllib.TOMLDecodeError, OSError) as e:
+        print(f"Warning: failed to parse {toml_path}: {e}", file=sys.stderr)
+        return []
+
+
+def _fence_code_block(text: str) -> str:
+    """Wrap text in a Markdown code fence safe against embedded backticks."""
+    fence = "```"
+    while fence in text:
+        fence += "`"
+    return f"{fence}\n{text}\n{fence}"
+
+
+def format_comment(json_path: str) -> str | None:
+    """Format osv-scanner JSON results as markdown."""
+    path = Path(json_path)
+    if not path.exists():
+        print(
+            "No osv-results.json found — osv-scanner may not have run.",
+            file=sys.stderr,
+        )
+        return None
+
+    try:
+        content = path.read_text()
+    except (OSError, UnicodeDecodeError) as e:
+        print(f"Failed to read {path}: {e}", file=sys.stderr)
+        return None
+
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as e:
+        print(f"Failed to parse JSON from {path}: {e}", file=sys.stderr)
+        return None
+
+    if not isinstance(data, dict):
+        print(
+            "Invalid JSON structure: top-level value is not an object",
+            file=sys.stderr,
+        )
+        return None
+
+    results = data.get("results", [])
+    if not isinstance(results, list):
+        print("Invalid JSON structure: 'results' is not a list", file=sys.stderr)
+        return None
+
+    osv_result = None
+    for result in results:
+        if isinstance(result, dict) and result.get("tool") == "osv_scanner":
+            osv_result = result
+            break
+
+    if osv_result is None:
+        print("osv-scanner did not produce results.", file=sys.stderr)
+        return None
+
+    ai_meta = osv_result.get("ai_metadata")
+    probe_suppressions: list[dict[str, object]] | None = None
+    if isinstance(ai_meta, dict) and isinstance(
+        ai_meta.get("suppressions"),
+        list,
+    ):
+        probe_suppressions = ai_meta["suppressions"]
+
+    sections: list[str] = []
+
+    sections.append("### 🔍 Checks Performed:")
+    sections.append(
+        "- **osv-scanner**: Scanned all lockfiles against the OSV database",
+    )
+    sections.append("")
+
+    issues_count = osv_result.get("issues_count", 0)
+    if issues_count > 0:
+        issues_list = osv_result.get("issues", [])
+        sections.append("### 🚨 Vulnerability Report:")
+        sections.append("| Vulnerability | File |")
+        sections.append("|---------------|------|")
+        if issues_list:
+            for issue in issues_list:
+                if not isinstance(issue, dict):
+                    continue
+                msg = _escape_md_cell(str(issue.get("message") or "?"))
+                file = _escape_md_cell(str(issue.get("file") or "?"))
+                sections.append(f"| {msg} | `{file}` |")
+        else:
+            sections.append(
+                f"| {issues_count} vulnerabilities found (details unavailable) | — |",
+            )
+        sections.append("")
+        sections.append("### 🔧 Recommended Actions:")
+        sections.append("1. Review the vulnerabilities above")
+        sections.append("2. Update affected packages if fixes are available")
+        sections.append("3. Suppress in .osv-scanner.toml when no fix exists")
+    elif osv_result.get("success") is False:
+        output_text = osv_result.get("output", "")
+        sections.append("### ⚠️ Scanner Error:")
+        sections.append("osv-scanner failed. Review the CI logs for details.")
+        if output_text:
+            preview = output_text[:500]
+            sections.append("")
+            sections.append(_fence_code_block(preview))
+    else:
+        sections.append("No security vulnerabilities found in dependencies.")
+
+    sections.append("")
+    sections.append("### 🔇 Suppressed Vulnerabilities:")
+    if probe_suppressions is not None:
+        if not probe_suppressions:
+            sections.append("No suppressions configured.")
+        else:
+            sections.append("| ID | Expires | Status | Reason |")
+            sections.append("|----|---------|--------|--------|")
+            for suppression in probe_suppressions:
+                if not isinstance(suppression, dict):
+                    continue
+                sid = _escape_md_cell(str(suppression.get("id", "?")))
+                expires = _escape_md_cell(str(suppression.get("ignore_until", "?")))
+                status = str(suppression.get("status", "active"))
+                reason = _escape_md_cell(str(suppression.get("reason", "")))
+                if status == "expired":
+                    sections.append(
+                        f"| :warning: `{sid}` | **EXPIRED** {expires} "
+                        f"| :warning: Expired | {reason} |",
+                    )
+                elif status == "stale":
+                    sections.append(
+                        f"| `{sid}` | {expires} "
+                        f"| :warning: **Stale — safe to remove** | {reason} |",
+                    )
+                else:
+                    sections.append(
+                        f"| `{sid}` | {expires} | Active | {reason} |",
+                    )
+    else:
+        toml_suppressions = _read_suppressions_from_toml()
+        if toml_suppressions:
+            sections.append("| ID | Expires | Reason |")
+            sections.append("|----|---------|--------|")
+            for suppression in toml_suppressions:
+                sid = _escape_md_cell(str(suppression.get("id", "?")))
+                expires = _escape_md_cell(str(suppression.get("ignoreUntil", "?")))
+                reason = _escape_md_cell(str(suppression.get("reason", "")))
+                sections.append(f"| `{sid}` | {expires} | {reason} |")
+        else:
+            sections.append("No suppressions configured.")
+
+    return "\n".join(sections)
+
+
+def main() -> None:
+    """Entry point."""
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <json_file>", file=sys.stderr)
+        sys.exit(1)
+
+    output = format_comment(sys.argv[1])
+    if output is not None:
+        print(output)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/security/run-lintro-audit.sh
+++ b/scripts/ci/security/run-lintro-audit.sh
@@ -54,6 +54,27 @@ if [[ -z "${MAP_HOST_USER}" ]] && [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
 	MAP_HOST_USER=true
 fi
 
+write_audit_github_output() {
+	local has_vulns="${1:-0}"
+	local audit_failed="${2:-0}"
+	local format_failed="${3:-0}"
+	local exit_code="${4:-0}"
+
+	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+		{
+			echo "has-vulns=${has_vulns}"
+			echo "audit-failed=${audit_failed}"
+			echo "format-failed=${format_failed}"
+			echo "exit-code=${exit_code}"
+			if [[ "${exit_code}" -eq 0 ]]; then
+				echo "status=passed"
+			else
+				echo "status=failed"
+			fi
+		} >>"${GITHUB_OUTPUT}"
+	fi
+}
+
 log_info "Pulling Lintro image: ${LINTRO_IMAGE}"
 set +e
 PULL_OUTPUT="$(docker pull "${LINTRO_IMAGE}" 2>&1)"
@@ -61,6 +82,7 @@ PULL_EC=$?
 set -e
 if [[ "${PULL_EC}" -ne 0 ]]; then
 	log_error "Failed to pull Lintro image ${LINTRO_IMAGE}: ${PULL_OUTPUT}"
+	write_audit_github_output 0 1 0 1
 	exit "${PULL_EC}"
 fi
 printf '%s\n' "${PULL_OUTPUT}"
@@ -187,19 +209,7 @@ if [[ "${AUDIT_FAILED}" -eq 1 ]] || [[ "${FORMAT_FAILED}" -eq 1 ]] || [[ "${HAS_
 	EXIT_CODE=1
 fi
 
-if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-	{
-		echo "has-vulns=${HAS_VULNS}"
-		echo "audit-failed=${AUDIT_FAILED}"
-		echo "format-failed=${FORMAT_FAILED}"
-		echo "exit-code=${EXIT_CODE}"
-		if [[ "${EXIT_CODE}" -eq 0 ]]; then
-			echo "status=passed"
-		else
-			echo "status=failed"
-		fi
-	} >>"${GITHUB_OUTPUT}"
-fi
+write_audit_github_output "${HAS_VULNS}" "${AUDIT_FAILED}" "${FORMAT_FAILED}" "${EXIT_CODE}"
 
 if [[ "${AUDIT_FAILED}" -eq 1 ]]; then
 	log_error "Security audit failed (tool/scan error)"

--- a/scripts/ci/security/run-lintro-audit.sh
+++ b/scripts/ci/security/run-lintro-audit.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Run osv-scanner via lintro in Docker and generate a security PR comment.
+#
+# Required environment variables:
+#   LINTRO_IMAGE   Pinned ghcr.io/lgtm-hq/py-lintro reference
+#
+# Optional environment variables:
+#   WORKSPACE              Absolute path to mount at /code (default: pwd)
+#   OSV_RESULTS            JSON output path (default: osv-results.json)
+#   OSV_OUTPUT             Scanner log path (default: osv-output.txt)
+#   COMMENT_FILE           PR comment artifact path (default: security-audit-comment.txt)
+#   COMMENT_TITLE          Report heading (default: Security Audit)
+#   FORMAT_SCRIPT          Path to format-security-comment.py (default: sibling script)
+#   MAP_HOST_USER          true|false (default: true on GitHub Actions)
+
+set -euo pipefail
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+run-lintro-audit.sh — run osv-scanner via lintro Docker and write PR comment artifact.
+
+Requires: LINTRO_IMAGE=ghcr.io/lgtm-hq/py-lintro@sha256:...
+
+Optional: WORKSPACE, OSV_RESULTS, OSV_OUTPUT, COMMENT_FILE, COMMENT_TITLE,
+FORMAT_SCRIPT, MAP_HOST_USER
+EOF
+	exit 0
+fi
+
+: "${LINTRO_IMAGE:?LINTRO_IMAGE is required}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+if [[ -f "$LIB_DIR/log.sh" ]]; then
+	# shellcheck source=../lib/log.sh
+	source "$LIB_DIR/log.sh"
+fi
+
+if [[ -f "$LIB_DIR/github/format.sh" ]]; then
+	# shellcheck source=../lib/github/format.sh
+	source "$LIB_DIR/github/format.sh"
+fi
+
+: "${WORKSPACE:=$(pwd)}"
+: "${OSV_RESULTS:=osv-results.json}"
+: "${OSV_OUTPUT:=osv-output.txt}"
+: "${COMMENT_FILE:=security-audit-comment.txt}"
+: "${COMMENT_TITLE:=Security Audit}"
+: "${FORMAT_SCRIPT:=$SCRIPT_DIR/format-security-comment.py}"
+: "${MAP_HOST_USER:=}"
+if [[ -z "${MAP_HOST_USER}" ]] && [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+	MAP_HOST_USER=true
+fi
+
+log_info "Pulling Lintro image: ${LINTRO_IMAGE}"
+set +e
+PULL_OUTPUT="$(docker pull "${LINTRO_IMAGE}" 2>&1)"
+PULL_EC=$?
+set -e
+if [[ "${PULL_EC}" -ne 0 ]]; then
+	log_error "Failed to pull Lintro image ${LINTRO_IMAGE}: ${PULL_OUTPUT}"
+	exit "${PULL_EC}"
+fi
+printf '%s\n' "${PULL_OUTPUT}"
+
+rm -f "${WORKSPACE}/${OSV_RESULTS}" "${WORKSPACE}/${OSV_OUTPUT}"
+
+log_info "Running osv-scanner via lintro in Docker..."
+
+declare -a docker_args=(
+	docker run --rm
+	-e HOME=/tmp
+	-v "${WORKSPACE}:/code"
+	-w /code
+)
+if [[ "${MAP_HOST_USER}" == "true" ]]; then
+	docker_args+=(--user "$(id -u):$(id -g)")
+fi
+docker_args+=("${LINTRO_IMAGE}")
+
+OSV_EXIT_CODE=0
+set +e
+set -o pipefail
+"${docker_args[@]}" \
+	lintro check . --tools osv_scanner \
+	--output-format json --output "/code/${OSV_RESULTS}" \
+	2>&1 | tee "${WORKSPACE}/${OSV_OUTPUT}"
+OSV_EXIT_CODE="${PIPESTATUS[0]}"
+set +o pipefail
+set -e
+
+PARSE_OK=0
+HAS_VULNS=0
+if [[ -f "${WORKSPACE}/${OSV_RESULTS}" ]]; then
+	PYRC=0
+	python3 -c "
+import json, sys
+path = sys.argv[1]
+try:
+    data = json.load(open(path))
+    if not isinstance(data, dict):
+        print(f'Unexpected JSON root (not a dict) in {path}', file=sys.stderr)
+        sys.exit(2)
+    result = next(
+        (x for x in data.get('results', []) if isinstance(x, dict) and x.get('tool') == 'osv_scanner'),
+        None,
+    )
+    if result is None:
+        print(f'No osv_scanner result in {path}', file=sys.stderr)
+        sys.exit(2)
+    sys.exit(0 if result.get('issues_count', 0) > 0 else 1)
+except Exception as exc:
+    print(f'Failed to interpret {path}: {exc!r}', file=sys.stderr)
+    sys.exit(2)
+" "${WORKSPACE}/${OSV_RESULTS}" || PYRC=$?
+	case "${PYRC}" in
+	0)
+		PARSE_OK=1
+		HAS_VULNS=1
+		;;
+	1) PARSE_OK=1 ;;
+	*) PARSE_OK=0 ;;
+	esac
+fi
+
+AUDIT_FAILED=0
+if [[ "${OSV_EXIT_CODE}" -ne 0 ]] && [[ "${HAS_VULNS}" -eq 0 ]]; then
+	log_info "osv-scanner exited non-zero but no valid vulnerability data found"
+	AUDIT_FAILED=1
+fi
+if [[ "${OSV_EXIT_CODE}" -eq 0 ]] && [[ "${PARSE_OK}" -eq 0 ]]; then
+	log_error "osv-scanner exited 0 but results are missing or unparseable"
+	AUDIT_FAILED=1
+fi
+
+format_err="$(mktemp)"
+FORMAT_FAILED=0
+if ! COMMENT_BODY="$(
+	python3 "${FORMAT_SCRIPT}" "${WORKSPACE}/${OSV_RESULTS}" 2>"${format_err}"
+)"; then
+	log_error "format-security-comment.py failed:"
+	cat "${format_err}" >&2
+	COMMENT_BODY="Failed to format security audit results. See CI logs for details."
+	FORMAT_FAILED=1
+fi
+rm -f "${format_err}"
+
+if [[ "${AUDIT_FAILED}" -eq 1 ]]; then
+	STATUS="⚠️ AUDIT FAILED"
+elif [[ "${FORMAT_FAILED}" -eq 1 ]]; then
+	STATUS="⚠️ FORMAT FAILED"
+elif [[ "${HAS_VULNS}" -eq 1 ]]; then
+	STATUS="⚠️ VULNERABILITIES FOUND"
+else
+	STATUS="✅ PASSED"
+fi
+
+BUILD_URL=""
+if declare -f get_github_actions_run_url &>/dev/null; then
+	BUILD_URL=$(get_github_actions_run_url || true)
+fi
+BUILD_LINK_BLOCK=""
+if [[ -n "${BUILD_URL}" ]]; then
+	BUILD_LINK_BLOCK="
+
+---
+
+[View full build details](${BUILD_URL})"
+fi
+
+{
+	printf '%s\n\n' "## 🔐 ${COMMENT_TITLE} Report"
+	printf '%s\n\n' "### 📊 Status: ${STATUS}"
+	printf '%s\n' "${COMMENT_BODY}"
+	printf '%s\n' "${BUILD_LINK_BLOCK}"
+	printf '\n<sub>Generated by lgtm-ci security audit workflow</sub>\n'
+} >"${WORKSPACE}/${COMMENT_FILE}"
+
+if [[ "${HAS_VULNS}" -eq 0 ]] && [[ "${AUDIT_FAILED}" -eq 0 ]] && [[ "${FORMAT_FAILED}" -eq 0 ]]; then
+	rm -f "${WORKSPACE}/${OSV_RESULTS}" "${WORKSPACE}/${OSV_OUTPUT}"
+fi
+
+EXIT_CODE=0
+if [[ "${AUDIT_FAILED}" -eq 1 ]] || [[ "${FORMAT_FAILED}" -eq 1 ]] || [[ "${HAS_VULNS}" -eq 1 ]]; then
+	EXIT_CODE=1
+fi
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+	{
+		echo "has-vulns=${HAS_VULNS}"
+		echo "audit-failed=${AUDIT_FAILED}"
+		echo "format-failed=${FORMAT_FAILED}"
+		echo "exit-code=${EXIT_CODE}"
+		if [[ "${EXIT_CODE}" -eq 0 ]]; then
+			echo "status=passed"
+		else
+			echo "status=failed"
+		fi
+	} >>"${GITHUB_OUTPUT}"
+fi
+
+if [[ "${AUDIT_FAILED}" -eq 1 ]]; then
+	log_error "Security audit failed (tool/scan error)"
+	exit 1
+elif [[ "${FORMAT_FAILED}" -eq 1 ]]; then
+	log_error "Security audit comment formatting failed"
+	exit 1
+elif [[ "${HAS_VULNS}" -eq 1 ]]; then
+	log_error "Security audit found vulnerabilities"
+	exit 1
+fi
+
+log_success "Security audit passed"
+exit 0

--- a/tests/bats/integration/test_reusable_pr_comment_split.bats
+++ b/tests/bats/integration/test_reusable_pr_comment_split.bats
@@ -191,3 +191,23 @@ _orchestrator_delegates_publish() {
 		"${PROJECT_ROOT}/.github/workflows/reusable-publish-test-summary.yml"
 	assert_success
 }
+
+@test "reusable-security-audit: security-audit job has no pull-requests permission" {
+	run awk '
+		/^  security-audit:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  security-audit:/ { in_job = 0 }
+		in_job && /pull-requests:/ { found = 1; exit }
+		END { exit found }
+	' "${PROJECT_ROOT}/.github/workflows/reusable-security-audit.yml"
+	assert_success
+}
+
+@test "reusable-publish-security-audit-comment: declares pull-requests write" {
+	run awk '
+		/^  publish-security-audit-comment:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-security-audit-comment:/ { in_job = 0 }
+		in_job && /pull-requests: write/ { found = 1; exit }
+		END { exit !found }
+	' "${PROJECT_ROOT}/.github/workflows/reusable-publish-security-audit-comment.yml"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_security_audit.bats
+++ b/tests/bats/integration/test_reusable_security_audit.bats
@@ -91,6 +91,7 @@ PUBLISH_WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-publish-security-au
 	run awk '
 		/^  security-audit:/ { in_job = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  security-audit:/ { in_job = 0 }
+		in_job && /^      - name:/ { upload = 0 }
 		in_job && /- name: Upload comment artifact/ { upload = 1 }
 		upload && /if-no-files-found: warn/ { found = 1; exit }
 		END { exit !found }

--- a/tests/bats/integration/test_reusable_security_audit.bats
+++ b/tests/bats/integration/test_reusable_security_audit.bats
@@ -88,7 +88,13 @@ PUBLISH_WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-publish-security-au
 }
 
 @test "reusable-security-audit: upload uses warn when comment file is missing" {
-	run grep -F 'if-no-files-found: warn' "$WORKFLOW"
+	run awk '
+		/^  security-audit:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  security-audit:/ { in_job = 0 }
+		in_job && /- name: Upload comment artifact/ { upload = 1 }
+		upload && /if-no-files-found: warn/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
 	assert_success
 }
 

--- a/tests/bats/integration/test_reusable_security_audit.bats
+++ b/tests/bats/integration/test_reusable_security_audit.bats
@@ -5,6 +5,7 @@
 load "../../helpers/common"
 
 WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-security-audit.yml"
+PUBLISH_WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-publish-security-audit-comment.yml"
 
 @test "reusable-security-audit: egress-policy defaults to block" {
 	run awk '/^      egress-policy:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
@@ -33,22 +34,51 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-security-audit.yml"
 
 @test "reusable-security-audit: explicit fail step after audit" {
 	run awk '
-		/- name: Run security audit/ { audit = 1 }
-		audit && /- name: Fail on vulnerabilities/ { found = 1; exit }
+		/^  security-audit:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  security-audit:/ { in_job = 0 }
+		in_job && /- name: Run security audit/ { audit = 1 }
+		in_job && audit && /- name: Fail on vulnerabilities/ { found = 1; exit }
 		END { exit !found }
 	' "$WORKFLOW"
 	assert_success
-	run grep -F "steps.audit.outcome == 'failure'" "$WORKFLOW"
+	run awk '
+		/^  security-audit:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  security-audit:/ { in_job = 0 }
+		in_job && /steps\.audit\.outcome == '\''failure'\''/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
 	assert_success
 }
 
-@test "reusable-security-audit: publish job uses post-pr-comment action" {
-	run grep -F './.lgtm-ci-tooling/.github/actions/post-pr-comment' "$WORKFLOW"
+@test "reusable-security-audit: no pull-requests permission" {
+	run awk '
+		/^jobs:/ { in_jobs = 1 }
+		in_jobs && /^[^ ]/ && !/^jobs:/ { in_jobs = 0 }
+		in_jobs && /pull-requests:/ { found = 1; exit }
+		END { exit found }
+	' "$WORKFLOW"
 	assert_success
 }
 
-@test "reusable-security-audit: publish job skips fork PRs" {
-	run grep -F 'github.event.pull_request.head.repo.fork == false' "$WORKFLOW"
+@test "reusable-security-audit: upload-artifact uses upload repo v7 SHA" {
+	run grep -F 'uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1' \
+		"$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-security-audit: does not pin download-artifact" {
+	run grep -F 'actions/download-artifact@' "$WORKFLOW"
+	assert_failure
+}
+
+@test "reusable-publish-security-audit-comment: uses post-pr-comment action" {
+	run grep -F './.lgtm-ci-tooling/.github/actions/post-pr-comment' "$PUBLISH_WORKFLOW"
+	assert_success
+}
+
+@test "reusable-publish-security-audit-comment: download-artifact uses download repo v8 SHA" {
+	run grep -F 'uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1' \
+		"$PUBLISH_WORKFLOW"
 	assert_success
 }
 

--- a/tests/bats/integration/test_reusable_security_audit.bats
+++ b/tests/bats/integration/test_reusable_security_audit.bats
@@ -87,6 +87,11 @@ PUBLISH_WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-publish-security-au
 	assert_success
 }
 
+@test "reusable-security-audit: upload uses warn when comment file is missing" {
+	run grep -F 'if-no-files-found: warn' "$WORKFLOW"
+	assert_success
+}
+
 @test "reusable-security-audit: resolve egress before harden-runner composite" {
 	run awk '
 		/^  security-audit:/ { in_job = 1 }

--- a/tests/bats/integration/test_reusable_security_audit.bats
+++ b/tests/bats/integration/test_reusable_security_audit.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-security-audit workflow inputs and job shape
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-security-audit.yml"
+
+@test "reusable-security-audit: egress-policy defaults to block" {
+	run awk '/^      egress-policy:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: "block"'
+}
+
+@test "reusable-security-audit: egress-preset defaults to quality" {
+	run awk '/^      egress-preset:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: "quality"'
+}
+
+@test "reusable-security-audit: audit job uses continue-on-error" {
+	run awk '
+		/^  security-audit:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  security-audit:/ { in_job = 0 }
+		in_job && /- name: Run security audit/ { audit = 1 }
+		audit && /continue-on-error: true/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-security-audit: explicit fail step after audit" {
+	run awk '
+		/- name: Run security audit/ { audit = 1 }
+		audit && /- name: Fail on vulnerabilities/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+	run grep -F "steps.audit.outcome == 'failure'" "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-security-audit: publish job uses post-pr-comment action" {
+	run grep -F './.lgtm-ci-tooling/.github/actions/post-pr-comment' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-security-audit: publish job skips fork PRs" {
+	run grep -F 'github.event.pull_request.head.repo.fork == false' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-security-audit: default audit script points to tooling run-lintro-audit.sh" {
+	run grep -F 'default: ".lgtm-ci-tooling/scripts/ci/security/run-lintro-audit.sh"' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-security-audit: resolve egress before harden-runner composite" {
+	run awk '
+		/^  security-audit:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  security-audit:/ { in_job = 0 }
+		in_job && /- name: Checkout repository/ { checkout = 1 }
+		in_job && /- name: Checkout lgtm-ci tooling/ { tooling = 1 }
+		in_job && /- name: Resolve egress allowlist/ { resolve = 1 }
+		in_job && resolve && /- name: Harden runner/ { found = 1 }
+		END { exit !(checkout && tooling && found) }
+	' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/unit/security/test_format_security_comment.bats
+++ b/tests/bats/unit/security/test_format_security_comment.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/security/format-security-comment.py
+
+load "../../../helpers/common"
+
+setup() {
+	setup_temp_dir
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "format-security-comment: formats clean scan with no vulnerabilities" {
+	local json_file="${BATS_TEST_TMPDIR}/osv-results.json"
+	cat >"$json_file" <<'EOF'
+{
+  "results": [
+    {
+      "tool": "osv_scanner",
+      "issues_count": 0,
+      "success": true,
+      "ai_metadata": {
+        "suppressions": []
+      }
+    }
+  ]
+}
+EOF
+
+	run python3 "${PROJECT_ROOT}/scripts/ci/security/format-security-comment.py" "$json_file"
+	assert_success
+	assert_output --partial "No security vulnerabilities found in dependencies."
+	assert_output --partial "No suppressions configured."
+}
+
+@test "format-security-comment: formats vulnerability table" {
+	local json_file="${BATS_TEST_TMPDIR}/osv-results.json"
+	cat >"$json_file" <<'EOF'
+{
+  "results": [
+    {
+      "tool": "osv_scanner",
+      "issues_count": 1,
+      "issues": [
+        {
+          "message": "GHSA-xxxx-yyyy-zzzz in example-crate",
+          "file": "Cargo.lock"
+        }
+      ],
+      "ai_metadata": {
+        "suppressions": []
+      }
+    }
+  ]
+}
+EOF
+
+	run python3 "${PROJECT_ROOT}/scripts/ci/security/format-security-comment.py" "$json_file"
+	assert_success
+	assert_output --partial "Vulnerability Report"
+	assert_output --partial "GHSA-xxxx-yyyy-zzzz in example-crate"
+	assert_output --partial "Cargo.lock"
+}
+
+@test "format-security-comment: fails on missing file" {
+	run python3 "${PROJECT_ROOT}/scripts/ci/security/format-security-comment.py" \
+		"${BATS_TEST_TMPDIR}/missing.json"
+	assert_failure
+}

--- a/tests/bats/unit/security/test_format_security_comment.bats
+++ b/tests/bats/unit/security/test_format_security_comment.bats
@@ -69,3 +69,30 @@ EOF
 		"${BATS_TEST_TMPDIR}/missing.json"
 	assert_failure
 }
+
+@test "format-security-comment: reads TOML suppressions without ignoreUntil" {
+	local json_file="${BATS_TEST_TMPDIR}/osv-results.json"
+	cat >"$json_file" <<'EOF'
+{
+  "results": [
+    {
+      "tool": "osv_scanner",
+      "issues_count": 0,
+      "success": true
+    }
+  ]
+}
+EOF
+
+	cat >"${BATS_TEST_TMPDIR}/.osv-scanner.toml" <<'EOF'
+[[IgnoredVulns]]
+id = "GHSA-xxxx-yyyy-zzzz"
+reason = "No fix available"
+EOF
+
+	run bash -c "cd '${BATS_TEST_TMPDIR}' && python3 '${PROJECT_ROOT}/scripts/ci/security/format-security-comment.py' osv-results.json"
+	assert_success
+	assert_output --partial "GHSA-xxxx-yyyy-zzzz"
+	assert_output --partial "No fix available"
+	refute_output --partial "No suppressions configured."
+}

--- a/tests/bats/unit/security/test_run_lintro_audit.bats
+++ b/tests/bats/unit/security/test_run_lintro_audit.bats
@@ -28,9 +28,30 @@ teardown() {
 
 @test "run-lintro-audit: writes comment file when scan results exist" {
 	local workspace="${BATS_TEST_TMPDIR}/workspace"
-	mkdir -p "$workspace"
-	local json_file="${workspace}/osv-results.json"
-	cat >"$json_file" <<'EOF'
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$workspace" "$mock_bin"
+
+	cat >"${mock_bin}/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "pull" ]]; then
+	printf 'mock pull %s\n' "${2:-}"
+	exit 0
+fi
+if [[ "${1:-}" == "run" ]]; then
+	workspace=""
+	for ((i = 1; i <= $#; i++)); do
+		if [[ "${!i}" == "-v" ]] && [[ $((i + 1)) -le $# ]]; then
+			next=$((i + 1))
+			mount="${!next}"
+			workspace="${mount%%:/code}"
+		fi
+	done
+	if [[ -z "$workspace" ]]; then
+		echo "mock docker: missing workspace mount" >&2
+		exit 1
+	fi
+	cat >"${workspace}/osv-results.json" <<'JSON'
 {
   "results": [
     {
@@ -43,38 +64,29 @@ teardown() {
     }
   ]
 }
+JSON
+	printf 'mock scan\n' >"${workspace}/osv-output.txt"
+	exit 0
+fi
+echo "unexpected docker invocation: $*" >&2
+exit 1
 EOF
+	chmod +x "${mock_bin}/docker"
 
 	run env \
-		PROJECT_ROOT="$PROJECT_ROOT" \
+		PATH="${mock_bin}:${PATH}" \
+		LINTRO_IMAGE="ghcr.io/lgtm-hq/py-lintro@sha256:deadbeef" \
 		GITHUB_OUTPUT="$GITHUB_OUTPUT" \
 		WORKSPACE="$workspace" \
 		COMMENT_FILE="security-audit-comment.txt" \
 		OSV_RESULTS="osv-results.json" \
-		FORMAT_SCRIPT="${PROJECT_ROOT}/scripts/ci/security/format-security-comment.py" \
-		bash -c '
-set -euo pipefail
-source "${PROJECT_ROOT}/scripts/ci/lib/log.sh"
-source "${PROJECT_ROOT}/scripts/ci/lib/github/format.sh"
-
-COMMENT_BODY="$(python3 "${FORMAT_SCRIPT}" "${WORKSPACE}/${OSV_RESULTS}")"
-{
-	printf "%s\n\n" "## 🔐 Security Audit Report"
-	printf "%s\n\n" "### 📊 Status: ✅ PASSED"
-	printf "%s\n" "${COMMENT_BODY}"
-} >"${WORKSPACE}/${COMMENT_FILE}"
-
-{
-	echo "has-vulns=0"
-	echo "audit-failed=0"
-	echo "format-failed=0"
-	echo "exit-code=0"
-	echo "status=passed"
-} >>"${GITHUB_OUTPUT}"
-'
+		OSV_OUTPUT="osv-output.txt" \
+		MAP_HOST_USER=false \
+		bash "${PROJECT_ROOT}/scripts/ci/security/run-lintro-audit.sh"
 
 	assert_success
 	assert_file_exists "${workspace}/security-audit-comment.txt"
 	assert_file_contains "${workspace}/security-audit-comment.txt" "Security Audit Report"
 	assert_file_contains "$GITHUB_OUTPUT" "status=passed"
+	assert_file_contains "$GITHUB_OUTPUT" "has-vulns=0"
 }

--- a/tests/bats/unit/security/test_run_lintro_audit.bats
+++ b/tests/bats/unit/security/test_run_lintro_audit.bats
@@ -90,3 +90,34 @@ EOF
 	assert_file_contains "$GITHUB_OUTPUT" "status=passed"
 	assert_file_contains "$GITHUB_OUTPUT" "has-vulns=0"
 }
+
+@test "run-lintro-audit: writes github outputs when docker pull fails" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+
+	cat >"${mock_bin}/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "pull" ]]; then
+	echo "mock pull failed" >&2
+	exit 1
+fi
+echo "unexpected docker invocation: $*" >&2
+exit 1
+EOF
+	chmod +x "${mock_bin}/docker"
+
+	run env \
+		PATH="${mock_bin}:${PATH}" \
+		LINTRO_IMAGE="ghcr.io/lgtm-hq/py-lintro@sha256:deadbeef" \
+		GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+		WORKSPACE="${BATS_TEST_TMPDIR}/workspace" \
+		MAP_HOST_USER=false \
+		bash "${PROJECT_ROOT}/scripts/ci/security/run-lintro-audit.sh"
+
+	assert_failure
+	assert_file_contains "$GITHUB_OUTPUT" "audit-failed=1"
+	assert_file_contains "$GITHUB_OUTPUT" "exit-code=1"
+	assert_file_contains "$GITHUB_OUTPUT" "status=failed"
+	assert_file_contains "$GITHUB_OUTPUT" "has-vulns=0"
+}

--- a/tests/bats/unit/security/test_run_lintro_audit.bats
+++ b/tests/bats/unit/security/test_run_lintro_audit.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/security/run-lintro-audit.sh and fail-audit.sh
+
+load "../../../helpers/common"
+
+setup() {
+	setup_temp_dir
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/github-output"
+	touch "$GITHUB_OUTPUT"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "fail-audit: exits with error annotation" {
+	run bash "${PROJECT_ROOT}/scripts/ci/security/fail-audit.sh"
+	assert_failure
+	assert_output --partial "::error::Security audit found vulnerabilities or failed"
+}
+
+@test "run-lintro-audit: requires LINTRO_IMAGE" {
+	run bash "${PROJECT_ROOT}/scripts/ci/security/run-lintro-audit.sh"
+	assert_failure
+	assert_output --partial "LINTRO_IMAGE is required"
+}
+
+@test "run-lintro-audit: writes comment file when scan results exist" {
+	local workspace="${BATS_TEST_TMPDIR}/workspace"
+	mkdir -p "$workspace"
+	local json_file="${workspace}/osv-results.json"
+	cat >"$json_file" <<'EOF'
+{
+  "results": [
+    {
+      "tool": "osv_scanner",
+      "issues_count": 0,
+      "success": true,
+      "ai_metadata": {
+        "suppressions": []
+      }
+    }
+  ]
+}
+EOF
+
+	run env \
+		PROJECT_ROOT="$PROJECT_ROOT" \
+		GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+		WORKSPACE="$workspace" \
+		COMMENT_FILE="security-audit-comment.txt" \
+		OSV_RESULTS="osv-results.json" \
+		FORMAT_SCRIPT="${PROJECT_ROOT}/scripts/ci/security/format-security-comment.py" \
+		bash -c '
+set -euo pipefail
+source "${PROJECT_ROOT}/scripts/ci/lib/log.sh"
+source "${PROJECT_ROOT}/scripts/ci/lib/github/format.sh"
+
+COMMENT_BODY="$(python3 "${FORMAT_SCRIPT}" "${WORKSPACE}/${OSV_RESULTS}")"
+{
+	printf "%s\n\n" "## 🔐 Security Audit Report"
+	printf "%s\n\n" "### 📊 Status: ✅ PASSED"
+	printf "%s\n" "${COMMENT_BODY}"
+} >"${WORKSPACE}/${COMMENT_FILE}"
+
+{
+	echo "has-vulns=0"
+	echo "audit-failed=0"
+	echo "format-failed=0"
+	echo "exit-code=0"
+	echo "status=passed"
+} >>"${GITHUB_OUTPUT}"
+'
+
+	assert_success
+	assert_file_exists "${workspace}/security-audit-comment.txt"
+	assert_file_contains "${workspace}/security-audit-comment.txt" "Security Audit Report"
+	assert_file_contains "$GITHUB_OUTPUT" "status=passed"
+}

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "lgtm-ci"
-version = "0.37.0"
+version = "0.38.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Add `reusable-security-audit.yml` to centralize the Rustume `security-dependency-review.yml` pattern: run osv-scanner via pinned py-lintro Docker, upload a PR comment artifact, and optionally publish a marker-based comment. Includes tooling scripts, BATS tests, and contract documentation for merge queue callers.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. New reusable only; consumers opt in by pinning SHA.

## Closes

- Closes #307 (section 3 — `reusable-security-audit`)

## Testing

- [x] `uv run lintro chk` — zero issues
- [x] `uv run lintro tst` — all tests pass
- [x] BATS unit tests for `format-security-comment.py`, `run-lintro-audit.sh`, `fail-audit.sh`
- [x] BATS integration tests for workflow contract (continue-on-error, env-routed scripts, fork skip)

## Quality Checks

- [x] Lint/format via lintro
- [x] Greptile + CodeRabbit pre-push review (P1 findings addressed)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add reusable security audit workflows for lintro osv-scanner with PR comment publishing
> - Adds [reusable-security-audit.yml](https://github.com/lgtm-hq/lgtm-ci/pull/325/files#diff-ed61203228de3f00e9bec4926b8843427a3764137faf09944ed3e2f2979db57f), which runs an osv-scanner audit via a pinned py-lintro Docker image, uploads a markdown comment artifact on pull requests, and exposes outputs (`has-vulns`, `audit-failed`, `status`, `exit-code`).
> - Adds [reusable-publish-security-audit-comment.yml](https://github.com/lgtm-hq/lgtm-ci/pull/325/files#diff-1b48936ea30c9f1d1f2598b23ece267f24378bfdd2d19ff6e7db509932954104), a companion workflow that downloads the comment artifact and upserts a marker-based PR comment, warning when the artifact is missing.
> - Adds [run-lintro-audit.sh](https://github.com/lgtm-hq/lgtm-ci/pull/325/files#diff-2b23fb8563163288a3d53d4737f0d369ca98895868a8f68dfb4d6010dbf744c8) and [format-security-comment.py](https://github.com/lgtm-hq/lgtm-ci/pull/325/files#diff-711ff5da8307d6d65a1fd76ede8a13ad1d46a8c6deeb556ef4d6036598a0e925) to produce structured markdown from osv-scanner JSON, plus [fail-audit.sh](https://github.com/lgtm-hq/lgtm-ci/pull/325/files#diff-052aab37475ff9c0f3989b6bd8265689faac2b483d44157c596bdb516fab9882) as an explicit fail step after a `continue-on-error` audit step.
> - The audit workflow separates the scan step (`continue-on-error`) from a downstream fail step so the PR comment artifact is always uploaded before the job fails.
> - Risk: the formatter invocation in `run-lintro-audit.sh` currently contains literal `+` tokens around `python3`, which will cause the formatting step to fail and set `format-failed=1` on every run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba8c78d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable security-audit and publish workflows to run containerized scans, generate/upload a PR comment artifact, and expose audit status outputs.

* **Documentation**
  * Updated README and docs with usage examples, inputs, trigger/permission guidance, and merge-queue recommendations.

* **Tests**
  * Added unit and integration tests covering audit/run/publish contract, comment formatting, artifact handling, runner hardening, and permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces two new reusable workflows (`reusable-security-audit.yml` and `reusable-publish-security-audit-comment.yml`) that centralize osv-scanner dependency auditing via a pinned py-lintro Docker image, with a clean permission-split pattern that keeps `pull-requests: write` out of the audit job. Supporting scripts, BATS tests, and contract documentation are included.

- **Audit workflow** runs `run-lintro-audit.sh` with `continue-on-error: true` and an explicit `fail-audit.sh` step, so the comment artifact is always generated before the job fails; `if-no-files-found: warn` prevents a missing artifact from masking the real failure.
- **Publish workflow** downloads the artifact in a separate job (with `pull-requests: write`) and upserts a marker-based PR comment via `post-pr-comment`, correctly guarded behind a fork check in the example caller.
- **`run-lintro-audit.sh`** exposes four documented outputs (`exit-code`, `has-vulns`, `audit-failed`, `status`) and correctly writes sentinel values on early `docker pull` failure; however, when `format-security-comment.py` fails, `audit-failed` stays `0` while `status` is `failed`, creating an ambiguous output combination not explained by any documented field.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge with one output-contract fix: format failures produce audit-failed=0 and has-vulns=0 simultaneously, which callers relying on the documented output fields cannot distinguish from a clean scan.

The overall workflow design is sound — permission split, continue-on-error with explicit fail step, warn-on-missing-artifact, and sentinel outputs on early docker pull failure are all correctly implemented. The one concrete defect is in run-lintro-audit.sh: when format-security-comment.py fails, AUDIT_FAILED stays 0 and the script writes audit-failed=0 alongside has-vulns=0 to GITHUB_OUTPUT, while still exiting 1. The workflow's documented output contract names audit-failed as the signal for tool/scan failures, but this class of failure falls through it silently.

scripts/ci/security/run-lintro-audit.sh — the write_audit_github_output call near the end of the file where AUDIT_FAILED is passed independently of FORMAT_FAILED.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/ci/security/run-lintro-audit.sh | Core audit runner — well-structured with early-exit sentinel writes and Docker user-mapping support, but audit-failed output is 0 on format failures, creating an ambiguous documented output state. |
| .github/workflows/reusable-security-audit.yml | Correctly uses continue-on-error + explicit fail step, if-no-files-found: warn, separate upload-artifact v7 SHA; previous SHA-mismatch and warn-vs-error issues have been addressed. |
| .github/workflows/reusable-publish-security-audit-comment.yml | Clean permission split (pull-requests: write only here), continue-on-error on download, warn path for missing artifact — no issues found. |
| scripts/ci/security/format-security-comment.py | Handles clean/vuln/error scan states, TOML suppression fallback, and Markdown table escaping; no new blocking issues beyond already-flagged byte-truncation concern. |
| docs/workflow-contract.md | Documents outputs as exit-code/has-vulns/audit-failed/status; omits format-failed as a possible failure signal which understates when audit-failed=0 but status=failed. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Caller Workflow
    participant Audit as security-audit job
    participant Docker as py-lintro Docker
    participant Upload as upload-artifact
    participant Publish as publish-security-audit-comment job
    participant GH as GitHub PR

    Caller->>Audit: workflow_call (pull_request)
    Audit->>Docker: docker pull + docker run (osv-scanner)
    Docker-->>Audit: osv-results.json (exit 0/1)
    Audit->>Audit: format-security-comment.py → comment file
    Audit->>Upload: upload artifact (if pull_request)
    Note over Audit: continue-on-error lets upload run on failure
    Audit->>Audit: "fail-audit.sh (if audit outcome == failure)"
    Audit-->>Caller: outputs: exit-code, has-vulns, audit-failed, status

    Caller->>Publish: "needs security-audit, if !cancelled && pull_request && !fork"
    Publish->>Upload: download-artifact
    alt artifact found
        Publish->>GH: upsert marker-based PR comment
    else artifact missing
        Publish->>GH: emit warning
    end
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `scripts/ci/security/run-lintro-audit.sh`, line 698-706 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/9e0f80fbcb1b7eb251e86f75a647539f7588306d/scripts/ci/security/run-lintro-audit.sh#L698-L706)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Unconditional use of conditionally-sourced log functions**

   `log_info`, `log_error`, and `log_success` are sourced from `log.sh` only when the file exists, but are called unconditionally throughout the script (first call at line 719). If the tooling checkout is missing or the sparse-checkout did not include `scripts/ci/lib/`, all `log_*` calls will fail with "command not found", producing a confusing error that hides the real root cause. Adding a `log_info() { echo "$*"; }` style fallback after the conditional source would make failures self-explanatory.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fsecurity%2Frun-lintro-audit.sh%0ALine%3A%20698-706%0A%0AComment%3A%0A**Unconditional%20use%20of%20conditionally-sourced%20log%20functions**%0A%0A%60log_info%60%2C%20%60log_error%60%2C%20and%20%60log_success%60%20are%20sourced%20from%20%60log.sh%60%20only%20when%20the%20file%20exists%2C%20but%20are%20called%20unconditionally%20throughout%20the%20script%20%28first%20call%20at%20line%20719%29.%20If%20the%20tooling%20checkout%20is%20missing%20or%20the%20sparse-checkout%20did%20not%20include%20%60scripts%2Fci%2Flib%2F%60%2C%20all%20%60log_*%60%20calls%20will%20fail%20with%20%22command%20not%20found%22%2C%20producing%20a%20confusing%20error%20that%20hides%20the%20real%20root%20cause.%20Adding%20a%20%60log_info%28%29%20%7B%20echo%20%22%24*%22%3B%20%7D%60%20style%20fallback%20after%20the%20conditional%20source%20would%20make%20failures%20self-explanatory.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fsecurity%2Frun-lintro-audit.sh%0ALine%3A%20698-706%0A%0AComment%3A%0A**Unconditional%20use%20of%20conditionally-sourced%20log%20functions**%0A%0A%60log_info%60%2C%20%60log_error%60%2C%20and%20%60log_success%60%20are%20sourced%20from%20%60log.sh%60%20only%20when%20the%20file%20exists%2C%20but%20are%20called%20unconditionally%20throughout%20the%20script%20%28first%20call%20at%20line%20719%29.%20If%20the%20tooling%20checkout%20is%20missing%20or%20the%20sparse-checkout%20did%20not%20include%20%60scripts%2Fci%2Flib%2F%60%2C%20all%20%60log_*%60%20calls%20will%20fail%20with%20%22command%20not%20found%22%2C%20producing%20a%20confusing%20error%20that%20hides%20the%20real%20root%20cause.%20Adding%20a%20%60log_info%28%29%20%7B%20echo%20%22%24*%22%3B%20%7D%60%20style%20fallback%20after%20the%20conditional%20source%20would%20make%20failures%20self-explanatory.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F307-reusable-security-audit%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F307-reusable-security-audit%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fsecurity%2Frun-lintro-audit.sh%0ALine%3A%20698-706%0A%0AComment%3A%0A**Unconditional%20use%20of%20conditionally-sourced%20log%20functions**%0A%0A%60log_info%60%2C%20%60log_error%60%2C%20and%20%60log_success%60%20are%20sourced%20from%20%60log.sh%60%20only%20when%20the%20file%20exists%2C%20but%20are%20called%20unconditionally%20throughout%20the%20script%20%28first%20call%20at%20line%20719%29.%20If%20the%20tooling%20checkout%20is%20missing%20or%20the%20sparse-checkout%20did%20not%20include%20%60scripts%2Fci%2Flib%2F%60%2C%20all%20%60log_*%60%20calls%20will%20fail%20with%20%22command%20not%20found%22%2C%20producing%20a%20confusing%20error%20that%20hides%20the%20real%20root%20cause.%20Adding%20a%20%60log_info%28%29%20%7B%20echo%20%22%24*%22%3B%20%7D%60%20style%20fallback%20after%20the%20conditional%20source%20would%20make%20failures%20self-explanatory.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `scripts/ci/security/format-security-comment.py`, line 591 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/9e0f80fbcb1b7eb251e86f75a647539f7588306d/scripts/ci/security/format-security-comment.py#L591)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Byte-boundary truncation can split multi-byte UTF-8 characters**

   `output_text[:500]` slices by Python `str` code points, not encoded bytes, so it won't split a UTF-8 byte sequence. However, it can still cut in the middle of a multi-codepoint grapheme cluster (e.g., emoji with ZWJ sequences or combined diacritics), producing a visually malformed code block in the PR comment. A simple guard like `output_text[:500].rstrip()` at minimum avoids trailing partial escapes, though the real fix is to encode then decode with `errors="ignore"` or truncate on newline boundaries.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fsecurity%2Fformat-security-comment.py%0ALine%3A%20591%0A%0AComment%3A%0A**Byte-boundary%20truncation%20can%20split%20multi-byte%20UTF-8%20characters**%0A%0A%60output_text%5B%3A500%5D%60%20slices%20by%20Python%20%60str%60%20code%20points%2C%20not%20encoded%20bytes%2C%20so%20it%20won't%20split%20a%20UTF-8%20byte%20sequence.%20However%2C%20it%20can%20still%20cut%20in%20the%20middle%20of%20a%20multi-codepoint%20grapheme%20cluster%20%28e.g.%2C%20emoji%20with%20ZWJ%20sequences%20or%20combined%20diacritics%29%2C%20producing%20a%20visually%20malformed%20code%20block%20in%20the%20PR%20comment.%20A%20simple%20guard%20like%20%60output_text%5B%3A500%5D.rstrip%28%29%60%20at%20minimum%20avoids%20trailing%20partial%20escapes%2C%20though%20the%20real%20fix%20is%20to%20encode%20then%20decode%20with%20%60errors%3D%22ignore%22%60%20or%20truncate%20on%20newline%20boundaries.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fsecurity%2Fformat-security-comment.py%0ALine%3A%20591%0A%0AComment%3A%0A**Byte-boundary%20truncation%20can%20split%20multi-byte%20UTF-8%20characters**%0A%0A%60output_text%5B%3A500%5D%60%20slices%20by%20Python%20%60str%60%20code%20points%2C%20not%20encoded%20bytes%2C%20so%20it%20won't%20split%20a%20UTF-8%20byte%20sequence.%20However%2C%20it%20can%20still%20cut%20in%20the%20middle%20of%20a%20multi-codepoint%20grapheme%20cluster%20%28e.g.%2C%20emoji%20with%20ZWJ%20sequences%20or%20combined%20diacritics%29%2C%20producing%20a%20visually%20malformed%20code%20block%20in%20the%20PR%20comment.%20A%20simple%20guard%20like%20%60output_text%5B%3A500%5D.rstrip%28%29%60%20at%20minimum%20avoids%20trailing%20partial%20escapes%2C%20though%20the%20real%20fix%20is%20to%20encode%20then%20decode%20with%20%60errors%3D%22ignore%22%60%20or%20truncate%20on%20newline%20boundaries.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F307-reusable-security-audit%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F307-reusable-security-audit%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fsecurity%2Fformat-security-comment.py%0ALine%3A%20591%0A%0AComment%3A%0A**Byte-boundary%20truncation%20can%20split%20multi-byte%20UTF-8%20characters**%0A%0A%60output_text%5B%3A500%5D%60%20slices%20by%20Python%20%60str%60%20code%20points%2C%20not%20encoded%20bytes%2C%20so%20it%20won't%20split%20a%20UTF-8%20byte%20sequence.%20However%2C%20it%20can%20still%20cut%20in%20the%20middle%20of%20a%20multi-codepoint%20grapheme%20cluster%20%28e.g.%2C%20emoji%20with%20ZWJ%20sequences%20or%20combined%20diacritics%29%2C%20producing%20a%20visually%20malformed%20code%20block%20in%20the%20PR%20comment.%20A%20simple%20guard%20like%20%60output_text%5B%3A500%5D.rstrip%28%29%60%20at%20minimum%20avoids%20trailing%20partial%20escapes%2C%20though%20the%20real%20fix%20is%20to%20encode%20then%20decode%20with%20%60errors%3D%22ignore%22%60%20or%20truncate%20on%20newline%20boundaries.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

3. `scripts/ci/security/run-lintro-audit.sh`, line 760-779 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/9e0f80fbcb1b7eb251e86f75a647539f7588306d/scripts/ci/security/run-lintro-audit.sh#L760-L779)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Inverted exit-code convention in the inline Python snippet**

   The inline Python script exits `0` when vulnerabilities are found (`issues_count > 0`) and `1` when the scan is clean — the opposite of POSIX convention. The `case` statement below handles it correctly, but anyone reading or maintaining this code will expect `0` to mean success/clean and `1` to mean failure/found. This inversion also means any `set -e` context that might wrap this snippet would misinterpret a clean scan as an error. Consider flipping the semantics: `sys.exit(1 if result.get('issues_count', 0) > 0 else 0)` and updating the case accordingly, using a distinct code (e.g., `2`) for parse errors.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fsecurity%2Frun-lintro-audit.sh%0ALine%3A%20760-779%0A%0AComment%3A%0A**Inverted%20exit-code%20convention%20in%20the%20inline%20Python%20snippet**%0A%0AThe%20inline%20Python%20script%20exits%20%600%60%20when%20vulnerabilities%20are%20found%20%28%60issues_count%20%3E%200%60%29%20and%20%601%60%20when%20the%20scan%20is%20clean%20%E2%80%94%20the%20opposite%20of%20POSIX%20convention.%20The%20%60case%60%20statement%20below%20handles%20it%20correctly%2C%20but%20anyone%20reading%20or%20maintaining%20this%20code%20will%20expect%20%600%60%20to%20mean%20success%2Fclean%20and%20%601%60%20to%20mean%20failure%2Ffound.%20This%20inversion%20also%20means%20any%20%60set%20-e%60%20context%20that%20might%20wrap%20this%20snippet%20would%20misinterpret%20a%20clean%20scan%20as%20an%20error.%20Consider%20flipping%20the%20semantics%3A%20%60sys.exit%281%20if%20result.get%28'issues_count'%2C%200%29%20%3E%200%20else%200%29%60%20and%20updating%20the%20case%20accordingly%2C%20using%20a%20distinct%20code%20%28e.g.%2C%20%602%60%29%20for%20parse%20errors.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fsecurity%2Frun-lintro-audit.sh%0ALine%3A%20760-779%0A%0AComment%3A%0A**Inverted%20exit-code%20convention%20in%20the%20inline%20Python%20snippet**%0A%0AThe%20inline%20Python%20script%20exits%20%600%60%20when%20vulnerabilities%20are%20found%20%28%60issues_count%20%3E%200%60%29%20and%20%601%60%20when%20the%20scan%20is%20clean%20%E2%80%94%20the%20opposite%20of%20POSIX%20convention.%20The%20%60case%60%20statement%20below%20handles%20it%20correctly%2C%20but%20anyone%20reading%20or%20maintaining%20this%20code%20will%20expect%20%600%60%20to%20mean%20success%2Fclean%20and%20%601%60%20to%20mean%20failure%2Ffound.%20This%20inversion%20also%20means%20any%20%60set%20-e%60%20context%20that%20might%20wrap%20this%20snippet%20would%20misinterpret%20a%20clean%20scan%20as%20an%20error.%20Consider%20flipping%20the%20semantics%3A%20%60sys.exit%281%20if%20result.get%28'issues_count'%2C%200%29%20%3E%200%20else%200%29%60%20and%20updating%20the%20case%20accordingly%2C%20using%20a%20distinct%20code%20%28e.g.%2C%20%602%60%29%20for%20parse%20errors.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F307-reusable-security-audit%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F307-reusable-security-audit%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fsecurity%2Frun-lintro-audit.sh%0ALine%3A%20760-779%0A%0AComment%3A%0A**Inverted%20exit-code%20convention%20in%20the%20inline%20Python%20snippet**%0A%0AThe%20inline%20Python%20script%20exits%20%600%60%20when%20vulnerabilities%20are%20found%20%28%60issues_count%20%3E%200%60%29%20and%20%601%60%20when%20the%20scan%20is%20clean%20%E2%80%94%20the%20opposite%20of%20POSIX%20convention.%20The%20%60case%60%20statement%20below%20handles%20it%20correctly%2C%20but%20anyone%20reading%20or%20maintaining%20this%20code%20will%20expect%20%600%60%20to%20mean%20success%2Fclean%20and%20%601%60%20to%20mean%20failure%2Ffound.%20This%20inversion%20also%20means%20any%20%60set%20-e%60%20context%20that%20might%20wrap%20this%20snippet%20would%20misinterpret%20a%20clean%20scan%20as%20an%20error.%20Consider%20flipping%20the%20semantics%3A%20%60sys.exit%281%20if%20result.get%28'issues_count'%2C%200%29%20%3E%200%20else%200%29%60%20and%20updating%20the%20case%20accordingly%2C%20using%20a%20distinct%20code%20%28e.g.%2C%20%602%60%29%20for%20parse%20errors.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

4. `scripts/ci/security/run-lintro-audit.sh`, line 969-973 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/ba8c78dfc063e141f72b2aea2d8e0ff95baba275/scripts/ci/security/run-lintro-audit.sh#L969-L973)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`audit-failed` output silently stays `0` on format failure**

   When `format-security-comment.py` exits non-zero, `FORMAT_FAILED` is set to 1 but `AUDIT_FAILED` stays 0. The call at line 973 writes `audit-failed=0`, `has-vulns=0`, `exit-code=1`, `status=failed`. Any caller that branches on `needs.security-audit.outputs.audit-failed == '1'` to detect tool errors — as the contract docs suggest — will silently miss this failure mode, receiving a state where nothing in the documented outputs explains why the job failed. The fix is either to treat format failure as an audit failure (`AUDIT_FAILED=1` when `FORMAT_FAILED=1`) or to expose `format-failed` as a documented workflow output.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fsecurity%2Frun-lintro-audit.sh%0ALine%3A%20969-973%0A%0AComment%3A%0A**%60audit-failed%60%20output%20silently%20stays%20%600%60%20on%20format%20failure**%0A%0AWhen%20%60format-security-comment.py%60%20exits%20non-zero%2C%20%60FORMAT_FAILED%60%20is%20set%20to%201%20but%20%60AUDIT_FAILED%60%20stays%200.%20The%20call%20at%20line%20973%20writes%20%60audit-failed%3D0%60%2C%20%60has-vulns%3D0%60%2C%20%60exit-code%3D1%60%2C%20%60status%3Dfailed%60.%20Any%20caller%20that%20branches%20on%20%60needs.security-audit.outputs.audit-failed%20%3D%3D%20'1'%60%20to%20detect%20tool%20errors%20%E2%80%94%20as%20the%20contract%20docs%20suggest%20%E2%80%94%20will%20silently%20miss%20this%20failure%20mode%2C%20receiving%20a%20state%20where%20nothing%20in%20the%20documented%20outputs%20explains%20why%20the%20job%20failed.%20The%20fix%20is%20either%20to%20treat%20format%20failure%20as%20an%20audit%20failure%20%28%60AUDIT_FAILED%3D1%60%20when%20%60FORMAT_FAILED%3D1%60%29%20or%20to%20expose%20%60format-failed%60%20as%20a%20documented%20workflow%20output.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fsecurity%2Frun-lintro-audit.sh%0ALine%3A%20969-973%0A%0AComment%3A%0A**%60audit-failed%60%20output%20silently%20stays%20%600%60%20on%20format%20failure**%0A%0AWhen%20%60format-security-comment.py%60%20exits%20non-zero%2C%20%60FORMAT_FAILED%60%20is%20set%20to%201%20but%20%60AUDIT_FAILED%60%20stays%200.%20The%20call%20at%20line%20973%20writes%20%60audit-failed%3D0%60%2C%20%60has-vulns%3D0%60%2C%20%60exit-code%3D1%60%2C%20%60status%3Dfailed%60.%20Any%20caller%20that%20branches%20on%20%60needs.security-audit.outputs.audit-failed%20%3D%3D%20'1'%60%20to%20detect%20tool%20errors%20%E2%80%94%20as%20the%20contract%20docs%20suggest%20%E2%80%94%20will%20silently%20miss%20this%20failure%20mode%2C%20receiving%20a%20state%20where%20nothing%20in%20the%20documented%20outputs%20explains%20why%20the%20job%20failed.%20The%20fix%20is%20either%20to%20treat%20format%20failure%20as%20an%20audit%20failure%20%28%60AUDIT_FAILED%3D1%60%20when%20%60FORMAT_FAILED%3D1%60%29%20or%20to%20expose%20%60format-failed%60%20as%20a%20documented%20workflow%20output.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F307-reusable-security-audit%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F307-reusable-security-audit%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fsecurity%2Frun-lintro-audit.sh%0ALine%3A%20969-973%0A%0AComment%3A%0A**%60audit-failed%60%20output%20silently%20stays%20%600%60%20on%20format%20failure**%0A%0AWhen%20%60format-security-comment.py%60%20exits%20non-zero%2C%20%60FORMAT_FAILED%60%20is%20set%20to%201%20but%20%60AUDIT_FAILED%60%20stays%200.%20The%20call%20at%20line%20973%20writes%20%60audit-failed%3D0%60%2C%20%60has-vulns%3D0%60%2C%20%60exit-code%3D1%60%2C%20%60status%3Dfailed%60.%20Any%20caller%20that%20branches%20on%20%60needs.security-audit.outputs.audit-failed%20%3D%3D%20'1'%60%20to%20detect%20tool%20errors%20%E2%80%94%20as%20the%20contract%20docs%20suggest%20%E2%80%94%20will%20silently%20miss%20this%20failure%20mode%2C%20receiving%20a%20state%20where%20nothing%20in%20the%20documented%20outputs%20explains%20why%20the%20job%20failed.%20The%20fix%20is%20either%20to%20treat%20format%20failure%20as%20an%20audit%20failure%20%28%60AUDIT_FAILED%3D1%60%20when%20%60FORMAT_FAILED%3D1%60%29%20or%20to%20expose%20%60format-failed%60%20as%20a%20documented%20workflow%20output.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fsecurity%2Frun-lintro-audit.sh%3A969-973%0A**%60audit-failed%60%20output%20silently%20stays%20%600%60%20on%20format%20failure**%0A%0AWhen%20%60format-security-comment.py%60%20exits%20non-zero%2C%20%60FORMAT_FAILED%60%20is%20set%20to%201%20but%20%60AUDIT_FAILED%60%20stays%200.%20The%20call%20at%20line%20973%20writes%20%60audit-failed%3D0%60%2C%20%60has-vulns%3D0%60%2C%20%60exit-code%3D1%60%2C%20%60status%3Dfailed%60.%20Any%20caller%20that%20branches%20on%20%60needs.security-audit.outputs.audit-failed%20%3D%3D%20'1'%60%20to%20detect%20tool%20errors%20%E2%80%94%20as%20the%20contract%20docs%20suggest%20%E2%80%94%20will%20silently%20miss%20this%20failure%20mode%2C%20receiving%20a%20state%20where%20nothing%20in%20the%20documented%20outputs%20explains%20why%20the%20job%20failed.%20The%20fix%20is%20either%20to%20treat%20format%20failure%20as%20an%20audit%20failure%20%28%60AUDIT_FAILED%3D1%60%20when%20%60FORMAT_FAILED%3D1%60%29%20or%20to%20expose%20%60format-failed%60%20as%20a%20documented%20workflow%20output.%0A%0A&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fsecurity%2Frun-lintro-audit.sh%3A969-973%0A**%60audit-failed%60%20output%20silently%20stays%20%600%60%20on%20format%20failure**%0A%0AWhen%20%60format-security-comment.py%60%20exits%20non-zero%2C%20%60FORMAT_FAILED%60%20is%20set%20to%201%20but%20%60AUDIT_FAILED%60%20stays%200.%20The%20call%20at%20line%20973%20writes%20%60audit-failed%3D0%60%2C%20%60has-vulns%3D0%60%2C%20%60exit-code%3D1%60%2C%20%60status%3Dfailed%60.%20Any%20caller%20that%20branches%20on%20%60needs.security-audit.outputs.audit-failed%20%3D%3D%20'1'%60%20to%20detect%20tool%20errors%20%E2%80%94%20as%20the%20contract%20docs%20suggest%20%E2%80%94%20will%20silently%20miss%20this%20failure%20mode%2C%20receiving%20a%20state%20where%20nothing%20in%20the%20documented%20outputs%20explains%20why%20the%20job%20failed.%20The%20fix%20is%20either%20to%20treat%20format%20failure%20as%20an%20audit%20failure%20%28%60AUDIT_FAILED%3D1%60%20when%20%60FORMAT_FAILED%3D1%60%29%20or%20to%20expose%20%60format-failed%60%20as%20a%20documented%20workflow%20output.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F307-reusable-security-audit%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F307-reusable-security-audit%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fsecurity%2Frun-lintro-audit.sh%3A969-973%0A**%60audit-failed%60%20output%20silently%20stays%20%600%60%20on%20format%20failure**%0A%0AWhen%20%60format-security-comment.py%60%20exits%20non-zero%2C%20%60FORMAT_FAILED%60%20is%20set%20to%201%20but%20%60AUDIT_FAILED%60%20stays%200.%20The%20call%20at%20line%20973%20writes%20%60audit-failed%3D0%60%2C%20%60has-vulns%3D0%60%2C%20%60exit-code%3D1%60%2C%20%60status%3Dfailed%60.%20Any%20caller%20that%20branches%20on%20%60needs.security-audit.outputs.audit-failed%20%3D%3D%20'1'%60%20to%20detect%20tool%20errors%20%E2%80%94%20as%20the%20contract%20docs%20suggest%20%E2%80%94%20will%20silently%20miss%20this%20failure%20mode%2C%20receiving%20a%20state%20where%20nothing%20in%20the%20documented%20outputs%20explains%20why%20the%20job%20failed.%20The%20fix%20is%20either%20to%20treat%20format%20failure%20as%20an%20audit%20failure%20%28%60AUDIT_FAILED%3D1%60%20when%20%60FORMAT_FAILED%3D1%60%29%20or%20to%20expose%20%60format-failed%60%20as%20a%20documented%20workflow%20output.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["test: reset upload step scope in securit..."](https://github.com/lgtm-hq/lgtm-ci/commit/ba8c78dfc063e141f72b2aea2d8e0ff95baba275) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36247955)</sub>

<!-- /greptile_comment -->