### PR TITLE
fix(ci): reusable-scorecards missing results_file breaks SARIF output

### DIFF
--- a/.github/workflows/reusable-scorecards.yml
+++ b/.github/workflows/reusable-scorecards.yml
@@ -19,6 +19,14 @@ on:
         required: false
         type: boolean
         default: true
+      results-file:
+        description: >-
+          Scorecard results output path. Defaults to "results.sarif"; callers
+          using a non-sarif results-format should override this to match their
+          chosen format (e.g. "results.json").
+        required: false
+        type: string
+        default: "results.sarif"
 
       tooling-ref:
         description: >-
@@ -107,11 +115,13 @@ jobs:
       - name: Run OpenSSF Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
+          repo_token: ${{ github.token }}
           results_format: ${{ inputs.results-format }}
+          results_file: ${{ inputs.results-file }}
           publish_results: ${{ inputs.publish-results }}
 
       - name: Upload SARIF
         if: inputs.upload-sarif && inputs.results-format == 'sarif'
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
-          sarif_file: results.sarif
+          sarif_file: ${{ inputs.results-file }}

--- a/.github/workflows/reusable-scorecards.yml
+++ b/.github/workflows/reusable-scorecards.yml
@@ -5,7 +5,9 @@ on:
   workflow_call:
     inputs:
       results-format:
-        description: "Scorecard output format"
+        description: >-
+          Scorecard output format (default sarif). When overriding to a non-sarif
+          format, also set results-file to a matching path (e.g. results.json).
         required: false
         type: string
         default: "sarif"

