### PR TITLE
feat(workflows): add reusable Docker health check testing between build and publish

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1724,11 +1724,12 @@ jobs:
   script run on the runner with env `IMAGE`, `PLATFORM`, `REGISTRY`. Script
   owns the `docker run` invocation — full control over flags, env, network,
   tmpfs, etc. Mutually exclusive with `smoke-test` (default: '')
-- `health-check-cmd` - Optional command run inside a detached container before
-  publish (e.g. `curl -f http://localhost:8080/health`). Gates push/merge on
-  success. Skipped when empty (default: '')
-- `health-check-port` - Container port to publish on `127.0.0.1` and wait for
-  before running `health-check-cmd` (default: '')
+- `health-check-cmd` - Optional command run on the runner against the published
+  localhost port before publish (e.g. `curl -f http://127.0.0.1:8080/health`).
+  Gates push/merge on success. Requires `health-check-port`. Skipped when empty
+  (default: '')
+- `health-check-port` - Container port published on `127.0.0.1`; required when
+  `health-check-cmd` is set (default: '')
 - `health-check-timeout` - Max wait for the port to accept connections (default:
   `30s`)
 - `tooling-ref` - Git ref for the lgtm-ci tooling checkout. Defaults to the
@@ -1765,9 +1766,10 @@ job, so setting both fails fast before any build runs.
 **Detached-container health checks:**
 
 Set `health-check-cmd` to validate a running service before publish. The
-workflow starts a detached container from the built image, optionally waits
-for `health-check-port` on `127.0.0.1`, runs the command via `docker exec`,
-and tears down with logs on failure. On the split push path, a per-platform
+workflow starts a detached container from the built image, waits for
+`health-check-port` on `127.0.0.1`, runs the command on the runner (so
+distroless images work without curl/wget inside the container), and tears
+down with logs on failure. On the split push path, a per-platform
 `health-check-per-platform` job gates manifest merge; on the single build
 path, publish runs only after the local health check passes.
 

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1724,6 +1724,13 @@ jobs:
   script run on the runner with env `IMAGE`, `PLATFORM`, `REGISTRY`. Script
   owns the `docker run` invocation — full control over flags, env, network,
   tmpfs, etc. Mutually exclusive with `smoke-test` (default: '')
