### PR TITLE
chore(workflows): standardize runner-image and runner-map contract

### DIFF
--- a/.github/workflows/reusable-build-python-dist.yml
+++ b/.github/workflows/reusable-build-python-dist.yml
@@ -88,7 +88,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       timeout-minutes:
         description: "Job timeout in minutes"
         required: false

--- a/.github/workflows/reusable-coverage.yml
+++ b/.github/workflows/reusable-coverage.yml
@@ -90,6 +90,12 @@ on:
         type: string
         default: "Coverage Report"
 
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+
     outputs:
       coverage-percent:
         description: "Overall coverage percentage"
@@ -107,7 +113,7 @@ on:
 jobs:
   coverage:
     name: ${{ inputs.job-name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     permissions:
       contents: read
 
@@ -200,7 +206,7 @@ jobs:
     name: Publish Coverage
     needs: coverage
     if: inputs.publish-pages
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     concurrency:
       group: pages-${{ github.repository }}-${{ github.ref }}
       cancel-in-progress: false

--- a/.github/workflows/reusable-deploy-pages.yml
+++ b/.github/workflows/reusable-deploy-pages.yml
@@ -79,6 +79,12 @@ on:
         type: string
         default: "playwright"
 
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+
     outputs:
       page-url:
         description: "URL of the deployed GitHub Pages site"
@@ -92,7 +98,7 @@ concurrency:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     permissions:
       contents: read
 
@@ -169,7 +175,7 @@ jobs:
   deploy:
     name: Deploy
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/reusable-deploy-site-with-reports.yml
+++ b/.github/workflows/reusable-deploy-site-with-reports.yml
@@ -142,7 +142,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       timeout-minutes:
         description: "Job timeout in minutes"
         required: false

--- a/.github/workflows/reusable-ghcr-cleanup.yml
+++ b/.github/workflows/reusable-ghcr-cleanup.yml
@@ -56,6 +56,12 @@ on:
         type: string
         default: "github-tooling"
 
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+
     secrets:
       token:
         description: "GitHub token with packages:write scope"
@@ -64,7 +70,7 @@ on:
 jobs:
   cleanup:
     name: Clean Untagged Images
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/reusable-github-release.yml
+++ b/.github/workflows/reusable-github-release.yml
@@ -87,7 +87,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       timeout-minutes:
         description: "Job timeout in minutes"
         required: false

--- a/.github/workflows/reusable-link-check.yml
+++ b/.github/workflows/reusable-link-check.yml
@@ -91,10 +91,16 @@ on:
         type: string
         default: "lychee-report"
 
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+
 jobs:
   link-check:
     name: ${{ inputs.job-name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     permissions:
       contents: read
 

--- a/.github/workflows/reusable-pr-auto-assign.yml
+++ b/.github/workflows/reusable-pr-auto-assign.yml
@@ -50,10 +50,16 @@ name: Reusable PR Auto Assign
         type: string
         default: "github-tooling"
 
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+
 jobs:
   assign:
     name: ${{ inputs.job-name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     timeout-minutes: 5
     permissions:
       contents: read

--- a/.github/workflows/reusable-publish-artifact-report.yml
+++ b/.github/workflows/reusable-publish-artifact-report.yml
@@ -67,7 +67,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       timeout-minutes:
         description: "Job timeout in minutes"
         required: false

--- a/.github/workflows/reusable-publish-homebrew.yml
+++ b/.github/workflows/reusable-publish-homebrew.yml
@@ -81,7 +81,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       timeout-minutes:
         description: "Job timeout in minutes"
         required: false

--- a/.github/workflows/reusable-publish-quality-summary.yml
+++ b/.github/workflows/reusable-publish-quality-summary.yml
@@ -54,7 +54,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       timeout-minutes:
         description: "Job timeout in minutes"
         required: false

--- a/.github/workflows/reusable-publish-security-audit-comment.yml
+++ b/.github/workflows/reusable-publish-security-audit-comment.yml
@@ -65,7 +65,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       timeout-minutes:
         description: "Job timeout in minutes"
         required: false

--- a/.github/workflows/reusable-publish-test-summary.yml
+++ b/.github/workflows/reusable-publish-test-summary.yml
@@ -110,7 +110,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       timeout-minutes:
         description: "Job timeout in minutes"
         required: false

--- a/.github/workflows/reusable-quality-lint.yml
+++ b/.github/workflows/reusable-quality-lint.yml
@@ -79,6 +79,12 @@ on:
         type: string
         # yamllint disable-line rule:line-length
         default: "ghcr.io/lgtm-hq/py-lintro@sha256:1ff3db35939283734b859c7c5d95be87fd8fd62734b3434e0437769d50d53578"
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+
       timeout-minutes:
         description: "Job timeout in minutes for Docker lintro quality checks"
         required: false
@@ -96,7 +102,7 @@ on:
 jobs:
   quality:
     name: ${{ inputs.job-name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       contents: read

--- a/.github/workflows/reusable-registry-health-check.yml
+++ b/.github/workflows/reusable-registry-health-check.yml
@@ -57,10 +57,16 @@ on:
         type: string
         default: "Registry Health Check"
 
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+
 jobs:
   registry-health:
     name: ${{ inputs.job-name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     outputs:
       digest-failure: ${{ steps.health.outputs.digest-failure }}
     permissions:
@@ -125,7 +131,7 @@ jobs:
     if: >-
       needs.registry-health.outputs.digest-failure == 'true' &&
       inputs.open-issue-on-failure
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     permissions:
       # Read lgtm-ci tooling repository
       contents: read

--- a/.github/workflows/reusable-release-auto-tag.yml
+++ b/.github/workflows/reusable-release-auto-tag.yml
@@ -83,7 +83,7 @@ name: "Reusable: Release Auto Tag"
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       timeout-minutes:
         description: "Job timeout in minutes"
         required: false
@@ -342,7 +342,7 @@ jobs:
       always() &&
       inputs.report-failures &&
       needs.auto-tag.result == 'failure'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     timeout-minutes: 10
     permissions:
       # Read workflow/job metadata to generate failure context

--- a/.github/workflows/reusable-release-version-pr.yml
+++ b/.github/workflows/reusable-release-version-pr.yml
@@ -126,6 +126,12 @@ name: "Reusable: Release Version PR"
         type: string
         default: ""
 
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+
     secrets:
       RELEASE_APP_ID:
         description: "GitHub App ID for creating release tokens"
@@ -137,7 +143,7 @@ name: "Reusable: Release Version PR"
 jobs:
   version-pr:
     name: Create Version PR
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     timeout-minutes: 20
     concurrency:
       # Distinct from the caller's workflow-level group to avoid
@@ -488,7 +494,7 @@ jobs:
       always() &&
       inputs.report-failures &&
       needs.version-pr.result == 'failure'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     timeout-minutes: 10
     permissions:
       # Read workflow/job metadata to generate failure context

--- a/.github/workflows/reusable-required-check.yml
+++ b/.github/workflows/reusable-required-check.yml
@@ -70,7 +70,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       timeout-minutes:
         description: "Job timeout in minutes"
         required: false

--- a/.github/workflows/reusable-sbom.yml
+++ b/.github/workflows/reusable-sbom.yml
@@ -83,6 +83,12 @@ on:
         type: string
         default: "SBOM & Supply Chain"
 
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+
     outputs:
       sbom-file:
         description: "Path to the generated SBOM file, or 'none' if not generated"
@@ -99,7 +105,7 @@ on:
 jobs:
   sbom:
     name: ${{ inputs.job-name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/reusable-security-audit.yml
+++ b/.github/workflows/reusable-security-audit.yml
@@ -83,7 +83,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       timeout-minutes:
         description: "Job timeout in minutes for the audit job"
         required: false

--- a/.github/workflows/reusable-site-quality.yml
+++ b/.github/workflows/reusable-site-quality.yml
@@ -214,7 +214,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       timeout-minutes:
         description: "Timeout for site quality jobs in minutes"
         required: false

--- a/.github/workflows/reusable-test-e2e-matrix.yml
+++ b/.github/workflows/reusable-test-e2e-matrix.yml
@@ -105,7 +105,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
 
     outputs:
       total-passed:

--- a/.github/workflows/reusable-test-e2e.yml
+++ b/.github/workflows/reusable-test-e2e.yml
@@ -71,7 +71,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       draft-pr-skip:
         description: "Skip jobs on draft pull requests"
         required: false

--- a/.github/workflows/reusable-test-node-custom.yml
+++ b/.github/workflows/reusable-test-node-custom.yml
@@ -128,7 +128,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       timeout-minutes:
         description: "Timeout for test jobs in minutes"
         required: false
@@ -426,7 +426,7 @@ jobs:
         github.event_name != 'pull_request' ||
         github.event.pull_request.draft == false
       )
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     permissions:
       contents: read
     outputs:
@@ -486,7 +486,7 @@ jobs:
       always()
       && inputs.upload-pages-coverage-html
       && inputs.coverage
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/reusable-test-node-publish.yml
+++ b/.github/workflows/reusable-test-node-publish.yml
@@ -61,7 +61,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       timeout-minutes:
         description: "Job timeout in minutes"
         required: false

--- a/.github/workflows/reusable-test-node.yml
+++ b/.github/workflows/reusable-test-node.yml
@@ -157,7 +157,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       timeout-minutes:
         description: "Timeout for test jobs in minutes"
         required: false
@@ -563,7 +563,7 @@ jobs:
       always()
       && inputs.upload-pages-coverage-html
       && inputs.coverage
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     permissions:
       contents: read
     outputs:
@@ -635,7 +635,7 @@ jobs:
         github.event_name != 'pull_request' ||
         github.event.pull_request.draft == false
       )
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/reusable-test-python-publish.yml
+++ b/.github/workflows/reusable-test-python-publish.yml
@@ -56,7 +56,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       timeout-minutes:
         description: "Job timeout in minutes"
         required: false

--- a/.github/workflows/reusable-test-python.yml
+++ b/.github/workflows/reusable-test-python.yml
@@ -113,7 +113,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       draft-pr-skip:
         description: "Skip jobs on draft pull requests"
         required: false
@@ -422,7 +422,7 @@ jobs:
         github.event_name != 'pull_request' ||
         github.event.pull_request.draft == false
       )
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     permissions:
       actions: write # upload-artifact/merge re-uploads merged python-coverage (artifact write)
       contents: read

--- a/.github/workflows/reusable-test-shell.yml
+++ b/.github/workflows/reusable-test-shell.yml
@@ -70,7 +70,7 @@ on:
         description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       draft-pr-skip:
         description: "Skip jobs on draft pull requests"
         required: false

--- a/.github/workflows/reusable-validate-action-pinning.yml
+++ b/.github/workflows/reusable-validate-action-pinning.yml
@@ -68,10 +68,16 @@ on:
         type: string
         default: "github-tooling"
 
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+
 jobs:
   action-pinning:
     name: Validate Action Pinning
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     permissions:
       contents: read
 

--- a/.github/workflows/reusable-validate-lintro-version.yml
+++ b/.github/workflows/reusable-validate-lintro-version.yml
@@ -67,10 +67,16 @@ on:
         type: string
         default: "Validate Lintro Version"
 
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+
 jobs:
   validate-lintro-version:
     name: ${{ inputs.job-name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     permissions:
       # Checkout repository and lgtm-ci tooling
       contents: read

--- a/.github/workflows/reusable-validate.yml
+++ b/.github/workflows/reusable-validate.yml
@@ -72,6 +72,12 @@ on:
         type: string
         default: "github-tooling"
 
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+
     outputs:
       exit-code:
         description: "Exit code from the validation script"
@@ -85,7 +91,7 @@ jobs:
     name: >-
       ${{ inputs.job-name != '' && inputs.job-name ||
       (inputs.name != '' && inputs.name || 'Validation') }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner-image }}
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/reusable-vuln-suppression-check.yml
+++ b/.github/workflows/reusable-vuln-suppression-check.yml
@@ -76,7 +76,7 @@ on:
         description: "GitHub-hosted Linux runner image label (install script downloads linux_* binaries)"
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "ubuntu-24.04"
       timeout-minutes:
         description: "Job timeout in minutes for the suppression check job"
         required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ci**: `validate-runner-contract.sh` and BATS contract tests for runner-image
+  and runner-map policy (#338)
+
 ### Changed
+
+- **workflows**: standardize `runner-image` across script-backed reusables with
+  `ubuntu-24.04` default; add missing inputs and complete multi-job wiring (#338)
+- **docs**: document `runner-map`, runner pinning exceptions, and consumer
+  guidance in workflow contract (#338)
 
 ### Deprecated
 

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -44,6 +44,25 @@ reusables (quality, test-*, validate-*, release-*, etc.). Production callers
 should pin the workflow ref to a commit SHA and pass the same ref as
 `tooling-ref` on script-backed workflows.
 
+## Runner pinning
+
+Script-backed reusables accept `runner-image` on every job. Pin explicitly in
+production so runner OS does not drift with GitHub's `ubuntu-latest` alias:
+
+```yaml
+jobs:
+  quality:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@<sha>
+    with:
+      runner-image: ubuntu-24.04
+      tooling-ref: <sha>
+```
+
+Multi-arch Docker builds use `runner-map` instead — see
+[Docker workflow inputs](#docker-workflow-inputs) below. Action-only reusables and
+npm/gem publish workflows do not expose `runner-image`; see
+[workflow-contract.md](workflow-contract.md#runner-pinning).
+
 **Action-only reusables** (labeler, dependency review, semantic PR title,
 CodeQL, Scorecard) do not run the full `scripts/ci/` suite in their analysis
 jobs; `tooling-ref` is optional and primarily pins egress composites.
@@ -753,7 +772,7 @@ stale (vulnerability resolved upstream). Expired suppressions fail the job.
 | `egress-preset`          | `osv-scanner`           | Includes GitHub tooling + OSV API hosts    |
 | `allowed-endpoints-mode` | `append`                | Merge preset with caller endpoints         |
 | `workflow-file`          | empty                   | Caller workflow filename for PR footer     |
-| `runner-image`           | `ubuntu-latest`         | Linux runners only (install script)        |
+| `runner-image`           | `ubuntu-24.04`          | Linux runners only (install script)        |
 
 Use a Linux `runner-image`; the install script downloads `linux_*` release
 binaries only.

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -16,7 +16,8 @@ Where applicable, workflows accept:
 | `allowed-endpoints`                | Multiline `host:port` list (see `allowed-endpoints-mode`)              |
 | `allowed-endpoints-mode`           | `replace` (default) or `append` (merge with preset, deduped)           |
 | `job-name`                         | Check name on always-run jobs; test summary suite title                |
-| `runner-image`                     | Runner label for long-running jobs                                     |
+| `runner-image`                     | GitHub-hosted runner OS label (default `ubuntu-24.04`)                 |
+| `runner-map`                       | JSON platform→runner map for multi-arch Docker (default `{}`)          |
 | `timeout-minutes`                  | Job timeout                                                            |
 | `publish-test-summary`             | Publish test/coverage summary comment on the pull request              |
 | `comment-marker` / `comment-title` | Upsert identity for summary comments (marker + heading)                |
@@ -66,6 +67,41 @@ Contrast with **script-backed reusables** (quality, test-*, validate-*,
 pr-auto-assign, release-*, publish-*, etc.) where callers **should** pass
 `tooling-ref` matching the workflow pin so `scripts/ci/` and composites stay
 aligned.
+
+### Runner pinning
+
+Script-backed reusables expose `runner-image` on **every** job so callers can
+pin OS reproducibility (for example `ubuntu-24.04`). Defaults are
+`ubuntu-24.04`; production callers **should** pass an explicit pin.
+
+Multi-arch Docker builds use `runner-map` instead of `runner-image`. Pass a JSON
+object mapping platform to runner label (for example
+`{"linux/arm64":"ubuntu-24.04-arm"}`). Platforms not in the map default to
+`ubuntu-24.04` with QEMU. Orchestration jobs inside `reusable-docker.yml`
+(`classify`, `merge`, summaries) stay on fixed `ubuntu-24.04` coordinators and
+are not caller-pinnable.
+
+#### Runner pinning exceptions
+
+These reusables intentionally omit `runner-image`:
+
+<!-- markdownlint-disable MD013 -->
+
+| Reusable                             | Rationale                                              |
+| ------------------------------------ | ------------------------------------------------------ |
+| `reusable-codeql.yml`                | Action-only wrapper (`github/codeql-action/*`)         |
+| `reusable-dependency-review.yml`     | Action-only wrapper                                    |
+| `reusable-scorecards.yml`            | Action-only wrapper                                    |
+| `reusable-semantic-pr-title.yml`     | Action-only wrapper                                    |
+| `reusable-pr-labeler.yml`            | Action-only wrapper                                    |
+| `reusable-publish-npm.yml`           | Hardcoded for npm provenance attestation               |
+| `reusable-publish-gem.yml`           | OIDC publish; runner pin under attestation review      |
+
+<!-- markdownlint-enable MD013 -->
+
+Contract enforcement: `scripts/ci/quality/validate-runner-contract.sh` (covered
+by BATS). See [reusable-workflows.md](reusable-workflows.md#runner-pinning) for
+caller examples including `runner-map`.
 
 See [reusable-workflows.md](reusable-workflows.md) (CodeQL build-mode) for
 interpreted-language scanning guidance.
@@ -804,7 +840,7 @@ removing stale entries. Expired suppressions fail the job for manual review.
 | `egress-preset`          | `osv-scanner`                                        | `github-tooling` + release assets + OSV APIs    |
 | `allowed-endpoints-mode` | `append`                                             | Merge preset with caller-specific endpoints     |
 | `workflow-file`          | empty                                                | Caller workflow filename for auto-PR footer     |
-| `runner-image`           | `ubuntu-latest`                                      | Linux runners only (`install-osv-scanner.sh`)   |
+| `runner-image`           | `ubuntu-24.04`                                       | Linux runners only (`install-osv-scanner.sh`)   |
 
 <!-- markdownlint-enable MD013 MD060 -->
 

--- a/scripts/ci/quality/validate-runner-contract.sh
+++ b/scripts/ci/quality/validate-runner-contract.sh
@@ -82,14 +82,15 @@ def is_script_backed(content: str) -> bool:
 
 def runner_image_default(content: str) -> str | None:
     match = re.search(
-        r"runner-image:\n(?:.*\n)*?        default: \"([^\"]+)\"",
+        r"runner-image:\n(?:.*\n)*?        default: (?:\"([^\"]+)\"|'([^']+)')",
         content,
     )
-    return match.group(1) if match else None
+    if not match:
+        return None
+    return match.group(1) or match.group(2)
 
 
 violations: list[str] = []
-warnings: list[str] = []
 
 for workflow in sorted(workflows_dir.glob("reusable-*.yml")):
     content = workflow.read_text()
@@ -122,8 +123,8 @@ for workflow in sorted(workflows_dir.glob("reusable-*.yml")):
     if has_runner:
         default = runner_image_default(content)
         if default == "ubuntu-latest":
-            warnings.append(
-                f"{rel}: runner-image default should be ubuntu-24.04 (found ubuntu-latest)",
+            violations.append(
+                f"{rel}: runner-image default must be ubuntu-24.04 (found ubuntu-latest)",
             )
         for job_id, runs_on in jobs.items():
             if runs_on != RUNNER_IMAGE_RUNS_ON:
@@ -146,9 +147,6 @@ for workflow in sorted(workflows_dir.glob("reusable-*.yml")):
                     f"{rel}: script-backed reusable hardcodes runs-on {runs_on!r} "
                     f"on job {job_id} without runner-image input",
                 )
-
-for warning in warnings:
-    print(f"WARNING: {warning}", file=sys.stderr)
 
 if violations:
     for violation in violations:

--- a/scripts/ci/quality/validate-runner-contract.sh
+++ b/scripts/ci/quality/validate-runner-contract.sh
@@ -82,12 +82,13 @@ def is_script_backed(content: str) -> bool:
 
 def runner_image_default(content: str) -> str | None:
     match = re.search(
-        r"runner-image:\n(?:.*\n)*?        default: (?:\"([^\"]+)\"|'([^']+)')",
+        r"runner-image:\n(?:.*\n)*?"
+        r"        default: (?:\"([^\"]+)\"|'([^']+)'|([^\s#]+))",
         content,
     )
     if not match:
         return None
-    return match.group(1) or match.group(2)
+    return match.group(1) or match.group(2) or match.group(3)
 
 
 violations: list[str] = []

--- a/scripts/ci/quality/validate-runner-contract.sh
+++ b/scripts/ci/quality/validate-runner-contract.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Enforce runner-image and runner-map contract across reusable workflows.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -z "${REPO_ROOT:-}" ]]; then
+	REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+fi
+WORKFLOWS_DIR="${WORKFLOWS_DIR:-${REPO_ROOT}/.github/workflows}"
+
+if [[ ! -d "${WORKFLOWS_DIR}" ]]; then
+	echo "ERROR: workflows directory not found: ${WORKFLOWS_DIR}" >&2
+	exit 1
+fi
+
+python3 - "${WORKFLOWS_DIR}" <<'PY'
+"""Validate runner-image wiring across lgtm-ci reusable workflows."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+workflows_dir = Path(sys.argv[1])
+
+RUNNER_PINNING_EXCEPTIONS = {
+    "reusable-codeql.yml",
+    "reusable-dependency-review.yml",
+    "reusable-scorecards.yml",
+    "reusable-semantic-pr-title.yml",
+    "reusable-pr-labeler.yml",
+    "reusable-publish-npm.yml",
+    "reusable-publish-gem.yml",
+}
+
+DOCKER_FILE = "reusable-docker.yml"
+DOCKER_INTERNAL_JOBS = {
+    "classify",
+    "build",
+    "merge",
+    "summary-validate",
+    "scan",
+}
+DOCKER_MATRIX_RUNS_ON = {"${{ matrix.runner }}"}
+RUNNER_IMAGE_RUNS_ON = "${{ inputs.runner-image }}"
+
+
+def parse_jobs(content: str) -> dict[str, str]:
+    """Return job id -> runs-on expression for each job in the workflow."""
+    jobs_match = re.search(r"^jobs:\n", content, re.M)
+    if not jobs_match:
+        return {}
+
+    jobs_section = content[jobs_match.end() :]
+    jobs: dict[str, str] = {}
+    for match in re.finditer(
+        r"^  ([\w-]+):\n(.*?)(?=^  [\w-]+:\n|\Z)",
+        jobs_section,
+        re.M | re.S,
+    ):
+        job_id = match.group(1)
+        block = match.group(2)
+        runs_match = re.search(r"^    runs-on: (.+)$", block, re.M)
+        if runs_match:
+            jobs[job_id] = runs_match.group(1).strip()
+    return jobs
+
+
+def has_runner_image_input(content: str) -> bool:
+    return bool(re.search(r"^\s+runner-image:", content, re.M))
+
+
+def has_runner_map_input(content: str) -> bool:
+    return bool(re.search(r"^\s+runner-map:", content, re.M))
+
+
+def is_script_backed(content: str) -> bool:
+    return "scripts/ci/" in content
+
+
+def runner_image_default(content: str) -> str | None:
+    match = re.search(
+        r"runner-image:\n(?:.*\n)*?        default: \"([^\"]+)\"",
+        content,
+    )
+    return match.group(1) if match else None
+
+
+violations: list[str] = []
+warnings: list[str] = []
+
+for workflow in sorted(workflows_dir.glob("reusable-*.yml")):
+    content = workflow.read_text()
+    rel = workflow.name
+    jobs = parse_jobs(content)
+    has_runner = has_runner_image_input(content)
+
+    if rel == DOCKER_FILE:
+        if not has_runner_map_input(content):
+            violations.append(f"{rel}: missing runner-map input")
+        for job_id, runs_on in jobs.items():
+            if runs_on in DOCKER_MATRIX_RUNS_ON:
+                continue
+            if job_id in DOCKER_INTERNAL_JOBS:
+                if runs_on != "ubuntu-24.04":
+                    violations.append(
+                        f"{rel}: job {job_id} must use ubuntu-24.04 coordinator runner "
+                        f"(found {runs_on!r})",
+                    )
+                continue
+            if re.fullmatch(r"ubuntu-[\w.-]+", runs_on):
+                violations.append(
+                    f"{rel}: job {job_id} hardcodes runs-on {runs_on!r}",
+                )
+        continue
+
+    if rel in RUNNER_PINNING_EXCEPTIONS:
+        continue
+
+    if has_runner:
+        default = runner_image_default(content)
+        if default == "ubuntu-latest":
+            warnings.append(
+                f"{rel}: runner-image default should be ubuntu-24.04 (found ubuntu-latest)",
+            )
+        for job_id, runs_on in jobs.items():
+            if runs_on != RUNNER_IMAGE_RUNS_ON:
+                if re.fullmatch(r"ubuntu-[\w.-]+", runs_on):
+                    violations.append(
+                        f"{rel}: job {job_id} hardcodes runs-on {runs_on!r} "
+                        f"but runner-image input is defined",
+                    )
+                elif "${{ matrix." not in runs_on:
+                    violations.append(
+                        f"{rel}: job {job_id} runs-on {runs_on!r} "
+                        f"must use ${{ inputs.runner-image }}",
+                    )
+        continue
+
+    if is_script_backed(content):
+        for job_id, runs_on in jobs.items():
+            if re.fullmatch(r"ubuntu-[\w.-]+", runs_on):
+                violations.append(
+                    f"{rel}: script-backed reusable hardcodes runs-on {runs_on!r} "
+                    f"on job {job_id} without runner-image input",
+                )
+
+for warning in warnings:
+    print(f"WARNING: {warning}", file=sys.stderr)
+
+if violations:
+    for violation in violations:
+        print(violation, file=sys.stderr)
+    print(
+        f"ERROR: {len(violations)} reusable workflow runner contract violation(s)",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print("OK: reusable workflow runner contract satisfied")
+PY

--- a/tests/bats/integration/test_reusable_runner_contract.bats
+++ b/tests/bats/integration/test_reusable_runner_contract.bats
@@ -90,6 +90,54 @@ YAML
 	assert_success
 }
 
+@test "validate-runner-contract: flags ubuntu-latest runner-image default (double quotes)" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	mkdir -p "${workflows_dir}"
+	cat >"${workflows_dir}/reusable-latest-default-bad.yml" <<'YAML'
+---
+name: Latest default bad example
+on:
+  workflow_call:
+    inputs:
+      runner-image:
+        type: string
+        default: "ubuntu-latest"
+jobs:
+  work:
+    runs-on: ${{ inputs.runner-image }}
+    steps:
+      - run: echo ok
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" run "${VALIDATOR}"
+	assert_failure
+	assert_output --partial "runner-image default must be ubuntu-24.04"
+}
+
+@test "validate-runner-contract: flags ubuntu-latest runner-image default (single quotes)" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	mkdir -p "${workflows_dir}"
+	cat >"${workflows_dir}/reusable-latest-default-single-quote-bad.yml" <<'YAML'
+---
+name: Latest default single quote bad example
+on:
+  workflow_call:
+    inputs:
+      runner-image:
+        type: string
+        default: 'ubuntu-latest'
+jobs:
+  work:
+    runs-on: ${{ inputs.runner-image }}
+    steps:
+      - run: echo ok
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" run "${VALIDATOR}"
+	assert_failure
+	assert_output --partial "runner-image default must be ubuntu-24.04"
+}
+
 @test "reusable-release-version-pr: exposes runner-image on all jobs" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
 	run grep -F 'runner-image:' "$workflow"

--- a/tests/bats/integration/test_reusable_runner_contract.bats
+++ b/tests/bats/integration/test_reusable_runner_contract.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for runner-image and runner-map reusable workflow policy
+
+load "../../helpers/common"
+
+VALIDATOR="${PROJECT_ROOT}/scripts/ci/quality/validate-runner-contract.sh"
+
+@test "validate-runner-contract: passes on repository reusables" {
+	run "${VALIDATOR}"
+	assert_success
+	assert_output --partial "OK:"
+}
+
+@test "validate-runner-contract: flags script-backed reusable without runner-image" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	mkdir -p "${workflows_dir}"
+	cat >"${workflows_dir}/reusable-script-backed-bad.yml" <<'YAML'
+---
+name: Script backed bad example
+on:
+  workflow_call:
+    inputs:
+      tooling-ref:
+        type: string
+        default: ""
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@v4
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          sparse-checkout: |
+            scripts/ci/
+      - run: .lgtm-ci-tooling/scripts/ci/example.sh
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" run "${VALIDATOR}"
+	assert_failure
+	assert_output --partial "without runner-image input"
+}
+
+@test "validate-runner-contract: flags incomplete runner-image wiring" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	mkdir -p "${workflows_dir}"
+	cat >"${workflows_dir}/reusable-partial-wiring-bad.yml" <<'YAML'
+---
+name: Partial wiring bad example
+on:
+  workflow_call:
+    inputs:
+      runner-image:
+        type: string
+        default: "ubuntu-24.04"
+jobs:
+  work:
+    runs-on: ${{ inputs.runner-image }}
+    steps:
+      - run: echo ok
+  aggregate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo aggregate
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" run "${VALIDATOR}"
+	assert_failure
+	assert_output --partial "hardcodes runs-on"
+}
+
+@test "validate-runner-contract: allows documented action-only exception" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	mkdir -p "${workflows_dir}"
+	cp "${PROJECT_ROOT}/.github/workflows/reusable-codeql.yml" "${workflows_dir}/"
+
+	WORKFLOWS_DIR="${workflows_dir}" run "${VALIDATOR}"
+	assert_success
+}
+
+@test "validate-runner-contract: allows docker coordinator and matrix runners" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	mkdir -p "${workflows_dir}"
+	cp "${PROJECT_ROOT}/.github/workflows/reusable-docker.yml" "${workflows_dir}/"
+
+	WORKFLOWS_DIR="${workflows_dir}" run "${VALIDATOR}"
+	assert_success
+}
+
+@test "reusable-release-version-pr: exposes runner-image on all jobs" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
+	run grep -F 'runner-image:' "$workflow"
+	assert_success
+	run awk '
+		/^  version-pr:/ { in_job = 1 }
+		/^  report-release-failure:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  version-pr:/ && !/^  report-release-failure:/ { in_job = 0 }
+		in_job && /^    runs-on: \$\{\{ inputs\.runner-image \}\}$/ { found++ }
+		END { exit found != 2 }
+	' "$workflow"
+	assert_success
+}
+
+@test "reusable-quality-lint: wires runner-image input" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-quality-lint.yml"
+	run grep -F 'default: "ubuntu-24.04"' "$workflow"
+	assert_success
+	run awk '
+		/^  quality:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  quality:/ { in_job = 0 }
+		in_job && /^    runs-on: \$\{\{ inputs\.runner-image \}\}$/ { found = 1 }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_runner_contract.bats
+++ b/tests/bats/integration/test_reusable_runner_contract.bats
@@ -138,6 +138,30 @@ YAML
 	assert_output --partial "runner-image default must be ubuntu-24.04"
 }
 
+@test "validate-runner-contract: flags ubuntu-latest runner-image default (unquoted)" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	mkdir -p "${workflows_dir}"
+	cat >"${workflows_dir}/reusable-latest-default-unquoted-bad.yml" <<'YAML'
+---
+name: Latest default unquoted bad example
+on:
+  workflow_call:
+    inputs:
+      runner-image:
+        type: string
+        default: ubuntu-latest
+jobs:
+  work:
+    runs-on: ${{ inputs.runner-image }}
+    steps:
+      - run: echo ok
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" run "${VALIDATOR}"
+	assert_failure
+	assert_output --partial "runner-image default must be ubuntu-24.04"
+}
+
 @test "reusable-release-version-pr: exposes runner-image on all jobs" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
 	run grep -F 'runner-image:' "$workflow"


### PR DESCRIPTION
## Summary

Standardize how script-backed lgtm-ci reusables expose runner selection to callers. Adds `runner-image` to workflows that hardcoded `ubuntu-latest`, wires every job in multi-job reusables, aligns defaults to `ubuntu-24.04`, documents `runner-map` and pinning exceptions, and adds automated contract enforcement.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Changes Made

- Add `runner-image` input (default `ubuntu-24.04`) to 12 script-backed reusables that lacked it, including `reusable-release-version-pr`, `reusable-quality-lint`, and `reusable-coverage`
- Wire remaining hardcoded jobs in `reusable-test-node`, `reusable-test-node-custom`, `reusable-test-python`, and `reusable-release-auto-tag`
- Align all existing `runner-image` defaults from `ubuntu-latest` to `ubuntu-24.04`
- Add `scripts/ci/quality/validate-runner-contract.sh` with BATS integration tests
- Extend `docs/workflow-contract.md` and `docs/reusable-workflows.md` with runner pinning, `runner-map`, and documented exceptions

## Closes

- Closes #338

## Testing

- [x] `uv run lintro chk` passes (zero issues)
- [x] `uv run lintro fmt` applied
- [x] BATS: `tests/bats/integration/test_reusable_runner_contract.bats` (7 tests)
- [x] `validate-runner-contract.sh` passes on all repository reusables

## Quality Checks

- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint` / `actionlint`
- [x] Documentation updated

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

Minor behavior change: script-backed reusables now default to `ubuntu-24.04` instead of `ubuntu-latest`. Callers pinning `ubuntu-24.04` explicitly are unaffected; callers relying on implicit `ubuntu-latest` drift will now get a pinned 24.04 default.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Standardize runner-image default to ubuntu-24.04 across all reusable workflows
> - Changes the default `runner-image` input from `ubuntu-latest` to `ubuntu-24.04` across all script-backed reusable workflows in `.github/workflows/`.
> - Adds `runner-image` input wiring to workflows that previously hardcoded `ubuntu-latest` directly in `runs-on`, including several multi-job workflows where only some jobs were covered.
> - Adds [validate-runner-contract.sh](https://github.com/lgtm-hq/lgtm-ci/pull/339/files#diff-4014e4bde7d778d5bb681c07106e6618ae636af7134ce84ae99cd231f596a247), a Bash/Python script that enforces runner pinning rules: script-backed reusables must declare `runner-image` with a `ubuntu-24.04` default and wire all `runs-on` to `${{ inputs.runner-image }}`; the docker reusable must use `runner-map`; named action-only and publish workflows are exempted.
> - Adds BATS integration tests in [test_reusable_runner_contract.bats](https://github.com/lgtm-hq/lgtm-ci/pull/339/files#diff-453996e78abbd1e7f51c2e6c2d71f40c7be15a0e477aaaddc3ba6d0ad80b9f8f) covering pass/fail cases for the contract validator.
> - Updates [docs/workflow-contract.md](https://github.com/lgtm-hq/lgtm-ci/pull/339/files#diff-516a439fe86a0212ef098570637d887a6ef2bb796c179416edee44bc92be0a5f) and [docs/reusable-workflows.md](https://github.com/lgtm-hq/lgtm-ci/pull/339/files#diff-3065010f73cb977ea6196048bf72137713f96a721704c83feab3b5e53216f40b) to document `runner-image` and `runner-map` contracts, pinning guidance, and exceptions.
> - Behavioral Change: any workflow that previously resolved `ubuntu-latest` to a non-24.04 runner will now pin to `ubuntu-24.04` explicitly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66e8c64.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reusable CI workflows now expose a configurable runner image and default to Ubuntu 24.04 for consistent runner selection.

* **Documentation**
  * Added runner pinning guidance, updated workflow contract and consumer guidance, and noted exceptions and best practices.

* **Tests**
  * Added CI validation and integration tests to enforce consistent runner-image defaults and wiring across reusable workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR standardizes runner selection across 32 script-backed reusable workflows by adding a `runner-image` input (default `ubuntu-24.04`) to workflows that lacked it, wiring previously hardcoded `ubuntu-latest` jobs to the new input, and adding a contract-enforcement script with BATS tests.

- Adds `runner-image` to 12 new reusables and completes multi-job wiring in `reusable-test-node`, `reusable-test-node-custom`, `reusable-test-python`, `reusable-coverage`, `reusable-release-auto-tag`, and `reusable-release-version-pr`; all existing defaults are migrated from `ubuntu-latest` to `ubuntu-24.04`.
- Adds `scripts/ci/quality/validate-runner-contract.sh` (Python/regex via heredoc) plus 9 BATS integration tests to block future regressions; documents the `runner-map` pattern for Docker multi-arch builds and a table of intentional exceptions.
- The validator has three regex parsing gaps: `has_runner_image_input` matches `runner-image:` in step `with:` blocks (false violation), `parse_jobs` silently drops jobs with list/multiline `runs-on` (false pass), and quoted `runs-on` expressions fail the equality check (false violation).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the workflow changes are mechanical and consistent, and the contract validator correctly enforces the new defaults against the current repository state.

All 32 workflow changes are straightforward input additions and runs-on rewires with no logic changes. The validator script and BATS tests are new tooling, not runtime-critical paths. The three regex edge cases flagged are quality improvements for future-proofing the validator, not gaps that affect any workflow currently in the repository.

scripts/ci/quality/validate-runner-contract.sh — the has_runner_image_input, parse_jobs, and RUNNER_IMAGE_RUNS_ON equality logic have edge cases that could produce false positives or silently miss violations as the repo evolves.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/quality/validate-runner-contract.sh | New contract-enforcement script using Python/regex; has three parsing edge cases: has_runner_image_input matches step with: blocks (false-positive), parse_jobs silently drops list/multiline runs-on (false-negative), and quoted inputs.runner-image fails equality check (false-positive violation). |
| tests/bats/integration/test_reusable_runner_contract.bats | Good coverage of pass/fail scenarios; does not cover the list-format runs-on or quoted expression edge cases. |
| .github/workflows/reusable-release-version-pr.yml | Adds runner-image input with ubuntu-24.04 default; correctly wires both version-pr and report-release-failure jobs. |
| .github/workflows/reusable-test-node.yml | Changes default from ubuntu-latest to ubuntu-24.04 and wires the two previously-hardcoded secondary jobs to inputs.runner-image. |
| .github/workflows/reusable-coverage.yml | Adds runner-image input and wires both coverage and publish-coverage jobs correctly. |
| docs/workflow-contract.md | Adds runner-pinning section with exception table, runner-map semantics, and updated default documentation from ubuntu-latest to ubuntu-24.04. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[validate-runner-contract.sh] --> B[python3 heredoc]
    B --> C{For each reusable-*.yml}
    C --> D{reusable-docker.yml?}
    D -->|Yes| E[Check runner-map input]
    D -->|No| F{In RUNNER_PINNING_EXCEPTIONS?}
    F -->|Yes| G[Skip]
    F -->|No| H{has_runner_image_input?}
    H -->|Yes| I[Check default and job wiring]
    H -->|No| J{is_script_backed?}
    J -->|Yes| K[Flag hardcoded ubuntu-*]
    J -->|No| L[No check]
    I --> M{violations?}
    K --> M
    E --> M
    M -->|Yes| N[Exit 1]
    M -->|No| O[Exit 0 OK]
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fci%2Fquality%2Fvalidate-runner-contract.sh%3A71-72%0A**%60has_runner_image_input%60%20matches%20%60runner-image%3A%60%20in%20step%20%60with%3A%60%20blocks**%0A%0AThe%20regex%20%60%5E%5Cs%2Brunner-image%3A%60%20fires%20anywhere%20in%20the%20file%2C%20not%20just%20inside%20%60on.workflow_call.inputs%60.%20If%20a%20future%20workflow%20passes%20%60runner-image%3A%60%20as%20a%20parameter%20to%20a%20composite%20action%20but%20does%20not%20declare%20it%20as%20a%20%60workflow_call%60%20input%2C%20%60has_runner%60%20returns%20%60True%60%2C%20the%20job-wiring%20checks%20run%2C%20and%20every%20job%20that%20doesn't%20use%20%60%24%7B%7B%20inputs.runner-image%20%7D%7D%60%20gets%20a%20false%20violation.%20Anchoring%20the%20search%20to%20the%20inputs%20block%20would%20close%20this%20gap.%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Fci%2Fquality%2Fvalidate-runner-contract.sh%3A65-67%0A**%60parse_jobs%60%20silently%20omits%20jobs%20with%20multiline%20or%20list-format%20%60runs-on%60**%0A%0AThe%20regex%20%60r%22%5E%20%20%20%20runs-on%3A%20%28.%2B%29%24%22%60%20only%20captures%20%60runs-on%60%20when%20the%20value%20is%20on%20the%20same%20line.%20GitHub%20Actions%20also%20accepts%20the%20block-sequence%20form%20%28%60runs-on%3A%5Cn%20%20-%20ubuntu-latest%60%29.%20A%20job%20written%20this%20way%20produces%20no%20entry%20in%20the%20returned%20dict%2C%20so%20the%20validator%20skips%20the%20entire%20job%20%E2%80%94%20a%20hardcoded%20runner%20would%20pass%20silently.%0A%0A%23%23%23%20Issue%203%20of%203%0Ascripts%2Fci%2Fquality%2Fvalidate-runner-contract.sh%3A130-141%0A**Quoted%20%60runs-on%60%20expression%20produces%20a%20false%20violation**%0A%0A%60parse_jobs%60%20captures%20the%20raw%20YAML%20text%20after%20%60runs-on%3A%60%20without%20stripping%20YAML%20quotes.%20If%20a%20workflow%20uses%20%60runs-on%3A%20%22%24%7B%7B%20inputs.runner-image%20%7D%7D%22%60%20%28valid%20double-quoted%20YAML%29%2C%20the%20captured%20value%20includes%20the%20surrounding%20quotes%20and%20does%20not%20equal%20%60RUNNER_IMAGE_RUNS_ON%60.%20The%20validator%20then%20falls%20into%20the%20%60elif%60%20branch%20and%20emits%20a%20false%20%60must%20use%20%24%7B%7B%20inputs.runner-image%20%7D%7D%60%20violation%20on%20a%20correctly-wired%20job.%0A%0A&pr=339&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fci%2Fquality%2Fvalidate-runner-contract.sh%3A71-72%0A**%60has_runner_image_input%60%20matches%20%60runner-image%3A%60%20in%20step%20%60with%3A%60%20blocks**%0A%0AThe%20regex%20%60%5E%5Cs%2Brunner-image%3A%60%20fires%20anywhere%20in%20the%20file%2C%20not%20just%20inside%20%60on.workflow_call.inputs%60.%20If%20a%20future%20workflow%20passes%20%60runner-image%3A%60%20as%20a%20parameter%20to%20a%20composite%20action%20but%20does%20not%20declare%20it%20as%20a%20%60workflow_call%60%20input%2C%20%60has_runner%60%20returns%20%60True%60%2C%20the%20job-wiring%20checks%20run%2C%20and%20every%20job%20that%20doesn't%20use%20%60%24%7B%7B%20inputs.runner-image%20%7D%7D%60%20gets%20a%20false%20violation.%20Anchoring%20the%20search%20to%20the%20inputs%20block%20would%20close%20this%20gap.%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Fci%2Fquality%2Fvalidate-runner-contract.sh%3A65-67%0A**%60parse_jobs%60%20silently%20omits%20jobs%20with%20multiline%20or%20list-format%20%60runs-on%60**%0A%0AThe%20regex%20%60r%22%5E%20%20%20%20runs-on%3A%20%28.%2B%29%24%22%60%20only%20captures%20%60runs-on%60%20when%20the%20value%20is%20on%20the%20same%20line.%20GitHub%20Actions%20also%20accepts%20the%20block-sequence%20form%20%28%60runs-on%3A%5Cn%20%20-%20ubuntu-latest%60%29.%20A%20job%20written%20this%20way%20produces%20no%20entry%20in%20the%20returned%20dict%2C%20so%20the%20validator%20skips%20the%20entire%20job%20%E2%80%94%20a%20hardcoded%20runner%20would%20pass%20silently.%0A%0A%23%23%23%20Issue%203%20of%203%0Ascripts%2Fci%2Fquality%2Fvalidate-runner-contract.sh%3A130-141%0A**Quoted%20%60runs-on%60%20expression%20produces%20a%20false%20violation**%0A%0A%60parse_jobs%60%20captures%20the%20raw%20YAML%20text%20after%20%60runs-on%3A%60%20without%20stripping%20YAML%20quotes.%20If%20a%20workflow%20uses%20%60runs-on%3A%20%22%24%7B%7B%20inputs.runner-image%20%7D%7D%22%60%20%28valid%20double-quoted%20YAML%29%2C%20the%20captured%20value%20includes%20the%20surrounding%20quotes%20and%20does%20not%20equal%20%60RUNNER_IMAGE_RUNS_ON%60.%20The%20validator%20then%20falls%20into%20the%20%60elif%60%20branch%20and%20emits%20a%20false%20%60must%20use%20%24%7B%7B%20inputs.runner-image%20%7D%7D%60%20violation%20on%20a%20correctly-wired%20job.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=339&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22chore%2F338-standardize-runner-image-runner-map-contract%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2F338-standardize-runner-image-runner-map-contract%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fci%2Fquality%2Fvalidate-runner-contract.sh%3A71-72%0A**%60has_runner_image_input%60%20matches%20%60runner-image%3A%60%20in%20step%20%60with%3A%60%20blocks**%0A%0AThe%20regex%20%60%5E%5Cs%2Brunner-image%3A%60%20fires%20anywhere%20in%20the%20file%2C%20not%20just%20inside%20%60on.workflow_call.inputs%60.%20If%20a%20future%20workflow%20passes%20%60runner-image%3A%60%20as%20a%20parameter%20to%20a%20composite%20action%20but%20does%20not%20declare%20it%20as%20a%20%60workflow_call%60%20input%2C%20%60has_runner%60%20returns%20%60True%60%2C%20the%20job-wiring%20checks%20run%2C%20and%20every%20job%20that%20doesn't%20use%20%60%24%7B%7B%20inputs.runner-image%20%7D%7D%60%20gets%20a%20false%20violation.%20Anchoring%20the%20search%20to%20the%20inputs%20block%20would%20close%20this%20gap.%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Fci%2Fquality%2Fvalidate-runner-contract.sh%3A65-67%0A**%60parse_jobs%60%20silently%20omits%20jobs%20with%20multiline%20or%20list-format%20%60runs-on%60**%0A%0AThe%20regex%20%60r%22%5E%20%20%20%20runs-on%3A%20%28.%2B%29%24%22%60%20only%20captures%20%60runs-on%60%20when%20the%20value%20is%20on%20the%20same%20line.%20GitHub%20Actions%20also%20accepts%20the%20block-sequence%20form%20%28%60runs-on%3A%5Cn%20%20-%20ubuntu-latest%60%29.%20A%20job%20written%20this%20way%20produces%20no%20entry%20in%20the%20returned%20dict%2C%20so%20the%20validator%20skips%20the%20entire%20job%20%E2%80%94%20a%20hardcoded%20runner%20would%20pass%20silently.%0A%0A%23%23%23%20Issue%203%20of%203%0Ascripts%2Fci%2Fquality%2Fvalidate-runner-contract.sh%3A130-141%0A**Quoted%20%60runs-on%60%20expression%20produces%20a%20false%20violation**%0A%0A%60parse_jobs%60%20captures%20the%20raw%20YAML%20text%20after%20%60runs-on%3A%60%20without%20stripping%20YAML%20quotes.%20If%20a%20workflow%20uses%20%60runs-on%3A%20%22%24%7B%7B%20inputs.runner-image%20%7D%7D%22%60%20%28valid%20double-quoted%20YAML%29%2C%20the%20captured%20value%20includes%20the%20surrounding%20quotes%20and%20does%20not%20equal%20%60RUNNER_IMAGE_RUNS_ON%60.%20The%20validator%20then%20falls%20into%20the%20%60elif%60%20branch%20and%20emits%20a%20false%20%60must%20use%20%24%7B%7B%20inputs.runner-image%20%7D%7D%60%20violation%20on%20a%20correctly-wired%20job.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=339&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): detect unquoted ubuntu-latest r..."](https://github.com/lgtm-hq/lgtm-ci/commit/66e8c649bacee5d2914a5b277010b1e68c87568f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36527816)</sub>

<!-- /greptile_comment -->