### PR TITLE
test(release): validate CHANGELOG-only caller for phase 6.1 (#55)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,8 @@ Sample caller layouts for lgtm-hq repositories. Copy and adapt into your
 
 ## Reusable workflows (recommended)
 
-Examples such as `publish-python-release.yml` call `lgtm-hq/lgtm-ci` **reusable
+Examples such as `publish-python-release.yml` and
+`release-version-pr-changelog-only.yml` call `lgtm-hq/lgtm-ci` **reusable
 workflows** at a pinned commit SHA and pass `tooling-ref` with the same SHA.
 
 You do **not** need to vendor copies of:

--- a/examples/release-version-pr-changelog-only.yml
+++ b/examples/release-version-pr-changelog-only.yml
@@ -1,5 +1,8 @@
----
-name: "Release: Create Version PR"
+# SPDX-License-Identifier: MIT
+# Thin caller for CHANGELOG-only repos (no package version files to bump).
+# lgtm-ci itself uses this pattern — see .github/workflows/release-version-pr.yml.
+
+name: Release Version PR
 
 on:
   push:
@@ -12,10 +15,10 @@ concurrency:
 
 jobs:
   version-pr:
-    # yamllint disable-line rule:line-length
-    uses: ./.github/workflows/reusable-release-version-pr.yml
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@<sha>
     with:
       max-bump: minor
+      tooling-ref: <sha>
     secrets:
       RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
       RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/examples/release-version-pr-changelog-only.yml
+++ b/examples/release-version-pr-changelog-only.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   version-pr:
+    # Replace both <sha> placeholders with the same pinned commit SHA.
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@<sha>
     with:
       max-bump: minor

--- a/tests/bats/integration/test_reusable_release_version_pr.bats
+++ b/tests/bats/integration/test_reusable_release_version_pr.bats
@@ -38,9 +38,35 @@ load "../../helpers/common"
 	assert_success
 	run grep -F "ecosystem-config:" "$workflow"
 	assert_success
-	run grep -F "RELEASE_APP_ID:" "$workflow"
+	run awk '
+		/^      RELEASE_APP_ID:/ {
+			while ((getline line) > 0) {
+				if (line ~ /^      [A-Za-z_][A-Za-z0-9_-]+:/) {
+					break
+				}
+				if (line ~ /^        required: true$/) {
+					found_app_id = 1
+					break
+				}
+			}
+		}
+		END { exit !found_app_id }
+	' "$workflow"
 	assert_success
-	run grep -F "RELEASE_APP_PRIVATE_KEY:" "$workflow"
+	run awk '
+		/^      RELEASE_APP_PRIVATE_KEY:/ {
+			while ((getline line) > 0) {
+				if (line ~ /^      [A-Za-z_][A-Za-z0-9_-]+:/) {
+					break
+				}
+				if (line ~ /^        required: true$/) {
+					found_private_key = 1
+					break
+				}
+			}
+		}
+		END { exit !found_private_key }
+	' "$workflow"
 	assert_success
 }
 

--- a/tests/bats/integration/test_reusable_release_version_pr.bats
+++ b/tests/bats/integration/test_reusable_release_version_pr.bats
@@ -96,8 +96,9 @@ load "../../helpers/common"
 	run awk '
 		/^  version-pr:/ { in_job = 1 }
 		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /version-pr:/ { in_job = 0 }
-		in_job && /cancel-in-progress: false/ { found = 1; exit }
-		END { exit !found }
+		in_job && /cancel-in-progress: false/ { found_cancel = 1 }
+		in_job && /group: reusable-release-version-pr-/ { found_group = 1 }
+		END { exit !(found_cancel && found_group) }
 	' "$workflow"
 	assert_success
 }

--- a/tests/bats/integration/test_reusable_release_version_pr.bats
+++ b/tests/bats/integration/test_reusable_release_version_pr.bats
@@ -23,9 +23,9 @@ load "../../helpers/common"
 @test "release-version-pr caller: passes release app secrets" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/release-version-pr.yml"
 