+- `health-check-cmd` - Optional command run inside a detached container before
+  publish (e.g. `curl -f http://localhost:8080/health`). Gates push/merge on
+  success. Skipped when empty (default: '')
+- `health-check-port` - Container port to publish on `127.0.0.1` and wait for
+  before running `health-check-cmd` (default: '')
+- `health-check-timeout` - Max wait for the port to accept connections (default:
+  `30s`)
 - `tooling-ref` - Git ref for the lgtm-ci tooling checkout. Defaults to the
   reusable workflow commit (the workflow's own pinned commit). Override to pin
   a specific tag or SHA (default: '')
@@ -1754,6 +1761,15 @@ image. `smoke-test` is a convenience for trivial checks like `--version`;
 reach for `smoke-test-script` when you need `-e`, `--network`, `--read-only`,
 or any other `docker run` flag. Validation is performed in the `classify`
 job, so setting both fails fast before any build runs.
+
+**Detached-container health checks:**
+
+Set `health-check-cmd` to validate a running service before publish. The
+workflow starts a detached container from the built image, optionally waits
+for `health-check-port` on `127.0.0.1`, runs the command via `docker exec`,
+and tears down with logs on failure. On the split push path, a per-platform
+`health-check-per-platform` job gates manifest merge; on the single build
+path, publish runs only after the local health check passes.
 
 **Migration from vendored scripts:**
 

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -710,8 +710,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: ${{ inputs.push }}
           load: >-
-            ${{ inputs.health-check-cmd != '' ||
-              (inputs.push == false && (inputs.validate-on-pr || inputs.scan)) }}
+            ${{ inputs.push == false && (inputs.health-check-cmd != '' ||
+              inputs.validate-on-pr || inputs.scan) }}
           # yamllint disable rule:line-length
           tags: >-
             ${{ inputs.push

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -106,19 +106,20 @@ on:
         default: ""
       health-check-cmd:
         description: >-
-          Optional command run inside a detached container before publish, e.g.
-          `curl -f http://localhost:8080/health`. Starts the built image,
-          optionally waits for `health-check-port`, runs the command, then
-          tears down. When set with `push: true`, publish is gated on success.
-          Skipped when empty (preserves current behavior).
+          Optional command run on the runner against the published localhost
+          port before publish, e.g. `curl -f http://127.0.0.1:8080/health`.
+          Starts a detached container, waits for `health-check-port`, runs the
+          command on the runner (not inside the image), then tears down. Requires
+          `health-check-port`. When set with `push: true`, publish is gated on
+          success. Skipped when empty (preserves current behavior).
         required: false
         type: string
         default: ""
       health-check-port:
         description: >-
           Container port to publish on 127.0.0.1 and wait for before running
-          `health-check-cmd`. Omit when the command does not depend on a
-          listening port.
+          `health-check-cmd` on the runner. Required when `health-check-cmd`
+          is set.
         required: false
         type: string
         default: ""
@@ -443,8 +444,8 @@ jobs:
           platforms: ${{ inputs.platforms }}
           push: ${{ inputs.push && inputs.health-check-cmd == '' }}
           load: >-
-            ${{ (inputs.health-check-cmd != '' && (inputs.push || inputs.validate-on-pr || inputs.scan))
-              || (inputs.push == false && (inputs.validate-on-pr || inputs.scan)) }}
+            ${{ inputs.health-check-cmd != '' ||
+              (inputs.push == false && (inputs.validate-on-pr || inputs.scan)) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ inputs.build-args }}
@@ -479,6 +480,24 @@ jobs:
           HEALTH_CHECK_PORT: ${{ inputs.health-check-port }}
           HEALTH_CHECK_TIMEOUT: ${{ inputs.health-check-timeout }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Install Syft
+        if: inputs.push && inputs.sbom && inputs.health-check-cmd != ''
+        shell: bash
+        env:
+          STEP: install
+        run: .lgtm-ci-tooling/scripts/ci/actions/generate-sbom.sh
+
+      - name: Generate SBOM for attestation
+        if: inputs.push && inputs.sbom && inputs.health-check-cmd != ''
+        shell: bash
+        env:
+          STEP: generate
+          TARGET: ${{ steps.local-health-check-image.outputs.image }}
+          TARGET_TYPE: image
+          FORMAT: spdx-json
+          OUTPUT_FILE: sbom.spdx.json
+        run: .lgtm-ci-tooling/scripts/ci/actions/generate-sbom.sh
 
       - name: Push image after health check
         if: inputs.push && inputs.health-check-cmd != ''
@@ -534,6 +553,16 @@ jobs:
         with:
           subject-name: ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
           subject-digest: ${{ steps.metadata.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate SBOM attestation
+        if: inputs.push && inputs.sbom && inputs.health-check-cmd != ''
+        # Pinned to SHA for supply chain security
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-name: ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
+          subject-digest: ${{ steps.metadata.outputs.digest }}
+          sbom-path: sbom.spdx.json
           push-to-registry: true
 
       - name: Install Cosign
@@ -681,8 +710,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: ${{ inputs.push }}
           load: >-
-            ${{ (inputs.health-check-cmd != '' && inputs.validate-on-pr && inputs.push == false)
-              || (inputs.push == false && (inputs.validate-on-pr || inputs.scan)) }}
+            ${{ inputs.health-check-cmd != '' ||
+              (inputs.push == false && (inputs.validate-on-pr || inputs.scan)) }}
           # yamllint disable rule:line-length
           tags: >-
             ${{ inputs.push
@@ -887,11 +916,15 @@ jobs:
   # Gates manifest merge on runtime validation of each staging image.
   health-check-per-platform:
     name: Docker health check per platform
-    needs: [classify, build-per-platform]
+    needs: [classify, build-per-platform, verify-per-platform]
     if: >-
+      always() &&
       needs.classify.outputs.use-split == 'true' &&
       inputs.push &&
-      inputs.health-check-cmd != ''
+      inputs.health-check-cmd != '' &&
+      needs.build-per-platform.result == 'success' &&
+      (needs.verify-per-platform.result == 'success' ||
+       needs.verify-per-platform.result == 'skipped')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -480,38 +480,24 @@ jobs:
           HEALTH_CHECK_TIMEOUT: ${{ inputs.health-check-timeout }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
-      - name: Build and push after health check
-        id: build-push
+      - name: Push image after health check
         if: inputs.push && inputs.health-check-cmd != ''
-        # Pinned to SHA for supply chain security
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: ${{ inputs.context }}
-          file: ${{ inputs.file }}
-          platforms: ${{ inputs.platforms }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: ${{ inputs.build-args }}
-          target: ${{ inputs.target }}
-          # yamllint disable rule:line-length
-          cache-from: |
-            ${{ inputs.no-cache == false && 'type=gha' || '' }}
-            ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && format('type=registry,ref={0}', inputs.cache-registry-ref) || '' }}
-          cache-to: |
-            ${{ inputs.no-cache == false && 'type=gha,mode=max' || '' }}
-            ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && format('type=registry,ref={0},mode=max', inputs.cache-registry-ref) || '' }}
-          # yamllint enable rule:line-length
-          provenance: ${{ inputs.provenance && inputs.push }}
-          sbom: ${{ inputs.sbom && inputs.push }}
+        shell: bash
+        env:
+          STEP: push
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
       - name: Extract digest
         id: metadata
         if: inputs.push || inputs.validate-on-pr
         shell: bash
         env:
-          STEP: set-output-digest
-          DIGEST: ${{ steps.build-push.outputs.digest || steps.build.outputs.digest }}
+          STEP: ${{ inputs.push && inputs.health-check-cmd != '' && 'metadata' || 'set-output-digest' }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          BUILT_TAGS: ${{ steps.meta.outputs.tags }}
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
       - name: Resolve local image for scan
@@ -547,7 +533,7 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
-          subject-digest: ${{ steps.build-push.outputs.digest || steps.build.outputs.digest }}
+          subject-digest: ${{ steps.metadata.outputs.digest }}
           push-to-registry: true
 
       - name: Install Cosign
@@ -559,7 +545,7 @@ jobs:
         shell: bash
         env:
           STEP: sign-image
-          DIGEST: ${{ steps.build-push.outputs.digest || steps.build.outputs.digest }}
+          DIGEST: ${{ steps.metadata.outputs.digest }}
           REGISTRY: ${{ inputs.registry }}
           IMAGE_NAME: ${{ inputs.image-name || github.repository }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
@@ -911,6 +897,7 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.classify.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
+    # packages: read — pull per-platform staging images by digest before merge.
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -930,6 +930,7 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.classify.outputs.matrix) }}
     runs-on: ${{ matrix.runner }}
+    # contents: read — sparse-checkout lgtm-ci tooling scripts for build-docker.sh.
     # packages: read — pull per-platform staging images by digest before merge.
     permissions:
       contents: read

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -104,6 +104,31 @@ on:
         required: false
         type: string
         default: ""
+      health-check-cmd:
+        description: >-
+          Optional command run inside a detached container before publish, e.g.
+          `curl -f http://localhost:8080/health`. Starts the built image,
+          optionally waits for `health-check-port`, runs the command, then
+          tears down. When set with `push: true`, publish is gated on success.
+          Skipped when empty (preserves current behavior).
+        required: false
+        type: string
+        default: ""
+      health-check-port:
+        description: >-
+          Container port to publish on 127.0.0.1 and wait for before running
+          `health-check-cmd`. Omit when the command does not depend on a
+          listening port.
+        required: false
+        type: string
+        default: ""
+      health-check-timeout:
+        description: >-
+          Max wait time for `health-check-port` to accept connections before
+          running `health-check-cmd` (e.g. 30s).
+        required: false
+        type: string
+        default: "30s"
       validate-on-pr:
         description: >-
           When true AND push is false, use the split per-platform path (native
@@ -288,6 +313,9 @@ jobs:
           RUNNER_MAP: ${{ inputs.runner-map }}
           SMOKE_TEST: ${{ inputs.smoke-test }}
           SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
+          HEALTH_CHECK_CMD: ${{ inputs.health-check-cmd }}
+          HEALTH_CHECK_PORT: ${{ inputs.health-check-port }}
+          HEALTH_CHECK_TIMEOUT: ${{ inputs.health-check-timeout }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
   # Single-platform builds, or multi-platform when push is disabled (QEMU fallback)
@@ -413,8 +441,10 @@ jobs:
           context: ${{ inputs.context }}
           file: ${{ inputs.file }}
           platforms: ${{ inputs.platforms }}
-          push: ${{ inputs.push }}
-          load: ${{ inputs.push == false && (inputs.validate-on-pr || inputs.scan) }}
+          push: ${{ inputs.push && inputs.health-check-cmd == '' }}
+          load: >-
+            ${{ (inputs.health-check-cmd != '' && (inputs.push || inputs.validate-on-pr || inputs.scan))
+              || (inputs.push == false && (inputs.validate-on-pr || inputs.scan)) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: ${{ inputs.build-args }}
@@ -427,6 +457,51 @@ jobs:
             ${{ inputs.no-cache == false && 'type=gha,mode=max' || '' }}
             ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && inputs.push && format('type=registry,ref={0},mode=max', inputs.cache-registry-ref) || '' }}
           # yamllint enable rule:line-length
+          provenance: ${{ inputs.provenance && inputs.push && inputs.health-check-cmd == '' }}
+          sbom: ${{ inputs.sbom && inputs.push && inputs.health-check-cmd == '' }}
+
+      - name: Resolve local image for health check
+        if: inputs.health-check-cmd != ''
+        id: local-health-check-image
+        shell: bash
+        env:
+          STEP: resolve-local-health-check-image
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Health check
+        if: inputs.health-check-cmd != ''
+        shell: bash
+        env:
+          STEP: health-check-local
+          IMAGE: ${{ steps.local-health-check-image.outputs.image }}
+          HEALTH_CHECK_CMD: ${{ inputs.health-check-cmd }}
+          HEALTH_CHECK_PORT: ${{ inputs.health-check-port }}
+          HEALTH_CHECK_TIMEOUT: ${{ inputs.health-check-timeout }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Build and push after health check
+        id: build-push
+        if: inputs.push && inputs.health-check-cmd != ''
+        # Pinned to SHA for supply chain security
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.file }}
+          platforms: ${{ inputs.platforms }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ inputs.build-args }}
+          target: ${{ inputs.target }}
+          # yamllint disable rule:line-length
+          cache-from: |
+            ${{ inputs.no-cache == false && 'type=gha' || '' }}
+            ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && format('type=registry,ref={0}', inputs.cache-registry-ref) || '' }}
+          cache-to: |
+            ${{ inputs.no-cache == false && 'type=gha,mode=max' || '' }}
+            ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && format('type=registry,ref={0},mode=max', inputs.cache-registry-ref) || '' }}
+          # yamllint enable rule:line-length
           provenance: ${{ inputs.provenance && inputs.push }}
           sbom: ${{ inputs.sbom && inputs.push }}
 
@@ -436,7 +511,7 @@ jobs:
         shell: bash
         env:
           STEP: set-output-digest
-          DIGEST: ${{ steps.build.outputs.digest }}
+          DIGEST: ${{ steps.build-push.outputs.digest || steps.build.outputs.digest }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
       - name: Resolve local image for scan
@@ -472,7 +547,7 @@ jobs:
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
-          subject-digest: ${{ steps.build.outputs.digest }}
+          subject-digest: ${{ steps.build-push.outputs.digest || steps.build.outputs.digest }}
           push-to-registry: true
 
       - name: Install Cosign
@@ -484,7 +559,7 @@ jobs:
         shell: bash
         env:
           STEP: sign-image
-          DIGEST: ${{ steps.build.outputs.digest }}
+          DIGEST: ${{ steps.build-push.outputs.digest || steps.build.outputs.digest }}
           REGISTRY: ${{ inputs.registry }}
           IMAGE_NAME: ${{ inputs.image-name || github.repository }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
@@ -502,6 +577,7 @@ jobs:
           DIGEST: ${{ steps.metadata.outputs.digest || '' }}
           COSIGN_SIGNED: ${{ inputs.cosign-sign && inputs.push }}
           SCAN_ENABLED: ${{ inputs.scan }}
+          HEALTH_CHECK_ENABLED: ${{ inputs.health-check-cmd != '' }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
   # Per-platform native build leg (multi-arch split path).
@@ -618,7 +694,9 @@ jobs:
           file: ${{ inputs.file }}
           platforms: ${{ matrix.platform }}
           push: ${{ inputs.push }}
-          load: ${{ inputs.push == false && (inputs.validate-on-pr || inputs.scan) }}
+          load: >-
+            ${{ (inputs.health-check-cmd != '' && inputs.validate-on-pr && inputs.push == false)
+              || (inputs.push == false && (inputs.validate-on-pr || inputs.scan)) }}
           # yamllint disable rule:line-length
           tags: >-
             ${{ inputs.push
@@ -659,6 +737,22 @@ jobs:
           PLATFORM: ${{ matrix.platform }}
           SMOKE_TEST: ${{ inputs.smoke-test }}
           SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Health check (${{ matrix.platform }})
+        if: >-
+          inputs.validate-on-pr && inputs.push == false &&
+          inputs.health-check-cmd != ''
+        shell: bash
+        env:
+          STEP: health-check-local
+          IMAGE: >-
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:validate-${{
+            matrix.slug }}
+          PLATFORM: ${{ matrix.platform }}
+          HEALTH_CHECK_CMD: ${{ inputs.health-check-cmd }}
+          HEALTH_CHECK_PORT: ${{ inputs.health-check-port }}
+          HEALTH_CHECK_TIMEOUT: ${{ inputs.health-check-timeout }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
       - name: Run Trivy vulnerability scanner (${{ matrix.platform }})
@@ -803,17 +897,119 @@ jobs:
           SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
+  # Optional per-platform detached-container health check (push path only).
+  # Gates manifest merge on runtime validation of each staging image.
+  health-check-per-platform:
+    name: Docker health check per platform
+    needs: [classify, build-per-platform]
+    if: >-
+      needs.classify.outputs.use-split == 'true' &&
+      inputs.push &&
+      inputs.health-check-cmd != ''
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.classify.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+      - name: Setup QEMU
+        if: ${{ matrix.qemu }}
+        # Pinned to SHA for supply chain security
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+      - name: Validate registry
+        if: inputs.push
+        shell: bash
+        env:
+          STEP: validate
+          REGISTRY: ${{ inputs.registry }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/docker-login.sh
+
+      - name: Login to GHCR
+        if: inputs.push && inputs.registry == 'ghcr.io'
+        # Pinned to SHA for supply chain security
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Login to Docker Hub
+        if: inputs.push && inputs.registry == 'docker.io'
+        # Pinned to SHA for supply chain security
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Download staging digest
+        if: inputs.push
+        # Pinned to SHA for supply chain security
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: staging-digest-${{ matrix.slug }}
+          path: ${{ runner.temp }}/staging-digest
+
+      - name: Health check (${{ matrix.platform }})
+        shell: bash
+        env:
+          STEP: health-check
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+          DIGEST_FILE: ${{ runner.temp }}/staging-digest/digest.txt
+          PLATFORM: ${{ matrix.platform }}
+          HEALTH_CHECK_CMD: ${{ inputs.health-check-cmd }}
+          HEALTH_CHECK_PORT: ${{ inputs.health-check-port }}
+          HEALTH_CHECK_TIMEOUT: ${{ inputs.health-check-timeout }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
   # Assemble multi-arch manifest from per-platform staging images
   merge:
     name: Merge Manifests
-    needs: [classify, build-per-platform, verify-per-platform]
+    needs: [classify, build-per-platform, verify-per-platform, health-check-per-platform]
     if: >-
       always() &&
       inputs.push &&
       needs.classify.outputs.use-split == 'true' &&
       needs.build-per-platform.result == 'success' &&
       (needs.verify-per-platform.result == 'success' ||
-       needs.verify-per-platform.result == 'skipped')
+       needs.verify-per-platform.result == 'skipped') &&
+      (needs.health-check-per-platform.result == 'success' ||
+       needs.health-check-per-platform.result == 'skipped')
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -984,12 +1180,13 @@ jobs:
           DIGEST: ${{ steps.metadata.outputs.digest || '' }}
           COSIGN_SIGNED: ${{ inputs.cosign-sign && inputs.push }}
           SCAN_ENABLED: ${{ inputs.scan }}
+          HEALTH_CHECK_ENABLED: ${{ inputs.health-check-cmd != '' }}
           MATRIX: ${{ needs.classify.outputs.matrix }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
   summary-validate:
     name: Validation Summary
-    needs: [classify, build-per-platform, verify-per-platform]
+    needs: [classify, build-per-platform, verify-per-platform, health-check-per-platform]
     if: >-
       always() &&
       needs.classify.outputs.use-split == 'true' &&
@@ -1046,6 +1243,7 @@ jobs:
           PUSH: ${{ inputs.push }}
           SCAN_ENABLED: ${{ inputs.scan }}
           VALIDATE_ON_PR: true
+          HEALTH_CHECK_ENABLED: ${{ inputs.health-check-cmd != '' }}
           MATRIX: ${{ needs.classify.outputs.matrix }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **workflows**: optional detached-container health check in `reusable-docker.yml`
+  gates publish on runtime validation (`health-check-cmd`, `health-check-port`,
+  `health-check-timeout`) (#65)
+
 ### Changed
 
 ### Deprecated

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -579,14 +579,14 @@ jobs:
     with:
       push: true
       runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
-      health-check-cmd: curl -f http://localhost:8080/health
+      health-check-cmd: curl -f http://127.0.0.1:8080/health
       health-check-port: "8080"
       health-check-timeout: "30s"
 ```
 
 When `health-check-cmd` is set, the workflow loads or pulls the built image,
-starts a detached container, optionally waits for `health-check-port`, runs the
-command, and only then publishes the final manifest/tags.
+starts a detached container, waits for `health-check-port` on `127.0.0.1`, runs
+the command on the runner, and only then publishes the final manifest/tags.
 
 ### Combined push and PR validation
 

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -581,7 +581,7 @@ jobs:
       runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
       health-check-cmd: curl -f http://localhost:8080/health
       health-check-port: "8080"
-      health-check-timeout: 30s
+      health-check-timeout: "30s"
 ```
 
 When `health-check-cmd` is set, the workflow loads or pulls the built image,

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -564,6 +564,30 @@ jobs:
       smoke-test: --version
 ```
 
+### Push with runtime health check
+
+```yaml
+jobs:
+  docker:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@<sha>
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      security-events: write
+    with:
+      push: true
+      runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
+      health-check-cmd: curl -f http://localhost:8080/health
+      health-check-port: "8080"
+      health-check-timeout: 30s
+```
+
+When `health-check-cmd` is set, the workflow loads or pulls the built image,
+starts a detached container, optionally waits for `health-check-port`, runs the
+command, and only then publishes the final manifest/tags.
+
 ### Combined push and PR validation
 
 ```yaml

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -94,10 +94,16 @@ run_health_check() {
 		echo "::endgroup::"
 	fi
 
-	echo "::group::Health check command (runner): ${HEALTH_CHECK_CMD}"
+	echo "::group::Health check command (runner): <redacted>"
 	# Run on the runner against the published localhost port so distroless images
 	# do not need curl/wget inside the container.
-	bash -c "$HEALTH_CHECK_CMD"
+	if ! timeout "${timeout_secs}s" bash -c "$HEALTH_CHECK_CMD"; then
+		local cmd_exit=$?
+		if [[ "$cmd_exit" -eq 124 ]]; then
+			die "Health check command timed out after ${HEALTH_CHECK_TIMEOUT}"
+		fi
+		die "Health check command failed (exit ${cmd_exit})"
+	fi
 	echo "::endgroup::"
 
 	trap - EXIT

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -404,8 +404,12 @@ classify)
 		die "smoke-test and smoke-test-script are mutually exclusive (set at most one)"
 	fi
 
-	if [[ -n "$HEALTH_CHECK_PORT" && ! "$HEALTH_CHECK_PORT" =~ ^[0-9]+$ ]]; then
-		die "health-check-port must be a positive integer: ${HEALTH_CHECK_PORT}"
+	if [[ -n "$HEALTH_CHECK_PORT" && (
+		! "$HEALTH_CHECK_PORT" =~ ^[0-9]+$ ||
+		"$HEALTH_CHECK_PORT" -eq 0 ||
+		"$HEALTH_CHECK_PORT" -gt 65535) ]] \
+		; then
+		die "health-check-port must be a positive integer (1-65535): ${HEALTH_CHECK_PORT}"
 	fi
 	if [[ -n "$HEALTH_CHECK_CMD" ]]; then
 		parse_duration_seconds "$HEALTH_CHECK_TIMEOUT" >/dev/null

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -5,7 +5,9 @@
 # Required environment variables:
 #   STEP - Which step to run: setup, build, push, metadata, parse-tags, summary,
 #          set-output-digest, classify, record-digest, smoke-test, smoke-test-local,
-#          resolve-local-scan-image, sign-image, merge-manifests, cleanup-staging
+#          health-check, health-check-local, resolve-local-health-check-image,
+#          resolve-local-scan-image, sign-image,
+#          merge-manifests, cleanup-staging
 #
 # Optional environment variables:
 #   CONTEXT - Build context path (default: .)
@@ -34,6 +36,74 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
 source "$SCRIPT_DIR/../lib/actions.sh"
 # shellcheck source=../lib/docker.sh
 source "$SCRIPT_DIR/../lib/docker.sh"
+# shellcheck source=../lib/network/port.sh
+source "$SCRIPT_DIR/../lib/network/port.sh"
+
+# Parse a duration string (e.g. 30s) into whole seconds.
+parse_duration_seconds() {
+	local raw="${1:-30s}"
+
+	if [[ "$raw" =~ ^([0-9]+)s$ ]]; then
+		echo "${BASH_REMATCH[1]}"
+	elif [[ "$raw" =~ ^[0-9]+$ ]]; then
+		echo "$raw"
+	else
+		die "Invalid HEALTH_CHECK_TIMEOUT: ${raw} (use e.g. 30s)"
+	fi
+}
+
+# Run a detached-container health check against IMAGE.
+run_health_check() {
+	: "${IMAGE:?IMAGE is required}"
+	: "${HEALTH_CHECK_CMD:?HEALTH_CHECK_CMD is required}"
+	: "${HEALTH_CHECK_TIMEOUT:=30s}"
+	: "${HEALTH_CHECK_PORT:=}"
+	: "${PLATFORM:=}"
+
+	local timeout_secs container_id=""
+	timeout_secs=$(parse_duration_seconds "$HEALTH_CHECK_TIMEOUT")
+
+	cleanup_health_check_container() {
+		if [[ -n "$container_id" ]]; then
+			echo "::group::Container logs (${container_id})"
+			docker logs "$container_id" 2>&1 || true
+			echo "::endgroup::"
+			docker rm -f "$container_id" >/dev/null 2>&1 || true
+			container_id=""
+		fi
+	}
+	trap cleanup_health_check_container EXIT
+
+	local -a run_opts=(-d)
+	if [[ -n "$HEALTH_CHECK_PORT" ]]; then
+		run_opts+=(-p "127.0.0.1:${HEALTH_CHECK_PORT}:${HEALTH_CHECK_PORT}")
+	fi
+	if [[ -n "$PLATFORM" ]]; then
+		run_opts+=(--platform "${PLATFORM}")
+	fi
+
+	echo "::group::Starting container from ${IMAGE}"
+	container_id=$(docker run "${run_opts[@]}" "${IMAGE}")
+	echo "::endgroup::"
+
+	if [[ -n "$HEALTH_CHECK_PORT" ]]; then
+		echo "::group::Waiting for port ${HEALTH_CHECK_PORT}"
+		if ! wait_for_port_listen "$HEALTH_CHECK_PORT" "$timeout_secs" 1; then
+			die "Port ${HEALTH_CHECK_PORT} not ready within ${HEALTH_CHECK_TIMEOUT}"
+		fi
+		echo "::endgroup::"
+	fi
+
+	echo "::group::Health check command: ${HEALTH_CHECK_CMD}"
+	# Intentionally word-split HEALTH_CHECK_CMD so callers can pass flags+args
+	# shellcheck disable=SC2086
+	docker exec "${container_id}" ${HEALTH_CHECK_CMD}
+	echo "::endgroup::"
+
+	trap - EXIT
+	cleanup_health_check_container
+	log_success "Health check passed for ${IMAGE}"
+}
 
 case "$STEP" in
 setup)
@@ -312,6 +382,9 @@ classify)
 	#   SMOKE_TEST        - Smoke-test shorthand command (validated only; not used here).
 	#   SMOKE_TEST_SCRIPT - Smoke-test script path (validated only; not used here).
 	#                       SMOKE_TEST and SMOKE_TEST_SCRIPT are mutually exclusive.
+	#   HEALTH_CHECK_CMD  - Optional detached-container health check command.
+	#   HEALTH_CHECK_PORT - Optional container port to expose and wait for.
+	#   HEALTH_CHECK_TIMEOUT - Optional wait timeout (default: 30s).
 	#
 	# Outputs:
 	#   use-split - "true" when split per-platform build should be used
@@ -322,10 +395,20 @@ classify)
 	: "${RUNNER_MAP:={}}"
 	: "${SMOKE_TEST:=}"
 	: "${SMOKE_TEST_SCRIPT:=}"
+	: "${HEALTH_CHECK_CMD:=}"
+	: "${HEALTH_CHECK_PORT:=}"
+	: "${HEALTH_CHECK_TIMEOUT:=30s}"
 
 	# Mutex: smoke-test and smoke-test-script cannot both be set
 	if [[ -n "$SMOKE_TEST" && -n "$SMOKE_TEST_SCRIPT" ]]; then
 		die "smoke-test and smoke-test-script are mutually exclusive (set at most one)"
+	fi
+
+	if [[ -n "$HEALTH_CHECK_PORT" && ! "$HEALTH_CHECK_PORT" =~ ^[0-9]+$ ]]; then
+		die "health-check-port must be a positive integer: ${HEALTH_CHECK_PORT}"
+	fi
+	if [[ -n "$HEALTH_CHECK_CMD" ]]; then
+		parse_duration_seconds "$HEALTH_CHECK_TIMEOUT" >/dev/null
 	fi
 
 	# Validate RUNNER_MAP is parseable JSON
@@ -505,6 +588,25 @@ smoke-test)
 	fi
 	;;
 
+resolve-local-health-check-image)
+	# Resolve the first metadata tag for a locally loaded health-check image.
+	#
+	# Required environment variables:
+	#   TAGS - Newline-separated image tags from docker/metadata-action
+	#
+	# Outputs:
+	#   image - First tag suitable for detached-container health checks
+	: "${TAGS:?TAGS is required}"
+
+	first_tag=$(echo "$TAGS" | head -1 | tr -d '[:space:]')
+	if [[ -z "$first_tag" ]]; then
+		die "No image tag available for local health check"
+	fi
+
+	set_github_output "image" "$first_tag"
+	log_info "Local health-check image: ${first_tag}"
+	;;
+
 resolve-local-scan-image)
 	# Resolve the first metadata tag for scanning a locally loaded image.
 	#
@@ -522,6 +624,67 @@ resolve-local-scan-image)
 
 	set_github_output "ref" "$first_tag"
 	log_info "Local scan image: ${first_tag}"
+	;;
+
+health-check)
+	# Run a detached-container health check against a staging image by digest.
+	#
+	# Required environment variables:
+	#   REGISTRY           - Container registry URL
+	#   IMAGE_NAME         - Registry-relative image name
+	#   PLATFORM           - Target platform (e.g. linux/arm64)
+	#   DIGEST_FILE        - Path to sha256 digest for the staging image
+	#   HEALTH_CHECK_CMD   - Command executed inside the running container
+	#
+	# Optional environment variables:
+	#   HEALTH_CHECK_PORT     - Port to publish and wait for before the command
+	#   HEALTH_CHECK_TIMEOUT  - Max wait time (default: 30s)
+	: "${REGISTRY:?REGISTRY is required}"
+	: "${IMAGE_NAME:?IMAGE_NAME is required}"
+	: "${PLATFORM:?PLATFORM is required}"
+	: "${DIGEST_FILE:?DIGEST_FILE is required}"
+	: "${HEALTH_CHECK_CMD:?HEALTH_CHECK_CMD is required}"
+	: "${HEALTH_CHECK_PORT:=}"
+	: "${HEALTH_CHECK_TIMEOUT:=30s}"
+
+	if [[ ! -s "$DIGEST_FILE" ]]; then
+		die "DIGEST_FILE missing or empty: ${DIGEST_FILE}"
+	fi
+
+	digest=$(<"$DIGEST_FILE")
+	if ! [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+		die "Invalid digest in ${DIGEST_FILE}: ${digest}"
+	fi
+
+	IMAGE="${REGISTRY}/${IMAGE_NAME}@${digest}"
+	export IMAGE PLATFORM HEALTH_CHECK_CMD HEALTH_CHECK_PORT HEALTH_CHECK_TIMEOUT
+
+	echo "::group::Pulling ${IMAGE} (${PLATFORM})"
+	docker pull --platform "${PLATFORM}" "${IMAGE}"
+	echo "::endgroup::"
+
+	run_health_check
+	;;
+
+health-check-local)
+	# Run a detached-container health check against a locally loaded image.
+	#
+	# Required environment variables:
+	#   IMAGE              - Full local image reference (registry/name:tag)
+	#   HEALTH_CHECK_CMD   - Command executed inside the running container
+	#
+	# Optional environment variables:
+	#   PLATFORM              - Target platform (e.g. linux/arm64)
+	#   HEALTH_CHECK_PORT     - Port to publish and wait for before the command
+	#   HEALTH_CHECK_TIMEOUT  - Max wait time (default: 30s)
+	: "${IMAGE:?IMAGE is required}"
+	: "${HEALTH_CHECK_CMD:?HEALTH_CHECK_CMD is required}"
+	: "${PLATFORM:=}"
+	: "${HEALTH_CHECK_PORT:=}"
+	: "${HEALTH_CHECK_TIMEOUT:=30s}"
+
+	export IMAGE PLATFORM HEALTH_CHECK_CMD HEALTH_CHECK_PORT HEALTH_CHECK_TIMEOUT
+	run_health_check
 	;;
 
 smoke-test-local)
@@ -703,6 +866,7 @@ summary)
 	: "${SCAN_ENABLED:=false}"
 	: "${VALIDATE_ON_PR:=false}"
 	: "${MATRIX:=}"
+	: "${HEALTH_CHECK_ENABLED:=false}"
 
 	full_image="${REGISTRY}/${IMAGE_NAME}"
 
@@ -769,6 +933,13 @@ summary)
 		add_github_summary "### Vulnerability scan"
 		add_github_summary ""
 		add_github_summary "Trivy scanned CRITICAL/HIGH findings. Review the Security tab for SARIF results."
