### PR TITLE
feat(ci): add reusable-vuln-suppression-check for stale OSV suppression cleanup

### DIFF
--- a/.github/actions/harden-runner/lib/egress/presets.sh
+++ b/.github/actions/harden-runner/lib/egress/presets.sh
@@ -194,6 +194,14 @@ egress_preset_endpoints() {
 			api.scorecard.dev:443 \
 			api.securityscorecards.dev:443
 		;;
+	osv-scanner)
+		# Direct osv-scanner binary install + scan (reusable-vuln-suppression-check).
+		egress_preset_endpoints github-tooling
+		printf '%s\n' \
+			release-assets.githubusercontent.com:443 \
+			api.osv.dev:443 \
+			api.deps.dev:443
+		;;
 	rust-release)
 		# Rust cross-compile release builds (reusable-build-rust-binaries.yml).
 		# Minimal base: GitHub checkout/tooling, Rust/crates, cross Docker, apt, Sigstore.

--- a/.github/actions/resolve-egress-allowlist/action.yml
+++ b/.github/actions/resolve-egress-allowlist/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: >-
       Named baseline allowlist for block policy (github-minimal, github-pages,
       github-tooling, docker, playwright, pypi, rubygems, npm-publish, quality,
-      rust-release, sbom, scorecard)
+      osv-scanner, rust-release, sbom, scorecard)
     required: false
     default: ""
   allowed-endpoints:

--- a/.github/workflows/reusable-vuln-suppression-check.yml
+++ b/.github/workflows/reusable-vuln-suppression-check.yml
@@ -139,7 +139,7 @@ jobs:
         env:
           OSV_VERSION: ${{ inputs.osv-version }}
           INSTALL_SCRIPT: ${{ inputs.install-script }}
-        run: bash "$GITHUB_WORKSPACE/$INSTALL_SCRIPT" "${{ inputs.osv-version }}"
+        run: bash "$GITHUB_WORKSPACE/$INSTALL_SCRIPT" "$OSV_VERSION"
 
       - name: Check suppression staleness
         shell: bash