-	run grep -F "RELEASE_APP_ID:" "$workflow"
+	run grep -F "RELEASE_APP_ID: \${{ secrets.RELEASE_APP_ID }}" "$workflow"
 	assert_success
-	run grep -F "RELEASE_APP_PRIVATE_KEY:" "$workflow"
+	run grep -F "RELEASE_APP_PRIVATE_KEY: \${{ secrets.RELEASE_APP_PRIVATE_KEY }}" "$workflow"
 	assert_success
 }
 
@@ -48,8 +48,14 @@ load "../../helpers/common"
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
 
 	run awk '
-		/- name: Create GitHub App installation token/ { token_line = NR }
-		/fetch-depth: 0/ { checkout_line = NR }
+		/- name: Create GitHub App installation token/ { token_line = NR; after_token = 1 }
+		after_token && !checkout_line && /^      - name: Checkout repository/ {
+			in_auth_checkout = 1
+		}
+		in_auth_checkout && /fetch-depth: 0/ { checkout_line = NR }
+		in_auth_checkout && /^      - name:/ && $0 !~ /Checkout repository/ {
+			in_auth_checkout = 0
+		}
 		END { exit !(token_line && checkout_line && token_line < checkout_line) }
 	' "$workflow"
 	assert_success

--- a/tests/bats/integration/test_reusable_release_version_pr.bats
+++ b/tests/bats/integration/test_reusable_release_version_pr.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-release-version-pr and lgtm-ci caller
+
+load "../../helpers/common"
+
+@test "release-version-pr caller: delegates to same-repo reusable workflow" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/release-version-pr.yml"
+
+	run grep -F "uses: ./.github/workflows/reusable-release-version-pr.yml" "$workflow"
+	assert_success
+}
+
+@test "release-version-pr caller: is CHANGELOG-only (no ecosystems or update script)" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/release-version-pr.yml"
+
+	run grep -E '^\s+ecosystems:' "$workflow"
+	assert_failure
+	run grep -E '^\s+version-update-script:' "$workflow"
+	assert_failure
+}
+
+@test "release-version-pr caller: passes release app secrets" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/release-version-pr.yml"
+
+	run grep -F "RELEASE_APP_ID:" "$workflow"
+	assert_success
+	run grep -F "RELEASE_APP_PRIVATE_KEY:" "$workflow"
+	assert_success
+}
+
+@test "reusable-release-version-pr: defines workflow_call inputs and secrets" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
+
+	run grep -F "workflow_call:" "$workflow"
+	assert_success
+	run grep -F "ecosystems:" "$workflow"
+	assert_success
+	run grep -F "ecosystem-config:" "$workflow"
+	assert_success
+	run grep -F "RELEASE_APP_ID:" "$workflow"
+	assert_success
+	run grep -F "RELEASE_APP_PRIVATE_KEY:" "$workflow"
+	assert_success
+}
+
+@test "reusable-release-version-pr: creates GitHub App token before authenticated checkout" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
+
+	run awk '
+		/- name: Create GitHub App installation token/ { token_line = NR }
+		/fetch-depth: 0/ { checkout_line = NR }
+		END { exit !(token_line && checkout_line && token_line < checkout_line) }
+	' "$workflow"
+	assert_success
+	run grep -F "actions/create-github-app-token" "$workflow"
+	assert_success
+}
+
+@test "reusable-release-version-pr: uses App token for create-pull-request" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
+
+	run awk '
+		/- name: Create or update version PR/ { in_step = 1 }
+		in_step && /peter-evans\/create-pull-request/ { saw_cpr = 1 }
+		in_step && /token: \$\{\{ steps\.app-token\.outputs\.token \}\}/ { saw_token = 1 }
+		in_step && /^      - name:/ && $0 !~ /Create or update version PR/ { in_step = 0 }
+		END { exit !(saw_cpr && saw_token) }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-release-version-pr: wires CHANGELOG-only expect flag when ecosystems empty" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
+
+	run grep -F "EXPECT_VERSION_FILES:" "$workflow"
+	assert_success
+	run grep -F "inputs.ecosystems != ''" "$workflow"
+	assert_success
+	run grep -F "inputs.version-update-script != ''" "$workflow"
+	assert_success
+}
+
+@test "reusable-release-version-pr: uses version-specific release branch prefix" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
+
+	run grep -F "release-branch-prefix:" "$workflow"
+	assert_success
+	run grep -F "steps.version.outputs.next-version" "$workflow"
+	assert_success
+}
+
+@test "reusable-release-version-pr: serializes with cancel-in-progress false" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
+
+	run awk '
+		/^  version-pr:/ { in_job = 1 }
+		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /version-pr:/ { in_job = 0 }
+		in_job && /cancel-in-progress: false/ { found = 1; exit }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-release-version-pr: enforces 20 minute job timeout" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
+
+	run awk '
+		/^  version-pr:/ { in_job = 1 }
+		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /version-pr:/ { in_job = 0 }
+		in_job && /timeout-minutes: 20/ { found = 1; exit }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-release-version-pr: runs guard before version calculation" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
+
+	run awk '
+		/- name: Guard release commit/ { saw_guard = 1 }
+		saw_guard && /- name: Calculate next version/ { saw_calc = 1; exit }
+		END { exit !saw_calc }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-release-version-pr: removes tooling checkout before PR creation" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
+
+	run awk '
+		/- name: Remove tooling checkout before PR creation/ { saw_remove = 1 }
+		saw_remove && /- name: Create or update version PR/ { saw_create = 1; exit }
+		END { exit !(saw_remove && saw_create) }
+	' "$workflow"
+	assert_success
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Complete Phase 6.1 of issue #55 by switching lgtm-ci's own `release-version-pr`
caller to CHANGELOG-only mode (no ecosystem updaters) and adding contract tests
that lock down the reusable workflow's release PR behavior for same-repo callers.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. lgtm-ci releases are driven by CHANGELOG and tags; removing `ecosystems:
python` from the internal caller aligns with the issue design and avoids
requiring version file changes in release PRs.

## Closes

- Relates to #55

## Changes Made

- Remove `ecosystems: python` from `.github/workflows/release-version-pr.yml`
  so lgtm-ci uses CHANGELOG-only release PR creation
- Add `examples/release-version-pr-changelog-only.yml` for external callers
- Add `tests/bats/integration/test_reusable_release_version_pr.bats` with 12
  contract tests (App token ordering, CHANGELOG-only flag wiring, concurrency
  group isolation, step ordering)

## Testing

- [x] `uv run lintro chk` — zero issues
- [x] `bats tests/bats/integration/test_reusable_release_version_pr.bats` — 12/12 pass
- [x] Greptile review — addressed P2 concurrency group + SHA pinning comments
- [x] CodeRabbit review — 0 findings

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CHANGELOG-only caller example and bats tests for reusable release version PR workflow
> - Adds [release-version-pr-changelog-only.yml](https://github.com/lgtm-hq/lgtm-ci/pull/335/files#diff-28b6da00e3e647fb3b4cf973a6fda16e0dc5417fcba53a87ae156068fa7f925a) as an example caller workflow for repos that only update a CHANGELOG (no ecosystem version files or update scripts).
> - Removes the `ecosystems: python` input from [release-version-pr.yml](https://github.com/lgtm-hq/lgtm-ci/pull/335/files#diff-547ba6795e1ec9f5765d5329826f8a86afbf5358fb4c4f29cc03a1e13b1174eb), making it a CHANGELOG-only caller.
> - Adds bats integration tests in [test_reusable_release_version_pr.bats](https://github.com/lgtm-hq/lgtm-ci/pull/335/files#diff-5f208903944c0cad3f3f211c2dd3b82fb32275cc099c5a068306a4288b843064) covering secrets forwarding, step ordering, concurrency, timeout, and CHANGELOG-only flag wiring for the reusable workflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b4332e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated examples with additional recommended reusable workflows for release automation.

* **New Features**
  * Added a changelog-only release workflow example to simplify version PRs.

* **Tests**
  * Added integration tests validating workflow contracts and release automation behavior.

* **Chores**
  * Simplified the example workflow invocation to reduce required inputs for callers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR completes Phase 6.1 by removing `ecosystems: python` from lgtm-ci's own `release-version-pr` caller (switching it to CHANGELOG-only mode) and adding an example template plus a Bats contract test suite to lock down the reusable workflow's behaviour.

- Removes the single `ecosystems: python` line from `.github/workflows/release-version-pr.yml`, letting the `ecosystems` input default to `""` and setting `EXPECT_VERSION_FILES=false` in the reusable workflow.
- Adds `examples/release-version-pr-changelog-only.yml` as a copy-and-adapt template for external callers, with correct permission grants and `<sha>` placeholders for supply-chain-safe pinning.
- Adds 12 Bats contract tests covering delegation, secret wiring, App-token ordering, `EXPECT_VERSION_FILES` logic, concurrency isolation, job timeout, and step-ordering invariants against both the caller and reusable workflow files.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-line deletion in the caller workflow, the new example file is template-only, and the contract tests are well-scoped and correct.

The diff is minimal and narrowly focused: one line removed from the caller, a read-only example file, and additive test coverage. The awk scripts in the tests correctly scope in_job to the version-pr job via the 2-space indentation boundary, the !checkout_line guard prevents false-positive ordering assertions from a hypothetical second checkout step, and all 12 tests map cleanly to invariants that exist in the reusable workflow today. No logic changes were made to the reusable workflow itself.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-version-pr.yml | Removes the single `ecosystems: python` input so lgtm-ci's own caller uses CHANGELOG-only mode; minimal one-line deletion with no side-effects. |
| examples/release-version-pr-changelog-only.yml | New example caller template for CHANGELOG-only mode; uses `<sha>` placeholders with clear inline instruction, correct permissions for both `version-pr` and `report-release-failure` jobs. |
| tests/bats/integration/test_reusable_release_version_pr.bats | Adds 12 contract tests covering delegation, CHANGELOG-only flag wiring, secret passing, App-token ordering, concurrency/cancel settings, timeout, step-ordering invariants, and tooling cleanup; awk guards are correct. |
| examples/README.md | One-sentence documentation update to reference the new example workflow alongside the existing one. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as release-version-pr.yml<br/>(lgtm-ci caller)
    participant Reusable as reusable-release-version-pr.yml
    participant AppToken as actions/create-github-app-token
    participant Checkout as actions/checkout
    participant CPR as peter-evans/create-pull-request

    Caller->>Reusable: uses (max-bump: minor, no ecosystems)
    Note over Reusable: Checkout repo (unauthenticated)
    Reusable->>AppToken: Create installation token
    AppToken-->>Reusable: token
    Reusable->>Checkout: Authenticated checkout (fetch-depth: 0)
    Reusable->>Reusable: Guard release commit
    Reusable->>Reusable: Calculate next version
    Reusable->>Reusable: Generate + update CHANGELOG
    Note over Reusable: EXPECT_VERSION_FILES=false<br/>(ecosystems="" → CHANGELOG-only)
    Reusable->>Reusable: Check version file changes
    Reusable->>Reusable: Remove tooling checkout
    Reusable->>CPR: Create/update version PR (App token)
    CPR-->>Reusable: PR number + URL
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(release): assert workflow\_call secr..."](https://github.com/lgtm-hq/lgtm-ci/commit/6b4332ea3000361e3bb99c498aa97b169976cd24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36401145)</sub>

<!-- /greptile_comment -->