+		add_github_summary ""
+	fi
+
+	if [[ "$HEALTH_CHECK_ENABLED" == "true" ]]; then
+		add_github_summary "### Health check"
+		add_github_summary ""
+		add_github_summary "Detached-container health check passed before publish."
 		add_github_summary ""
 	fi
 

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -97,8 +97,7 @@ run_health_check() {
 	echo "::group::Health check command (runner): ${HEALTH_CHECK_CMD}"
 	# Run on the runner against the published localhost port so distroless images
 	# do not need curl/wget inside the container.
-	# shellcheck disable=SC2086
-	${HEALTH_CHECK_CMD}
+	bash -c "$HEALTH_CHECK_CMD"
 	echo "::endgroup::"
 
 	trap - EXIT
@@ -646,7 +645,6 @@ health-check)
 	#   HEALTH_CHECK_PORT  - Port published on 127.0.0.1 for the command
 	#
 	# Optional environment variables:
-	#   HEALTH_CHECK_TIMEOUT  - Max wait time (default: 30s)
 	#   HEALTH_CHECK_TIMEOUT  - Max wait time (default: 30s)
 	: "${REGISTRY:?REGISTRY is required}"
 	: "${IMAGE_NAME:?IMAGE_NAME is required}"

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -94,10 +94,11 @@ run_health_check() {
 		echo "::endgroup::"
 	fi
 
-	echo "::group::Health check command: ${HEALTH_CHECK_CMD}"
-	# Intentionally word-split HEALTH_CHECK_CMD so callers can pass flags+args
+	echo "::group::Health check command (runner): ${HEALTH_CHECK_CMD}"
+	# Run on the runner against the published localhost port so distroless images
+	# do not need curl/wget inside the container.
 	# shellcheck disable=SC2086
-	docker exec "${container_id}" ${HEALTH_CHECK_CMD}
+	${HEALTH_CHECK_CMD}
 	echo "::endgroup::"
 
 	trap - EXIT
@@ -412,6 +413,9 @@ classify)
 		die "health-check-port must be a positive integer (1-65535): ${HEALTH_CHECK_PORT}"
 	fi
 	if [[ -n "$HEALTH_CHECK_CMD" ]]; then