--- a/tests/bats/integration/test_reusable_scorecards.bats
+++ b/tests/bats/integration/test_reusable_scorecards.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-scorecards workflow (#329)
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-scorecards.yml"
+
+@test "reusable-scorecards: results-file defaults to results.sarif" {
+	run awk '/^      results-file:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: "results.sarif"'
+}
+
+@test "reusable-scorecards: scorecard step passes repo_token" {
+	run awk '
+		/^  scorecards:/ { in_job = 1; scorecard = 0 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  scorecards:/ { in_job = 0; scorecard = 0 }
+		in_job && /- name: Run OpenSSF Scorecard/ { scorecard = 1 }
+		in_job && scorecard && /repo_token: \$\{\{ github\.token \}\}/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-scorecards: scorecard step passes results_file" {
+	run awk '
+		/^  scorecards:/ { in_job = 1; scorecard = 0 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  scorecards:/ { in_job = 0; scorecard = 0 }
+		in_job && /- name: Run OpenSSF Scorecard/ { scorecard = 1 }
+		in_job && scorecard && /results_file: \$\{\{ inputs\.results-file \}\}/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-scorecards: upload-sarif uses results-file input" {
+	run awk '
+		/^  scorecards:/ { in_job = 1; upload = 0 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  scorecards:/ { in_job = 0; upload = 0 }
+		in_job && /- name: Upload SARIF/ { upload = 1 }
+		in_job && upload && /sarif_file: \$\{\{ inputs\.results-file \}\}/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-scorecards: resolve egress before harden-runner composite" {
+	run egress_tooling_checkout_order_ok "$WORKFLOW" scorecards
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_scorecards.bats
+++ b/tests/bats/integration/test_reusable_scorecards.bats
@@ -35,6 +35,22 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-scorecards.yml"
 	assert_success
 }
 
+@test "reusable-scorecards: upload-sarif conditional checks upload-sarif and results-format" {
+	run awk '
+		/^  scorecards:/ { in_job = 1; upload = 0 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  scorecards:/ { in_job = 0; upload = 0 }
+		in_job && /- name: Upload SARIF/ { upload = 1 }
+		in_job && upload && /^        if:/ {
+			if ($0 ~ /inputs\.upload-sarif/ && $0 ~ /inputs\.results-format == '\''sarif'\''/) {
+				found = 1
+				exit
+			}
+		}
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
 @test "reusable-scorecards: upload-sarif uses results-file input" {
 	run awk '
 		/^  scorecards:/ { in_job = 1; upload = 0 }


### PR DESCRIPTION
## Summary

Fixes `reusable-scorecards.yml` so the OpenSSF Scorecard action receives the required `results_file` and `repo_token` inputs. Without these, consumers using the default SARIF format fail with `validating options: results path is empty`.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #329
- Relates to lgtm-hq/Rustume#278

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `reusable-scorecards` workflow to pass `results_file` and `repo_token` to Scorecard action
> - The Scorecard action was missing `results_file` and `repo_token` inputs, causing the SARIF output to be written to a default path that the Upload SARIF step couldn't find.
> - [reusable-scorecards.yml](.github/workflows/reusable-scorecards.yml) now accepts a `results-file` input (default `results.sarif`) and passes it to both the Scorecard action and the SARIF upload step.
> - Adds a Bats integration test suite in [test_reusable_scorecards.bats](https://github.com/lgtm-hq/lgtm-ci/pull/331/files#diff-fe4512ddb6271b1c8e86eb6f7922fd8b56600af5ecea56f8b22528635e42fdeb) that validates the new inputs, step conditions, and egress allowlist ordering.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed74ebe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reusable Scorecard workflow accepts a configurable results-file input so users can choose where scorecard output is written (default: results.sarif).
  * Results-format guidance updated to remind callers to set results-file when using non-SARIF formats.

* **Tests**
  * Added integration tests validating input defaults, step wiring, conditional SARIF upload, and file handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the `reusable-scorecards` workflow by adding the missing `repo_token` and `results_file` inputs to the `ossf/scorecard-action` step, and introduces a new `results-file` workflow input (defaulting to `results.sarif`) so callers can customise the output path.

- Adds `results-file` input with a sensible default and updated `results-format` description to guide callers who override the format.
- Wires `repo_token: ${{ github.token }}` and `results_file: ${{ inputs.results-file }}` into the scorecard action, and replaces the previously hardcoded `results.sarif` path in the upload step.
- Adds a new Bats integration test file with six contract tests covering the default value, parameter wiring, upload conditional, and egress step ordering.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are a minimal, backward-compatible bug fix that wires two previously missing required inputs into an existing action step.

The workflow change is additive: the new `results-file` input defaults to `results.sarif`, preserving the previous hardcoded behavior for all existing callers. Both `repo_token` and `results_file` were simply absent before; adding them with the standard `github.token` and a parameterised path is the correct fix. The upload step's guard condition is unchanged and remains correct. The new Bats tests provide solid structural contracts for all four changed lines.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-scorecards.yml | Adds `results-file` input (default `results.sarif`), wires `repo_token` and `results_file` into the scorecard action step, and replaces the hardcoded SARIF path in the upload step with the new input. |
| tests/bats/integration/test_reusable_scorecards.bats | New Bats integration test file with six contract tests covering the default value, parameter wiring, SARIF conditional, and egress-step ordering for the scorecards workflow. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Caller Workflow
    participant Scorecard as ossf/scorecard-action
    participant Upload as upload-sarif step

    Caller->>Scorecard: repo_token: github.token
    Caller->>Scorecard: results_format: inputs.results-format
    Caller->>Scorecard: results_file: inputs.results-file
    Caller->>Scorecard: publish_results: inputs.publish-results
    Scorecard-->>Caller: writes results to inputs.results-file

    alt "inputs.upload-sarif && inputs.results-format == 'sarif'"
        Caller->>Upload: sarif_file: inputs.results-file
        Upload-->>Caller: SARIF uploaded to Security tab
    else "format != sarif or upload-sarif == false"
        Caller-->>Caller: upload step skipped
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(ci): document results-format coupli..."](https://github.com/lgtm-hq/lgtm-ci/commit/ed74ebec0c80de317136ae4c4c0161c409d96b58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36304016)</sub>

<!-- /greptile_comment -->