--- a/.github/workflows/reusable-vuln-suppression-check.yml
+++ b/.github/workflows/reusable-vuln-suppression-check.yml
@@ -1,0 +1,151 @@
+---
+name: Reusable Vulnerability Suppression Check Workflow
+
+on:
+  workflow_call:
+    inputs:
+      job-name:
+        description: "GitHub check run name for the suppression check job"
+        required: false
+        type: string
+        default: "Check Vulnerability Suppressions"
+      osv-version:
+        description: "osv-scanner release version to install"
+        required: false
+        type: string
+        default: "2.3.5"
+      config-path:
+        description: "Path to suppression TOML relative to repository root"
+        required: false
+        type: string
+        default: ".osv-scanner.toml"
+      check-script:
+        description: >-
+          Path to suppression check script (repo checkout or tooling checkout).
+          Defaults to tooling check-vuln-suppressions.sh.
+        required: false
+        type: string
+        default: ".lgtm-ci-tooling/scripts/ci/security/check-vuln-suppressions.sh"
+      install-script:
+        description: >-
+          Path to osv-scanner install script (repo checkout or tooling checkout).
+          Defaults to tooling install-osv-scanner.sh.
+        required: false
+        type: string
+        default: ".lgtm-ci-tooling/scripts/ci/security/install-osv-scanner.sh"
+      workflow-file:
+        description: >-
+          Caller workflow filename for auto-PR footer link (e.g.
+          vuln-suppression-check.yml)
+        required: false
+        type: string
+        default: ""
+      tooling-ref:
+        description: "Git ref to use when checking out lgtm-ci tooling scripts"
+        required: false
+        type: string
+        default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "block"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "append"
+
+      egress-preset:
+        description: >-
+          Named allowlist when allowed-endpoints is empty and egress-policy is
+          block (github-minimal, github-pages, github-tooling, docker, playwright,
+          pypi, rubygems, npm-publish, quality, osv-scanner, sbom, scorecard)
+        required: false
+        type: string
+        default: "osv-scanner"
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-latest"
+      timeout-minutes:
+        description: "Job timeout in minutes for the suppression check job"
+        required: false
+        type: number
+        default: 10
+
+    secrets:
+      GH_TOKEN:
+        description: "GitHub token for PR creation (typically secrets.GITHUB_TOKEN)"
+        required: true
+
+jobs:
+  vuln-suppression-check:
+    name: ${{ inputs.job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        # Pinned to SHA for supply chain security
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+
+      - name: Install osv-scanner
+        shell: bash
+        env:
+          OSV_VERSION: ${{ inputs.osv-version }}
+          INSTALL_SCRIPT: ${{ inputs.install-script }}
+        run: bash "$GITHUB_WORKSPACE/$INSTALL_SCRIPT" "${{ inputs.osv-version }}"
+
+      - name: Check suppression staleness
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          CONFIG_PATH: ${{ inputs.config-path }}
+          WORKFLOW_FILE: ${{ inputs.workflow-file }}
+          CHECK_SCRIPT: ${{ inputs.check-script }}
+        run: bash "$GITHUB_WORKSPACE/$CHECK_SCRIPT"

--- a/.github/workflows/reusable-vuln-suppression-check.yml
+++ b/.github/workflows/reusable-vuln-suppression-check.yml
@@ -73,7 +73,7 @@ on:
         type: string
         default: "osv-scanner"
       runner-image:
-        description: "GitHub-hosted runner image label"
+        description: "GitHub-hosted Linux runner image label (install script downloads linux_* binaries)"
         required: false
         type: string
         default: "ubuntu-latest"

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ steps:
 | `reusable-dependency-review.yml`       | Dependency review gate                       |
 | `reusable-security-audit.yml`          | lintro/osv-scanner audit + comment artifact    |
 | `reusable-publish-security-audit-comment.yml` | Publish security audit PR comment     |
+| `reusable-vuln-suppression-check.yml`  | Weekly stale OSV suppression cleanup + auto-PR   |
 | `reusable-site-quality.yml`            | Docs site build, lychee, and site tests        |
 | `reusable-scorecards.yml`              | OpenSSF Scorecard analysis                   |
 | `reusable-semantic-pr-title.yml`       | Conventional PR title validation + comments  |

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -715,6 +715,42 @@ jobs:
 For push/schedule workflows, omit the publish job and pass
 `upload-comment-artifact: false`.
 
+### Vulnerability suppression check (osv-scanner)
+
+`reusable-vuln-suppression-check.yml` installs `osv-scanner` directly (no Docker),
+probes the repository without suppressions, and opens a cleanup PR when entries are
+stale (vulnerability resolved upstream). Expired suppressions fail the job.
+
+| Input                    | Default                 | Notes                                      |
+| ------------------------ | ----------------------- | ------------------------------------------ |
+| `osv-version`            | `2.3.5`                 | osv-scanner release version                |
+| `config-path`            | `.osv-scanner.toml`     | Suppression TOML path                      |
+| `egress-preset`          | `osv-scanner`           | Includes GitHub tooling + OSV API hosts    |
+| `allowed-endpoints-mode` | `append`                | Merge preset with caller endpoints         |
+| `workflow-file`          | empty                   | Caller workflow filename for PR footer     |
+
+```yaml
+'on':
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  check-suppressions:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-vuln-suppression-check.yml@<sha>
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      tooling-ref: '<sha>'
+      job-name: '🔍 Check Vulnerability Suppressions'
+      workflow-file: vuln-suppression-check.yml
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ### Documentation site quality
 
 `reusable-site-quality.yml` runs Astro (or similar) docs build, lychee link

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -725,6 +725,7 @@ stale (vulnerability resolved upstream). Expired suppressions fail the job.
 | ------------------------ | ----------------------- | ------------------------------------------ |
 | `osv-version`            | `2.3.5`                 | osv-scanner release version                |
 | `config-path`            | `.osv-scanner.toml`     | Suppression TOML path                      |
+| `check-script`           | tooling default         | Repo-local override supported              |
 | `egress-preset`          | `osv-scanner`           | Includes GitHub tooling + OSV API hosts    |
 | `allowed-endpoints-mode` | `append`                | Merge preset with caller endpoints         |
 | `workflow-file`          | empty                   | Caller workflow filename for PR footer     |

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -729,6 +729,10 @@ stale (vulnerability resolved upstream). Expired suppressions fail the job.
 | `egress-preset`          | `osv-scanner`           | Includes GitHub tooling + OSV API hosts    |
 | `allowed-endpoints-mode` | `append`                | Merge preset with caller endpoints         |
 | `workflow-file`          | empty                   | Caller workflow filename for PR footer     |
+| `runner-image`           | `ubuntu-latest`         | Linux runners only (install script)        |
+
+Use a Linux `runner-image`; the install script downloads `linux_*` release
+binaries only.
 
 ```yaml
 'on':

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -785,6 +785,33 @@ reusable itself requires only `contents: read` and `packages: read`.
 
 Outputs: `exit-code`, `has-vulns`, `audit-failed`, `status`.
 
+## Vulnerability suppression check (osv-scanner)
+
+`reusable-vuln-suppression-check.yml` centralizes the weekly stale/expired OSV
+suppression cleanup pattern used by Rustume, py-lintro, and turbo-themes. The job
+installs `osv-scanner` directly (no Docker), runs
+`scripts/ci/security/check-vuln-suppressions.sh`, and may open a cleanup PR
+removing stale entries. Expired suppressions fail the job for manual review.
+
+<!-- markdownlint-disable MD013 MD060 -- wide input reference table -->
+
+| Input                    | Default                                              | Notes                                           |
+| ------------------------ | ---------------------------------------------------- | ----------------------------------------------- |
+| `osv-version`            | `2.3.5`                                              | osv-scanner release to install                  |
+| `config-path`            | `.osv-scanner.toml`                                  | Suppression TOML relative to repo root          |
+| `check-script`           | `.lgtm-ci-tooling/scripts/ci/security/check-vuln-suppressions.sh` | Repo-local override supported |
+| `egress-preset`          | `osv-scanner`                                        | `github-tooling` + release assets + OSV APIs    |
+| `allowed-endpoints-mode` | `append`                                             | Merge preset with caller-specific endpoints     |
+| `workflow-file`          | empty                                                | Caller workflow filename for auto-PR footer     |
+
+<!-- markdownlint-enable MD013 MD060 -->
+
+Caller `on:` triggers are consumer-owned (`schedule`, `workflow_dispatch`).
+Grant `contents: write` and `pull-requests: write` on the caller job. Forward
+`secrets.GH_TOKEN` (typically `secrets.GITHUB_TOKEN`).
+
+Required secrets: `GH_TOKEN`.
+
 ## Documentation site quality
 
 `reusable-site-quality.yml` centralizes the docs-site pattern used by Rust

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -517,6 +517,7 @@ Use `append` to keep lgtm-ci defaults and add project-specific hosts. Empty
 | `rust-release`   | Rust cross-compile releases (`reusable-build-rust-binaries.yml`)     |
 | `sbom`           | SBOM, Grype scan, Sigstore attestation                               |
 | `scorecard`      | OpenSSF Scorecard (`reusable-scorecards.yml`)                        |
+| `osv-scanner`    | GitHub tooling + release assets + OSV APIs                           |
 
 ```yaml
 egress-policy: block

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -804,12 +804,14 @@ removing stale entries. Expired suppressions fail the job for manual review.
 | `egress-preset`          | `osv-scanner`                                        | `github-tooling` + release assets + OSV APIs    |
 | `allowed-endpoints-mode` | `append`                                             | Merge preset with caller-specific endpoints     |
 | `workflow-file`          | empty                                                | Caller workflow filename for auto-PR footer     |
+| `runner-image`           | `ubuntu-latest`                                      | Linux runners only (`install-osv-scanner.sh`)   |
 
 <!-- markdownlint-enable MD013 MD060 -->
 
 Caller `on:` triggers are consumer-owned (`schedule`, `workflow_dispatch`).
 Grant `contents: write` and `pull-requests: write` on the caller job. Forward
-`secrets.GH_TOKEN` (typically `secrets.GITHUB_TOKEN`).
+`secrets.GH_TOKEN` (typically `secrets.GITHUB_TOKEN`). Use a Linux
+`runner-image`; the install script downloads `linux_*` release binaries only.
 
 Required secrets: `GH_TOKEN`.
 

--- a/scripts/ci/lib/egress/presets.sh
+++ b/scripts/ci/lib/egress/presets.sh
@@ -194,6 +194,14 @@ egress_preset_endpoints() {
 			api.scorecard.dev:443 \
 			api.securityscorecards.dev:443
 		;;
+	osv-scanner)
+		# Direct osv-scanner binary install + scan (reusable-vuln-suppression-check).
+		egress_preset_endpoints github-tooling
+		printf '%s\n' \
+			release-assets.githubusercontent.com:443 \
+			api.osv.dev:443 \
+			api.deps.dev:443
+		;;
 	rust-release)
 		# Rust cross-compile release builds (reusable-build-rust-binaries.yml).
 		# Minimal base: GitHub checkout/tooling, Rust/crates, cross Docker, apt, Sigstore.

--- a/scripts/ci/security/check-vuln-suppressions.sh
+++ b/scripts/ci/security/check-vuln-suppressions.sh
@@ -116,67 +116,69 @@ if [[ "$PR_LIST_EXIT" -ne 0 ]]; then
 	log_error "gh pr list failed: $PR_LIST_OUTPUT"
 	exit 1
 fi
+OPEN_CLEANUP_PR=""
 if [[ -n "$PR_LIST_OUTPUT" ]]; then
-	log_info "Cleanup PR #${PR_LIST_OUTPUT} already open. Skipping."
-	exit 0
+	log_info "Cleanup PR #${PR_LIST_OUTPUT} already open. Skipping PR creation."
+	OPEN_CLEANUP_PR="$PR_LIST_OUTPUT"
 fi
 
-if [[ ${#REMOVE_IDS[@]} -eq 0 ]]; then
-	log_info "No stale suppressions to remove."
-else
-	export REMOVE_IDS_JSON
-	REMOVE_IDS_JSON=$(printf '%s\n' "${REMOVE_IDS[@]}" | python3 -c "
+if [[ -z "$OPEN_CLEANUP_PR" ]]; then
+	if [[ ${#REMOVE_IDS[@]} -eq 0 ]]; then
+		log_info "No stale suppressions to remove."
+	else
+		export REMOVE_IDS_JSON
+		REMOVE_IDS_JSON=$(printf '%s\n' "${REMOVE_IDS[@]}" | python3 -c "
 import json, sys
 print(json.dumps([line.strip() for line in sys.stdin if line.strip()]))
 ")
 
-	python3 "$SCRIPTS_DIR/remove_stale_suppressions.py" "$OSV_TOML"
+		python3 "$SCRIPTS_DIR/remove_stale_suppressions.py" "$OSV_TOML"
 
-	if [[ -f "$OSV_TOML" ]]; then
-		if ! grep -qE '^\[' "$OSV_TOML"; then
-			log_info "No entries left in $OSV_TOML, removing file"
-			rm -f "$OSV_TOML"
+		if [[ -f "$OSV_TOML" ]]; then
+			if ! grep -qE '^\[' "$OSV_TOML"; then
+				log_info "No entries left in $OSV_TOML, removing file"
+				rm -f "$OSV_TOML"
+			fi
 		fi
-	fi
 
-	if ! git diff --quiet; then
-		REMOVED_LIST=""
-		for id in "${REMOVE_IDS[@]+"${REMOVE_IDS[@]}"}"; do
-			REMOVED_LIST="${REMOVED_LIST}- \`${id}\`
+		if ! git diff --quiet; then
+			REMOVED_LIST=""
+			for id in "${REMOVE_IDS[@]+"${REMOVE_IDS[@]}"}"; do
+				REMOVED_LIST="${REMOVED_LIST}- \`${id}\`
 "
-		done
+			done
 
-		EXPIRED_LIST=""
-		for id in "${EXPIRED_IDS[@]+"${EXPIRED_IDS[@]}"}"; do
-			EXPIRED_LIST="${EXPIRED_LIST}- \`${id}\`
+			EXPIRED_LIST=""
+			for id in "${EXPIRED_IDS[@]+"${EXPIRED_IDS[@]}"}"; do
+				EXPIRED_LIST="${EXPIRED_LIST}- \`${id}\`
 "
-		done
+			done
 
-		BRANCH="chore/remove-stale-vulns-$(date +%Y%m%d%H%M%S)"
-		configure_git_ci_user
-		git checkout -b "$BRANCH"
-		git add -A -- "$OSV_TOML"
-		git commit -m "$(
-			cat <<EOF
+			BRANCH="chore/remove-stale-vulns-$(date +%Y%m%d%H%M%S)"
+			configure_git_ci_user
+			git checkout -b "$BRANCH"
+			git add -A -- "$OSV_TOML"
+			git commit -m "$(
+				cat <<EOF
 chore(security): remove stale vulnerability suppressions
 
 The following suppressions are no longer needed:
 ${REMOVED_LIST}
 Detected by the weekly vuln-suppression-check workflow.
 EOF
-		)"
+			)"
 
-		git push -u origin "$BRANCH"
+			git push -u origin "$BRANCH"
 
-		WF_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions"
-		if [[ -n "${WORKFLOW_FILE:-}" ]]; then
-			WF_URL="${WF_URL}/workflows/${WORKFLOW_FILE}"
-		fi
+			WF_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions"
+			if [[ -n "${WORKFLOW_FILE:-}" ]]; then
+				WF_URL="${WF_URL}/workflows/${WORKFLOW_FILE}"
+			fi
 
-		gh pr create \
-			--title "chore(security): remove stale vulnerability suppressions" \
-			--body "$(
-				cat <<EOF
+			gh pr create \
+				--title "chore(security): remove stale vulnerability suppressions" \
+				--body "$(
+					cat <<EOF
 ## Summary
 - Remove stale vulnerability suppressions (vuln resolved upstream)
 ${REMOVED_LIST:+
@@ -193,11 +195,12 @@ ${EXPIRED_LIST}}
 ---
 *Auto-created by [vuln-suppression-check](${WF_URL}).*
 EOF
-			)"
+				)"
 
-		log_success "Cleanup PR created on branch $BRANCH"
-	else
-		log_info "No file changes needed."
+			log_success "Cleanup PR created on branch $BRANCH"
+		else
+			log_info "No file changes needed."
+		fi
 	fi
 fi
 

--- a/scripts/ci/security/check-vuln-suppressions.sh
+++ b/scripts/ci/security/check-vuln-suppressions.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+#
+# check-vuln-suppressions.sh — Detect stale or expired vulnerability
+# suppressions in .osv-scanner.toml and open a cleanup PR removing them.
+#
+# Usage:
+#   check-vuln-suppressions.sh
+#
+# Environment:
+#   GH_TOKEN     - GitHub token for PR creation (required)
+#   CONFIG_PATH  - Suppression TOML path (default: .osv-scanner.toml)
+#   WORKFLOW_FILE - Caller workflow filename for PR footer link (optional)
+
+set -euo pipefail
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Usage: check-vuln-suppressions.sh
+
+Detect stale or expired vulnerability suppressions in .osv-scanner.toml.
+
+Runs osv-scanner recursively without suppressions to scan all
+supported lockfiles and see which suppressed vulnerabilities are still
+present. Opens a PR removing entries that are stale (vuln resolved).
+
+Requires GH_TOKEN for PR management.
+EOF
+	exit 0
+fi
+
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${GITHUB_WORKSPACE:-$(cd "$SCRIPTS_DIR/../../../.." && pwd)}"
+LIB_DIR="$SCRIPTS_DIR/../lib"
+
+# shellcheck source=../lib/log.sh
+source "$LIB_DIR/log.sh"
+# shellcheck source=../lib/github/output.sh
+source "$LIB_DIR/github/output.sh"
+
+cd "$REPO_ROOT"
+
+OSV_TOML="${CONFIG_PATH:-.osv-scanner.toml}"
+
+if [[ ! -f "$OSV_TOML" ]]; then
+	log_success "No $OSV_TOML found. Nothing to check."
+	exit 0
+fi
+
+if [[ -z "${GH_TOKEN:-}" ]]; then
+	log_error "GH_TOKEN is required"
+	exit 1
+fi
+
+log_info "Probing osv-scanner without suppressions..."
+PROBE_EXIT=0
+PROBE_OUTPUT=$(
+	osv-scanner scan --recursive --format json --config /dev/null \
+		.
+) || PROBE_EXIT=$?
+
+if [[ "$PROBE_EXIT" -gt 1 ]]; then
+	log_error "osv-scanner failed with exit code $PROBE_EXIT"
+	echo "$PROBE_OUTPUT" >&2
+	exit "$PROBE_EXIT"
+fi
+
+log_info "Classifying suppressions..."
+export CONFIG_PATH="$OSV_TOML"
+CLASSIFICATION_JSON=$(echo "$PROBE_OUTPUT" | python3 "$SCRIPTS_DIR/classify-suppressions.py")
+
+STALE_IDS=()
+EXPIRED_IDS=()
+ACTIVE_IDS=()
+while IFS= read -r line; do
+	category="${line%%:*}"
+	vid="${line#*:}"
+	case "$category" in
+	STALE) STALE_IDS+=("$vid") ;;
+	EXPIRED) EXPIRED_IDS+=("$vid") ;;
+	ACTIVE) ACTIVE_IDS+=("$vid") ;;
+	esac
+done < <(echo "$CLASSIFICATION_JSON" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for k in ('stale', 'expired', 'active'):
+    for i in d.get(k, []):
+        print(f'{k.upper()}:{i}')
+")
+
+REMOVE_IDS=("${STALE_IDS[@]+"${STALE_IDS[@]}"}")
+
+for id in "${ACTIVE_IDS[@]+"${ACTIVE_IDS[@]}"}"; do
+	log_success "Active: $id"
+done
+for id in "${STALE_IDS[@]+"${STALE_IDS[@]}"}"; do
+	log_warning "Stale: $id"
+done
+for id in "${EXPIRED_IDS[@]+"${EXPIRED_IDS[@]}"}"; do
+	log_warning "Expired: $id"
+done
+
+if [[ ${#REMOVE_IDS[@]} -eq 0 && ${#EXPIRED_IDS[@]} -eq 0 ]]; then
+	log_success "All suppressions are active. Nothing to do."
+	exit 0
+fi
+
+PR_LIST_OUTPUT=""
+PR_LIST_EXIT=0
+PR_LIST_OUTPUT=$(
+	gh pr list --state open \
+		--search "chore(security): remove stale vulnerability" \
+		--json number --jq '.[0].number // empty' 2>&1
+) || PR_LIST_EXIT=$?
+if [[ "$PR_LIST_EXIT" -ne 0 ]]; then
+	log_error "gh pr list failed: $PR_LIST_OUTPUT"
+	exit 1
+fi
+if [[ -n "$PR_LIST_OUTPUT" ]]; then
+	log_info "Cleanup PR #${PR_LIST_OUTPUT} already open. Skipping."
+	exit 0
+fi
+
+export REMOVE_IDS_JSON
+REMOVE_IDS_JSON=$(printf '%s\n' "${REMOVE_IDS[@]}" | python3 -c "
+import json, sys
+print(json.dumps([line.strip() for line in sys.stdin if line.strip()]))
+")
+
+python3 - "$OSV_TOML" <<'PYEOF'
+import json, os, sys, tomllib
+from pathlib import Path
+
+toml_path = Path(sys.argv[1])
+remove_ids = set(json.loads(os.environ["REMOVE_IDS_JSON"]))
+
+with toml_path.open("rb") as f:
+    data = tomllib.load(f)
+
+ignored = data.get("IgnoredVulns", [])
+kept = [e for e in ignored if e.get("id") not in remove_ids]
+
+lines = toml_path.read_text().splitlines(keepends=True)
+header = []
+for line in lines:
+    if line.strip().startswith("#") or not line.strip():
+        header.append(line)
+    else:
+        break
+
+with toml_path.open("w") as f:
+    for line in header:
+        f.write(line)
+    for entry in kept:
+        f.write("[[IgnoredVulns]]\n")
+        f.write(f'id = "{entry["id"]}"\n')
+        if "ignoreUntil" in entry:
+            val = entry["ignoreUntil"]
+            iu = val.isoformat() if hasattr(val, "isoformat") else str(val)
+            f.write(f"ignoreUntil = {iu}\n")
+        if entry.get("reason"):
+            escaped = entry["reason"].replace("\\", "\\\\").replace('"', '\\"')
+            f.write(f'reason = "{escaped}"\n')
+        f.write("\n")
+
+removed = remove_ids - {e.get("id") for e in kept}
+for vid in sorted(removed):
+    print(f"Removed: {vid}", file=sys.stderr)
+PYEOF
+
+if [[ -f "$OSV_TOML" ]]; then
+	if ! grep -qE '^\[' "$OSV_TOML"; then
+		log_info "No entries left in $OSV_TOML, removing file"
+		rm -f "$OSV_TOML"
+	fi
+fi
+
+if ! git diff --quiet; then
+	REMOVED_LIST=""
+	for id in "${REMOVE_IDS[@]+"${REMOVE_IDS[@]}"}"; do
+		REMOVED_LIST="${REMOVED_LIST}- \`${id}\`
+"
+	done
+
+	EXPIRED_LIST=""
+	for id in "${EXPIRED_IDS[@]+"${EXPIRED_IDS[@]}"}"; do
+		EXPIRED_LIST="${EXPIRED_LIST}- \`${id}\`
+"
+	done
+
+	BRANCH="chore/remove-stale-vulns-$(date +%Y%m%d%H%M%S)"
+	configure_git_ci_user
+	git checkout -b "$BRANCH"
+	git add -A -- "$OSV_TOML"
+	git commit -m "$(
+		cat <<EOF
+chore(security): remove stale vulnerability suppressions
+
+The following suppressions are no longer needed:
+${REMOVED_LIST}
+Detected by the weekly vuln-suppression-check workflow.
+EOF
+	)"
+
+	git push -u origin "$BRANCH"
+
+	WF_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions"
+	if [[ -n "${WORKFLOW_FILE:-}" ]]; then
+		WF_URL="${WF_URL}/workflows/${WORKFLOW_FILE}"
+	fi
+
+	gh pr create \
+		--title "chore(security): remove stale vulnerability suppressions" \
+		--body "$(
+			cat <<EOF
+## Summary
+- Remove stale vulnerability suppressions (vuln resolved upstream)
+${REMOVED_LIST:+
+### Removed (stale)
+${REMOVED_LIST}}${EXPIRED_LIST:+
+### ⚠️ Expired (needs manual review)
+The following suppressions have passed their ignoreUntil date but
+the vulnerability may still be present. Renew or fix:
+${EXPIRED_LIST}}
+## Test plan
+- [ ] CI security audit passes without these suppressions
+- [ ] osv-scanner scan passes without these suppressions
+
+---
+*Auto-created by [vuln-suppression-check](${WF_URL}).*
+EOF
+		)"
+
+	log_success "Cleanup PR created on branch $BRANCH"
+else
+	log_info "No file changes needed."
+fi
+
+if [[ ${#EXPIRED_IDS[@]} -gt 0 ]]; then
+	log_error "Expired suppressions need manual review — renew or fix:"
+	for id in "${EXPIRED_IDS[@]}"; do
+		log_error "  $id"
+	done
+	exit 1
+fi

--- a/scripts/ci/security/check-vuln-suppressions.sh
+++ b/scripts/ci/security/check-vuln-suppressions.sh
@@ -121,13 +121,16 @@ if [[ -n "$PR_LIST_OUTPUT" ]]; then
 	exit 0
 fi
 
-export REMOVE_IDS_JSON
-REMOVE_IDS_JSON=$(printf '%s\n' "${REMOVE_IDS[@]}" | python3 -c "
+if [[ ${#REMOVE_IDS[@]} -eq 0 ]]; then
+	log_info "No stale suppressions to remove."
+else
+	export REMOVE_IDS_JSON
+	REMOVE_IDS_JSON=$(printf '%s\n' "${REMOVE_IDS[@]}" | python3 -c "
 import json, sys
 print(json.dumps([line.strip() for line in sys.stdin if line.strip()]))
 ")
 
-python3 - "$OSV_TOML" <<'PYEOF'
+	python3 - "$OSV_TOML" <<'PYEOF'
 import json, os, sys, tomllib
 from pathlib import Path
 
@@ -168,51 +171,51 @@ for vid in sorted(removed):
     print(f"Removed: {vid}", file=sys.stderr)
 PYEOF
 
-if [[ -f "$OSV_TOML" ]]; then
-	if ! grep -qE '^\[' "$OSV_TOML"; then
-		log_info "No entries left in $OSV_TOML, removing file"
-		rm -f "$OSV_TOML"
+	if [[ -f "$OSV_TOML" ]]; then
+		if ! grep -qE '^\[' "$OSV_TOML"; then
+			log_info "No entries left in $OSV_TOML, removing file"
+			rm -f "$OSV_TOML"
+		fi
 	fi
-fi
 
-if ! git diff --quiet; then
-	REMOVED_LIST=""
-	for id in "${REMOVE_IDS[@]+"${REMOVE_IDS[@]}"}"; do
-		REMOVED_LIST="${REMOVED_LIST}- \`${id}\`
+	if ! git diff --quiet; then
+		REMOVED_LIST=""
+		for id in "${REMOVE_IDS[@]+"${REMOVE_IDS[@]}"}"; do
+			REMOVED_LIST="${REMOVED_LIST}- \`${id}\`
 "
-	done
+		done
 
-	EXPIRED_LIST=""
-	for id in "${EXPIRED_IDS[@]+"${EXPIRED_IDS[@]}"}"; do
-		EXPIRED_LIST="${EXPIRED_LIST}- \`${id}\`
+		EXPIRED_LIST=""
+		for id in "${EXPIRED_IDS[@]+"${EXPIRED_IDS[@]}"}"; do
+			EXPIRED_LIST="${EXPIRED_LIST}- \`${id}\`
 "
-	done
+		done
 
-	BRANCH="chore/remove-stale-vulns-$(date +%Y%m%d%H%M%S)"
-	configure_git_ci_user
-	git checkout -b "$BRANCH"
-	git add -A -- "$OSV_TOML"
-	git commit -m "$(
-		cat <<EOF
+		BRANCH="chore/remove-stale-vulns-$(date +%Y%m%d%H%M%S)"
+		configure_git_ci_user
+		git checkout -b "$BRANCH"
+		git add -A -- "$OSV_TOML"
+		git commit -m "$(
+			cat <<EOF
 chore(security): remove stale vulnerability suppressions
 
 The following suppressions are no longer needed:
 ${REMOVED_LIST}
 Detected by the weekly vuln-suppression-check workflow.
 EOF
-	)"
+		)"
 
-	git push -u origin "$BRANCH"
+		git push -u origin "$BRANCH"
 
-	WF_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions"
-	if [[ -n "${WORKFLOW_FILE:-}" ]]; then
-		WF_URL="${WF_URL}/workflows/${WORKFLOW_FILE}"
-	fi
+		WF_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions"
+		if [[ -n "${WORKFLOW_FILE:-}" ]]; then
+			WF_URL="${WF_URL}/workflows/${WORKFLOW_FILE}"
+		fi
 
-	gh pr create \
-		--title "chore(security): remove stale vulnerability suppressions" \
-		--body "$(
-			cat <<EOF
+		gh pr create \
+			--title "chore(security): remove stale vulnerability suppressions" \
+			--body "$(
+				cat <<EOF
 ## Summary
 - Remove stale vulnerability suppressions (vuln resolved upstream)
 ${REMOVED_LIST:+
@@ -229,11 +232,12 @@ ${EXPIRED_LIST}}
 ---
 *Auto-created by [vuln-suppression-check](${WF_URL}).*
 EOF
-		)"
+			)"
 
-	log_success "Cleanup PR created on branch $BRANCH"
-else
-	log_info "No file changes needed."
+		log_success "Cleanup PR created on branch $BRANCH"
+	else
+		log_info "No file changes needed."
+	fi
 fi
 
 if [[ ${#EXPIRED_IDS[@]} -gt 0 ]]; then

--- a/scripts/ci/security/check-vuln-suppressions.sh
+++ b/scripts/ci/security/check-vuln-suppressions.sh
@@ -30,7 +30,7 @@ EOF
 fi
 
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="${GITHUB_WORKSPACE:-$(cd "$SCRIPTS_DIR/../../../.." && pwd)}"
+REPO_ROOT="${GITHUB_WORKSPACE:-$(cd "$SCRIPTS_DIR/../../.." && pwd)}"
 LIB_DIR="$SCRIPTS_DIR/../lib"
 
 # shellcheck source=../lib/log.sh
@@ -135,8 +135,8 @@ print(json.dumps([line.strip() for line in sys.stdin if line.strip()]))
 		python3 "$SCRIPTS_DIR/remove_stale_suppressions.py" "$OSV_TOML"
 
 		if [[ -f "$OSV_TOML" ]]; then
-			if ! grep -qE '^\[' "$OSV_TOML"; then
-				log_info "No entries left in $OSV_TOML, removing file"
+			if ! grep -qEv '^[[:space:]]*(#.*)?$' "$OSV_TOML"; then
+				log_info "No substantive content left in $OSV_TOML, removing file"
 				rm -f "$OSV_TOML"
 			fi
 		fi

--- a/scripts/ci/security/check-vuln-suppressions.sh
+++ b/scripts/ci/security/check-vuln-suppressions.sh
@@ -130,46 +130,7 @@ import json, sys
 print(json.dumps([line.strip() for line in sys.stdin if line.strip()]))
 ")
 
-	python3 - "$OSV_TOML" <<'PYEOF'
-import json, os, sys, tomllib
-from pathlib import Path
-
-toml_path = Path(sys.argv[1])
-remove_ids = set(json.loads(os.environ["REMOVE_IDS_JSON"]))
-
-with toml_path.open("rb") as f:
-    data = tomllib.load(f)
-
-ignored = data.get("IgnoredVulns", [])
-kept = [e for e in ignored if e.get("id") not in remove_ids]
-
-lines = toml_path.read_text().splitlines(keepends=True)
-header = []
-for line in lines:
-    if line.strip().startswith("#") or not line.strip():
-        header.append(line)
-    else:
-        break
-
-with toml_path.open("w") as f:
-    for line in header:
-        f.write(line)
-    for entry in kept:
-        f.write("[[IgnoredVulns]]\n")
-        f.write(f'id = "{entry["id"]}"\n')
-        if "ignoreUntil" in entry:
-            val = entry["ignoreUntil"]
-            iu = val.isoformat() if hasattr(val, "isoformat") else str(val)
-            f.write(f"ignoreUntil = {iu}\n")
-        if entry.get("reason"):
-            escaped = entry["reason"].replace("\\", "\\\\").replace('"', '\\"')
-            f.write(f'reason = "{escaped}"\n')
-        f.write("\n")
-
-removed = remove_ids - {e.get("id") for e in kept}
-for vid in sorted(removed):
-    print(f"Removed: {vid}", file=sys.stderr)
-PYEOF
+	python3 "$SCRIPTS_DIR/remove_stale_suppressions.py" "$OSV_TOML"
 
 	if [[ -f "$OSV_TOML" ]]; then
 		if ! grep -qE '^\[' "$OSV_TOML"; then

--- a/scripts/ci/security/classify-suppressions.py
+++ b/scripts/ci/security/classify-suppressions.py
@@ -36,7 +36,7 @@ class SuppressionEntry:
     """A single [[IgnoredVulns]] entry from .osv-scanner.toml."""
 
     id: str
-    ignore_until: date
+    ignore_until: date | None
     reason: str
 
 
@@ -56,11 +56,19 @@ def parse_suppressions(toml_path: Path) -> list[SuppressionEntry]:
         if not isinstance(vuln_id, str) or not vuln_id:
             continue
         ignore_until = item.get("ignoreUntil")
-        if isinstance(ignore_until, datetime) or not isinstance(ignore_until, date):
+        if ignore_until is None:
+            pass
+        elif isinstance(ignore_until, datetime):
             print(
-                f"WARNING: skipping '{vuln_id}': ignoreUntil is "
-                f"{type(ignore_until).__name__} ({ignore_until!r}), "
-                f"expected date (not datetime)",
+                f"WARNING: skipping '{vuln_id}': ignoreUntil must be a date, "
+                f"not datetime ({ignore_until!r})",
+                file=sys.stderr,
+            )
+            continue
+        elif not isinstance(ignore_until, date):
+            print(
+                f"WARNING: skipping '{vuln_id}': ignoreUntil has unsupported "
+                f"type {type(ignore_until).__name__} ({ignore_until!r})",
                 file=sys.stderr,
             )
             continue
@@ -106,7 +114,7 @@ def classify(
 
     result: dict[str, list[str]] = {"active": [], "stale": [], "expired": []}
     for entry in entries:
-        if today > entry.ignore_until:
+        if entry.ignore_until is not None and today > entry.ignore_until:
             result["expired"].append(entry.id)
         elif entry.id in probe_ids:
             result["active"].append(entry.id)

--- a/scripts/ci/security/classify-suppressions.py
+++ b/scripts/ci/security/classify-suppressions.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Classify vulnerability suppressions as active, stale, or expired.
+
+Standalone version — does not depend on the lintro Python package.
+Reads osv-scanner probe output from stdin and the suppression TOML from
+CONFIG_PATH (default: .osv-scanner.toml). Outputs a JSON object with stale,
+expired, and active ID arrays.
+
+Usage:
+    osv-scanner scan --recursive --format json --config /dev/null . \
+        | python3 classify-suppressions.py
+
+Environment:
+    CONFIG_PATH  Path to suppression TOML (default: .osv-scanner.toml)
+
+Exit codes:
+    0 - Success (JSON printed to stdout)
+    1 - Error
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tomllib
+import traceback
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class SuppressionEntry:
+    """A single [[IgnoredVulns]] entry from .osv-scanner.toml."""
+
+    id: str
+    ignore_until: date
+    reason: str
+
+
+def parse_suppressions(toml_path: Path) -> list[SuppressionEntry]:
+    """Parse [[IgnoredVulns]] entries from .osv-scanner.toml."""
+    if not toml_path.is_file():
+        return []
+
+    with toml_path.open("rb") as f:
+        data = tomllib.load(f)
+
+    entries: list[SuppressionEntry] = []
+    for item in data.get("IgnoredVulns", []):
+        if not isinstance(item, dict):
+            continue
+        vuln_id = item.get("id")
+        if not isinstance(vuln_id, str) or not vuln_id:
+            continue
+        ignore_until = item.get("ignoreUntil")
+        if isinstance(ignore_until, datetime) or not isinstance(ignore_until, date):
+            print(
+                f"WARNING: skipping '{vuln_id}': ignoreUntil is "
+                f"{type(ignore_until).__name__} ({ignore_until!r}), "
+                f"expected date (not datetime)",
+                file=sys.stderr,
+            )
+            continue
+        reason = item.get("reason", "")
+        entries.append(
+            SuppressionEntry(id=vuln_id, ignore_until=ignore_until, reason=reason),
+        )
+    return entries
+
+
+def parse_probe_vuln_ids(probe_output: str) -> set[str]:
+    """Extract vulnerability IDs from osv-scanner JSON output."""
+    try:
+        data = json.loads(probe_output)
+    except json.JSONDecodeError as e:
+        print(
+            f"ERROR: failed to parse osv-scanner JSON output: {e}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    ids: set[str] = set()
+    for result in data.get("results", []):
+        for pkg in result.get("packages", []):
+            for vuln in pkg.get("vulnerabilities", []):
+                vid = vuln.get("id")
+                if vid:
+                    ids.add(str(vid))
+            for group in pkg.get("groups", []):
+                for vid in group.get("ids", []):
+                    ids.add(str(vid))
+    return ids
+
+
+def classify(
+    entries: list[SuppressionEntry],
+    probe_ids: set[str],
+    today: date | None = None,
+) -> dict[str, list[str]]:
+    """Classify suppressions as active, stale, or expired."""
+    if today is None:
+        today = date.today()
+
+    result: dict[str, list[str]] = {"active": [], "stale": [], "expired": []}
+    for entry in entries:
+        if today > entry.ignore_until:
+            result["expired"].append(entry.id)
+        elif entry.id in probe_ids:
+            result["active"].append(entry.id)
+        else:
+            result["stale"].append(entry.id)
+    return result
+
+
+def main() -> None:
+    """Entry point."""
+    toml_path = Path(os.environ.get("CONFIG_PATH", ".osv-scanner.toml"))
+    entries = parse_suppressions(toml_path)
+
+    probe_output = sys.stdin.read()
+    if not probe_output.strip():
+        print(
+            "ERROR: osv-scanner produced no output — cannot classify "
+            "suppressions without scan results",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    probe_ids = parse_probe_vuln_ids(probe_output)
+    result = classify(entries, probe_ids)
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+        sys.exit(1)

--- a/scripts/ci/security/install-osv-scanner.sh
+++ b/scripts/ci/security/install-osv-scanner.sh
@@ -31,6 +31,12 @@ source "$LIB_DIR/fs.sh"
 
 OSV_VERSION="${1:-${OSV_VERSION:-2.3.5}}"
 
+OS=$(uname -s)
+if [[ "$OS" != "Linux" ]]; then
+	log_error "osv-scanner install supports Linux runners only (detected: $OS)"
+	exit 1
+fi
+
 ARCH=$(uname -m)
 case "$ARCH" in
 x86_64) PLATFORM="linux_amd64" ;;
@@ -76,7 +82,9 @@ else
 	log_info "Release does not publish SHA256SUMS sigstore assets; verifying binary checksum only"
 fi
 
-EXPECTED=$(grep "osv-scanner_${PLATFORM}" "${TMPDIR}/SHA256SUMS" | awk '{print $1}')
+EXPECTED=$(
+	awk -v fn="osv-scanner_${PLATFORM}" '$2 == fn { print $1; exit }' "${TMPDIR}/SHA256SUMS"
+)
 if [[ -z "$EXPECTED" ]]; then
 	log_error "No checksum entry for osv-scanner_${PLATFORM} in SHA256SUMS"
 	exit 1

--- a/scripts/ci/security/install-osv-scanner.sh
+++ b/scripts/ci/security/install-osv-scanner.sh
@@ -60,18 +60,18 @@ CHECKSUMS_SIG_URL="${BASE_URL}/osv-scanner_SHA256SUMS.sig"
 CHECKSUMS_CERT_URL="${BASE_URL}/osv-scanner_SHA256SUMS.pem"
 if curl -fsSL "$CHECKSUMS_SIG_URL" -o "${TMPDIR}/SHA256SUMS.sig" 2>/dev/null &&
 	curl -fsSL "$CHECKSUMS_CERT_URL" -o "${TMPDIR}/SHA256SUMS.pem" 2>/dev/null; then
-	if ! command -v cosign >/dev/null 2>&1; then
-		log_error "cosign is required to verify osv-scanner_SHA256SUMS signature"
-		exit 1
+	if command -v cosign >/dev/null 2>&1; then
+		log_info "Verifying SHA256SUMS sigstore signature..."
+		cosign verify-blob \
+			--signature "${TMPDIR}/SHA256SUMS.sig" \
+			--certificate "${TMPDIR}/SHA256SUMS.pem" \
+			--certificate-identity-regexp='https://github\.com/google/osv-scanner/.*' \
+			--certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+			"${TMPDIR}/SHA256SUMS"
+		log_success "SHA256SUMS signature verified"
+	else
+		log_warn "cosign not found; skipping SHA256SUMS signature verification"
 	fi
-	log_info "Verifying SHA256SUMS sigstore signature..."
-	cosign verify-blob \
-		--signature "${TMPDIR}/SHA256SUMS.sig" \
-		--certificate "${TMPDIR}/SHA256SUMS.pem" \
-		--certificate-identity-regexp='https://github\.com/google/osv-scanner/.*' \
-		--certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
-		"${TMPDIR}/SHA256SUMS"
-	log_success "SHA256SUMS signature verified"
 else
 	log_info "Release does not publish SHA256SUMS sigstore assets; verifying binary checksum only"
 fi

--- a/scripts/ci/security/install-osv-scanner.sh
+++ b/scripts/ci/security/install-osv-scanner.sh
@@ -56,17 +56,36 @@ log_info "Installing osv-scanner v${OSV_VERSION}..."
 curl -fsSL "$BINARY_URL" -o "${TMPDIR}/osv-scanner"
 curl -fsSL "$CHECKSUMS_URL" -o "${TMPDIR}/SHA256SUMS"
 
-EXPECTED=$(grep "osv-scanner_${PLATFORM}" "${TMPDIR}/SHA256SUMS" | awk '{print $1}')
-ACTUAL=$(sha256sum "${TMPDIR}/osv-scanner" | awk '{print $1}')
+CHECKSUMS_SIG_URL="${BASE_URL}/osv-scanner_SHA256SUMS.sig"
+CHECKSUMS_CERT_URL="${BASE_URL}/osv-scanner_SHA256SUMS.pem"
+if curl -fsSL "$CHECKSUMS_SIG_URL" -o "${TMPDIR}/SHA256SUMS.sig" 2>/dev/null &&
+	curl -fsSL "$CHECKSUMS_CERT_URL" -o "${TMPDIR}/SHA256SUMS.pem" 2>/dev/null; then
+	if ! command -v cosign >/dev/null 2>&1; then
+		log_error "cosign is required to verify osv-scanner_SHA256SUMS signature"
+		exit 1
+	fi
+	log_info "Verifying SHA256SUMS sigstore signature..."
+	cosign verify-blob \
+		--signature "${TMPDIR}/SHA256SUMS.sig" \
+		--certificate "${TMPDIR}/SHA256SUMS.pem" \
+		--certificate-identity-regexp='https://github\.com/google/osv-scanner/.*' \
+		--certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
+		"${TMPDIR}/SHA256SUMS"
+	log_success "SHA256SUMS signature verified"
+else
+	log_info "Release does not publish SHA256SUMS sigstore assets; verifying binary checksum only"
+fi
 
-if [[ "$EXPECTED" != "$ACTUAL" ]]; then
-	log_error "SHA256 mismatch for osv-scanner v${OSV_VERSION}"
-	log_error "Expected: ${EXPECTED}"
-	log_error "Actual:   ${ACTUAL}"
+EXPECTED=$(grep "osv-scanner_${PLATFORM}" "${TMPDIR}/SHA256SUMS" | awk '{print $1}')
+if [[ -z "$EXPECTED" ]]; then
+	log_error "No checksum entry for osv-scanner_${PLATFORM} in SHA256SUMS"
 	exit 1
 fi
 
-log_success "SHA256 verified: ${ACTUAL}"
+printf '%s  osv-scanner\n' "$EXPECTED" | (
+	cd "${TMPDIR}" && sha256sum -c -
+)
+log_success "SHA256 verified: ${EXPECTED}"
 
 chmod +x "${TMPDIR}/osv-scanner"
 mv "${TMPDIR}/osv-scanner" "${INSTALL_DIR}/osv-scanner"

--- a/scripts/ci/security/install-osv-scanner.sh
+++ b/scripts/ci/security/install-osv-scanner.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+#
+# install-osv-scanner.sh — Download and verify osv-scanner binary.
+#
+# Usage:
+#   install-osv-scanner.sh [version]
+#
+# Resolves version as: $1 > $OSV_VERSION env var > 2.3.5 (hardcoded default).
+# Resolves install dir as: $INSTALL_DIR env var > /usr/local/bin > ~/.local/bin.
+
+set -euo pipefail
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+	cat <<'EOF'
+Usage: install-osv-scanner.sh [version]
+
+Download and verify the osv-scanner release binary.
+
+Version: $1 > $OSV_VERSION > 2.3.5
+Install dir: $INSTALL_DIR > /usr/local/bin > ~/.local/bin
+EOF
+	exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+# shellcheck source=../lib/fs.sh
+source "$LIB_DIR/fs.sh"
+
+OSV_VERSION="${1:-${OSV_VERSION:-2.3.5}}"
+
+ARCH=$(uname -m)
+case "$ARCH" in
+x86_64) PLATFORM="linux_amd64" ;;
+aarch64 | arm64) PLATFORM="linux_arm64" ;;
+*)
+	log_error "Unsupported architecture: $ARCH"
+	exit 1
+	;;
+esac
+
+BASE_URL="https://github.com/google/osv-scanner/releases/download/v${OSV_VERSION}"
+BINARY_URL="${BASE_URL}/osv-scanner_${PLATFORM}"
+CHECKSUMS_URL="${BASE_URL}/osv-scanner_SHA256SUMS"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+if [[ ! -w "$INSTALL_DIR" ]]; then
+	INSTALL_DIR="${HOME}/.local/bin"
+	mkdir -p "$INSTALL_DIR"
+fi
+TMPDIR=$(create_temp_dir)
+
+log_info "Installing osv-scanner v${OSV_VERSION}..."
+
+curl -fsSL "$BINARY_URL" -o "${TMPDIR}/osv-scanner"
+curl -fsSL "$CHECKSUMS_URL" -o "${TMPDIR}/SHA256SUMS"
+
+EXPECTED=$(grep "osv-scanner_${PLATFORM}" "${TMPDIR}/SHA256SUMS" | awk '{print $1}')
+ACTUAL=$(sha256sum "${TMPDIR}/osv-scanner" | awk '{print $1}')
+
+if [[ "$EXPECTED" != "$ACTUAL" ]]; then
+	log_error "SHA256 mismatch for osv-scanner v${OSV_VERSION}"
+	log_error "Expected: ${EXPECTED}"
+	log_error "Actual:   ${ACTUAL}"
+	exit 1
+fi
+
+log_success "SHA256 verified: ${ACTUAL}"
+
+chmod +x "${TMPDIR}/osv-scanner"
+mv "${TMPDIR}/osv-scanner" "${INSTALL_DIR}/osv-scanner"
+
+"${INSTALL_DIR}/osv-scanner" --version
+log_success "osv-scanner v${OSV_VERSION} installed to ${INSTALL_DIR}"
+
+if [[ ":$PATH:" != *":${INSTALL_DIR}:"* ]]; then
+	export PATH="${INSTALL_DIR}:${PATH}"
+	if [[ -n "${GITHUB_PATH:-}" ]]; then
+		echo "$INSTALL_DIR" >>"$GITHUB_PATH"
+	fi
+fi

--- a/scripts/ci/security/remove_stale_suppressions.py
+++ b/scripts/ci/security/remove_stale_suppressions.py
@@ -20,7 +20,7 @@ import re
 import sys
 from pathlib import Path
 
-_ID_PATTERN = re.compile(r'^id\s*=\s*"([^"]+)"')
+_ID_PATTERN = re.compile(r"""^id\s*=\s*['"]([^'"]+)['"]""")
 
 
 def remove_stale_ignored_vulns(

--- a/scripts/ci/security/remove_stale_suppressions.py
+++ b/scripts/ci/security/remove_stale_suppressions.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Remove stale [[IgnoredVulns]] blocks from .osv-scanner.toml.
+
+Preserves all non-IgnoredVulns sections (for example [PackageOverrides]) and
+per-entry comments by rewriting only matching array-of-tables blocks.
+
+Usage:
+    REMOVE_IDS_JSON='["GHSA-abc"]' python3 remove_stale_suppressions.py path.toml
+
+Environment:
+    REMOVE_IDS_JSON  JSON array of vulnerability IDs to remove (required)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+_ID_PATTERN = re.compile(r'^id\s*=\s*"([^"]+)"')
+
+
+def remove_stale_ignored_vulns(
+    content: str,
+    remove_ids: set[str],
+) -> tuple[str, set[str]]:
+    """Drop [[IgnoredVulns]] blocks whose id is in remove_ids.
+
+    Args:
+        content: Full TOML file contents.
+        remove_ids: Vulnerability IDs to remove.
+
+    Returns:
+        Tuple of rewritten content and the set of IDs actually removed.
+    """
+    lines = content.splitlines(keepends=True)
+    out: list[str] = []
+    removed: set[str] = set()
+    index = 0
+
+    while index < len(lines):
+        if lines[index].strip() != "[[IgnoredVulns]]":
+            out.append(lines[index])
+            index += 1
+            continue
+
+        block_lines = [lines[index]]
+        index += 1
+
+        while index < len(lines):
+            stripped = lines[index].strip()
+            if stripped.startswith("["):
+                break
+            block_lines.append(lines[index])
+            index += 1
+
+        vuln_id: str | None = None
+        for block_line in block_lines:
+            match = _ID_PATTERN.match(block_line.strip())
+            if match:
+                vuln_id = match.group(1)
+                break
+
+        if vuln_id is not None and vuln_id in remove_ids:
+            removed.add(vuln_id)
+        else:
+            out.extend(block_lines)
+
+    return "".join(out), removed
+
+
+def main() -> None:
+    """Entry point."""
+    if len(sys.argv) != 2:
+        print(
+            "Usage: REMOVE_IDS_JSON='[...]' remove_stale_suppressions.py <toml-path>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    toml_path = Path(sys.argv[1])
+    remove_ids = set(json.loads(os.environ["REMOVE_IDS_JSON"]))
+    original = toml_path.read_text()
+    rewritten, removed = remove_stale_ignored_vulns(original, remove_ids)
+
+    if rewritten != original:
+        toml_path.write_text(rewritten)
+
+    for vuln_id in sorted(removed):
+        print(f"Removed: {vuln_id}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/bats/integration/test_reusable_vuln_suppression_check.bats
+++ b/tests/bats/integration/test_reusable_vuln_suppression_check.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-vuln-suppression-check workflow inputs and job shape
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-vuln-suppression-check.yml"
+
+@test "reusable-vuln-suppression-check: egress-policy defaults to block" {
+	run awk '/^      egress-policy:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: "block"'
+}
+
+@test "reusable-vuln-suppression-check: egress-preset defaults to osv-scanner" {
+	run awk '/^      egress-preset:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: "osv-scanner"'
+}
+
+@test "reusable-vuln-suppression-check: allowed-endpoints-mode defaults to append" {
+	run awk '/^      allowed-endpoints-mode:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: "append"'
+}
+
+@test "reusable-vuln-suppression-check: requires GH_TOKEN secret" {
+	run awk '/^    secrets:$/,/^jobs:/' "$WORKFLOW"
+	assert_success
+	assert_output --partial 'GH_TOKEN:'
+}
+
+@test "reusable-vuln-suppression-check: job grants contents and pull-requests write" {
+	run awk '
+		/^  vuln-suppression-check:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  vuln-suppression-check:/ { in_job = 0 }
+		in_job && /contents: write/ { contents = 1 }
+		in_job && /pull-requests: write/ { prs = 1 }
+		END { exit !(contents && prs) }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-vuln-suppression-check: checkout uses caller GH_TOKEN for git push" {
+	run awk '
+		/^  vuln-suppression-check:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  vuln-suppression-check:/ { in_job = 0 }
+		in_job && /- name: Checkout repository/ { checkout = 1 }
+		checkout && /token: \$\{\{ secrets\.GH_TOKEN \}\}/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-vuln-suppression-check: default check script points to tooling script" {
+	run grep -F \
+		'default: ".lgtm-ci-tooling/scripts/ci/security/check-vuln-suppressions.sh"' \
+		"$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-vuln-suppression-check: resolve egress before harden-runner composite" {
+	run awk '
+		/^  vuln-suppression-check:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  vuln-suppression-check:/ { in_job = 0 }
+		in_job && /- name: Checkout repository/ { checkout = 1 }
+		in_job && /- name: Checkout lgtm-ci tooling/ { tooling = 1 }
+		in_job && /- name: Resolve egress allowlist/ { resolve = 1 }
+		in_job && resolve && /- name: Harden runner/ { found = 1 }
+		END { exit !(checkout && tooling && found) }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-vuln-suppression-check: installs osv-scanner before check step" {
+	run awk '
+		/^  vuln-suppression-check:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  vuln-suppression-check:/ { in_job = 0 }
+		in_job && /- name: Install osv-scanner/ { install = 1 }
+		install && /- name: Check suppression staleness/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/unit/lib/egress/test_presets.bats
+++ b/tests/bats/unit/lib/egress/test_presets.bats
@@ -97,6 +97,15 @@ PRESETS="${PROJECT_ROOT}/scripts/ci/lib/egress/presets.sh"
 	assert_output --partial 'pipelines.actions.githubusercontent.com:443'
 }
 
+@test "egress preset osv-scanner includes release assets and OSV API hosts" {
+	run bash -c "source '$PRESETS' && egress_preset_endpoints osv-scanner"
+	assert_success
+	assert_output --partial 'release-assets.githubusercontent.com:443'
+	assert_output --partial 'api.osv.dev:443'
+	assert_output --partial 'api.deps.dev:443'
+	assert_output --partial 'codeload.github.com:443'
+}
+
 @test "egress preset quality includes artifact pipeline host" {
 	run bash -c "source '$PRESETS' && egress_preset_endpoints quality"
 	assert_success
@@ -151,6 +160,7 @@ PRESETS="${PROJECT_ROOT}/scripts/ci/lib/egress/presets.sh"
 		rubygems
 		npm-publish
 		quality
+		osv-scanner
 		rust-release
 		sbom
 		scorecard

--- a/tests/bats/unit/security/test_classify_suppressions.bats
+++ b/tests/bats/unit/security/test_classify_suppressions.bats
@@ -75,6 +75,26 @@ EOF
 	assert_output --partial '"active": ["CVE-2024-00001"]'
 }
 
+@test "classify-suppressions: treats missing ignoreUntil as permanent suppression" {
+	cat >".osv-scanner.toml" <<'EOF'
+[[IgnoredVulns]]
+id = "GHSA-permanent-stale"
+reason = "no expiry date"
+
+[[IgnoredVulns]]
+id = "GHSA-permanent-active"
+reason = "no expiry date"
+EOF
+
+	local probe_json='{"results":[{"packages":[{"vulnerabilities":[{"id":"GHSA-permanent-active"}]}]}]}'
+
+	run bash -c "printf '%s' '$probe_json' | python3 '$CLASSIFY_SCRIPT'"
+	assert_success
+	assert_output --partial '"active": ["GHSA-permanent-active"]'
+	assert_output --partial '"stale": ["GHSA-permanent-stale"]'
+	assert_output --partial '"expired": []'
+}
+
 @test "classify-suppressions: fails on empty probe output" {
 	cat >".osv-scanner.toml" <<'EOF'
 [[IgnoredVulns]]

--- a/tests/bats/unit/security/test_classify_suppressions.bats
+++ b/tests/bats/unit/security/test_classify_suppressions.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/security/classify-suppressions.py
+
+load "../../../helpers/common"
+
+CLASSIFY_SCRIPT="${PROJECT_ROOT}/scripts/ci/security/classify-suppressions.py"
+
+setup() {
+	setup_temp_dir
+	cd "$BATS_TEST_TMPDIR"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "classify-suppressions: classifies active stale and expired entries" {
+	cat >".osv-scanner.toml" <<'EOF'
+[[IgnoredVulns]]
+id = "GHSA-active-1111"
+ignoreUntil = 2099-12-31
+reason = "still present"
+
+[[IgnoredVulns]]
+id = "GHSA-stale-2222"
+ignoreUntil = 2099-12-31
+reason = "resolved upstream"
+
+[[IgnoredVulns]]
+id = "GHSA-expired-3333"
+ignoreUntil = 2020-01-01
+reason = "past due"
+EOF
+
+	local probe_json
+	probe_json=$(
+		cat <<'EOF'
+{
+  "results": [
+    {
+      "packages": [
+        {
+          "vulnerabilities": [
+            { "id": "GHSA-active-1111" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+EOF
+	)
+
+	run bash -c "printf '%s' '$probe_json' | python3 '$CLASSIFY_SCRIPT'"
+	assert_success
+	assert_output --partial '"active": ["GHSA-active-1111"]'
+	assert_output --partial '"stale": ["GHSA-stale-2222"]'
+	assert_output --partial '"expired": ["GHSA-expired-3333"]'
+}
+
+@test "classify-suppressions: honors CONFIG_PATH override" {
+	mkdir -p config
+	cat >"config/custom.toml" <<'EOF'
+[[IgnoredVulns]]
+id = "CVE-2024-00001"
+ignoreUntil = 2099-06-01
+reason = "custom path"
+EOF
+
+	local probe_json='{"results":[{"packages":[{"vulnerabilities":[{"id":"CVE-2024-00001"}]}]}]}'
+
+	run bash -c "export CONFIG_PATH=config/custom.toml; printf '%s' '$probe_json' | python3 '$CLASSIFY_SCRIPT'"
+	assert_success
+	assert_output --partial '"active": ["CVE-2024-00001"]'
+}
+
+@test "classify-suppressions: fails on empty probe output" {
+	cat >".osv-scanner.toml" <<'EOF'
+[[IgnoredVulns]]
+id = "GHSA-only-1111"
+ignoreUntil = 2099-12-31
+reason = "probe missing"
+EOF
+
+	run bash -c "printf '' | python3 '$CLASSIFY_SCRIPT'"
+	assert_failure
+}

--- a/tests/bats/unit/security/test_remove_stale_suppressions.bats
+++ b/tests/bats/unit/security/test_remove_stale_suppressions.bats
@@ -62,3 +62,23 @@ EOF
 	run grep -F 'GHSA-active-4444' .osv-scanner.toml
 	assert_success
 }
+
+@test "remove-stale-suppressions: handles single-quoted id" {
+	cat >".osv-scanner.toml" <<'EOF'
+[[IgnoredVulns]]
+id = 'GHSA-stale-XXXX'
+reason = "resolved upstream"
+
+[[IgnoredVulns]]
+id = "GHSA-active-5555"
+reason = "still present"
+EOF
+
+	run bash -c "export REMOVE_IDS_JSON='[\"GHSA-stale-XXXX\"]'; python3 '$REMOVE_SCRIPT' .osv-scanner.toml"
+	assert_success
+	assert_output --partial "Removed: GHSA-stale-XXXX"
+	run grep -q 'GHSA-stale-XXXX' .osv-scanner.toml
+	assert_failure
+	run grep -F 'GHSA-active-5555' .osv-scanner.toml
+	assert_success
+}

--- a/tests/bats/unit/security/test_remove_stale_suppressions.bats
+++ b/tests/bats/unit/security/test_remove_stale_suppressions.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/security/remove_stale_suppressions.py
+
+load "../../../helpers/common"
+
+REMOVE_SCRIPT="${PROJECT_ROOT}/scripts/ci/security/remove_stale_suppressions.py"
+
+setup() {
+	setup_temp_dir
+	cd "$BATS_TEST_TMPDIR"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "remove-stale-suppressions: preserves non-IgnoredVulns sections" {
+	cat >".osv-scanner.toml" <<'EOF'
+# Suppression config
+[PackageOverrides]
+path = "vendor/"
+
+[[IgnoredVulns]]
+id = "GHSA-stale-1111"
+ignoreUntil = 2099-12-31
+reason = "resolved"
+
+[[IgnoredVulns]]
+id = "GHSA-active-2222"
+ignoreUntil = 2099-12-31
+reason = "still present"
+EOF
+
+	run bash -c "export REMOVE_IDS_JSON='[\"GHSA-stale-1111\"]'; python3 '$REMOVE_SCRIPT' .osv-scanner.toml"
+	assert_success
+	assert_output --partial "Removed: GHSA-stale-1111"
+	run grep -F '[PackageOverrides]' .osv-scanner.toml
+	assert_success
+	run grep -F 'GHSA-active-2222' .osv-scanner.toml
+	assert_success
+	run grep -q 'GHSA-stale-1111' .osv-scanner.toml
+	assert_failure
+}
+
+@test "remove-stale-suppressions: keeps comments inside retained blocks" {
+	cat >".osv-scanner.toml" <<'EOF'
+[[IgnoredVulns]]
+id = "GHSA-stale-3333"
+reason = "resolved upstream"
+
+[[IgnoredVulns]]
+# still relevant
+id = "GHSA-active-4444"
+reason = "active"
+EOF
+
+	run bash -c "export REMOVE_IDS_JSON='[\"GHSA-stale-3333\"]'; python3 '$REMOVE_SCRIPT' .osv-scanner.toml"
+	assert_success
+	run grep -F '# still relevant' .osv-scanner.toml
+	assert_success
+	run grep -F 'GHSA-active-4444' .osv-scanner.toml
+	assert_success
+}


### PR DESCRIPTION
## Summary

Add `reusable-vuln-suppression-check.yml` to centralize the weekly vulnerability
suppression staleness check currently duplicated across Rustume, py-lintro, and
turbo-themes. Consumer repos can replace inline workflows and vendored scripts
with a thin caller that forwards `GH_TOKEN` and optional `workflow-file`.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Changes Made

- Add `reusable-vuln-suppression-check.yml` with tooling checkout, egress
  resolution, osv-scanner install, and suppression check orchestration
- Lift `check-vuln-suppressions.sh`, `classify-suppressions.py`, and
  `install-osv-scanner.sh` into `scripts/ci/security/`
- Add `osv-scanner` egress preset (`github-tooling` + release assets + OSV APIs)
- Document caller contract in `docs/reusable-workflows.md` and
  `docs/workflow-contract.md`
- Add BATS contract and unit tests for workflow shape, presets, and classifier
- Guard TOML rewrite so expired-only runs fail without opening misleading PRs

## Closes

- Closes #330
- Relates to #168
- Relates to #325

## Testing

- [x] `uv run lintro chk` — zero issues
- [x] `uv run lintro fmt` — formatting clean
- [x] BATS: `test_reusable_vuln_suppression_check.bats`
- [x] BATS: `test_classify_suppressions.bats`
- [x] BATS: `test_presets.bats` (osv-scanner preset)
- [x] Greptile review — addressed P1 expired-only rewrite guard
- [x] CodeRabbit review — added `check-script` to docs table

## Quality Checks

- [x] Lint/format (`uv run lintro chk` / `uv run lintro fmt`)
- [x] Shellcheck + shfmt via lintro
- [x] actionlint + yamllint via lintro
- [x] BATS unit/integration tests for new scripts and workflow contract

## Breaking Changes

None

## Related Issues

<!-- Replaced by ## Closes above per repo PR convention -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add reusable workflow to detect and auto-remove stale OSV vulnerability suppressions
> - Introduces [reusable-vuln-suppression-check.yml](.github/workflows/reusable-vuln-suppression-check.yml), a callable workflow that installs `osv-scanner`, classifies suppressions as active/stale/expired, and opens a cleanup PR to remove stale entries.
> - Adds [check-vuln-suppressions.sh](scripts/ci/security/check-vuln-suppressions.sh) as the main orchestration script; it runs `osv-scanner`, pipes results to [classify-suppressions.py](scripts/ci/security/classify-suppressions.py), and invokes [remove_stale_suppressions.py](scripts/ci/security/remove_stale_suppressions.py) to rewrite the TOML config in place.
> - Adds an `osv-scanner` egress preset to both [scripts/ci/lib/egress/presets.sh](scripts/ci/lib/egress/presets.sh) and [.github/actions/harden-runner/lib/egress/presets.sh](.github/actions/harden-runner/lib/egress/presets.sh), allowlisting `api.osv.dev:443`, `api.deps.dev:443`, and `release-assets.githubusercontent.com:443`.
> - The workflow defaults to `egress-policy: block` with the `osv-scanner` preset, so callers that omit egress settings automatically get network lockdown.
> - Risk: the check script exits non-zero when expired suppressions are found, which will fail CI until those entries are manually reviewed and removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 851cfa4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reusable workflow to detect and clean up stale vulnerability suppressions and open cleanup PRs.
  * New OSV scanner egress preset and automated installer for the OSV scanner.
  * New CLI tools to classify and remove stale/expired suppressions and a CI helper to run the check.

* **Documentation**
  * Added docs and README entry describing the workflow, inputs, and egress preset.

* **Tests**
  * Added integration and unit tests covering the workflow, egress preset, and suppression tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a reusable `vuln-suppression-check` workflow that installs osv-scanner, classifies `.osv-scanner.toml` suppression entries as active/stale/expired, and opens a cleanup PR for stale ones while failing CI on expired entries that need manual review.

- **New reusable workflow** (`reusable-vuln-suppression-check.yml`) with hardened egress defaults (`block` + `osv-scanner` preset), sparse-checkout of tooling, and correct step ordering (egress resolve → harden → install → check).
- **Three new scripts**: `install-osv-scanner.sh` (download + cosign/SHA256 verify), `classify-suppressions.py` (active/stale/expired classification from osv probe output), `remove_stale_suppressions.py` (line-by-line TOML rewriter that preserves non-`IgnoredVulns` sections and per-block comments).
- **New `osv-scanner` egress preset** in both preset files, delegating to `github-tooling` and appending `release-assets.githubusercontent.com`, `api.osv.dev`, and `api.deps.dev`; the preset is missing the Rekor/Fulcio/sigstore-TUF endpoints that `cosign verify-blob --certificate` contacts by default.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the cosign/Rekor egress gap; all other logic is sound.

The install script's `cosign verify-blob --certificate` contacts `rekor.sigstore.dev` by default for transparency-log verification. That host is absent from the new `osv-scanner` preset, while `release-assets.githubusercontent.com` (which hosts the `.sig`/`.pem` files) IS present — so the download branch is taken, cosign is invoked, hits the blocked endpoint, and the install step fails on every run under the default `block` policy on ubuntu-latest (where cosign is pre-installed). Everything else — the TOML classifier, the line-by-line rewriter, the expired-only guard, the PR deduplication, and the workflow structure — is correct and well-tested.

scripts/ci/security/install-osv-scanner.sh and both copies of scripts/ci/lib/egress/presets.sh / .github/actions/harden-runner/lib/egress/presets.sh need the cosign/sigstore fix.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/security/install-osv-scanner.sh | Downloads and verifies osv-scanner binary; cosign verify-blob contacts Rekor by default, but Rekor endpoints are absent from the osv-scanner egress preset, causing the step to fail under block policy on runners where cosign is pre-installed. |
| .github/workflows/reusable-vuln-suppression-check.yml | New reusable workflow; structure, permissions, step ordering, and egress-preset defaulting are all correct. The install step will fail at runtime due to the Rekor-access issue in the install script. |
| scripts/ci/security/check-vuln-suppressions.sh | Orchestration script for scan → classify → TOML rewrite → PR creation; expired-only guard and git add/push/pr-create flow are correct. |
| scripts/ci/security/classify-suppressions.py | Classifies suppressions as active/stale/expired; handles None ignoreUntil correctly (falls through to active/stale), collects aliases from groups, error handling is solid. |
| scripts/ci/security/remove_stale_suppressions.py | Line-by-line TOML rewriter that preserves non-IgnoredVulns sections and per-block comments; block boundary detection and id-pattern matching are correct for the standard OSV scanner TOML format. |
| scripts/ci/lib/egress/presets.sh | Adds osv-scanner preset as github-tooling + release assets + OSV APIs; missing Rekor/Fulcio/sigstore-TUF endpoints needed by cosign verify-blob. |
| .github/actions/harden-runner/lib/egress/presets.sh | Mirror of scripts/ci/lib/egress/presets.sh; same osv-scanner preset with same missing sigstore endpoints. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Caller Workflow
    participant WF as reusable-vuln-suppression-check
    participant OSV as osv-scanner (binary)
    participant CLS as classify-suppressions.py
    participant REM as remove_stale_suppressions.py
    participant GH as GitHub API (gh CLI)

    Caller->>WF: workflow_call (GH_TOKEN, config-path, ...)
    WF->>WF: checkout repo + sparse-checkout tooling
    WF->>WF: resolve egress allowlist (osv-scanner preset)
    WF->>WF: harden runner (block policy)
    WF->>OSV: install-osv-scanner.sh (download + SHA256 + cosign verify)
    WF->>OSV: scan --recursive --format json --config /dev/null .
    OSV-->>WF: probe JSON (all vulns, no suppressions)
    WF->>CLS: "stdin=probe JSON, CONFIG_PATH=.osv-scanner.toml"
    CLS-->>WF: "{active:[...], stale:[...], expired:[...]}"
    alt stale IDs present
        WF->>REM: "REMOVE_IDS_JSON=[...] remove_stale_suppressions.py toml"
        REM-->>WF: rewrites TOML in-place
        WF->>GH: gh pr list (check for existing cleanup PR)
        WF->>GH: git push + gh pr create (cleanup branch)
    end
    alt expired IDs present
        WF-->>Caller: exit 1 (manual review required)
    end
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fsecurity%2Finstall-osv-scanner.sh%3A67-83%0A**Cosign%20Rekor%20verification%20blocked%20by%20egress%20preset**%0A%0A%60cosign%20verify-blob%20--certificate%60%20without%20%60--insecure-ignore-tlog%60%20contacts%20the%20Rekor%20transparency%20log%20%28%60rekor.sigstore.dev%3A443%60%29%20to%20confirm%20the%20certificate%20was%20logged.%20The%20%60osv-scanner%60%20egress%20preset%20only%20adds%20%60release-assets.githubusercontent.com%60%2C%20%60api.osv.dev%60%2C%20and%20%60api.deps.dev%60%20to%20%60github-tooling%60%3B%20it%20omits%20the%20sigstore%20endpoints.%20On%20GitHub-hosted%20ubuntu%20runners%20where%20cosign%20is%20pre-installed%2C%20the%20%60.sig%60%20and%20%60.pem%60%20files%20will%20download%20successfully%20%28the%20host%20is%20in%20the%20allowlist%29%2C%20the%20%60if%60%20branch%20is%20taken%2C%20%60cosign%20verify-blob%60%20runs%20%E2%80%94%20then%20immediately%20hits%20a%20blocked%20egress%20call%20to%20Rekor%20and%20exits%20non-zero.%20With%20%60set%20-euo%20pipefail%60%20in%20effect%2C%20the%20whole%20install%20step%20fails.%0A%0AEither%20add%20%60--insecure-ignore-tlog%60%20to%20the%20%60cosign%20verify-blob%60%20invocation%20%28relying%20on%20the%20SHA256%20checksum%20%2B%20certificate-identity%20check%20alone%29%2C%20or%20add%20%60rekor.sigstore.dev%3A443%60%2C%20%60fulcio.sigstore.dev%3A443%60%2C%20and%20%60tuf-repo-cdn.sigstore.dev%3A443%60%20to%20the%20%60osv-scanner%60%20egress%20preset%20to%20match%20the%20pattern%20used%20in%20the%20%60sbom%60%20and%20%60npm-publish%60%20presets.%0A%0A&pr=332&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fsecurity%2Finstall-osv-scanner.sh%3A67-83%0A**Cosign%20Rekor%20verification%20blocked%20by%20egress%20preset**%0A%0A%60cosign%20verify-blob%20--certificate%60%20without%20%60--insecure-ignore-tlog%60%20contacts%20the%20Rekor%20transparency%20log%20%28%60rekor.sigstore.dev%3A443%60%29%20to%20confirm%20the%20certificate%20was%20logged.%20The%20%60osv-scanner%60%20egress%20preset%20only%20adds%20%60release-assets.githubusercontent.com%60%2C%20%60api.osv.dev%60%2C%20and%20%60api.deps.dev%60%20to%20%60github-tooling%60%3B%20it%20omits%20the%20sigstore%20endpoints.%20On%20GitHub-hosted%20ubuntu%20runners%20where%20cosign%20is%20pre-installed%2C%20the%20%60.sig%60%20and%20%60.pem%60%20files%20will%20download%20successfully%20%28the%20host%20is%20in%20the%20allowlist%29%2C%20the%20%60if%60%20branch%20is%20taken%2C%20%60cosign%20verify-blob%60%20runs%20%E2%80%94%20then%20immediately%20hits%20a%20blocked%20egress%20call%20to%20Rekor%20and%20exits%20non-zero.%20With%20%60set%20-euo%20pipefail%60%20in%20effect%2C%20the%20whole%20install%20step%20fails.%0A%0AEither%20add%20%60--insecure-ignore-tlog%60%20to%20the%20%60cosign%20verify-blob%60%20invocation%20%28relying%20on%20the%20SHA256%20checksum%20%2B%20certificate-identity%20check%20alone%29%2C%20or%20add%20%60rekor.sigstore.dev%3A443%60%2C%20%60fulcio.sigstore.dev%3A443%60%2C%20and%20%60tuf-repo-cdn.sigstore.dev%3A443%60%20to%20the%20%60osv-scanner%60%20egress%20preset%20to%20match%20the%20pattern%20used%20in%20the%20%60sbom%60%20and%20%60npm-publish%60%20presets.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=332&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F330-add-reusable-vuln-suppression-check%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F330-add-reusable-vuln-suppression-check%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Fsecurity%2Finstall-osv-scanner.sh%3A67-83%0A**Cosign%20Rekor%20verification%20blocked%20by%20egress%20preset**%0A%0A%60cosign%20verify-blob%20--certificate%60%20without%20%60--insecure-ignore-tlog%60%20contacts%20the%20Rekor%20transparency%20log%20%28%60rekor.sigstore.dev%3A443%60%29%20to%20confirm%20the%20certificate%20was%20logged.%20The%20%60osv-scanner%60%20egress%20preset%20only%20adds%20%60release-assets.githubusercontent.com%60%2C%20%60api.osv.dev%60%2C%20and%20%60api.deps.dev%60%20to%20%60github-tooling%60%3B%20it%20omits%20the%20sigstore%20endpoints.%20On%20GitHub-hosted%20ubuntu%20runners%20where%20cosign%20is%20pre-installed%2C%20the%20%60.sig%60%20and%20%60.pem%60%20files%20will%20download%20successfully%20%28the%20host%20is%20in%20the%20allowlist%29%2C%20the%20%60if%60%20branch%20is%20taken%2C%20%60cosign%20verify-blob%60%20runs%20%E2%80%94%20then%20immediately%20hits%20a%20blocked%20egress%20call%20to%20Rekor%20and%20exits%20non-zero.%20With%20%60set%20-euo%20pipefail%60%20in%20effect%2C%20the%20whole%20install%20step%20fails.%0A%0AEither%20add%20%60--insecure-ignore-tlog%60%20to%20the%20%60cosign%20verify-blob%60%20invocation%20%28relying%20on%20the%20SHA256%20checksum%20%2B%20certificate-identity%20check%20alone%29%2C%20or%20add%20%60rekor.sigstore.dev%3A443%60%2C%20%60fulcio.sigstore.dev%3A443%60%2C%20and%20%60tuf-repo-cdn.sigstore.dev%3A443%60%20to%20the%20%60osv-scanner%60%20egress%20preset%20to%20match%20the%20pattern%20used%20in%20the%20%60sbom%60%20and%20%60npm-publish%60%20presets.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=332&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["fix(ci): harden vuln-suppression path an..."](https://github.com/lgtm-hq/lgtm-ci/commit/851cfa4ff2e656e5809eb2ff73a079d5bac1dd21) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36305668)</sub>

<!-- /greptile_comment -->