+		if [[ -z "$HEALTH_CHECK_PORT" ]]; then
+			die "health-check-port is required when health-check-cmd is set (command runs on the runner against 127.0.0.1:PORT)"
+		fi
 		parse_duration_seconds "$HEALTH_CHECK_TIMEOUT" >/dev/null
 	fi
 
@@ -638,17 +642,18 @@ health-check)
 	#   IMAGE_NAME         - Registry-relative image name
 	#   PLATFORM           - Target platform (e.g. linux/arm64)
 	#   DIGEST_FILE        - Path to sha256 digest for the staging image
-	#   HEALTH_CHECK_CMD   - Command executed inside the running container
+	#   HEALTH_CHECK_CMD   - Command executed on the runner (requires port)
+	#   HEALTH_CHECK_PORT  - Port published on 127.0.0.1 for the command
 	#
 	# Optional environment variables:
-	#   HEALTH_CHECK_PORT     - Port to publish and wait for before the command
+	#   HEALTH_CHECK_TIMEOUT  - Max wait time (default: 30s)
 	#   HEALTH_CHECK_TIMEOUT  - Max wait time (default: 30s)
 	: "${REGISTRY:?REGISTRY is required}"
 	: "${IMAGE_NAME:?IMAGE_NAME is required}"
 	: "${PLATFORM:?PLATFORM is required}"
 	: "${DIGEST_FILE:?DIGEST_FILE is required}"
 	: "${HEALTH_CHECK_CMD:?HEALTH_CHECK_CMD is required}"
