### PR TITLE
feat(workflows): add reusable-site-quality for docs site CI (#307 §2)

### DIFF
--- a/.github/workflows/reusable-site-quality.yml
+++ b/.github/workflows/reusable-site-quality.yml
@@ -1,0 +1,513 @@
+---
+name: Reusable Documentation Site Quality Workflow
+
+on:
+  workflow_call:
+    inputs:
+      job-name:
+        description: "GitHub check name for the build and link-check job"
+        required: false
+        type: string
+        default: "Build and check documentation site"
+      test-job-name:
+        description: "GitHub check name for the site test job"
+        required: false
+        type: string
+        default: "Test documentation site"
+      build-command:
+        description: >-
+          Shell command to build the documentation site (e.g.
+          ./scripts/ci/site/build.sh). Runs in working-directory.
+        required: true
+        type: string
+      build-env:
+        description: >-
+          Multiline KEY=VALUE lines exported before build-command (e.g.
+          ASTRO_BASE=/)
+        required: false
+        type: string
+        default: ""
+      check-command:
+        description: >-
+          Optional shell command before tests (e.g. ./scripts/ci/site/check.sh).
+          Runs in working-directory.
+        required: false
+        type: string
+        default: ""
+      test-command:
+        description: >-
+          Shell command to run site tests (e.g. ./scripts/ci/site/test-all.sh).
+          Runs in working-directory.
+        required: true
+        type: string
+      python-test-command:
+        description: >-
+          Optional Python test hook run after check-command and before
+          test-command when python-version is set
+        required: false
+        type: string
+        default: ""
+      site-working-directory:
+        description: "Working directory for Node/Bun dependency install"
+        required: false
+        type: string
+        default: "."
+      working-directory:
+        description: "Working directory for caller build/check/test commands"
+        required: false
+        type: string
+        default: "."
+      node-version:
+        description: "Node.js version to use"
+        required: false
+        type: string
+        default: "22"
+      package-manager:
+        description: "Package manager for dependency install: npm, bun, pnpm"
+        required: false
+        type: string
+        default: "bun"
+      cache-dependency-path:
+        description: "Lockfile path for Node/Bun cache key (relative to repo root)"
+        required: false
+        type: string
+        default: ""
+      python-version:
+        description: >-
+          Python version for optional site Python tests. Empty skips Python setup.
+        required: false
+        type: string
+        default: ""
+      install-python-dependencies:
+        description: "Run uv sync when Python setup is enabled"
+        required: false
+        type: boolean
+        default: false
+      enable-lychee:
+        description: "Run lychee link check after build-command"
+        required: false
+        type: boolean
+        default: true
+      lychee-paths:
+        description: "Comma-separated files or directories to scan with lychee"
+        required: false
+        type: string
+        default: "."
+      lychee-file-extensions:
+        description: "File extensions to scan with lychee, comma-separated"
+        required: false
+        type: string
+        default: "md,html"
+      lychee-exclude-patterns:
+        description: "Comma-separated path or URL patterns to exclude from lychee"
+        required: false
+        type: string
+        default: ""
+      check-external:
+        description: "Check external HTTP(S) links with lychee"
+        required: false
+        type: boolean
+        default: false
+      lychee-timeout:
+        description: "HTTP timeout in seconds for lychee"
+        required: false
+        type: string
+        default: "10"
+      lychee-root-dir:
+        description: >-
+          Root directory passed to lychee --root-dir for built HTML (e.g.
+          apps/site/dist)
+        required: false
+        type: string
+        default: ""
+      upload-site-artifact:
+        description: "Upload built site dist as a workflow artifact"
+        required: false
+        type: boolean
+        default: true
+      site-artifact-name:
+        description: "Artifact name for the built site upload"
+        required: false
+        type: string
+        default: "site-dist"
+      site-artifact-path:
+        description: >-
+          Path to built site output for artifact upload. Defaults to the first
+          lychee-path when empty.
+        required: false
+        type: string
+        default: ""
+      vitest-json-path:
+        description: >-
+          Optional Vitest JSON results path relative to working-directory for
+          non-default summary layouts
+        required: false
+        type: string
+        default: ""
+      publish-test-summary:
+        description: >-
+          Publish pass/fail test summary on pull requests when vitest-json-path
+          is set
+        required: false
+        type: boolean
+        default: false
+      comment-marker:
+        description: "Upsert marker for site test summary comments"
+        required: false
+        type: string
+        default: "site-test-results"
+      draft-pr-skip:
+        description: "Skip jobs on draft pull requests"
+        required: false
+        type: boolean
+        default: true
+      tooling-ref:
+        description: "Git ref to use when checking out lgtm-ci tooling scripts"
+        required: false
+        type: string
+        default: ""
+
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "block"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block (build job)"
+        required: false
+        type: string
+        default: ""
+
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
+      egress-preset:
+        description: >-
+          Named allowlist when allowed-endpoints is empty and egress-policy is
+          block (github-minimal, github-pages, github-tooling, docker, playwright, pypi,
+          rubygems, npm-publish, quality, sbom, scorecard)
+        required: false
+        type: string
+        default: "github-tooling"
+      test-egress-preset:
+        description: >-
+          Egress preset override for the site-test job. Falls back to egress-preset
+          when empty.
+        required: false
+        type: string
+        default: ""
+      test-allowed-endpoints:
+        description: >-
+          Allowed endpoints override for the site-test job. Falls back to
+          allowed-endpoints when empty.
+        required: false
+        type: string
+        default: ""
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Timeout for site quality jobs in minutes"
+        required: false
+        type: number
+        default: 15
+
+    outputs:
+      passed:
+        description: "Whether both site build/link and test jobs succeeded"
+        value: >-
+          ${{ jobs.site-build-link.outputs.passed == 'true'
+          && jobs.site-test.outputs.passed == 'true' }}
+      build-passed:
+        description: "Whether the build and link-check job succeeded"
+        value: ${{ jobs.site-build-link.outputs.passed }}
+      test-passed:
+        description: "Whether the site test job succeeded"
+        value: ${{ jobs.site-test.outputs.passed }}
+
+jobs:
+  site-build-link:
+    name: ${{ inputs.job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    if: >-
+      !inputs.draft-pr-skip ||
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
+    permissions:
+      contents: read
+    outputs:
+      passed: ${{ steps.record.outputs.passed }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+            .github/actions/setup-node
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+
+      - name: Setup Node.js
+        uses: ./.lgtm-ci-tooling/.github/actions/setup-node
+        with:
+          node-version: ${{ inputs.node-version }}
+          working-directory: ${{ inputs.site-working-directory }}
+          cache-dependency-path: >-
+            ${{ inputs.cache-dependency-path != '' && inputs.cache-dependency-path
+            || format('{0}/bun.lock', inputs.site-working-directory) }}
+
+      - name: Apply build environment
+        if: inputs.build-env != ''
+        shell: bash
+        env:
+          BUILD_ENV: ${{ inputs.build-env }}
+        run: |
+          while IFS= read -r line || [[ -n "$line" ]]; do
+            line="${line#"${line%%[![:space:]]*}"}"
+            line="${line%"${line##*[![:space:]]}"}"
+            [[ -z "$line" || "$line" =~ ^# ]] && continue
+            echo "$line" >>"$GITHUB_ENV"
+          done <<<"$BUILD_ENV"
+
+      - name: Build site
+        id: build
+        shell: bash
+        env:
+          COMMAND: ${{ inputs.build-command }}
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/run-command.sh
+
+      - name: Build Lychee arguments
+        if: inputs.enable-lychee
+        id: lychee-args
+        shell: bash
+        env:
+          PATHS: ${{ inputs.lychee-paths }}
+          FILE_EXTENSIONS: ${{ inputs.lychee-file-extensions }}
+          EXCLUDE_PATTERNS: ${{ inputs.lychee-exclude-patterns }}
+          CHECK_EXTERNAL: ${{ inputs.check-external }}
+          TIMEOUT: ${{ inputs.lychee-timeout }}
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/build-lychee-args.sh
+
+      - name: Prepare Lychee action inputs
+        if: inputs.enable-lychee
+        id: lychee-action
+        shell: bash
+        env:
+          RAW_ARGS: ${{ steps.lychee-args.outputs.args }}
+          LYCHEE_ROOT_DIR: >-
+            ${{ inputs.lychee-root-dir != '' && inputs.lychee-root-dir
+            || inputs.lychee-paths }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/prepare-lychee-action-args.sh
+
+      - name: Check links
+        if: inputs.enable-lychee
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: ${{ steps.lychee-action.outputs.args }}
+          format: markdown
+          output: lychee-report.md
+          token: ${{ github.token }}
+          fail: true
+
+      - name: Upload site artifact
+        if: >-
+          always()
+          && inputs.upload-site-artifact
+          && steps.build.outcome == 'success'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.site-artifact-name }}
+          path: >-
+            ${{ inputs.site-artifact-path != '' && inputs.site-artifact-path
+            || inputs.lychee-paths }}
+          retention-days: 1
+
+      - name: Record build and link result
+        if: always()
+        id: record
+        shell: bash
+        run: |
+          if [[ "${{ job.status }}" == "success" ]]; then
+            echo "passed=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "passed=false" >>"$GITHUB_OUTPUT"
+          fi
+
+  site-test:
+    name: ${{ inputs.test-job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    if: >-
+      !inputs.draft-pr-skip ||
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false
+    permissions:
+      contents: read
+    outputs:
+      passed: ${{ steps.record.outputs.passed }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+            .github/actions/setup-node
+            .github/actions/setup-python
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: >-
+            ${{ inputs.test-egress-preset != '' && inputs.test-egress-preset
+            || inputs.egress-preset }}
+          allowed-endpoints: >-
+            ${{ inputs.test-allowed-endpoints != '' && inputs.test-allowed-endpoints
+            || inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+
+      - name: Setup Python and uv
+        if: inputs.python-version != ''
+        uses: ./.lgtm-ci-tooling/.github/actions/setup-python
+        with:
+          python-version: ${{ inputs.python-version }}
+          install-dependencies: ${{ inputs.install-python-dependencies }}
+
+      - name: Setup Node.js
+        uses: ./.lgtm-ci-tooling/.github/actions/setup-node
+        with:
+          node-version: ${{ inputs.node-version }}
+          working-directory: ${{ inputs.site-working-directory }}
+          cache-dependency-path: >-
+            ${{ inputs.cache-dependency-path != '' && inputs.cache-dependency-path
+            || format('{0}/bun.lock', inputs.site-working-directory) }}
+
+      - name: Run check command
+        if: inputs.check-command != ''
+        shell: bash
+        env:
+          COMMAND: ${{ inputs.check-command }}
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/run-command.sh
+
+      - name: Run Python test hook
+        if: inputs.python-version != '' && inputs.python-test-command != ''
+        shell: bash
+        env:
+          COMMAND: ${{ inputs.python-test-command }}
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/run-command.sh
+
+      - name: Run site tests
+        id: test-run
+        shell: bash
+        env:
+          COMMAND: ${{ inputs.test-command }}
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/run-command.sh
+
+      - name: Parse Vitest JSON results
+        if: always() && inputs.vitest-json-path != ''
+        shell: bash
+        env:
+          STEP: parse
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+          RESULTS_FILE: ${{ inputs.working-directory }}/${{ inputs.vitest-json-path }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/run-vitest.sh
+
+      - name: Fail on site test errors
+        if: steps.test-run.outcome == 'failure'
+        run: exit 1
+
+      - name: Record site test result
+        if: always()
+        id: record
+        shell: bash
+        run: |
+          if [[ "${{ job.status }}" == "success" ]]; then
+            echo "passed=true" >>"$GITHUB_OUTPUT"
+          else
+            echo "passed=false" >>"$GITHUB_OUTPUT"
+          fi
+
+  publish-test-summary:
+    needs: site-test
+    if: >-
+      always()
+      && inputs.publish-test-summary
+      && inputs.vitest-json-path != ''
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.fork == false
+      && (
+        !inputs.draft-pr-skip ||
+        github.event.pull_request.draft == false
+      )
+    uses: ./.github/workflows/reusable-publish-test-summary.yml
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      test-suite-name: ${{ inputs.test-job-name }}
+      comment-marker: ${{ inputs.comment-marker }}
+      job-result: ${{ needs.site-test.result }}
+      tooling-ref: ${{ inputs.tooling-ref }}

--- a/.github/workflows/reusable-site-quality.yml
+++ b/.github/workflows/reusable-site-quality.yml
@@ -121,10 +121,12 @@ on:
         type: string
         default: ""
       upload-site-artifact:
-        description: "Upload built site dist as a workflow artifact"
+        description: >-
+          Upload built site dist as a workflow artifact. Requires
+          site-artifact-path or a non-default lychee-paths value.
         required: false
         type: boolean
-        default: true
+        default: false
       site-artifact-name:
         description: "Artifact name for the built site upload"
         required: false
@@ -352,6 +354,13 @@ jobs:
           always()
           && inputs.upload-site-artifact
           && steps.build.outcome == 'success'
+          && (
+            inputs.site-artifact-path != ''
+            || (
+              inputs.lychee-paths != ''
+              && inputs.lychee-paths != '.'
+            )
+          )
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.site-artifact-name }}

--- a/.github/workflows/reusable-site-quality.yml
+++ b/.github/workflows/reusable-site-quality.yml
@@ -298,6 +298,9 @@ jobs:
       - name: Setup pnpm
         if: inputs.package-manager == 'pnpm'
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          package_json_file: >-
+            ${{ format('{0}/package.json', inputs.site-working-directory) }}
 
       - name: Get bun cache directory
         if: inputs.package-manager == 'bun'
@@ -499,6 +502,9 @@ jobs:
       - name: Setup pnpm
         if: inputs.package-manager == 'pnpm'
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          package_json_file: >-
+            ${{ format('{0}/package.json', inputs.site-working-directory) }}
 
       - name: Get bun cache directory
         if: inputs.package-manager == 'bun'

--- a/.github/workflows/reusable-site-quality.yml
+++ b/.github/workflows/reusable-site-quality.yml
@@ -264,7 +264,6 @@ jobs:
           sparse-checkout: |
             .github/actions/harden-runner
             .github/actions/resolve-egress-allowlist
-            .github/actions/setup-node
             scripts/ci/
           sparse-checkout-cone-mode: true
           persist-credentials: false
@@ -286,13 +285,50 @@ jobs:
           allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Setup Node.js
-        uses: ./.lgtm-ci-tooling/.github/actions/setup-node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
-          working-directory: ${{ inputs.site-working-directory }}
-          cache-dependency-path: >-
-            ${{ inputs.cache-dependency-path != '' && inputs.cache-dependency-path
-            || format('{0}/bun.lock', inputs.site-working-directory) }}
+
+      - name: Setup Bun
+        if: inputs.package-manager == 'bun'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Setup pnpm
+        if: inputs.package-manager == 'pnpm'
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Get bun cache directory
+        if: inputs.package-manager == 'bun'
+        id: bun-cache
+        shell: bash
+        env:
+          STEP: bun-cache
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/setup-node.sh
+
+      - name: Cache bun dependencies
+        if: inputs.package-manager == 'bun'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ${{ steps.bun-cache.outputs.dir }}
+            ${{ inputs.site-working-directory }}/node_modules
+          key: >-
+            bun-${{ runner.os }}-${{ inputs.node-version }}-${{
+            hashFiles(inputs.cache-dependency-path != '' && inputs.cache-dependency-path
+            || format('{0}/bun.lock', inputs.site-working-directory)) }}
+          restore-keys: |
+            bun-${{ runner.os }}-${{ inputs.node-version }}-
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        shell: bash
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
+          WORKING_DIRECTORY: ${{ inputs.site-working-directory }}
+          FROZEN_LOCKFILE: "true"
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/setup-package-manager.sh
 
       - name: Apply build environment
         if: inputs.build-env != ''
@@ -355,24 +391,26 @@ jobs:
           retention-days: 1
           if-no-files-found: ignore
 
+      - name: Resolve site artifact path
+        if: inputs.upload-site-artifact
+        id: site-artifact
+        shell: bash
+        env:
+          SITE_ARTIFACT_PATH: ${{ inputs.site-artifact-path }}
+          LYCHEE_PATHS: ${{ inputs.lychee-paths }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/resolve-site-artifact-path.sh
+
       - name: Upload site artifact
         if: >-
           always()
           && inputs.upload-site-artifact
           && steps.build.outcome == 'success'
-          && (
-            inputs.site-artifact-path != ''
-            || (
-              inputs.lychee-paths != ''
-              && inputs.lychee-paths != '.'
-            )
-          )
+          && steps.site-artifact.outputs.path != ''
+          && steps.site-artifact.outputs.path != '.'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.site-artifact-name }}
-          path: >-
-            ${{ inputs.site-artifact-path != '' && inputs.site-artifact-path
-            || inputs.lychee-paths }}
+          path: ${{ steps.site-artifact.outputs.path }}
           retention-days: 1
 
       - name: Record build and link result
@@ -415,7 +453,6 @@ jobs:
           sparse-checkout: |
             .github/actions/harden-runner
             .github/actions/resolve-egress-allowlist
-            .github/actions/setup-node
             .github/actions/setup-python
             scripts/ci/
           sparse-checkout-cone-mode: true
@@ -449,13 +486,50 @@ jobs:
           install-dependencies: ${{ inputs.install-python-dependencies }}
 
       - name: Setup Node.js
-        uses: ./.lgtm-ci-tooling/.github/actions/setup-node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ inputs.node-version }}
-          working-directory: ${{ inputs.site-working-directory }}
-          cache-dependency-path: >-
-            ${{ inputs.cache-dependency-path != '' && inputs.cache-dependency-path
-            || format('{0}/bun.lock', inputs.site-working-directory) }}
+
+      - name: Setup Bun
+        if: inputs.package-manager == 'bun'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Setup pnpm
+        if: inputs.package-manager == 'pnpm'
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Get bun cache directory
+        if: inputs.package-manager == 'bun'
+        id: bun-cache
+        shell: bash
+        env:
+          STEP: bun-cache
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/setup-node.sh
+
+      - name: Cache bun dependencies
+        if: inputs.package-manager == 'bun'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ${{ steps.bun-cache.outputs.dir }}
+            ${{ inputs.site-working-directory }}/node_modules
+          key: >-
+            bun-${{ runner.os }}-${{ inputs.node-version }}-${{
+            hashFiles(inputs.cache-dependency-path != '' && inputs.cache-dependency-path
+            || format('{0}/bun.lock', inputs.site-working-directory)) }}
+          restore-keys: |
+            bun-${{ runner.os }}-${{ inputs.node-version }}-
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        shell: bash
+        env:
+          PACKAGE_MANAGER: ${{ inputs.package-manager }}
+          WORKING_DIRECTORY: ${{ inputs.site-working-directory }}
+          FROZEN_LOCKFILE: "true"
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/setup-package-manager.sh
 
       - name: Run check command
         if: inputs.check-command != ''

--- a/.github/workflows/reusable-site-quality.yml
+++ b/.github/workflows/reusable-site-quality.yml
@@ -299,13 +299,7 @@ jobs:
         shell: bash
         env:
           BUILD_ENV: ${{ inputs.build-env }}
-        run: |
-          while IFS= read -r line || [[ -n "$line" ]]; do
-            line="${line#"${line%%[![:space:]]*}"}"
-            line="${line%"${line##*[![:space:]]}"}"
-            [[ -z "$line" || "$line" =~ ^# ]] && continue
-            echo "$line" >>"$GITHUB_ENV"
-          done <<<"$BUILD_ENV"
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/apply-build-env.sh
 
       - name: Build site
         id: build
@@ -348,6 +342,18 @@ jobs:
           output: lychee-report.md
           token: ${{ github.token }}
           fail: true
+
+      - name: Upload lychee report
+        if: >-
+          always()
+          && inputs.enable-lychee
+          && hashFiles('lychee-report.md') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lychee-report
+          path: lychee-report.md
+          retention-days: 1
+          if-no-files-found: ignore
 
       - name: Upload site artifact
         if: >-
@@ -484,6 +490,7 @@ jobs:
           RESULTS_FILE: ${{ inputs.working-directory }}/${{ inputs.vitest-json-path }}
         run: bash .lgtm-ci-tooling/scripts/ci/actions/run-vitest.sh
 
+      # Re-fail after always() Vitest parse so test-run failures are not masked.
       - name: Fail on site test errors
         if: steps.test-run.outcome == 'failure'
         run: exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **workflows**: forward `package-manager` to site-quality Node install steps
+- **workflows**: resolve first `lychee-path` for site artifact uploads
 - **workflows**: upload `lychee-report` artifact on link-check failure in
   `reusable-site-quality`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **workflows**: upload `lychee-report` artifact on link-check failure in
+  `reusable-site-quality`
+
 ### Security
+
+- **workflows**: reject unsafe `build-env` lines in `reusable-site-quality`
+  (`apply-build-env.sh` blocks `GITHUB_ENV` heredoc injection)
 
 ## [0.39.0] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **workflows**: add `reusable-site-quality` for Astro docs build, lychee link
+  check, and mixed Node/Python site tests (#307)
+
 ### Changed
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ steps:
 | `reusable-dependency-review.yml`       | Dependency review gate                       |
 | `reusable-security-audit.yml`          | lintro/osv-scanner audit + comment artifact    |
 | `reusable-publish-security-audit-comment.yml` | Publish security audit PR comment     |
+| `reusable-site-quality.yml`            | Docs site build, lychee, and site tests        |
 | `reusable-scorecards.yml`              | OpenSSF Scorecard analysis                   |
 | `reusable-semantic-pr-title.yml`       | Conventional PR title validation + comments  |
 | `reusable-validate-action-pinning.yml` | GitHub Action SHA pinning validation         |

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -715,6 +715,80 @@ jobs:
 For push/schedule workflows, omit the publish job and pass
 `upload-comment-artifact: false`.
 
+### Documentation site quality
+
+`reusable-site-quality.yml` runs Astro (or similar) docs build, lychee link
+check on built HTML, and caller-provided check/test commands in two parallel
+jobs. Consumer repo scripts (e.g. `scripts/ci/site/build.sh`) stay in the
+consumer and are passed as command inputs.
+
+<!-- markdownlint-disable MD013 -->
+
+| Input                    | Default                    | Notes                                      |
+| ------------------------ | -------------------------- | ------------------------------------------ |
+| `build-command`          | required                   | Site build script or inline command        |
+| `test-command`           | required                   | Site test orchestrator                     |
+| `check-command`          | empty                      | Optional type-check step before tests      |
+| `build-env`              | empty                      | Multiline `KEY=VALUE` for build (ASTRO_BASE) |
+| `site-working-directory` | `.`                        | Node/Bun install path                      |
+| `lychee-paths`           | `.`                        | Built dist path for link check             |
+| `lychee-root-dir`        | first `lychee-paths` entry | `--root-dir` for relative href resolution  |
+| `python-version`         | empty                      | Enables Python setup when set              |
+| `vitest-json-path`       | empty                      | Non-default Vitest JSON for PR summaries   |
+
+<!-- markdownlint-enable MD013 -->
+
+```yaml
+jobs:
+  site-quality:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-site-quality.yml@<sha>
+    permissions:
+      contents: read
+    with:
+      tooling-ref: "<sha>"
+      job-name: "Build and check documentation site"
+      test-job-name: "Test documentation site"
+      node-version: "22"
+      package-manager: bun
+      site-working-directory: apps/site
+      cache-dependency-path: apps/site/bun.lock
+      build-command: ./scripts/ci/site/build.sh
+      build-env: |
+        ASTRO_BASE=/
+      lychee-paths: apps/site/dist
+      lychee-file-extensions: html
+      check-external: false
+      lychee-root-dir: apps/site/dist
+      check-command: ./scripts/ci/site/check.sh
+      test-command: ./scripts/ci/site/test-all.sh
+      python-version: "3.12"
+      install-python-dependencies: false
+      egress-policy: block
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
+        registry.npmjs.org:443
+        bun.sh:443
+      test-allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
+        release-assets.githubusercontent.com:443
+        raw.githubusercontent.com:443
+        registry.npmjs.org:443
+        bun.sh:443
+        pypi.org:443
+        files.pythonhosted.org:443
+```
+
+Path filters and concurrency remain on the caller workflow. Set
+`publish-test-summary: true` and `vitest-json-path` when adopting lgtm-ci
+Vitest JSON output for PR summaries.
+
 ```yaml
 jobs:
   semantic-title:

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -733,8 +733,11 @@ consumer and are passed as command inputs.
 | `site-working-directory` | `.`                        | Node/Bun install path                      |
 | `lychee-paths`           | `.`                        | Built dist path for link check             |
 | `lychee-root-dir`        | first `lychee-paths` entry | `--root-dir` for relative href resolution  |
+| `upload-site-artifact`   | `false`                    | Set `true` with explicit artifact path     |
 | `python-version`         | empty                      | Enables Python setup when set              |
+| `python-test-command`    | empty                      | Hook before `test-command` when Python set |
 | `vitest-json-path`       | empty                      | Non-default Vitest JSON for PR summaries   |
+| `test-egress-preset`     | falls back to `egress-preset` | Override egress for site-test job       |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -759,6 +762,8 @@ jobs:
       lychee-file-extensions: html
       check-external: false
       lychee-root-dir: apps/site/dist
+      upload-site-artifact: true
+      site-artifact-path: apps/site/dist
       check-command: ./scripts/ci/site/check.sh
       test-command: ./scripts/ci/site/test-all.sh
       python-version: "3.12"

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -805,7 +805,7 @@ The reusable runs two parallel jobs (`site-build-link`, `site-test`). Lychee use
 | `build-command`          | required                        | e.g. `./scripts/ci/site/build.sh`               |
 | `test-command`           | required                        | e.g. `./scripts/ci/site/test-all.sh`            |
 | `check-command`          | empty                           | Optional type-check before tests                |
-| `build-env`              | empty                           | Multiline `KEY=VALUE` exported before build     |
+| `build-env`              | empty                           | Multiline `KEY=VALUE` (`apply-build-env.sh`)    |
 | `site-working-directory` | `.`                             | Node/Bun install path (e.g. `apps/site`)        |
 | `lychee-paths`           | `.`                             | Built dist path for link check                  |
 | `lychee-root-dir`        | first `lychee-paths` entry      | `--root-dir` for built HTML link resolution     |

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -785,6 +785,39 @@ reusable itself requires only `contents: read` and `packages: read`.
 
 Outputs: `exit-code`, `has-vulns`, `audit-failed`, `status`.
 
+## Documentation site quality
+
+`reusable-site-quality.yml` centralizes the docs-site pattern used by Rust
+monorepos: Astro (or similar) build, lychee link check on built HTML, and
+caller-provided check/test commands. Repo scripts such as `scripts/ci/site/build.sh`
+remain consumer-owned and are passed as `build-command`, `check-command`, and
+`test-command` inputs.
+
+The reusable runs two parallel jobs (`site-build-link`, `site-test`). Lychee uses
+`build-lychee-args.sh` plus `prepare-lychee-action-args.sh` to strip duplicate
+`--format`/`--output` flags and add `--root-dir` for built dist output. Set
+`lychee-root-dir` when the default (first `lychee-paths` value) is insufficient.
+
+<!-- markdownlint-disable MD013 MD060 -- wide input reference table -->
+
+| Input                    | Default                         | Notes                                           |
+| ------------------------ | ------------------------------- | ----------------------------------------------- |
+| `build-command`          | required                        | e.g. `./scripts/ci/site/build.sh`               |
+| `test-command`           | required                        | e.g. `./scripts/ci/site/test-all.sh`            |
+| `build-env`              | empty                           | Multiline `KEY=VALUE` exported before build     |
+| `site-working-directory` | `.`                             | Node/Bun install path (e.g. `apps/site`)        |
+| `python-version`         | empty                           | When set, enables optional Python setup         |
+| `python-test-command`    | empty                           | Hook before `test-command` when Python enabled  |
+| `lychee-root-dir`        | first `lychee-paths` entry      | `--root-dir` for built HTML link resolution     |
+| `vitest-json-path`       | empty                           | Optional non-default Vitest JSON for summaries  |
+| `test-egress-preset`     | falls back to `egress-preset`   | Override egress for Python+Node test job        |
+
+<!-- markdownlint-enable MD013 MD060 -->
+
+Work jobs require only `contents: read`. Optional `publish-test-summary` delegates
+to `reusable-publish-test-summary.yml` (requires `pull-requests: write` on the
+caller publish job path). Outputs: `passed`, `build-passed`, `test-passed`.
+
 ## Merge queue (`merge_group`)
 
 Callers using GitHub merge queue can add `merge_group:` triggers to thin
@@ -796,6 +829,7 @@ caller workflows alongside `pull_request:`.
 | `reusable-validate-action-pinning.yml` | Safe to run — no PR context required           |
 | `reusable-dependency-review.yml`       | Runs on `merge_group` (same as PR)             |
 | `reusable-security-audit.yml`          | Audit on `merge_group`; PR comment on PR only  |
+| `reusable-site-quality.yml`            | Safe to run — no PR context required           |
 | `reusable-semantic-pr-title.yml`       | Skips on `merge_group` — title validated on PR |
 
 Semantic title validation is intentionally skipped in the merge queue because

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -804,11 +804,14 @@ The reusable runs two parallel jobs (`site-build-link`, `site-test`). Lychee use
 | ------------------------ | ------------------------------- | ----------------------------------------------- |
 | `build-command`          | required                        | e.g. `./scripts/ci/site/build.sh`               |
 | `test-command`           | required                        | e.g. `./scripts/ci/site/test-all.sh`            |
+| `check-command`          | empty                           | Optional type-check before tests                |
 | `build-env`              | empty                           | Multiline `KEY=VALUE` exported before build     |
 | `site-working-directory` | `.`                             | Node/Bun install path (e.g. `apps/site`)        |
+| `lychee-paths`           | `.`                             | Built dist path for link check                  |
+| `lychee-root-dir`        | first `lychee-paths` entry      | `--root-dir` for built HTML link resolution     |
+| `upload-site-artifact`   | `false`                         | Set `true` with explicit artifact path          |
 | `python-version`         | empty                           | When set, enables optional Python setup         |
 | `python-test-command`    | empty                           | Hook before `test-command` when Python enabled  |
-| `lychee-root-dir`        | first `lychee-paths` entry      | `--root-dir` for built HTML link resolution     |
 | `vitest-json-path`       | empty                           | Optional non-default Vitest JSON for summaries  |
 | `test-egress-preset`     | falls back to `egress-preset`   | Override egress for Python+Node test job        |
 

--- a/scripts/ci/actions/apply-build-env.sh
+++ b/scripts/ci/actions/apply-build-env.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Apply caller build-env lines to GITHUB_ENV without heredoc injection.
+# SPDX-License-Identifier: MIT
+set -euo pipefail
+
+: "${BUILD_ENV:=}"
+: "${GITHUB_ENV:?GITHUB_ENV is required}"
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+	line="${line#"${line%%[![:space:]]*}"}"
+	line="${line%"${line##*[![:space:]]}"}"
+	[[ -z "$line" || "$line" =~ ^# ]] && continue
+	if [[ ! "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
+		echo "::error::Invalid build-env line rejected: ${line%%=*}" >&2
+		exit 1
+	fi
+	echo "$line" >>"$GITHUB_ENV"
+done <<<"$BUILD_ENV"

--- a/scripts/ci/actions/prepare-lychee-action-args.sh
+++ b/scripts/ci/actions/prepare-lychee-action-args.sh
@@ -7,6 +7,13 @@ set -euo pipefail
 : "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
 : "${LYCHEE_ROOT_DIR:?LYCHEE_ROOT_DIR is required}"
 
+# When callers pass comma-separated lychee-paths, use the first entry only.
+if [[ "$LYCHEE_ROOT_DIR" == *","* ]]; then
+	LYCHEE_ROOT_DIR="${LYCHEE_ROOT_DIR%%,*}"
+	LYCHEE_ROOT_DIR="${LYCHEE_ROOT_DIR#"${LYCHEE_ROOT_DIR%%[![:space:]]*}"}"
+	LYCHEE_ROOT_DIR="${LYCHEE_ROOT_DIR%"${LYCHEE_ROOT_DIR##*[![:space:]]}"}"
+fi
+
 read -r -a tokens <<<"$RAW_ARGS"
 filtered=()
 skip_next=false

--- a/scripts/ci/actions/prepare-lychee-action-args.sh
+++ b/scripts/ci/actions/prepare-lychee-action-args.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 : "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
 : "${LYCHEE_ROOT_DIR:?LYCHEE_ROOT_DIR is required}"
 
+LYCHEE_ROOT_DIR="${LYCHEE_ROOT_DIR#"${LYCHEE_ROOT_DIR%%[![:space:]]*}"}"
+LYCHEE_ROOT_DIR="${LYCHEE_ROOT_DIR%"${LYCHEE_ROOT_DIR##*[![:space:]]}"}"
+
 # When callers pass comma-separated lychee-paths, use the first entry only.
 if [[ "$LYCHEE_ROOT_DIR" == *","* ]]; then
 	LYCHEE_ROOT_DIR="${LYCHEE_ROOT_DIR%%,*}"

--- a/scripts/ci/actions/prepare-lychee-action-args.sh
+++ b/scripts/ci/actions/prepare-lychee-action-args.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Prepare lychee-action CLI args from lgtm-ci build-lychee-args output.
+# SPDX-License-Identifier: MIT
+set -euo pipefail
+
+: "${RAW_ARGS:?RAW_ARGS is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+: "${LYCHEE_ROOT_DIR:?LYCHEE_ROOT_DIR is required}"
+
+read -r -a tokens <<<"$RAW_ARGS"
+filtered=()
+skip_next=false
+for token in "${tokens[@]}"; do
+	if [[ "$skip_next" == true ]]; then
+		skip_next=false
+		continue
+	fi
+	case "$token" in
+	--format | --output) skip_next=true ;;
+	--format=* | --output=*) ;;
+	*) filtered+=("$token") ;;
+	esac
+done
+filtered+=(--root-dir "${LYCHEE_ROOT_DIR}")
+
+delimiter="lychee_action_args_$(openssl rand -hex 16)"
+{
+	echo "args<<${delimiter}"
+	printf '%s\n' "${filtered[*]}"
+	echo "${delimiter}"
+} >>"$GITHUB_OUTPUT"

--- a/scripts/ci/actions/resolve-site-artifact-path.sh
+++ b/scripts/ci/actions/resolve-site-artifact-path.sh
@@ -18,6 +18,9 @@ if [[ -n "$(trim "$SITE_ARTIFACT_PATH")" ]]; then
 	resolved="$(trim "$SITE_ARTIFACT_PATH")"
 else
 	resolved="$(trim "${LYCHEE_PATHS%%,*}")"
+	if [[ -z "$resolved" ]]; then
+		resolved="."
+	fi
 fi
 
 echo "path=$resolved" >>"$GITHUB_OUTPUT"

--- a/scripts/ci/actions/resolve-site-artifact-path.sh
+++ b/scripts/ci/actions/resolve-site-artifact-path.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Resolve site artifact upload path from explicit input or first lychee-path.
+# SPDX-License-Identifier: MIT
+set -euo pipefail
+
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+: "${SITE_ARTIFACT_PATH:=}"
+: "${LYCHEE_PATHS:=.}"
+
+trim() {
+	local value="$1"
+	value="${value#"${value%%[![:space:]]*}"}"
+	value="${value%"${value##*[![:space:]]}"}"
+	printf '%s' "$value"
+}
+
+if [[ -n "$(trim "$SITE_ARTIFACT_PATH")" ]]; then
+	resolved="$(trim "$SITE_ARTIFACT_PATH")"
+else
+	resolved="$(trim "${LYCHEE_PATHS%%,*}")"
+fi
+
+echo "path=$resolved" >>"$GITHUB_OUTPUT"

--- a/tests/bats/integration/test_reusable_site_quality.bats
+++ b/tests/bats/integration/test_reusable_site_quality.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-site-quality workflow inputs and job shape
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-site-quality.yml"
+
+@test "reusable-site-quality: requires build-command input" {
+	run grep -E '^      build-command:$' "$WORKFLOW"
+	assert_success
+	run awk '
+		/^      build-command:/ { in_input = 1 }
+		in_input && /^      [a-zA-Z0-9_-]+:/ && !/^      build-command:/ { in_input = 0 }
+		in_input && /required: true/ { found = 1 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-site-quality: requires test-command input" {
+	run grep -E '^      test-command:$' "$WORKFLOW"
+	assert_success
+	run awk '
+		/^      test-command:/ { in_input = 1 }
+		in_input && /^      [a-zA-Z0-9_-]+:/ && !/^      test-command:/ { in_input = 0 }
+		in_input && /required: true/ { found = 1 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-site-quality: build job checkout order preserves tooling" {
+	run egress_tooling_checkout_order_ok "$WORKFLOW" "site-build-link"
+	assert_success
+}
+
+@test "reusable-site-quality: test job checkout order preserves tooling" {
+	run egress_tooling_checkout_order_ok "$WORKFLOW" "site-test"
+	assert_success
+}
+
+@test "reusable-site-quality: no pull-requests permission on work jobs" {
+	run awk '
+		/^  site-build-link:/ { in_job = 1 }
+		/^  site-test:/ { in_job = 1 }
+		/^  publish-test-summary:/ { in_job = 0 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  site-build-link:/ && !/^  site-test:/ { in_job = 0 }
+		in_job && /pull-requests:/ { found = 1; exit }
+		END { exit found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-site-quality: uses prepare-lychee-action-args tooling script" {
+	run grep -F 'scripts/ci/actions/prepare-lychee-action-args.sh' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-site-quality: uses build-lychee-args tooling script" {
+	run grep -F 'scripts/ci/actions/build-lychee-args.sh' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-site-quality: lychee-action uses pinned SHA" {
+	run grep -F 'lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0' \
+		"$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-site-quality: upload-artifact uses upload repo v7 SHA" {
+	run grep -F 'uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1' \
+		"$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-site-quality: publish job delegates to reusable-publish-test-summary" {
+	run grep -F './.github/workflows/reusable-publish-test-summary.yml' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-site-quality: publish job declares pull-requests write" {
+	run awk '
+		/^  publish-test-summary:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ { in_job = 0 }
+		in_job && /pull-requests: write/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-site-quality: aggregate passed output combines both jobs" {
+	run grep -F 'jobs.site-build-link.outputs.passed' "$WORKFLOW"
+	assert_success
+	run grep -F 'jobs.site-test.outputs.passed' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-site-quality: optional Python setup when python-version is set" {
+	run awk '
+		/^  site-test:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  site-test:/ { in_job = 0 }
+		in_job && /inputs\.python-version != '\'''\''/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-site-quality: vitest-json-path wires run-vitest parse step" {
+	run grep -F 'scripts/ci/actions/run-vitest.sh' "$WORKFLOW"
+	assert_success
+	run grep -F 'inputs.vitest-json-path' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_site_quality.bats
+++ b/tests/bats/integration/test_reusable_site_quality.bats
@@ -112,3 +112,32 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-site-quality.yml"
 	run grep -F 'inputs.vitest-json-path' "$WORKFLOW"
 	assert_success
 }
+
+@test "reusable-site-quality: apply-build-env uses tooling script" {
+	run grep -F 'scripts/ci/actions/apply-build-env.sh' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-site-quality: uploads lychee report when markdown exists" {
+	run awk '
+		/^  site-build-link:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  site-build-link:/ { in_job = 0 }
+		in_job && /- name: Upload lychee report/ { upload = 1 }
+		upload && /hashFiles\('\''lychee-report\.md'\''\)/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-site-quality: fail step follows always vitest parse" {
+	run awk '
+		/^  site-test:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  site-test:/ { in_job = 0 }
+		in_job && /- name: Parse Vitest JSON results/ { parse = 1 }
+		in_job && parse && /if: always\(\)/ { parse_always = 1 }
+		in_job && /- name: Fail on site test errors/ { fail = 1 }
+		in_job && fail && /steps\.test-run\.outcome == '\''failure'\''/ { found = 1 }
+		END { exit !(parse_always && found) }
+	' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_site_quality.bats
+++ b/tests/bats/integration/test_reusable_site_quality.bats
@@ -103,6 +103,33 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-site-quality.yml"
 	assert_success
 }
 
+@test "reusable-site-quality: scopes pnpm setup to site-working-directory" {
+	run awk '
+		/^  site-build-link:/ { in_build = 1; in_test = 0 }
+		/^  site-test:/ { in_build = 0; in_test = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  site-build-link:/ && !/^  site-test:/ {
+			in_build = 0
+			in_test = 0
+		}
+		(in_build || in_test) && /- name: Setup pnpm/ { in_pnpm = 1 }
+		(in_build || in_test) && in_pnpm && /package_json_file:/ { has_key = 1 }
+		(in_build || in_test) && in_pnpm && /inputs\.site-working-directory/ {
+			has_site_dir = 1
+		}
+		(in_build || in_test) && in_pnpm && /^      - name:/ && !/- name: Setup pnpm/ {
+			if (has_key && has_site_dir) { count += 1 }
+			in_pnpm = 0
+			has_key = 0
+			has_site_dir = 0
+		}
+		END {
+			if (in_pnpm && has_key && has_site_dir) { count += 1 }
+			exit count < 2
+		}
+	' "$WORKFLOW"
+	assert_success
+}
+
 @test "reusable-site-quality: forwards package-manager to install step" {
 	run awk '
 		/^  site-build-link:/ { in_build = 1; in_test = 0 }

--- a/tests/bats/integration/test_reusable_site_quality.bats
+++ b/tests/bats/integration/test_reusable_site_quality.bats
@@ -90,9 +90,37 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-site-quality.yml"
 }
 
 @test "reusable-site-quality: aggregate passed output combines both jobs" {
-	run grep -F 'jobs.site-build-link.outputs.passed' "$WORKFLOW"
+	run awk '
+		/^on:/ { in_on = 1 }
+		/^jobs:/ { in_on = 0 }
+		in_on && /^    outputs:/ { in_outputs = 1 }
+		in_on && /^    [a-zA-Z0-9_-]+:/ && !/^    outputs:/ { in_outputs = 0 }
+		in_outputs && /^      passed:/ { has_passed_key = 1 }
+		in_outputs && /jobs\.site-build-link\.outputs\.passed/ { has_build = 1 }
+		in_outputs && /jobs\.site-test\.outputs\.passed/ { has_test = 1 }
+		END { exit !(has_passed_key && has_build && has_test) }
+	' "$WORKFLOW"
 	assert_success
-	run grep -F 'jobs.site-test.outputs.passed' "$WORKFLOW"
+}
+
+@test "reusable-site-quality: forwards package-manager to install step" {
+	run awk '
+		/^  site-build-link:/ { in_build = 1; in_test = 0 }
+		/^  site-test:/ { in_build = 0; in_test = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  site-build-link:/ && !/^  site-test:/ {
+			in_build = 0
+			in_test = 0
+		}
+		(in_build || in_test) && /PACKAGE_MANAGER: \$\{\{ inputs\.package-manager \}\}/ {
+			count += 1
+		}
+		END { exit count < 2 }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-site-quality: resolves site artifact path via tooling script" {
+	run grep -F 'scripts/ci/actions/resolve-site-artifact-path.sh' "$WORKFLOW"
 	assert_success
 }
 

--- a/tests/bats/unit/actions/test_apply_build_env.bats
+++ b/tests/bats/unit/actions/test_apply_build_env.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+
+load "../../../helpers/common"
+
+setup() {
+	export SCRIPT="$PROJECT_ROOT/scripts/ci/actions/apply-build-env.sh"
+	setup_temp_dir
+	export GITHUB_ENV="$BATS_TEST_TMPDIR/github_env"
+	: >"$GITHUB_ENV"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "apply-build-env writes valid KEY=value lines" {
+	export BUILD_ENV=$'ASTRO_BASE=/\n# comment\n\nFOO=bar'
+	run bash "$SCRIPT"
+	[ "$status" -eq 0 ]
+	grep -q '^ASTRO_BASE=/$' "$GITHUB_ENV"
+	grep -q '^FOO=bar$' "$GITHUB_ENV"
+	! grep -q '^#' "$GITHUB_ENV" || false
+}
+
+@test "apply-build-env rejects GITHUB_ENV heredoc injection lines" {
+	export BUILD_ENV=$'FOO<<EOF\ninjected\nEOF'
+	run bash "$SCRIPT" 2>&1
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"Invalid build-env line rejected"* ]]
+	! grep -q '^FOO=' "$GITHUB_ENV" || false
+}
+
+@test "apply-build-env rejects keys with invalid characters" {
+	export BUILD_ENV='bad-key=value'
+	run bash "$SCRIPT" 2>&1
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"Invalid build-env line rejected"* ]]
+}

--- a/tests/bats/unit/actions/test_prepare_lychee_action_args.bats
+++ b/tests/bats/unit/actions/test_prepare_lychee_action_args.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+
+load "../../../helpers/common"
+
+setup() {
+	export SCRIPT="$PROJECT_ROOT/scripts/ci/actions/prepare-lychee-action-args.sh"
+	setup_temp_dir
+	export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/github_output"
+	: >"$GITHUB_OUTPUT"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "prepare-lychee-action-args strips format and output flags" {
+	export RAW_ARGS="--no-progress --format markdown --output lychee-report.md --offline 'apps/site/dist/**/*.html'"
+	export LYCHEE_ROOT_DIR="apps/site/dist"
+	run bash "$SCRIPT"
+	[ "$status" -eq 0 ]
+	grep -q -- '--root-dir apps/site/dist' "$GITHUB_OUTPUT"
+	! grep -q -- '--format' "$GITHUB_OUTPUT" || false
+	! grep -q -- '--output' "$GITHUB_OUTPUT" || false
+}
+
+@test "prepare-lychee-action-args requires LYCHEE_ROOT_DIR" {
+	export RAW_ARGS="--offline"
+	unset LYCHEE_ROOT_DIR
+	run bash "$SCRIPT" 2>&1
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"LYCHEE_ROOT_DIR is required"* ]]
+}
+
+@test "prepare-lychee-action-args requires RAW_ARGS" {
+	unset RAW_ARGS
+	export LYCHEE_ROOT_DIR="dist"
+	run bash "$SCRIPT" 2>&1
+	[ "$status" -eq 1 ]
+	[[ "$output" == *"RAW_ARGS is required"* ]]
+}

--- a/tests/bats/unit/actions/test_prepare_lychee_action_args.bats
+++ b/tests/bats/unit/actions/test_prepare_lychee_action_args.bats
@@ -39,3 +39,12 @@ teardown() {
 	[ "$status" -eq 1 ]
 	[[ "$output" == *"RAW_ARGS is required"* ]]
 }
+
+@test "prepare-lychee-action-args uses first comma-separated root dir" {
+	export RAW_ARGS="--offline 'apps/site/dist/**/*.html'"
+	export LYCHEE_ROOT_DIR="apps/site/dist,apps/other/dist"
+	run bash "$SCRIPT"
+	[ "$status" -eq 0 ]
+	grep -q -- '--root-dir apps/site/dist' "$GITHUB_OUTPUT"
+	! grep -q -- 'apps/other/dist' "$GITHUB_OUTPUT" || false
+}

--- a/tests/bats/unit/actions/test_prepare_lychee_action_args.bats
+++ b/tests/bats/unit/actions/test_prepare_lychee_action_args.bats
@@ -48,3 +48,11 @@ teardown() {
 	grep -q -- '--root-dir apps/site/dist' "$GITHUB_OUTPUT"
 	! grep -q -- 'apps/other/dist' "$GITHUB_OUTPUT" || false
 }
+
+@test "prepare-lychee-action-args trims whitespace from root dir" {
+	export RAW_ARGS="--offline"
+	export LYCHEE_ROOT_DIR="  apps/site/dist  "
+	run bash "$SCRIPT"
+	[ "$status" -eq 0 ]
+	grep -q -- '--root-dir apps/site/dist' "$GITHUB_OUTPUT"
+}

--- a/tests/bats/unit/actions/test_resolve_site_artifact_path.bats
+++ b/tests/bats/unit/actions/test_resolve_site_artifact_path.bats
@@ -29,3 +29,43 @@ teardown() {
 	[ "$status" -eq 0 ]
 	grep -q '^path=apps/site/dist$' "$GITHUB_OUTPUT"
 }
+
+@test "resolve-site-artifact-path ignores whitespace-only site-artifact-path" {
+	export SITE_ARTIFACT_PATH="   "
+	export LYCHEE_PATHS="apps/site/dist"
+	run bash "$SCRIPT"
+	[ "$status" -eq 0 ]
+	grep -q '^path=apps/site/dist$' "$GITHUB_OUTPUT"
+}
+
+@test "resolve-site-artifact-path defaults to dot when lychee-paths unset" {
+	unset SITE_ARTIFACT_PATH
+	unset LYCHEE_PATHS
+	run bash "$SCRIPT"
+	[ "$status" -eq 0 ]
+	grep -q '^path=\.$' "$GITHUB_OUTPUT"
+}
+
+@test "resolve-site-artifact-path defaults to dot for empty lychee-paths" {
+	unset SITE_ARTIFACT_PATH
+	export LYCHEE_PATHS=""
+	run bash "$SCRIPT"
+	[ "$status" -eq 0 ]
+	grep -q '^path=\.$' "$GITHUB_OUTPUT"
+}
+
+@test "resolve-site-artifact-path defaults to dot for whitespace-only lychee-paths" {
+	unset SITE_ARTIFACT_PATH
+	export LYCHEE_PATHS="   "
+	run bash "$SCRIPT"
+	[ "$status" -eq 0 ]
+	grep -q '^path=\.$' "$GITHUB_OUTPUT"
+}
+
+@test "resolve-site-artifact-path uses single lychee path without comma" {
+	unset SITE_ARTIFACT_PATH
+	export LYCHEE_PATHS="apps/site/dist"
+	run bash "$SCRIPT"
+	[ "$status" -eq 0 ]
+	grep -q '^path=apps/site/dist$' "$GITHUB_OUTPUT"
+}

--- a/tests/bats/unit/actions/test_resolve_site_artifact_path.bats
+++ b/tests/bats/unit/actions/test_resolve_site_artifact_path.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+
+load "../../../helpers/common"
+
+setup() {
+	export SCRIPT="$PROJECT_ROOT/scripts/ci/actions/resolve-site-artifact-path.sh"
+	setup_temp_dir
+	export GITHUB_OUTPUT="$BATS_TEST_TMPDIR/github_output"
+	: >"$GITHUB_OUTPUT"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "resolve-site-artifact-path prefers explicit site-artifact-path" {
+	export SITE_ARTIFACT_PATH="apps/site/dist"
+	export LYCHEE_PATHS="other/dist,ignored"
+	run bash "$SCRIPT"
+	[ "$status" -eq 0 ]
+	grep -q '^path=apps/site/dist$' "$GITHUB_OUTPUT"
+}
+
+@test "resolve-site-artifact-path uses first comma-separated lychee path" {
+	unset SITE_ARTIFACT_PATH
+	export LYCHEE_PATHS=" apps/site/dist , apps/other/dist "
+	run bash "$SCRIPT"
+	[ "$status" -eq 0 ]
+	grep -q '^path=apps/site/dist$' "$GITHUB_OUTPUT"
+}

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "lgtm-ci"
-version = "0.38.0"
+version = "0.39.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "lgtm-ci"
-version = "0.39.0"
+version = "0.38.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Adds `reusable-site-quality.yml` so Rust monorepos can replace inline `site-quality.yml` with a thin caller. The reusable runs two parallel jobs: Astro (or similar) site build + lychee link check, and caller-provided check/test commands with optional Python setup.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Changes Made

- Add `reusable-site-quality.yml` with `build-command`, `check-command`, `test-command`, lychee integration, and optional Python/Vitest hooks
- Add `prepare-lychee-action-args.sh` to strip duplicate lychee flags and inject `--root-dir`
- Add BATS contract and unit tests
- Document caller contract in `workflow-contract.md` and `reusable-workflows.md`

## Closes

- Relates to #307

## Testing

- [x] BATS unit tests for `prepare-lychee-action-args.sh`
- [x] BATS integration contract tests for `reusable-site-quality.yml`
- [x] `uv run lintro chk` (zero issues)
- [x] Greptile and CodeRabbit pre-push review

## Quality Checks

- [x] Lint/format (`uv run lintro fmt` / `uv run lintro chk`)
- [x] Shell scripts pass shellcheck (via lintro)
- [x] YAML passes yamllint and actionlint (via lintro)

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add reusable `reusable-site-quality` workflow for docs site CI
> - Adds [reusable-site-quality.yml](.github/workflows/reusable-site-quality.yml) with two parallel jobs: `site-build-link` (build, lychee link check, artifact upload) and `site-test` (optional Python setup, dependency install, test run with Vitest JSON parsing).
> - Adds [apply-build-env.sh](scripts/ci/actions/apply-build-env.sh) to validate `KEY=VALUE` pairs before writing to `GITHUB_ENV`, rejecting heredoc injections and malformed keys.
> - Adds [prepare-lychee-action-args.sh](scripts/ci/actions/prepare-lychee-action-args.sh) to strip duplicate `--format`/`--output` flags from lychee inputs and inject a consistent `--root-dir`.
> - Adds [resolve-site-artifact-path.sh](scripts/ci/actions/resolve-site-artifact-path.sh) to pick an explicit artifact path or fall back to the first `lychee-paths` entry.
> - Covers all new scripts and the workflow structure with Bats unit and integration tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1eebc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable docs site quality workflow: configurable build/test commands, Node/Package-manager setup with optional caching, optional Python hook, lychee link checks, artifact upload resolution, PR Vitest summary publishing, and egress/runner controls; exposes pass/fail outputs.

* **Documentation**
  * Added docs, README entry, examples and changelog notes describing inputs, behavior and adoption guidance.

* **Security**
  * Build-env validation to reject unsafe lines and prevent env-injection.

* **Tests**
  * New integration and unit tests covering workflow contract, env handling, arg/path resolution and Vitest parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds `reusable-site-quality.yml`, a new reusable workflow that runs Astro/similar site builds with lychee link-checking and caller-provided check/test commands across two parallel jobs, plus three helper scripts (`apply-build-env.sh`, `prepare-lychee-action-args.sh`, `resolve-site-artifact-path.sh`) and full BATS coverage.

- `apply-build-env.sh` validates each `build-env` line against `^[A-Za-z_][A-Za-z0-9_]*=` before writing to `GITHUB_ENV`, blocking heredoc injection; blank lines and comments are skipped cleanly.
- `prepare-lychee-action-args.sh` strips duplicate `--format`/`--output` flags from raw lychee args and injects `--root-dir`, using a GITHUB_OUTPUT multiline heredoc for output; the `:?` guard on `LYCHEE_ROOT_DIR` fires before whitespace trimming (see inline comment).
- `resolve-site-artifact-path.sh` resolves the upload path from an explicit input or the first comma-separated lychee path, with a consistent post-trim empty fallback to `.`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the workflow, scripts, and tests are well-structured with no blocking defects.

The injection guard in `apply-build-env.sh` correctly requires `^[A-Za-z_][A-Za-z0-9_]*=` before writing to `GITHUB_ENV`, action SHAs are pinned throughout, and `always()`-guarded cleanup steps are placed correctly. The only finding is an edge-case gap in `prepare-lychee-action-args.sh` where an all-whitespace `LYCHEE_ROOT_DIR` survives the `:?` guard but becomes empty after trimming — unlike the analogous `resolve-site-artifact-path.sh` which already has an explicit post-trim fallback.

scripts/ci/actions/prepare-lychee-action-args.sh — missing post-trim empty guard for LYCHEE_ROOT_DIR (see inline comment).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-site-quality.yml | New 609-line reusable workflow with two parallel jobs (site-build-link, site-test) plus a conditional publish-test-summary job; pinned SHAs, runner hardening, correct draft-PR skip logic, and `always()`-guarded cleanup steps throughout. |
| scripts/ci/actions/apply-build-env.sh | Validates each `build-env` line against `^[A-Za-z_][A-Za-z0-9_]*=` before writing to `GITHUB_ENV`, effectively blocking heredoc injection; blank lines and comments are skipped. |
| scripts/ci/actions/prepare-lychee-action-args.sh | Strips `--format`/`--output` from raw lychee args and injects `--root-dir`; the `:?` guard on `LYCHEE_ROOT_DIR` fires before whitespace trimming, so an all-whitespace value silently produces an empty `--root-dir` arg (see inline comment). |
| scripts/ci/actions/resolve-site-artifact-path.sh | Correctly resolves artifact path from explicit input or first comma-separated lychee path, with a trim helper and an explicit empty-after-trim fallback to `.`. |
| tests/bats/unit/actions/test_prepare_lychee_action_args.bats | Five unit tests covering flag stripping, missing-env errors, comma-split, and whitespace trimming; no test for the all-whitespace `LYCHEE_ROOT_DIR` edge case. |
| tests/bats/integration/test_reusable_site_quality.bats | 17 contract tests covering required inputs, action pinning, permission scoping, and key structural assertions; awk-based parsing is thorough. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Caller Workflow
    participant SBL as site-build-link job
    participant ST as site-test job
    participant PTS as publish-test-summary job

    Caller->>SBL: "workflow_call (build-command, build-env, lychee-*)"
    Caller->>ST: "workflow_call (check-command, test-command, python-*)"

    SBL->>SBL: checkout + harden runner
    SBL->>SBL: install deps (Node/Bun/pnpm)
    SBL->>SBL: apply-build-env.sh → GITHUB_ENV
    SBL->>SBL: build-command
    SBL->>SBL: build-lychee-args.sh → raw args
    SBL->>SBL: prepare-lychee-action-args.sh → args + --root-dir
    SBL->>SBL: lychee-action (link check)
    SBL->>SBL: upload lychee-report (always)
    SBL->>SBL: resolve-site-artifact-path.sh
    SBL->>SBL: upload site artifact (on build success)
    SBL-->>Caller: build-passed output

    ST->>ST: checkout + harden runner
    ST->>ST: setup Python (optional)
    ST->>ST: install deps (Node/Bun/pnpm)
    ST->>ST: check-command (optional)
    ST->>ST: python-test-command (optional)
    ST->>ST: test-command → Vitest results
    ST->>ST: parse-vitest (always, optional)
    ST->>ST: re-fail on test-run failure
    ST-->>Caller: test-passed output

    ST->>PTS: needs site-test (PR only, non-fork)
    PTS->>PTS: reusable-publish-test-summary.yml
    PTS-->>Caller: PR comment upserted
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fprepare-lychee-action-args.sh%3A8-18%0AThe%20%60%3A%3F%60%20guard%20fires%20before%20whitespace%20trimming%2C%20so%20a%20%60LYCHEE_ROOT_DIR%60%20value%20that%20is%20all%20whitespace%20%28e.g.%20the%20caller%20sets%20%60lychee-root-dir%3A%20%22%20%20%20%22%60%29%20passes%20the%20non-empty%20check%20but%20becomes%20an%20empty%20string%20after%20trimming.%20Line%2034%20then%20appends%20%60--root-dir%20%22%22%60%20to%20the%20filtered%20args%2C%20which%20lychee%20would%20receive%20as%20%60--root-dir%20%60%20with%20no%20path.%20Notice%20that%20%60resolve-site-artifact-path.sh%60%20applies%20the%20same%20trim%20pattern%20but%20guards%20against%20empty-after-trim%20with%20an%20explicit%20check%3B%20a%20matching%20guard%20here%20would%20be%20consistent%20and%20defensive.%0A%0A%60%60%60suggestion%0A%3A%20%22%24%7BLYCHEE_ROOT_DIR%3A%3FLYCHEE_ROOT_DIR%20is%20required%7D%22%0A%0ALYCHEE_ROOT_DIR%3D%22%24%7BLYCHEE_ROOT_DIR%23%22%24%7BLYCHEE_ROOT_DIR%25%25%5B!%5B%3Aspace%3A%5D%5D*%7D%22%7D%22%0ALYCHEE_ROOT_DIR%3D%22%24%7BLYCHEE_ROOT_DIR%25%22%24%7BLYCHEE_ROOT_DIR%23%23*%5B!%5B%3Aspace%3A%5D%5D%7D%22%7D%22%0A%0A%23%20When%20callers%20pass%20comma-separated%20lychee-paths%2C%20use%20the%20first%20entry%20only.%0Aif%20%5B%5B%20%22%24LYCHEE_ROOT_DIR%22%20%3D%3D%20*%22%2C%22*%20%5D%5D%3B%20then%0A%09LYCHEE_ROOT_DIR%3D%22%24%7BLYCHEE_ROOT_DIR%25%25%2C*%7D%22%0A%09LYCHEE_ROOT_DIR%3D%22%24%7BLYCHEE_ROOT_DIR%23%22%24%7BLYCHEE_ROOT_DIR%25%25%5B!%5B%3Aspace%3A%5D%5D*%7D%22%7D%22%0A%09LYCHEE_ROOT_DIR%3D%22%24%7BLYCHEE_ROOT_DIR%25%22%24%7BLYCHEE_ROOT_DIR%23%23*%5B!%5B%3Aspace%3A%5D%5D%7D%22%7D%22%0Afi%0A%0Aif%20%5B%5B%20-z%20%22%24LYCHEE_ROOT_DIR%22%20%5D%5D%3B%20then%0A%09echo%20%22%3A%3Aerror%3A%3ALYCHEE_ROOT_DIR%20is%20empty%20after%20trimming%20whitespace%22%20%3E%262%0A%09exit%201%0Afi%0A%60%60%60%0A%0A&pr=327&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fprepare-lychee-action-args.sh%3A8-18%0AThe%20%60%3A%3F%60%20guard%20fires%20before%20whitespace%20trimming%2C%20so%20a%20%60LYCHEE_ROOT_DIR%60%20value%20that%20is%20all%20whitespace%20%28e.g.%20the%20caller%20sets%20%60lychee-root-dir%3A%20%22%20%20%20%22%60%29%20passes%20the%20non-empty%20check%20but%20becomes%20an%20empty%20string%20after%20trimming.%20Line%2034%20then%20appends%20%60--root-dir%20%22%22%60%20to%20the%20filtered%20args%2C%20which%20lychee%20would%20receive%20as%20%60--root-dir%20%60%20with%20no%20path.%20Notice%20that%20%60resolve-site-artifact-path.sh%60%20applies%20the%20same%20trim%20pattern%20but%20guards%20against%20empty-after-trim%20with%20an%20explicit%20check%3B%20a%20matching%20guard%20here%20would%20be%20consistent%20and%20defensive.%0A%0A%60%60%60suggestion%0A%3A%20%22%24%7BLYCHEE_ROOT_DIR%3A%3FLYCHEE_ROOT_DIR%20is%20required%7D%22%0A%0ALYCHEE_ROOT_DIR%3D%22%24%7BLYCHEE_ROOT_DIR%23%22%24%7BLYCHEE_ROOT_DIR%25%25%5B!%5B%3Aspace%3A%5D%5D*%7D%22%7D%22%0ALYCHEE_ROOT_DIR%3D%22%24%7BLYCHEE_ROOT_DIR%25%22%24%7BLYCHEE_ROOT_DIR%23%23*%5B!%5B%3Aspace%3A%5D%5D%7D%22%7D%22%0A%0A%23%20When%20callers%20pass%20comma-separated%20lychee-paths%2C%20use%20the%20first%20entry%20only.%0Aif%20%5B%5B%20%22%24LYCHEE_ROOT_DIR%22%20%3D%3D%20*%22%2C%22*%20%5D%5D%3B%20then%0A%09LYCHEE_ROOT_DIR%3D%22%24%7BLYCHEE_ROOT_DIR%25%25%2C*%7D%22%0A%09LYCHEE_ROOT_DIR%3D%22%24%7BLYCHEE_ROOT_DIR%23%22%24%7BLYCHEE_ROOT_DIR%25%25%5B!%5B%3Aspace%3A%5D%5D*%7D%22%7D%22%0A%09LYCHEE_ROOT_DIR%3D%22%24%7BLYCHEE_ROOT_DIR%25%22%24%7BLYCHEE_ROOT_DIR%23%23*%5B!%5B%3Aspace%3A%5D%5D%7D%22%7D%22%0Afi%0A%0Aif%20%5B%5B%20-z%20%22%24LYCHEE_ROOT_DIR%22%20%5D%5D%3B%20then%0A%09echo%20%22%3A%3Aerror%3A%3ALYCHEE_ROOT_DIR%20is%20empty%20after%20trimming%20whitespace%22%20%3E%262%0A%09exit%201%0Afi%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=327&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F307-docs-site-quality-reusable%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F307-docs-site-quality-reusable%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fprepare-lychee-action-args.sh%3A8-18%0AThe%20%60%3A%3F%60%20guard%20fires%20before%20whitespace%20trimming%2C%20so%20a%20%60LYCHEE_ROOT_DIR%60%20value%20that%20is%20all%20whitespace%20%28e.g.%20the%20caller%20sets%20%60lychee-root-dir%3A%20%22%20%20%20%22%60%29%20passes%20the%20non-empty%20check%20but%20becomes%20an%20empty%20string%20after%20trimming.%20Line%2034%20then%20appends%20%60--root-dir%20%22%22%60%20to%20the%20filtered%20args%2C%20which%20lychee%20would%20receive%20as%20%60--root-dir%20%60%20with%20no%20path.%20Notice%20that%20%60resolve-site-artifact-path.sh%60%20applies%20the%20same%20trim%20pattern%20but%20guards%20against%20empty-after-trim%20with%20an%20explicit%20check%3B%20a%20matching%20guard%20here%20would%20be%20consistent%20and%20defensive.%0A%0A%60%60%60suggestion%0A%3A%20%22%24%7BLYCHEE_ROOT_DIR%3A%3FLYCHEE_ROOT_DIR%20is%20required%7D%22%0A%0ALYCHEE_ROOT_DIR%3D%22%24%7BLYCHEE_ROOT_DIR%23%22%24%7BLYCHEE_ROOT_DIR%25%25%5B!%5B%3Aspace%3A%5D%5D*%7D%22%7D%22%0ALYCHEE_ROOT_DIR%3D%22%24%7BLYCHEE_ROOT_DIR%25%22%24%7BLYCHEE_ROOT_DIR%23%23*%5B!%5B%3Aspace%3A%5D%5D%7D%22%7D%22%0A%0A%23%20When%20callers%20pass%20comma-separated%20lychee-paths%2C%20use%20the%20first%20entry%20only.%0Aif%20%5B%5B%20%22%24LYCHEE_ROOT_DIR%22%20%3D%3D%20*%22%2C%22*%20%5D%5D%3B%20then%0A%09LYCHEE_ROOT_DIR%3D%22%24%7BLYCHEE_ROOT_DIR%25%25%2C*%7D%22%0A%09LYCHEE_ROOT_DIR%3D%22%24%7BLYCHEE_ROOT_DIR%23%22%24%7BLYCHEE_ROOT_DIR%25%25%5B!%5B%3Aspace%3A%5D%5D*%7D%22%7D%22%0A%09LYCHEE_ROOT_DIR%3D%22%24%7BLYCHEE_ROOT_DIR%25%22%24%7BLYCHEE_ROOT_DIR%23%23*%5B!%5B%3Aspace%3A%5D%5D%7D%22%7D%22%0Afi%0A%0Aif%20%5B%5B%20-z%20%22%24LYCHEE_ROOT_DIR%22%20%5D%5D%3B%20then%0A%09echo%20%22%3A%3Aerror%3A%3ALYCHEE_ROOT_DIR%20is%20empty%20after%20trimming%20whitespace%22%20%3E%262%0A%09exit%201%0Afi%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=327&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["fix: scope pnpm setup and harden artifac..."](https://github.com/lgtm-hq/lgtm-ci/commit/a1eebc5e9ceb8bc86ba835f63707352bbe087c7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36277513)</sub>

<!-- /greptile_comment -->