-	: "${HEALTH_CHECK_PORT:=}"
+	: "${HEALTH_CHECK_PORT:?HEALTH_CHECK_PORT is required}"
 	: "${HEALTH_CHECK_TIMEOUT:=30s}"
 
 	if [[ ! -s "$DIGEST_FILE" ]]; then
@@ -675,16 +680,16 @@ health-check-local)
 	#
 	# Required environment variables:
 	#   IMAGE              - Full local image reference (registry/name:tag)
-	#   HEALTH_CHECK_CMD   - Command executed inside the running container
+	#   HEALTH_CHECK_CMD   - Command executed on the runner (requires port)
+	#   HEALTH_CHECK_PORT  - Port published on 127.0.0.1 for the command
 	#
 	# Optional environment variables:
 	#   PLATFORM              - Target platform (e.g. linux/arm64)
-	#   HEALTH_CHECK_PORT     - Port to publish and wait for before the command
 	#   HEALTH_CHECK_TIMEOUT  - Max wait time (default: 30s)
 	: "${IMAGE:?IMAGE is required}"
 	: "${HEALTH_CHECK_CMD:?HEALTH_CHECK_CMD is required}"
+	: "${HEALTH_CHECK_PORT:?HEALTH_CHECK_PORT is required}"
 	: "${PLATFORM:=}"
-	: "${HEALTH_CHECK_PORT:=}"
 	: "${HEALTH_CHECK_TIMEOUT:=30s}"
 
 	export IMAGE PLATFORM HEALTH_CHECK_CMD HEALTH_CHECK_PORT HEALTH_CHECK_TIMEOUT

--- a/scripts/ci/lib/network/port.sh
+++ b/scripts/ci/lib/network/port.sh
@@ -54,6 +54,50 @@ port_available() {
 	fi
 }
 
+# Check if a TCP port is accepting connections on localhost.
+# Returns: 0 when the port is listening, 1 otherwise.
+port_listening() {
+	local port="$1"
+
+	if [[ -z "$port" || ! "$port" =~ ^[0-9]+$ ]] || ((port < 1 || port > 65535)); then
+		log_warn "Invalid port: $port"
+		return 1
+	fi
+
+	if command_exists nc; then
+		nc -z 127.0.0.1 "$port" 2>/dev/null
+	elif command_exists bash; then
+		bash -c "exec 3<>/dev/tcp/127.0.0.1/${port}" 2>/dev/null
+	else
+		log_warn "No port-listening probe available (nc or bash /dev/tcp), assuming port $port is ready"
+		return 0
+	fi
+}
+
+# Wait for a TCP port to start accepting connections on localhost.
+# Usage: wait_for_port_listen 8080 30 1
+# Returns: 0 when the port is listening, 1 on timeout.
+wait_for_port_listen() {
+	local port="${1:?port is required}"
+	local timeout="${2:-30}"
+	local interval="${3:-1}"
+	local elapsed=0
+
+	log_info "Waiting for port ${port} to accept connections (timeout: ${timeout}s)..."
+
+	while ! port_listening "$port"; do
+		if awk "BEGIN {exit !($elapsed >= $timeout)}"; then
+			log_error "Port ${port} not ready after ${timeout}s"
+			return 1
+		fi
+		sleep "$interval"
+		elapsed=$(awk "BEGIN {print $elapsed + $interval}")
+	done
+
+	log_success "Port ${port} is accepting connections"
+	return 0
+}
+
 # Wait for port to become available
 # Usage: wait_for_port 4000 10 0.5
 # Note: Returns 0 even on timeout (logs warning, continues anyway) for CI resilience.
@@ -82,4 +126,4 @@ wait_for_port() {
 # =============================================================================
 # Export functions
 # =============================================================================
-export -f port_available wait_for_port
+export -f port_available port_listening wait_for_port_listen wait_for_port

--- a/scripts/ci/lib/network/port.sh
+++ b/scripts/ci/lib/network/port.sh
@@ -18,6 +18,7 @@ if [[ -f "$_LGTM_CI_LIB_DIR/log.sh" ]]; then
 else
 	log_info() { echo "[INFO] $*" >&2; }
 	log_warn() { echo "[WARN] $*" >&2; }
+	log_error() { echo "[ERROR] $*" >&2; }
 	log_success() { echo "[SUCCESS] $*" >&2; }
 fi
 

--- a/scripts/ci/lib/network/port.sh
+++ b/scripts/ci/lib/network/port.sh
@@ -67,12 +67,16 @@ port_listening() {
 
 	if command_exists nc; then
 		nc -z 127.0.0.1 "$port" 2>/dev/null
-	elif command_exists bash; then
-		bash -c "exec 3<>/dev/tcp/127.0.0.1/${port}" 2>/dev/null
-	else
-		log_warn "No port-listening probe available (nc or bash /dev/tcp), assuming port $port is ready"
+		return $?
+	fi
+
+	# Bash /dev/tcp probe (this library is sourced from bash scripts).
+	if (exec 3<>/dev/tcp/127.0.0.1/"$port") 2>/dev/null; then
+		exec 3<&-
+		exec 3>&-
 		return 0
 	fi
+	return 1
 }
 
 # Wait for a TCP port to start accepting connections on localhost.

--- a/tests/bats/integration/test_build_docker.bats
+++ b/tests/bats/integration/test_build_docker.bats
@@ -22,7 +22,7 @@ setup() {
 	export PLATFORMS="linux/amd64,linux/arm64"
 	export PUSH="true"
 	export RUNNER_MAP='{"linux/arm64":"ubuntu-24.04-arm"}'
-	unset SMOKE_TEST SMOKE_TEST_SCRIPT || true
+	unset SMOKE_TEST SMOKE_TEST_SCRIPT HEALTH_CHECK_CMD HEALTH_CHECK_PORT HEALTH_CHECK_TIMEOUT || true
 }
 
 teardown() {
@@ -82,6 +82,34 @@ _run_script_any_bash() {
 }
 
 @test "build-docker classify: succeeds with neither smoke input set" {
+	_run_script
+	assert_success
+	assert_github_output "use-split" "true"
+}
+
+@test "build-docker classify: fails when health-check-port is not numeric" {
+	export HEALTH_CHECK_CMD="curl -f http://localhost:8080/health"
+	export HEALTH_CHECK_PORT="not-a-port"
+
+	_run_script
+	assert_failure
+	assert_output --partial "health-check-port must be a positive integer"
+}
+
+@test "build-docker classify: fails when health-check-timeout is invalid" {
+	export HEALTH_CHECK_CMD="curl -f http://localhost:8080/health"
+	export HEALTH_CHECK_TIMEOUT="30x"
+
+	_run_script
+	assert_failure
+	assert_output --partial "Invalid HEALTH_CHECK_TIMEOUT"
+}
+
+@test "build-docker classify: succeeds with health-check inputs set" {
+	export HEALTH_CHECK_CMD="curl -f http://localhost:8080/health"
+	export HEALTH_CHECK_PORT="8080"
+	export HEALTH_CHECK_TIMEOUT="45s"
+
 	_run_script
 	assert_success
 	assert_github_output "use-split" "true"
@@ -337,6 +365,28 @@ _run_script_any_bash() {
 	_run_script_any_bash
 	assert_failure
 	assert_output --partial "No image tag available"
+}
+
+# =============================================================================
+# resolve-local-health-check-image step
+# =============================================================================
+
+@test "build-docker resolve-local-health-check-image: writes first tag to GITHUB_OUTPUT" {
+	export STEP="resolve-local-health-check-image"
+	export TAGS=$'ghcr.io/org/repo:sha-abc123\nghcr.io/org/repo:main'
+
+	_run_script_any_bash
+	assert_success
+	assert_github_output "image" "ghcr.io/org/repo:sha-abc123"
+}
+
+@test "build-docker resolve-local-health-check-image: fails when TAGS is unset" {
+	export STEP="resolve-local-health-check-image"
+	unset TAGS
+
+	_run_script_any_bash
+	assert_failure
+	assert_output --partial "TAGS"
 }
 
 # =============================================================================

--- a/tests/bats/integration/test_build_docker.bats
+++ b/tests/bats/integration/test_build_docker.bats
@@ -88,7 +88,7 @@ _run_script_any_bash() {
 }
 
 @test "build-docker classify: fails when health-check-port is not numeric" {
-	export HEALTH_CHECK_CMD="curl -f http://localhost:8080/health"
+	export HEALTH_CHECK_CMD="curl -f http://127.0.0.1:8080/health"
 	export HEALTH_CHECK_PORT="not-a-port"
 
 	_run_script
@@ -97,7 +97,7 @@ _run_script_any_bash() {
 }
 
 @test "build-docker classify: fails when health-check-port is zero" {
-	export HEALTH_CHECK_CMD="curl -f http://localhost:8080/health"
+	export HEALTH_CHECK_CMD="curl -f http://127.0.0.1:8080/health"
 	export HEALTH_CHECK_PORT="0"
 
 	_run_script
@@ -106,7 +106,8 @@ _run_script_any_bash() {
 }
 
 @test "build-docker classify: fails when health-check-timeout is invalid" {
-	export HEALTH_CHECK_CMD="curl -f http://localhost:8080/health"
+	export HEALTH_CHECK_CMD="curl -f http://127.0.0.1:8080/health"
+	export HEALTH_CHECK_PORT="8080"
 	export HEALTH_CHECK_TIMEOUT="30x"
 
 	_run_script

--- a/tests/bats/integration/test_build_docker.bats
+++ b/tests/bats/integration/test_build_docker.bats
@@ -93,7 +93,16 @@ _run_script_any_bash() {
 
 	_run_script
 	assert_failure
-	assert_output --partial "health-check-port must be a positive integer"
+	assert_output --partial "health-check-port must be a positive integer (1-65535)"
+}
+
+@test "build-docker classify: fails when health-check-port is zero" {
+	export HEALTH_CHECK_CMD="curl -f http://localhost:8080/health"
+	export HEALTH_CHECK_PORT="0"
+
+	_run_script
+	assert_failure
+	assert_output --partial "health-check-port must be a positive integer (1-65535)"
 }
 
 @test "build-docker classify: fails when health-check-timeout is invalid" {

--- a/tests/bats/integration/test_build_docker.bats
+++ b/tests/bats/integration/test_build_docker.bats
@@ -115,13 +115,21 @@ _run_script_any_bash() {
 }
 
 @test "build-docker classify: succeeds with health-check inputs set" {
-	export HEALTH_CHECK_CMD="curl -f http://localhost:8080/health"
+	export HEALTH_CHECK_CMD="curl -f http://127.0.0.1:8080/health"
 	export HEALTH_CHECK_PORT="8080"
 	export HEALTH_CHECK_TIMEOUT="45s"
 
 	_run_script
 	assert_success
 	assert_github_output "use-split" "true"
+}
+
+@test "build-docker classify: fails when health-check-cmd is set without port" {
+	export HEALTH_CHECK_CMD="curl -f http://127.0.0.1:8080/health"
+
+	_run_script
+	assert_failure
+	assert_output --partial "health-check-port is required"
 }
 
 @test "build-docker classify: disables split when push is false and validate-on-pr is false" {

--- a/tests/bats/integration/test_reusable_docker_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_workflow.bats
@@ -21,7 +21,7 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
 @test "reusable-docker: build-per-platform job passes target input to build-push-action" {
 	run grep -cE '^[[:space:]]+target: \$\{\{ inputs\.target \}\}$' "$WORKFLOW"
 	assert_success
-	assert_output "3"
+	assert_output "2"
 }
 
 @test "reusable-docker: exposes target workflow input" {
@@ -30,10 +30,10 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
 }
 
 @test "reusable-docker: build job gates sbom and provenance on push" {
-	run grep -E '^[[:space:]]+provenance: \$\{\{ inputs\.provenance && inputs\.push \}\}$' "$WORKFLOW"
+	run grep -E '^[[:space:]]+provenance: \$\{\{ inputs\.provenance && inputs\.push' "$WORKFLOW"
 	assert_success
 
-	run grep -E '^[[:space:]]+sbom: \$\{\{ inputs\.sbom && inputs\.push \}\}$' "$WORKFLOW"
+	run grep -E '^[[:space:]]+sbom: \$\{\{ inputs\.sbom && inputs\.push' "$WORKFLOW"
 	assert_success
 }
 
@@ -76,6 +76,6 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
 }
 
 @test "reusable-docker: build job publishes only after health check when enabled" {
-	run grep -F 'Build and push after health check' "$WORKFLOW"
+	run grep -F 'Push image after health check' "$WORKFLOW"
 	assert_success
 }

--- a/tests/bats/integration/test_reusable_docker_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_workflow.bats
@@ -79,3 +79,20 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
 	run grep -F 'Push image after health check' "$WORKFLOW"
 	assert_success
 }
+
+@test "reusable-docker: health-check-per-platform waits for verify-per-platform" {
+	run grep -F 'needs: [classify, build-per-platform, verify-per-platform]' "$WORKFLOW" | grep -c 'health-check-per-platform' || true
+	run awk '
+		/name: Docker health check per platform/ { in_job = 1 }
+		in_job && /needs: \[classify, build-per-platform, verify-per-platform\]/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker: deferred push path generates SBOM attestation" {
+	run grep -F 'Generate SBOM attestation' "$WORKFLOW"
+	assert_success
+	run grep -F 'uses: actions/attest@' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_docker_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_workflow.bats
@@ -75,6 +75,23 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
 	assert_success
 }
 
+@test "reusable-docker: per-platform build avoids push and load together" {
+	run awk '
+		/name: Build and push \(\$\{\{ matrix\.platform \}\}\)/ { in_step = 1 }
+		in_step && /push: \$\{\{ inputs\.push \}\}/ { saw_push = 1 }
+		in_step && /load:/ { saw_load = 1 }
+		in_step && saw_push && saw_load {
+			if ($0 ~ /inputs\.push == false && \(inputs\.health-check-cmd/) {
+				found = 1
+				exit
+			}
+		}
+		in_step && /^[[:space:]]+- name:/ && !/Build and push/ { in_step = 0 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
 @test "reusable-docker: build job publishes only after health check when enabled" {
 	run grep -F 'Push image after health check' "$WORKFLOW"
 	assert_success

--- a/tests/bats/integration/test_reusable_docker_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_workflow.bats
@@ -21,7 +21,7 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
 @test "reusable-docker: build-per-platform job passes target input to build-push-action" {
 	run grep -cE '^[[:space:]]+target: \$\{\{ inputs\.target \}\}$' "$WORKFLOW"
 	assert_success
-	assert_output "2"
+	assert_output "3"
 }
 
 @test "reusable-docker: exposes target workflow input" {
@@ -49,4 +49,33 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
 @test "reusable-docker: build job does not pass raw sbom or provenance inputs" {
 	run grep -E '^[[:space:]]+(provenance|sbom): \$\{\{ inputs\.(provenance|sbom) \}\}$' "$WORKFLOW"
 	assert_failure
+}
+
+@test "reusable-docker: exposes health-check workflow inputs" {
+	run grep -E '^[[:space:]]+health-check-cmd:$' "$WORKFLOW"
+	assert_success
+	run grep -E '^[[:space:]]+health-check-port:$' "$WORKFLOW"
+	assert_success
+	run grep -E '^[[:space:]]+health-check-timeout:$' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker: per-platform jobs use static health-check display name" {
+	run grep -F 'name: Docker health check per platform' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker: merge job gates on health-check-per-platform success" {
+	run grep -F 'needs.health-check-per-platform.result ==' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker: build job defers push when health-check-cmd is set" {
+	run grep -E 'push: \$\{\{ inputs\.push && inputs\.health-check-cmd ==' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker: build job publishes only after health check when enabled" {
+	run grep -F 'Build and push after health check' "$WORKFLOW"
+	assert_success
 }

--- a/tests/bats/integration/test_reusable_static_job_names.bats
+++ b/tests/bats/integration/test_reusable_static_job_names.bats
@@ -116,6 +116,8 @@ YAML
 	assert_success
 	run grep -F 'name: Docker verify per platform' "$workflow"
 	assert_success
+	run grep -F 'name: Docker health check per platform' "$workflow"
+	assert_success
 }
 
 @test "reusable-test-e2e-matrix: test job uses static name" {

--- a/tests/bats/unit/lib/network/test_port.bats
+++ b/tests/bats/unit/lib/network/test_port.bats
@@ -116,6 +116,7 @@ teardown() {
 
 @test "wait_for_port_listen: logs waiting message" {
 	run bash -c 'source "$LIB_DIR/network/port.sh" && wait_for_port_listen 49993 1 0.1 2>&1'
+	assert_failure
 	assert_output --partial "Waiting for port 49993 to accept connections"
 }
 

--- a/tests/bats/unit/lib/network/test_port.bats
+++ b/tests/bats/unit/lib/network/test_port.bats
@@ -97,16 +97,26 @@ teardown() {
 # wait_for_port_listen tests
 # =============================================================================
 
-@test "wait_for_port_listen: succeeds when port is already listening" {
-	run bash -c 'source "$LIB_DIR/network/port.sh" && wait_for_port_listen 49995 1 0.1 2>&1'
-	# Port is not listening in test env; nc/bash probe should fail quickly on timeout
-	# unless a listener exists. Accept either outcome without hanging.
-	[[ "$status" -eq 0 || "$status" -eq 1 ]]
+@test "wait_for_port_listen: succeeds when a listener is already bound" {
+	run bash -c '
+		source "$LIB_DIR/network/port.sh"
+		nc -l 127.0.0.1 49995 >/dev/null 2>&1 &
+		listener_pid=$!
+		trap "kill ${listener_pid} 2>/dev/null || true" EXIT
+		sleep 0.2
+		wait_for_port_listen 49995 2 0.1
+	'
+	assert_success
+}
+
+@test "wait_for_port_listen: fails when no listener is bound" {
+	run bash -c 'source "$LIB_DIR/network/port.sh" && wait_for_port_listen 49994 1 0.1'
+	assert_failure
 }
 
 @test "wait_for_port_listen: logs waiting message" {
-	run bash -c 'source "$LIB_DIR/network/port.sh" && wait_for_port_listen 49994 1 0.1 2>&1'
-	assert_output --partial "Waiting for port 49994 to accept connections"
+	run bash -c 'source "$LIB_DIR/network/port.sh" && wait_for_port_listen 49993 1 0.1 2>&1'
+	assert_output --partial "Waiting for port 49993 to accept connections"
 }
 
 # =============================================================================

--- a/tests/bats/unit/lib/network/test_port.bats
+++ b/tests/bats/unit/lib/network/test_port.bats
@@ -94,6 +94,22 @@ teardown() {
 }
 
 # =============================================================================
+# wait_for_port_listen tests
+# =============================================================================
+
+@test "wait_for_port_listen: succeeds when port is already listening" {
+	run bash -c 'source "$LIB_DIR/network/port.sh" && wait_for_port_listen 49995 1 0.1 2>&1'
+	# Port is not listening in test env; nc/bash probe should fail quickly on timeout
+	# unless a listener exists. Accept either outcome without hanging.
+	[[ "$status" -eq 0 || "$status" -eq 1 ]]
+}
+
+@test "wait_for_port_listen: logs waiting message" {
+	run bash -c 'source "$LIB_DIR/network/port.sh" && wait_for_port_listen 49994 1 0.1 2>&1'
+	assert_output --partial "Waiting for port 49994 to accept connections"
+}
+
+# =============================================================================
 # Function export tests
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Add optional detached-container health checks to `reusable-docker.yml` so callers can validate a running image before it is published to GHCR. When `health-check-cmd` is set, the workflow starts the built image, optionally waits for `health-check-port`, runs the command, and gates publish/merge on success.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Changes Made

- Add `health-check-cmd`, `health-check-port`, and `health-check-timeout` inputs to `reusable-docker.yml`
- Implement `health-check` / `health-check-local` steps in `build-docker.sh` with container log capture on failure
- Add `wait_for_port_listen` helper in `scripts/ci/lib/network/port.sh`
- Gate single-build publish via load → health check → `docker push` of the same image
- Add `health-check-per-platform` job on the split push path before manifest merge
- Add BATS contract/unit coverage and document caller usage

## Closes

- Closes #65

## Testing

- [x] Ran `uv run lintro chk` locally (zero issues)
- [x] Ran affected BATS integration/unit tests for docker workflow and port helpers
- [ ] Full `tests/bats` suite in CI

## Quality Checks

- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint` / `actionlint`
- [x] Python tooling passes `ruff` and `black`
- [x] Greptile and CodeRabbit pre-push review completed; P1 findings addressed

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. Omitting the new inputs preserves existing behavior.

## Related Issues

- Relates to lgtm-hq/Rustume#49

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add reusable Docker health check step between build and publish in `reusable-docker.yml`
> - Adds three new workflow inputs (`health-check-cmd`, `health-check-port`, `health-check-timeout`) that, when set, gate image publishing on a passing runtime health check.
> - On the single-build path, the image is loaded locally, a detached container is started, and the health check command runs against it before the image is pushed to the registry.
> - On the split per-platform path, a new `health-check-per-platform` job pulls each staging image by digest and runs the same check before manifests are merged.
> - Core logic lives in [`scripts/ci/actions/build-docker.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/336/files#diff-5407c47fe92b444c749c9c3524e6eb3c73f76cb4afbca7595545a02470eab249) and a new [`scripts/ci/lib/network/port.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/336/files#diff-a9c0fbee067b47da6f2bbdcb5bb68cc74b759752cb82e1c652b25baf7d3c054d) library that polls a localhost TCP port until it accepts connections or times out.
> - Behavioral Change: when `health-check-cmd` is set, provenance and SBOM attestations are deferred until after the health check passes and the image is pushed, using the post-push digest.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c0f8a2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional runtime health check capability to Docker build/push workflow, gating image publishing on successful container health validation.
  * Supports single-platform and multi-platform builds with per-platform health checks.
  * New workflow inputs: `health-check-cmd`, `health-check-port`, and `health-check-timeout`.

* **Documentation**
  * Updated workflow documentation with health check configuration examples and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an optional detached-container health check step to `reusable-docker.yml`, gating image publication on a passing `health-check-cmd` run on the runner against a published localhost port before the final push.

- **Single-build path**: build sets `push=false, load=true`, runs the health check, then executes a deferred `docker push` with separate provenance and SBOM attestation steps; the `metadata` step resolves the final digest after push.
- **Split per-platform path**: a new `health-check-per-platform` job (needs `verify-per-platform`) pulls each staging image by digest, runs `run_health_check`, and gates the `merge` job on its result; the `validate-on-pr` path also gains an inline health-check step inside `build-per-platform`.
- **New helpers**: `port_listening` and `wait_for_port_listen` in `scripts/ci/lib/network/port.sh` back the port-readiness wait; BATS contract and unit tests cover input validation, tag resolution, and port helpers.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the timeout exit-code capture in run_health_check; all other paths are structurally sound.

The run_health_check function captures $? inside an `if !` block, where bash always sets $? to 0 (the negated condition result). This means the timed-out branch is unreachable on every invocation and every failure is reported as exit 0, masking the real reason the health check failed and making timeouts invisible in CI logs.

scripts/ci/actions/build-docker.sh — the exit-code capture in run_health_check around line 100.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/actions/build-docker.sh | Adds run_health_check(), health-check, health-check-local, and resolve-local-health-check-image step handlers; timeout exit-code capture inside `if !` is always 0, breaking timeout detection. |
| .github/workflows/reusable-docker.yml | Adds health-check-cmd/port/timeout inputs, deferred-push path (load→health-check→push), per-platform health-check-per-platform job, SBOM deferred attestation, and gates merge on new job result; logic is structurally sound. |
| scripts/ci/lib/network/port.sh | Adds port_listening() and wait_for_port_listen(); the /dev/tcp branch opens FD 3 inside a subshell so the parent-shell exec 3<&- / exec 3>&- are dead code, but the probes and loop logic are otherwise correct. |
| tests/bats/integration/test_build_docker.bats | Adds classify and resolve-local-health-check-image BATS coverage for the new health-check inputs; well-structured with happy path and validation failure cases. |
| tests/bats/integration/test_reusable_docker_workflow.bats | Adds contract tests asserting new inputs, job name, merge gating, deferred push, and SBOM attestation presence in the workflow YAML. |
| tests/bats/unit/lib/network/test_port.bats | Adds unit tests for wait_for_port_listen (success, failure, log message); coverage is appropriate for the new helper. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant W as Workflow
    participant B as build (single)
    participant HC as health-check-local
    participant R as Registry

    W->>B: "docker buildx (push=false, load=true)"
    B-->>W: image loaded locally
    W->>HC: docker run -d -p 127.0.0.1:PORT:PORT IMAGE
    HC-->>W: container_id
    W->>HC: wait_for_port_listen(PORT, timeout)
    HC-->>W: port ready
    W->>HC: timeout Ns bash -c HEALTH_CHECK_CMD
    alt check passes
        HC-->>W: exit 0
        W->>R: docker push (deferred)
        W->>R: attest provenance + SBOM
    else check fails / times out
        HC-->>W: non-zero (reported as exit 0 due to bug)
        W--xR: publish blocked
    end

    Note over W,R: Split path: health-check-per-platform pulls staging image by digest per platform and gates manifest merge
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fbuild-docker.sh%3A100-106%0A**%60cmd_exit%60%20is%20always%200%20%E2%80%94%20timeout%20detection%20is%20unreachable**%0A%0AIn%20bash%2C%20%60if%20!%20cmd%3B%20then%20%E2%80%A6%20fi%60%20sets%20%60%24%3F%60%20inside%20the%20then-block%20to%20the%20exit%20status%20of%20%60!%20cmd%60%2C%20which%20is%20the%20*negation*%20of%20the%20original%20exit%20code.%20When%20%60timeout%60%20exits%20124%20%28timed%20out%29%20or%20any%20other%20non-zero%20code%2C%20%60!%20timeout%20%E2%80%A6%60%20exits%200%2C%20so%20%60local%20cmd_exit%3D%24%3F%60%20always%20captures%200.%20%60%5B%5B%20%22%24cmd_exit%22%20-eq%20124%20%5D%5D%60%20therefore%20never%20evaluates%20to%20true%2C%20and%20the%20error%20message%20is%20always%20the%20misleading%20%22Health%20check%20command%20failed%20%28exit%200%29%22%20rather%20than%20the%20correct%20%22timed%20out%22%20message.%0A%0A%60%60%60suggestion%0A%09timeout%20%22%24%7Btimeout_secs%7Ds%22%20bash%20-c%20%22%24HEALTH_CHECK_CMD%22%20%7C%7C%20%7B%0A%09%09local%20cmd_exit%3D%24%3F%0A%09%09if%20%5B%5B%20%22%24cmd_exit%22%20-eq%20124%20%5D%5D%3B%20then%0A%09%09%09die%20%22Health%20check%20command%20timed%20out%20after%20%24%7BHEALTH_CHECK_TIMEOUT%7D%22%0A%09%09fi%0A%09%09die%20%22Health%20check%20command%20failed%20%28exit%20%24%7Bcmd_exit%7D%29%22%0A%09%7D%0A%60%60%60%0A%0A&pr=336&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fbuild-docker.sh%3A100-106%0A**%60cmd_exit%60%20is%20always%200%20%E2%80%94%20timeout%20detection%20is%20unreachable**%0A%0AIn%20bash%2C%20%60if%20!%20cmd%3B%20then%20%E2%80%A6%20fi%60%20sets%20%60%24%3F%60%20inside%20the%20then-block%20to%20the%20exit%20status%20of%20%60!%20cmd%60%2C%20which%20is%20the%20*negation*%20of%20the%20original%20exit%20code.%20When%20%60timeout%60%20exits%20124%20%28timed%20out%29%20or%20any%20other%20non-zero%20code%2C%20%60!%20timeout%20%E2%80%A6%60%20exits%200%2C%20so%20%60local%20cmd_exit%3D%24%3F%60%20always%20captures%200.%20%60%5B%5B%20%22%24cmd_exit%22%20-eq%20124%20%5D%5D%60%20therefore%20never%20evaluates%20to%20true%2C%20and%20the%20error%20message%20is%20always%20the%20misleading%20%22Health%20check%20command%20failed%20%28exit%200%29%22%20rather%20than%20the%20correct%20%22timed%20out%22%20message.%0A%0A%60%60%60suggestion%0A%09timeout%20%22%24%7Btimeout_secs%7Ds%22%20bash%20-c%20%22%24HEALTH_CHECK_CMD%22%20%7C%7C%20%7B%0A%09%09local%20cmd_exit%3D%24%3F%0A%09%09if%20%5B%5B%20%22%24cmd_exit%22%20-eq%20124%20%5D%5D%3B%20then%0A%09%09%09die%20%22Health%20check%20command%20timed%20out%20after%20%24%7BHEALTH_CHECK_TIMEOUT%7D%22%0A%09%09fi%0A%09%09die%20%22Health%20check%20command%20failed%20%28exit%20%24%7Bcmd_exit%7D%29%22%0A%09%7D%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=336&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F65-add-reusable-docker-health-check%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F65-add-reusable-docker-health-check%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fbuild-docker.sh%3A100-106%0A**%60cmd_exit%60%20is%20always%200%20%E2%80%94%20timeout%20detection%20is%20unreachable**%0A%0AIn%20bash%2C%20%60if%20!%20cmd%3B%20then%20%E2%80%A6%20fi%60%20sets%20%60%24%3F%60%20inside%20the%20then-block%20to%20the%20exit%20status%20of%20%60!%20cmd%60%2C%20which%20is%20the%20*negation*%20of%20the%20original%20exit%20code.%20When%20%60timeout%60%20exits%20124%20%28timed%20out%29%20or%20any%20other%20non-zero%20code%2C%20%60!%20timeout%20%E2%80%A6%60%20exits%200%2C%20so%20%60local%20cmd_exit%3D%24%3F%60%20always%20captures%200.%20%60%5B%5B%20%22%24cmd_exit%22%20-eq%20124%20%5D%5D%60%20therefore%20never%20evaluates%20to%20true%2C%20and%20the%20error%20message%20is%20always%20the%20misleading%20%22Health%20check%20command%20failed%20%28exit%200%29%22%20rather%20than%20the%20correct%20%22timed%20out%22%20message.%0A%0A%60%60%60suggestion%0A%09timeout%20%22%24%7Btimeout_secs%7Ds%22%20bash%20-c%20%22%24HEALTH_CHECK_CMD%22%20%7C%7C%20%7B%0A%09%09local%20cmd_exit%3D%24%3F%0A%09%09if%20%5B%5B%20%22%24cmd_exit%22%20-eq%20124%20%5D%5D%3B%20then%0A%09%09%09die%20%22Health%20check%20command%20timed%20out%20after%20%24%7BHEALTH_CHECK_TIMEOUT%7D%22%0A%09%09fi%0A%09%09die%20%22Health%20check%20command%20failed%20%28exit%20%24%7Bcmd_exit%7D%29%22%0A%09%7D%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=336&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["fix: address health-check PR review feed..."](https://github.com/lgtm-hq/lgtm-ci/commit/2c0f8a27ee08f2b47d56ee0e547e7e5f03fa1e3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36410023)</sub>

<!-- /greptile_comment -->