### PR TITLE
fix(release): align changelog generator with Keep a Changelog sections

### DIFF
--- a/scripts/ci/lib/release/changelog.sh
+++ b/scripts/ci/lib/release/changelog.sh
@@ -137,16 +137,17 @@ generate_changelog() {
 		esac
 	done <<<"$commits_output"
 
-	# Generate sections (breaking changes first)
-	generate_changelog_section "Breaking Changes" "$breaking_commits" "$format"
-	generate_changelog_section "Features" "$feat_commits" "$format"
-	generate_changelog_section "Bug Fixes" "$fix_commits" "$format"
-	generate_changelog_section "Documentation" "$docs_commits" "$format"
-
-	# Only include "Other" if explicitly requested
-	if [[ "$format" == "full" ]] && [[ -n "$other_commits" ]]; then
-		generate_changelog_section "Other Changes" "$other_commits" "$format"
+	local changed_commits=""
+	changed_commits+="$breaking_commits"
+	changed_commits+="$docs_commits"
+	if [[ "$format" == "full" ]]; then
+		changed_commits+="$other_commits"
 	fi
+
+	# Keep a Changelog standard section headings
+	generate_changelog_section "Added" "$feat_commits" "$format"
+	generate_changelog_section "Changed" "$changed_commits" "$format"
+	generate_changelog_section "Fixed" "$fix_commits" "$format"
 }
 
 # Generate release notes (more concise than changelog)

--- a/scripts/ci/lib/release/changelog_merge.sh
+++ b/scripts/ci/lib/release/changelog_merge.sh
@@ -112,7 +112,7 @@ parse_changelog_body() {
 			continue
 		fi
 
-		if [[ -z "$current_section" && ! "$line" =~ ^[-*+] ]]; then
+		if [[ -z "$current_section" && ! "$line" =~ ^[[:space:]]*[-*+] ]]; then
 			if [[ -n "$_MERGE_PROSE" ]]; then
 				_MERGE_PROSE+=$'\n'
 			fi

--- a/scripts/ci/lib/release/changelog_merge.sh
+++ b/scripts/ci/lib/release/changelog_merge.sh
@@ -95,18 +95,15 @@ parse_changelog_body() {
 			continue
 		fi
 
+		if [[ "$line" =~ ^\[ ]]; then
+			continue
+		fi
+
 		if $in_breaking; then
-			if [[ "$line" =~ ^\[ ]]; then
-				continue
-			fi
 			if [[ -n "$_MERGE_BREAKING" ]]; then
 				_MERGE_BREAKING+=$'\n'
 			fi
 			_MERGE_BREAKING+="$line"
-			continue
-		fi
-
-		if [[ "$line" =~ ^\[ ]]; then
 			continue
 		fi
 

--- a/scripts/ci/lib/release/changelog_merge.sh
+++ b/scripts/ci/lib/release/changelog_merge.sh
@@ -73,15 +73,14 @@ parse_changelog_body() {
 	_reset_merge_state
 
 	while IFS= read -r line || [[ -n "$line" ]]; do
-		if [[ "$line" =~ ^###\ [Bb]reaking\ [Cc]hanges$ ]]; then
-			in_breaking=true
-			current_section=""
-			continue
-		fi
-
 		if [[ "$line" =~ ^###\ (.+)$ ]]; then
 			in_breaking=false
 			heading="${BASH_REMATCH[1]}"
+			if [[ "$heading" =~ ^[Bb]reaking\ [Cc]hanges$ ]]; then
+				in_breaking=true
+				current_section=""
+				continue
+			fi
 			if [[ "$heading" == "Previously Unreleased" ]]; then
 				current_section="$_KAC_DEFAULT_SECTION"
 				continue
@@ -95,7 +94,7 @@ parse_changelog_body() {
 			continue
 		fi
 
-		if [[ "$line" =~ ^\[ ]]; then
+		if [[ "$line" =~ ^\[[^]]+\]: ]]; then
 			continue
 		fi
 

--- a/scripts/ci/lib/release/changelog_merge.sh
+++ b/scripts/ci/lib/release/changelog_merge.sh
@@ -96,6 +96,9 @@ parse_changelog_body() {
 		fi
 
 		if $in_breaking; then
+			if [[ "$line" =~ ^\[ ]]; then
+				continue
+			fi
 			if [[ -n "$_MERGE_BREAKING" ]]; then
 				_MERGE_BREAKING+=$'\n'
 			fi
@@ -111,7 +114,7 @@ parse_changelog_body() {
 			continue
 		fi
 
-		if [[ -z "$current_section" && ! "$line" =~ ^- ]]; then
+		if [[ -z "$current_section" && ! "$line" =~ ^[-*+] ]]; then
 			if [[ -n "$_MERGE_PROSE" ]]; then
 				_MERGE_PROSE+=$'\n'
 			fi

--- a/scripts/ci/lib/release/changelog_merge.sh
+++ b/scripts/ci/lib/release/changelog_merge.sh
@@ -68,7 +68,7 @@ parse_changelog_body() {
 	local body="${1:-}"
 	local current_section=""
 	local in_breaking=false
-	local line heading normalized
+	local line heading trimmed_heading normalized
 
 	_reset_merge_state
 
@@ -76,16 +76,18 @@ parse_changelog_body() {
 		if [[ "$line" =~ ^###\ (.+)$ ]]; then
 			in_breaking=false
 			heading="${BASH_REMATCH[1]}"
-			if [[ "$heading" =~ ^[Bb]reaking\ [Cc]hanges$ ]]; then
+			trimmed_heading="${heading#"${heading%%[![:space:]]*}"}"
+			trimmed_heading="${trimmed_heading%"${trimmed_heading##*[![:space:]]}"}"
+			if [[ "$trimmed_heading" =~ ^[Bb]reaking\ [Cc]hanges$ ]]; then
 				in_breaking=true
 				current_section=""
 				continue
 			fi
-			if [[ "$heading" == "Previously Unreleased" ]]; then
+			if [[ "$trimmed_heading" == "Previously Unreleased" ]]; then
 				current_section="$_KAC_DEFAULT_SECTION"
 				continue
 			fi
-			normalized=$(normalize_kac_section "$heading")
+			normalized=$(normalize_kac_section "$trimmed_heading")
 			if [[ -n "$normalized" ]]; then
 				current_section="$normalized"
 			else
@@ -106,7 +108,7 @@ parse_changelog_body() {
 			continue
 		fi
 
-		if [[ -z "$current_section" && -z "$line" ]]; then
+		if [[ -z "$current_section" && -z "$line" && -z "$_MERGE_PROSE" ]]; then
 			continue
 		fi
 

--- a/scripts/ci/lib/release/changelog_merge.sh
+++ b/scripts/ci/lib/release/changelog_merge.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Merge Keep a Changelog section bodies for release automation
+#
+# Combines auto-generated and hand-curated changelog content under the standard
+# Keep a Changelog section headings (Added, Changed, Deprecated, Removed, Fixed,
+# Security).
+
+# Guard against multiple sourcing
+[[ -n "${_RELEASE_CHANGELOG_MERGE_LOADED:-}" ]] && return 0
+readonly _RELEASE_CHANGELOG_MERGE_LOADED=1
+
+readonly _KAC_SECTION_ORDER=(
+	"Added"
+	"Changed"
+	"Deprecated"
+	"Removed"
+	"Fixed"
+	"Security"
+)
+
+readonly _KAC_DEFAULT_SECTION="Changed"
+
+# Normalize a ### heading to a Keep a Changelog section name when recognized.
+# Usage: normalize_kac_section "Features"
+normalize_kac_section() {
+	local heading="${1:-}"
+
+	case "$heading" in
+	Added | Features) echo "Added" ;;
+	Changed | "Breaking Changes" | Documentation | "Other Changes") echo "Changed" ;;
+	Deprecated) echo "Deprecated" ;;
+	Removed) echo "Removed" ;;
+	Fixed | "Bug Fixes") echo "Fixed" ;;
+	Security) echo "Security" ;;
+	*) echo "" ;;
+	esac
+}
+
+# Reset parse scratch variables (generated/final accumulators are managed by merge).
+_reset_merge_state() {
+	_MERGE_PROSE=""
+	_MERGE_BREAKING=""
+	for section in "${_KAC_SECTION_ORDER[@]}"; do
+		eval "_MERGE_SECTION_${section}=''"
+	done
+}
+
+# Append a line to a named KaC section accumulator.
+_append_to_section() {
+	local section="${1:-}"
+	local line="${2:-}"
+	local current_value
+
+	[[ -z "$section" ]] && return
+
+	eval "current_value=\"\${_MERGE_SECTION_${section}:-}\""
+	if [[ -n "$current_value" ]]; then
+		current_value+=$'\n'
+	fi
+	current_value+="$line"
+	eval "_MERGE_SECTION_${section}=\$current_value"
+}
+
+# Parse changelog body content into section arrays and prose/breaking blocks.
+# Usage: parse_changelog_body "$body"
+parse_changelog_body() {
+	local body="${1:-}"
+	local current_section=""
+	local in_breaking=false
+	local line heading normalized
+
+	_reset_merge_state
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		if [[ "$line" =~ ^###\ [Bb]reaking\ [Cc]hanges$ ]]; then
+			in_breaking=true
+			current_section=""
+			continue
+		fi
+
+		if [[ "$line" =~ ^###\ (.+)$ ]]; then
+			in_breaking=false
+			heading="${BASH_REMATCH[1]}"
+			if [[ "$heading" == "Previously Unreleased" ]]; then
+				current_section="$_KAC_DEFAULT_SECTION"
+				continue
+			fi
+			normalized=$(normalize_kac_section "$heading")
+			if [[ -n "$normalized" ]]; then
+				current_section="$normalized"
+			else
+				current_section="$_KAC_DEFAULT_SECTION"
+			fi
+			continue
+		fi
+
+		if $in_breaking; then
+			if [[ -n "$_MERGE_BREAKING" ]]; then
+				_MERGE_BREAKING+=$'\n'
+			fi
+			_MERGE_BREAKING+="$line"
+			continue
+		fi
+
+		if [[ "$line" =~ ^\[ ]]; then
+			continue
+		fi
+
+		if [[ -z "$current_section" && -z "$line" ]]; then
+			continue
+		fi
+
+		if [[ -z "$current_section" && ! "$line" =~ ^- ]]; then
+			if [[ -n "$_MERGE_PROSE" ]]; then
+				_MERGE_PROSE+=$'\n'
+			fi
+			_MERGE_PROSE+="$line"
+			continue
+		fi
+
+		if [[ -z "$current_section" ]]; then
+			current_section="$_KAC_DEFAULT_SECTION"
+		fi
+
+		_append_to_section "$current_section" "$line"
+	done <<<"$body"
+}
+
+# Merge generated and hand-curated changelog bodies into standard sections.
+# Usage: merge_changelog_sections "$generated_body" "$existing_unreleased"
+merge_changelog_sections() {
+	local generated="${1:-}"
+	local existing="${2:-}"
+	local section left right merged output=""
+
+	if [[ -z "$generated" && -z "$existing" ]]; then
+		return 0
+	fi
+
+	parse_changelog_body "$generated"
+	_MERGE_GENERATED_PROSE="$_MERGE_PROSE"
+	_MERGE_GENERATED_BREAKING="$_MERGE_BREAKING"
+	for section in "${_KAC_SECTION_ORDER[@]}"; do
+		eval "_MERGE_GENERATED_${section}=\"\${_MERGE_SECTION_${section}:-}\""
+	done
+
+	parse_changelog_body "$existing"
+	local existing_prose="$_MERGE_PROSE"
+	local existing_breaking="$_MERGE_BREAKING"
+
+	if [[ -n "$_MERGE_GENERATED_PROSE" && -n "$existing_prose" ]]; then
+		_MERGE_PROSE="${_MERGE_GENERATED_PROSE}"$'\n'"${existing_prose}"
+	elif [[ -n "$_MERGE_GENERATED_PROSE" ]]; then
+		_MERGE_PROSE="$_MERGE_GENERATED_PROSE"
+	else
+		_MERGE_PROSE="$existing_prose"
+	fi
+
+	if [[ -n "$_MERGE_GENERATED_BREAKING" && -n "$existing_breaking" ]]; then
+		_MERGE_BREAKING="${_MERGE_GENERATED_BREAKING}"$'\n'"${existing_breaking}"
+	elif [[ -n "$_MERGE_GENERATED_BREAKING" ]]; then
+		_MERGE_BREAKING="$_MERGE_GENERATED_BREAKING"
+	else
+		_MERGE_BREAKING="$existing_breaking"
+	fi
+
+	for section in "${_KAC_SECTION_ORDER[@]}"; do
+		eval "left=\"\${_MERGE_GENERATED_${section}:-}\""
+		eval "right=\"\${_MERGE_SECTION_${section}:-}\""
+		merged=""
+		if [[ -n "$left" && -n "$right" ]]; then
+			merged="${left}"$'\n'"${right}"
+		elif [[ -n "$left" ]]; then
+			merged="$left"
+		else
+			merged="$right"
+		fi
+		eval "_MERGE_FINAL_${section}=\$merged"
+	done
+
+	if [[ -n "$_MERGE_PROSE" ]]; then
+		output="$_MERGE_PROSE"
+	fi
+
+	for section in "${_KAC_SECTION_ORDER[@]}"; do
+		eval "merged=\"\${_MERGE_FINAL_${section}:-}\""
+		[[ -z "$merged" ]] && continue
+		if [[ -n "$output" ]]; then
+			output+=$'\n\n'
+		fi
+		output+="### ${section}"$'\n\n'"${merged}"
+	done
+
+	if [[ -n "$_MERGE_BREAKING" ]]; then
+		if [[ -n "$output" ]]; then
+			output+=$'\n\n'
+		fi
+		output+="### Breaking changes"$'\n\n'"${_MERGE_BREAKING}"
+	fi
+
+	printf '%s' "$output"
+}

--- a/scripts/ci/release/update-changelog.sh
+++ b/scripts/ci/release/update-changelog.sh
@@ -25,6 +25,8 @@ LIB_DIR="$SCRIPT_DIR/../lib"
 source "$LIB_DIR/log.sh"
 # shellcheck source=../lib/github.sh
 source "$LIB_DIR/github.sh"
+# shellcheck source=../lib/release/changelog_merge.sh
+source "$LIB_DIR/release/changelog_merge.sh"
 
 : "${VERSION:?VERSION is required}"
 : "${CHANGELOG_BODY=}"
@@ -96,97 +98,15 @@ capture && /^## \[/ { exit }
 capture { print }
 ' "$CHANGELOG_FILE")
 
-# Hand-curated bullets only (including indented continuation lines). Table rows,
-# prose, and ### Breaking changes blocks are extracted separately (MD032).
-EXISTING_ENTRIES=$(
-	echo "$EXISTING_UNRELEASED" | awk '
-		/^### / { if (in_bullet) print ""; in_bullet = 0; next }
-		/^\[/ { next }
-		/^$/ { if (in_bullet) print ""; in_bullet = 0; next }
-		/^-/ { if (in_bullet) print ""; print; in_bullet = 1; next }
-		in_bullet && /^[[:space:]]/ { print; next }
-		{ if (in_bullet) print ""; in_bullet = 0 }
-	'
-) || true
-
-# Prose lines (e.g. "Target release: …") outside Keep-a-Changelog sub-sections.
-EXISTING_PROSE=$(
-	echo "$EXISTING_UNRELEASED" | awk '
-		/^### [Bb]reaking changes/ { exit }
-		/^### / { next }
-		/^\[/ { next }
-		/^$/ { next }
-		/^\|/ { next }
-		/^-/ { next }
-		/^[[:space:]]/ { next }
-		{ print }
-	'
-) || true
-
-# Migration table and trailing docs link under ### Breaking changes.
-EXISTING_BREAKING=$(
-	echo "$EXISTING_UNRELEASED" | awk '
-		/^### [Bb]reaking changes/ { capture = 1; next }
-		capture && /^### / { exit }
-		capture { lines[++n] = $0 }
-		END {
-			while (n > 0 && lines[n] ~ /^[[:space:]]*$/) {
-				n--
-			}
-			for (i = 1; i <= n; i++) {
-				print lines[i]
-			}
-		}
-	'
-) || true
-
-# Assemble Previously Unreleased with blank lines between list, prose, and table.
-PREVIOUSLY_UNRELEASED=""
-if [[ -n "$EXISTING_PROSE" ]]; then
-	PREVIOUSLY_UNRELEASED="$EXISTING_PROSE"
-fi
-if [[ -n "$EXISTING_ENTRIES" ]]; then
-	if [[ -n "$PREVIOUSLY_UNRELEASED" ]]; then
-		PREVIOUSLY_UNRELEASED="${PREVIOUSLY_UNRELEASED}
-
-${EXISTING_ENTRIES}"
-	else
-		PREVIOUSLY_UNRELEASED="$EXISTING_ENTRIES"
-	fi
-fi
-if [[ -n "$EXISTING_BREAKING" ]]; then
-	if [[ -n "$PREVIOUSLY_UNRELEASED" ]]; then
-		PREVIOUSLY_UNRELEASED="${PREVIOUSLY_UNRELEASED}
-
-### Breaking changes
-
-${EXISTING_BREAKING}"
-	else
-		PREVIOUSLY_UNRELEASED="### Breaking changes
-
-${EXISTING_BREAKING}"
-	fi
-fi
-
 # Strip leading H2 heading from CHANGELOG_BODY if present.
 # generate-changelog.sh outputs "## Unreleased" or "## [version] - date"
 # as the first line, but update-changelog.sh creates its own versioned
 # heading — keeping both produces duplicate H2s that violate MD024.
 CHANGELOG_BODY=$(printf '%s' "$CHANGELOG_BODY" | sed '1{/^## /d;}' | sed '/./,$!d')
 
-# If we have both existing and generated entries, combine them
-if [[ -n "$PREVIOUSLY_UNRELEASED" ]] && [[ -n "$CHANGELOG_BODY" ]]; then
-	# Append existing entries under a "Previously Unreleased" sub-section
-	# to distinguish hand-curated entries from auto-generated ones
-	CHANGELOG_BODY="${CHANGELOG_BODY}
-
-### Previously Unreleased
-
-${PREVIOUSLY_UNRELEASED}"
-elif [[ -n "$PREVIOUSLY_UNRELEASED" ]]; then
-	CHANGELOG_BODY="### Previously Unreleased
-
-${PREVIOUSLY_UNRELEASED}"
+# Merge hand-curated [Unreleased] sections with generated release notes.
+if [[ -n "$EXISTING_UNRELEASED" ]] || [[ -n "$CHANGELOG_BODY" ]]; then
+	CHANGELOG_BODY=$(merge_changelog_sections "$CHANGELOG_BODY" "$EXISTING_UNRELEASED")
 fi
 
 # Rebuild NEW_SECTION with the merged content

--- a/tests/bats/integration/test_update_changelog.bats
+++ b/tests/bats/integration/test_update_changelog.bats
@@ -99,7 +99,7 @@ run_update_changelog() {
 
 [Unreleased]: https://github.com/test-org/test-repo/compare/v0.0.0...HEAD'
 
-	run_update_changelog "1.0.0" "### Features
+	run_update_changelog "1.0.0" "### Added
 
 - add new feature (abc1234)"
 	assert_success
@@ -139,7 +139,7 @@ run_update_changelog() {
 	# a "## Unreleased" heading followed by section content
 	run_update_changelog "1.0.0" "## Unreleased
 
-### Features
+### Added
 
 - add new feature (abc1234)"
 	assert_success
@@ -178,6 +178,89 @@ run_update_changelog() {
 # Tests: preserve existing unreleased entries
 # =============================================================================
 
+@test "update-changelog: merges hand-curated entries into standard sections" {
+	setup_changelog_repo
+
+	write_changelog '# Changelog
+
+## [Unreleased]
+
+### Added
+
+- Existing feature one ([#1])
+
+### Changed
+
+- Existing workflow change ([#2])
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+[Unreleased]: https://github.com/test-org/test-repo/compare/v0.0.0...HEAD
+[#1]: https://github.com/test-org/test-repo/pull/1
+[#2]: https://github.com/test-org/test-repo/pull/2'
+
+	run_update_changelog "1.0.0" "### Added
+
+- new auto-generated entry (def5678)"
+	assert_success
+
+	local changelog
+	changelog=$(cat "${MOCK_GIT_REPO}/CHANGELOG.md")
+
+	echo "$changelog" | grep -q 'Previously Unreleased' && fail "Previously Unreleased should not appear"
+	echo "$changelog" | grep -q 'Existing feature one' || fail "'Existing feature one' not found in changelog"
+	echo "$changelog" | grep -q 'Existing workflow change' || fail "'Existing workflow change' not found in changelog"
+	echo "$changelog" | grep -q 'new auto-generated entry' || fail "'new auto-generated entry' not found in changelog"
+
+	run bash -c "awk '/^## \\[1\\.0\\.0\\]/{capture=1;next} capture && /^## \\[/{exit} capture' '${MOCK_GIT_REPO}/CHANGELOG.md' | grep -q '^### Added$'"
+	assert_success
+
+	run bash -c "awk '/^## \\[1\\.0\\.0\\]/{capture=1;next} capture && /^## \\[/{exit} capture' '${MOCK_GIT_REPO}/CHANGELOG.md' | grep -q '^### Changed$'"
+	assert_success
+}
+
+@test "update-changelog: preserves bare unreleased bullets without subsection headings" {
+	setup_changelog_repo
+
+	write_changelog '# Changelog
+
+## [Unreleased]
+
+- Legacy flat entry ([#9])
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+[Unreleased]: https://github.com/test-org/test-repo/compare/v0.0.0...HEAD
+[#9]: https://github.com/test-org/test-repo/pull/9'
+
+	run_update_changelog "1.0.0" "### Added
+
+- generated entry (abc1234)"
+	assert_success
+
+	local changelog
+	changelog=$(cat "${MOCK_GIT_REPO}/CHANGELOG.md")
+
+	echo "$changelog" | grep -q 'Legacy flat entry' || fail "'Legacy flat entry' not found in changelog"
+	echo "$changelog" | grep -q 'generated entry' || fail "'generated entry' not found in changelog"
+}
+
 @test "update-changelog: preserves hand-curated unreleased entries" {
 	setup_changelog_repo
 
@@ -204,7 +287,7 @@ run_update_changelog() {
 [#1]: https://github.com/test-org/test-repo/pull/1
 [#2]: https://github.com/test-org/test-repo/pull/2'
 
-	run_update_changelog "1.0.0" "### Features
+	run_update_changelog "1.0.0" "### Added
 
 - new auto-generated entry (def5678)"
 	assert_success
@@ -283,7 +366,7 @@ run_update_changelog() {
 [#10]: https://github.com/test-org/test-repo/pull/10
 [#20]: https://github.com/test-org/test-repo/pull/20'
 
-	run_update_changelog "1.0.0" "### Features
+	run_update_changelog "1.0.0" "### Added
 
 - auto feature (aaa1111)"
 	assert_success
@@ -325,7 +408,7 @@ run_update_changelog() {
 
 [Unreleased]: https://github.com/test-org/test-repo/compare/v0.0.0...HEAD'
 
-	run_update_changelog "1.0.0" "### Features
+	run_update_changelog "1.0.0" "### Added
 
 - a feature (abc1234)"
 	assert_success
@@ -376,7 +459,7 @@ run_update_changelog() {
 [Unreleased]: https://github.com/test-org/test-repo/compare/v0.0.0...HEAD
 [#1]: https://github.com/test-org/test-repo/pull/1'
 
-	run_update_changelog "0.1.0" "### Features
+	run_update_changelog "0.1.0" "### Added
 
 - auto feature (bbb2222)"
 	assert_success
@@ -425,7 +508,7 @@ run_update_changelog() {
 
 [Unreleased]: https://github.com/test-org/test-repo/compare/v0.0.0...HEAD'
 
-	run_update_changelog "1.0.0" "### Features
+	run_update_changelog "1.0.0" "### Added
 
 - new feature (ccc3333)"
 	assert_success
@@ -469,7 +552,7 @@ run_update_changelog() {
 
 ## [0.1.0] - 2026-01-01
 
-### Features
+### Added
 
 - old feature (aaa1111)
 
@@ -478,7 +561,7 @@ run_update_changelog() {
 
 	(cd "$MOCK_GIT_REPO" && git tag v0.1.0)
 
-	run_update_changelog "0.2.0" "### Features
+	run_update_changelog "0.2.0" "### Added
 
 - newer feature (ddd4444)"
 	assert_success
@@ -532,7 +615,7 @@ run_update_changelog() {
 [Unreleased]: https://github.com/test-org/test-repo/compare/v0.0.0...HEAD
 [#1]: https://github.com/test-org/test-repo/pull/1'
 
-	run_update_changelog "1.0.0" "### Features
+	run_update_changelog "1.0.0" "### Added
 
 - new feature (abc1234)"
 	assert_success
@@ -564,7 +647,7 @@ run_update_changelog() {
 
 [Unreleased]: https://github.com/test-org/test-repo/compare/v0.0.0...HEAD'
 
-	run_update_changelog "1.0.0" "### Features
+	run_update_changelog "1.0.0" "### Added
 
 - a feature (abc1234)"
 	assert_success
@@ -601,13 +684,13 @@ run_update_changelog() {
 
 ## [0.6.0] - 2026-02-10
 
-### Features
+### Added
 
 - old feature from first run (aaa1111)
 
 ## [0.5.0] - 2026-02-09
 
-### Features
+### Added
 
 - even older feature (bbb2222)
 
@@ -617,11 +700,11 @@ run_update_changelog() {
 
 	(cd "$MOCK_GIT_REPO" && git tag v0.5.0)
 
-	run_update_changelog "0.6.0" "### Features
+	run_update_changelog "0.6.0" "### Added
 
 - old feature from first run (aaa1111)
 
-### Bug Fixes
+### Fixed
 
 - new fix added since first run (ccc3333)"
 	assert_success
@@ -682,18 +765,18 @@ run_update_changelog() {
 
 ## [1.0.0] - 2026-02-10
 
-### Features
+### Added
 
 - initial release feature (aaa1111)
 
 [Unreleased]: https://github.com/test-org/test-repo/compare/v1.0.0...HEAD
 [1.0.0]: https://github.com/test-org/test-repo/releases/tag/v1.0.0'
 
-	run_update_changelog "1.0.0" "### Features
+	run_update_changelog "1.0.0" "### Added
 
 - initial release feature (aaa1111)
 
-### Bug Fixes
+### Fixed
 
 - hotfix after version PR merged (bbb2222)"
 	assert_success
@@ -763,7 +846,7 @@ See [docs/example.md](docs/example.md).
 
 [Unreleased]: https://github.com/test-org/test-repo/compare/v0.0.0...HEAD'
 
-	run_update_changelog "0.25.0" "### Breaking Changes
+	run_update_changelog "0.25.0" "### Changed
 
 - **ci**: breaking change (abc1234)"
 	assert_success
@@ -843,7 +926,7 @@ See [docs/example.md](docs/example.md).
 [#1]: https://github.com/test-org/test-repo/pull/1
 [#2]: https://github.com/test-org/test-repo/pull/2'
 
-	run_update_changelog "1.0.0" "### Features
+	run_update_changelog "1.0.0" "### Added
 
 - new feature (abc1234)"
 	assert_success

--- a/tests/bats/unit/lib/release/test_changelog.bats
+++ b/tests/bats/unit/lib/release/test_changelog.bats
@@ -75,9 +75,9 @@ teardown() {
 	local commits
 	commits=$(printf 'abc1234567\x1Ffeat\x1Fauth\x1Fadd login\nabc1234568\x1Ffeat\x1F\x1Fadd logout')
 
-	run bash -c "source \"\$LIB_DIR/release/changelog.sh\" && generate_changelog_section \"Features\" '$commits' \"full\""
+	run bash -c "source \"\$LIB_DIR/release/changelog.sh\" && generate_changelog_section \"Added\" '$commits' \"full\""
 	assert_success
-	assert_output --partial "### Features"
+	assert_output --partial "### Added"
 	assert_output --partial "add login"
 	assert_output --partial "add logout"
 }
@@ -86,9 +86,9 @@ teardown() {
 	local commits
 	commits=$(printf 'abc1234567\x1Ffix\x1F\x1Ffix bug')
 
-	run bash -c "source \"\$LIB_DIR/release/changelog.sh\" && generate_changelog_section \"Bug Fixes\" '$commits' \"simple\""
+	run bash -c "source \"\$LIB_DIR/release/changelog.sh\" && generate_changelog_section \"Fixed\" '$commits' \"simple\""
 	assert_success
-	assert_output --partial "### Bug Fixes"
+	assert_output --partial "### Fixed"
 	assert_output --partial "- fix bug"
 }
 
@@ -114,42 +114,44 @@ teardown() {
 	assert_output --partial "## Unreleased"
 }
 
-@test "generate_changelog: includes features section" {
+@test "generate_changelog: includes added section" {
 	tag_mock_repo "v1.0.0"
 	add_commit "feat: add search"
 
 	run bash -c "cd \"$MOCK_GIT_REPO\" && source \"\$LIB_DIR/release/changelog.sh\" && generate_changelog \"v1.0.0\" \"HEAD\" \"1.1.0\""
 	assert_success
-	assert_output --partial "### Features"
+	assert_output --partial "### Added"
 	assert_output --partial "add search"
 }
 
-@test "generate_changelog: includes bug fixes section" {
+@test "generate_changelog: includes fixed section" {
 	tag_mock_repo "v1.0.0"
 	add_commit "fix: resolve crash"
 
 	run bash -c "cd \"$MOCK_GIT_REPO\" && source \"\$LIB_DIR/release/changelog.sh\" && generate_changelog \"v1.0.0\" \"HEAD\" \"1.0.1\""
 	assert_success
-	assert_output --partial "### Bug Fixes"
+	assert_output --partial "### Fixed"
 	assert_output --partial "resolve crash"
 }
 
-@test "generate_changelog: includes breaking changes section" {
+@test "generate_changelog: includes breaking changes under Changed" {
 	tag_mock_repo "v1.0.0"
 	add_commit "feat!: new API"
 
 	run bash -c "cd \"$MOCK_GIT_REPO\" && source \"\$LIB_DIR/release/changelog.sh\" && generate_changelog \"v1.0.0\" \"HEAD\" \"2.0.0\""
 	assert_success
-	assert_output --partial "### Breaking Changes"
+	assert_output --partial "### Changed"
+	assert_output --partial "new API"
 }
 
-@test "generate_changelog: includes other changes in full format" {
+@test "generate_changelog: includes other changes under Changed in full format" {
 	tag_mock_repo "v1.0.0"
 	add_commit "chore: update deps"
 
 	run bash -c "cd \"$MOCK_GIT_REPO\" && source \"\$LIB_DIR/release/changelog.sh\" && generate_changelog \"v1.0.0\" \"HEAD\" \"1.0.1\" \"full\""
 	assert_success
-	assert_output --partial "### Other Changes"
+	assert_output --partial "### Changed"
+	assert_output --partial "update deps"
 }
 
 # =============================================================================

--- a/tests/bats/unit/lib/release/test_changelog_merge.bats
+++ b/tests/bats/unit/lib/release/test_changelog_merge.bats
@@ -127,6 +127,16 @@ teardown() {
 	assert_output --partial "changed=- flat unreleased entry"
 }
 
+@test "parse_changelog_body: treats indented bullets as list entries" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		parse_changelog_body "  - indented entry"
+		echo "changed=${_MERGE_SECTION_Changed}"
+	'
+	assert_success
+	assert_output --partial "changed=  - indented entry"
+}
+
 @test "parse_changelog_body: treats asterisk and plus list markers as bullets" {
 	run bash -c '
 		source "$LIB_DIR/release/changelog_merge.sh"

--- a/tests/bats/unit/lib/release/test_changelog_merge.bats
+++ b/tests/bats/unit/lib/release/test_changelog_merge.bats
@@ -139,6 +139,21 @@ teardown() {
 	assert_output --partial "+ plus entry"
 }
 
+@test "parse_changelog_body: preserves markdown links while skipping reference definitions" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		parse_changelog_body "### Breaking changes
+
+See [migration guide](docs/migration.md).
+
+[Unreleased]: https://example.com/compare/v0.9.0...HEAD"
+		echo "breaking=${_MERGE_BREAKING}"
+	'
+	assert_success
+	assert_output --partial "breaking=See [migration guide](docs/migration.md)."
+	refute_output --partial "[Unreleased]:"
+}
+
 @test "parse_changelog_body: skips link definitions inside breaking block" {
 	run bash -c '
 		source "$LIB_DIR/release/changelog_merge.sh"

--- a/tests/bats/unit/lib/release/test_changelog_merge.bats
+++ b/tests/bats/unit/lib/release/test_changelog_merge.bats
@@ -127,6 +127,34 @@ teardown() {
 	assert_output --partial "changed=- flat unreleased entry"
 }
 
+@test "parse_changelog_body: treats asterisk and plus list markers as bullets" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		parse_changelog_body "* asterisk entry
++ plus entry"
+		echo "changed=${_MERGE_SECTION_Changed}"
+	'
+	assert_success
+	assert_output --partial "changed=* asterisk entry"
+	assert_output --partial "+ plus entry"
+}
+
+@test "parse_changelog_body: skips link definitions inside breaking block" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		parse_changelog_body "### Breaking changes
+
+| old | new |
+| --- | --- |
+
+[Unreleased]: https://example.com/compare/v0.9.0...HEAD"
+		echo "breaking=${_MERGE_BREAKING}"
+	'
+	assert_success
+	assert_output --partial "breaking=| old | new |"
+	refute_output --partial "[Unreleased]:"
+}
+
 @test "parse_changelog_body: routes each Keep a Changelog section" {
 	run bash -c '
 		source "$LIB_DIR/release/changelog_merge.sh"

--- a/tests/bats/unit/lib/release/test_changelog_merge.bats
+++ b/tests/bats/unit/lib/release/test_changelog_merge.bats
@@ -204,6 +204,32 @@ See [migration guide](docs/migration.md).
 	assert_output --partial "Security=- security"
 }
 
+@test "parse_changelog_body: trims whitespace from section headings" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		parse_changelog_body "### Added  
+
+- trimmed heading entry"
+		echo "added=${_MERGE_SECTION_Added}"
+	'
+	assert_success
+	assert_output --partial "added=- trimmed heading entry"
+}
+
+@test "parse_changelog_body: preserves blank lines between prose paragraphs" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		parse_changelog_body "First paragraph
+
+Second paragraph"
+		echo "prose=${_MERGE_PROSE}"
+	'
+	assert_success
+	assert_output --partial $'prose=First paragraph
+
+Second paragraph'
+}
+
 @test "parse_changelog_body: treats non-list lines before sections as prose" {
 	run bash -c '
 		source "$LIB_DIR/release/changelog_merge.sh"

--- a/tests/bats/unit/lib/release/test_changelog_merge.bats
+++ b/tests/bats/unit/lib/release/test_changelog_merge.bats
@@ -1,0 +1,271 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/lib/release/changelog_merge.sh
+
+load "../../../../helpers/common"
+load "../../../../helpers/mocks"
+
+setup() {
+	setup_temp_dir
+	save_path
+	export LIB_DIR
+	export BATS_TEST_TMPDIR
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+# =============================================================================
+# normalize_kac_section
+# =============================================================================
+
+@test "normalize_kac_section: maps Added and Features to Added" {
+	run bash -c 'source "$LIB_DIR/release/changelog_merge.sh" && normalize_kac_section "Added"'
+	assert_success
+	assert_output "Added"
+
+	run bash -c 'source "$LIB_DIR/release/changelog_merge.sh" && normalize_kac_section "Features"'
+	assert_success
+	assert_output "Added"
+}
+
+@test "normalize_kac_section: maps Changed aliases to Changed" {
+	local aliases=(
+		"Changed"
+		"Breaking Changes"
+		"Documentation"
+		"Other Changes"
+	)
+
+	for alias in "${aliases[@]}"; do
+		run bash -c "source \"\$LIB_DIR/release/changelog_merge.sh\" && normalize_kac_section \"$alias\""
+		assert_success
+		assert_output "Changed"
+	done
+}
+
+@test "normalize_kac_section: maps remaining KaC and legacy headings" {
+	run bash -c 'source "$LIB_DIR/release/changelog_merge.sh" && normalize_kac_section "Deprecated"'
+	assert_output "Deprecated"
+
+	run bash -c 'source "$LIB_DIR/release/changelog_merge.sh" && normalize_kac_section "Removed"'
+	assert_output "Removed"
+
+	run bash -c 'source "$LIB_DIR/release/changelog_merge.sh" && normalize_kac_section "Fixed"'
+	assert_output "Fixed"
+
+	run bash -c 'source "$LIB_DIR/release/changelog_merge.sh" && normalize_kac_section "Bug Fixes"'
+	assert_output "Fixed"
+
+	run bash -c 'source "$LIB_DIR/release/changelog_merge.sh" && normalize_kac_section "Security"'
+	assert_output "Security"
+}
+
+@test "normalize_kac_section: returns empty for unknown headings" {
+	run bash -c 'source "$LIB_DIR/release/changelog_merge.sh" && normalize_kac_section "Performance"'
+	assert_success
+	assert_output ""
+}
+
+# =============================================================================
+# parse_changelog_body
+# =============================================================================
+
+@test "parse_changelog_body: captures prose and ignores reference links" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		parse_changelog_body "Target release: v1.0.0
+
+### Added
+
+- new item
+
+[Unreleased]: https://example.com/compare/v0.9.0...HEAD"
+		echo "prose=${_MERGE_PROSE}"
+		echo "added=${_MERGE_SECTION_Added}"
+	'
+	assert_success
+	assert_output --partial "prose=Target release: v1.0.0"
+	assert_output --partial "added=- new item"
+}
+
+@test "parse_changelog_body: captures breaking changes block" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		parse_changelog_body "### Breaking Changes
+
+| Removed | Use instead |
+| --- | --- |
+| old.yml | new.yml"
+		echo "breaking=${_MERGE_BREAKING}"
+	'
+	assert_success
+	assert_output --partial "breaking=| Removed | Use instead |"
+}
+
+@test "parse_changelog_body: maps Previously Unreleased bullets to Changed" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		parse_changelog_body "### Previously Unreleased
+
+- legacy curated entry"
+		echo "changed=${_MERGE_SECTION_Changed}"
+	'
+	assert_success
+	assert_output --partial "changed=- legacy curated entry"
+}
+
+@test "parse_changelog_body: preserves bare bullets under Changed" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		parse_changelog_body "- flat unreleased entry"
+		echo "changed=${_MERGE_SECTION_Changed}"
+	'
+	assert_success
+	assert_output --partial "changed=- flat unreleased entry"
+}
+
+@test "parse_changelog_body: routes each Keep a Changelog section" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		parse_changelog_body "### Added
+- added
+
+### Changed
+- changed
+
+### Deprecated
+- deprecated
+
+### Removed
+- removed
+
+### Fixed
+- fixed
+
+### Security
+- security"
+		for section in Added Changed Deprecated Removed Fixed Security; do
+			eval "value=\${_MERGE_SECTION_${section}}"
+			echo "${section}=${value}"
+		done
+	'
+	assert_success
+	assert_output --partial "Added=- added"
+	assert_output --partial "Changed=- changed"
+	assert_output --partial "Deprecated=- deprecated"
+	assert_output --partial "Removed=- removed"
+	assert_output --partial "Fixed=- fixed"
+	assert_output --partial "Security=- security"
+}
+
+@test "parse_changelog_body: treats non-list lines before sections as prose" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		parse_changelog_body "Release notes preamble
+
+### Added
+- item"
+		echo "prose=${_MERGE_PROSE}"
+	'
+	assert_success
+	assert_output --partial "prose=Release notes preamble"
+}
+
+# =============================================================================
+# merge_changelog_sections
+# =============================================================================
+
+@test "merge_changelog_sections: returns nothing when both bodies are empty" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		merge_changelog_sections "" ""
+	'
+	assert_success
+	assert_output ""
+}
+
+@test "merge_changelog_sections: returns existing body when generated is empty" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		merge_changelog_sections "" "### Fixed
+
+- existing fix"
+	'
+	assert_success
+	assert_output --partial "### Fixed"
+	assert_output --partial "existing fix"
+}
+
+@test "merge_changelog_sections: returns generated body when existing is empty" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		merge_changelog_sections "### Added
+
+- generated entry" ""
+	'
+	assert_success
+	assert_output --partial "### Added"
+	assert_output --partial "generated entry"
+}
+
+@test "merge_changelog_sections: places generated bullets before existing bullets" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		merge_changelog_sections "### Added
+
+- generated entry" "### Added
+
+- existing entry"
+	'
+	assert_success
+	assert_output --partial "### Added"
+	assert_output --partial $'- generated entry
+- existing entry'
+}
+
+@test "merge_changelog_sections: concatenates prose and breaking blocks" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		merge_changelog_sections "Generated prose
+
+### Breaking changes
+
+generated-table" "Existing prose
+
+### Breaking changes
+
+existing-table"
+	'
+	assert_success
+	assert_output --partial "Generated prose"
+	assert_output --partial "Existing prose"
+	assert_output --partial "generated-table"
+	assert_output --partial "existing-table"
+}
+
+@test "merge_changelog_sections: routes title-case Breaking Changes into breaking block" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		merge_changelog_sections "### Breaking Changes
+
+- removed old workflow" ""
+	'
+	assert_success
+	assert_output --partial "### Breaking changes"
+	assert_output --partial "- removed old workflow"
+}
+
+@test "merge_changelog_sections: keeps bullets under unrecognized headings" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog_merge.sh"
+		merge_changelog_sections "" "### Performance
+
+- faster runner selection"
+	'
+	assert_success
+	assert_output --partial "### Changed"
+	assert_output --partial "faster runner selection"
+}


### PR DESCRIPTION
## Summary

Release automation now emits Keep a Changelog standard section headings (`Added`, `Changed`, `Fixed`) instead of non-standard blocks like `Features`, `Bug Fixes`, and `Previously Unreleased`. Hand-curated `[Unreleased]` entries are merged into the matching KaC sections when a version PR is created.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #343
- Relates to #341

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align changelog generator and merger with Keep a Changelog section headings
> - Reworks `generate_changelog` in [changelog.sh](https://github.com/lgtm-hq/lgtm-ci/pull/344/files#diff-602b6a3d47923ca9b0ed970c6efed259183b23d71a0f84cb1bd8ff5ed4799662) to emit `Added`, `Changed`, and `Fixed` sections instead of `Features`, `Bug Fixes`, `Breaking Changes`, `Documentation`, and `Other Changes`; breaking, docs, and other commits now aggregate under `Changed`.
> - Adds `merge_changelog_sections` and supporting functions in [changelog_merge.sh](https://github.com/lgtm-hq/lgtm-ci/pull/344/files#diff-e2d3f80e566bec08438f4a942b018661a6ad6626e02fb8433551c6845339305f) to merge auto-generated and hand-curated Unreleased content into standard KAC sections, appending a dedicated `Breaking changes` block when present.
> - Replaces bespoke awk/sed logic in [update-changelog.sh](https://github.com/lgtm-hq/lgtm-ci/pull/344/files#diff-1f75c315a03d8f04e1a1c61a36da12fca56634b4f01ebf19406c707916cc50a7) with a single call to `merge_changelog_sections`, removing the `Previously Unreleased` subsection pattern.
> - Updates unit and integration tests to expect the new headings and merge behavior.
> - Behavioral Change: existing changelogs or tooling that parses `Features`, `Bug Fixes`, or `Previously Unreleased` headings will no longer see those section names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b9f8b74.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized changelog section names and ordering to "Added", "Changed", "Fixed", "Deprecated", "Removed", "Security", consolidating breaking/documentation/other entries under "Changed".

* **Chores**
  * Introduced a reusable changelog merge utility and updated the release flow to consistently merge generated and hand-curated unreleased content (generated content appears first).

* **Tests**
  * Updated and added integration/unit tests and fixtures to validate parsing, heading normalization, and merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns the release automation with the Keep a Changelog standard by replacing `Features`, `Bug Fixes`, and `Breaking Changes` section names with `Added`, `Changed`, and `Fixed`, and introduces `changelog_merge.sh` — a reusable utility that merges auto-generated and hand-curated `[Unreleased]` content into canonical KaC sections before the versioned entry is written.

- `generate_changelog` in `changelog.sh` now consolidates breaking, docs, and (in full mode) other commits into a single `Changed` section instead of separate headings.
- `changelog_merge.sh` adds `parse_changelog_body` and `merge_changelog_sections`, with case-insensitive `[Bb]reaking [Cc]hanges` detection routing to a dedicated `### Breaking changes` output block, and a `Previously Unreleased` backwards-compat mapping to `Changed`.
- `update-changelog.sh` drops ~80 lines of bespoke awk/sed extraction in favour of a single `merge_changelog_sections` call; unit and integration tests are updated throughout to expect the new headings.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the rewrite is correct, all three previously-flagged issues are resolved, and the new merge logic is well-covered by dedicated unit and integration tests.

The core parsing and merge logic in `changelog_merge.sh` correctly handles all edge cases surfaced in prior review rounds: unknown headings now fall back to `Changed` instead of silently dropping bullets, the `[Bb]reaking [Cc]hanges` regex is properly case-folded for both words, and the new `test_changelog_merge.bats` file covers the key paths directly. The remaining observations are minor formatting quirks with no impact on correctness.

No files require special attention; `changelog_merge.sh` is the most complex new addition but is well-tested.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/lib/release/changelog.sh | Generates KaC-standard headings (Added/Changed/Fixed); breaking and docs commits are concatenated into `changed_commits` before passing to `generate_changelog_section`, which correctly parses them via unit-separator records. |
| scripts/ci/lib/release/changelog_merge.sh | New merge module; previous review issues (data-loss for unknown headings, regex case-folding, missing tests) are all addressed. Minor: blank lines inside `### Breaking changes` blocks accumulate trailing `\n` in `_MERGE_BREAKING`, which can produce extra blank lines when two breaking blocks are joined. |
| scripts/ci/release/update-changelog.sh | Replaced ~80 lines of bespoke awk/sed extraction with a single `merge_changelog_sections` call; the H2-strip and awk rewrite logic is unchanged and correct. |
| tests/bats/unit/lib/release/test_changelog_merge.bats | New unit test file covering normalize, parse, and merge paths including edge cases (empty bodies, prose, bare bullets, unrecognized headings, backwards-compat `Previously Unreleased`). |
| tests/bats/integration/test_update_changelog.bats | Updated section headings from `Features`/`Bug Fixes` to `Added`/`Fixed`; adds two new integration tests for merging hand-curated KaC sections and preserving bare (sectionless) bullets. |
| tests/bats/unit/lib/release/test_changelog.bats | Unit tests updated to expect KaC headings; breaking-change and other-changes tests now assert `### Changed` instead of the old dedicated section names. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UC as update-changelog.sh
    participant CL as changelog.sh
    participant CM as changelog_merge.sh
    participant CF as CHANGELOG.md

    UC->>CF: Extract EXISTING_UNRELEASED (awk)
    UC->>CL: CHANGELOG_BODY (env var from generate-changelog)
    UC->>UC: Strip leading H2 heading (sed)
    UC->>CM: merge_changelog_sections(CHANGELOG_BODY, EXISTING_UNRELEASED)
    CM->>CM: parse_changelog_body(generated)
    Note over CM: Routes Added/Changed/Fixed/Breaking into section accumulators
    CM->>CM: "save _MERGE_GENERATED_*"
    CM->>CM: parse_changelog_body(existing)
    Note over CM: Maps legacy headings (Features→Added, Bug Fixes→Fixed, Previously Unreleased→Changed)
    CM->>CM: Merge left(generated)+right(existing) per section
    CM-->>UC: merged CHANGELOG_BODY
    UC->>CF: Write NEW_SECTION + fresh UNRELEASED_SECTION (awk)
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Flib%2Frelease%2Fchangelog_merge.sh%3A103-109%0A**Trailing%20blank%20lines%20accumulate%20in%20%60_MERGE_BREAKING%60**%0A%0AWhen%20a%20blank%20line%20appears%20inside%20a%20%60%23%23%23%20Breaking%20changes%60%20block%20%28e.g.%2C%20between%20a%20table%20row%20and%20the%20next%20section%29%2C%20the%20%60in_breaking%60%20accumulation%20path%20appends%20the%20empty%20%60%24line%60%20unconditionally%20after%20a%20%60%24'%5Cn'%60%20separator.%20This%20means%20%60_MERGE_BREAKING%60%20picks%20up%20trailing%20%60%5Cn%60%20characters%20from%20blank%20lines%20that%20precede%20the%20next%20%60%23%23%23%60%20heading.%20When%20two%20breaking%20blocks%20are%20later%20joined%20with%20%60%24'%5Cn'%60%20in%20%60merge_changelog_sections%60%2C%20the%20result%20can%20have%20two%20or%20three%20consecutive%20blank%20lines%20between%20bullet%20items%2C%20which%20some%20linters%20flag.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Flib%2Frelease%2Fchangelog_merge.sh%3A29-38%0A**%60%22Breaking%20Changes%22%60%20arm%20in%20%60normalize_kac_section%60%20is%20dead%20code%20when%20called%20from%20%60parse_changelog_body%60**%0A%0A%60parse_changelog_body%60%20intercepts%20%60%5BBb%5Dreaking%20%5BCc%5Dhanges%60%20headings%20at%20line%2081%20and%20sets%20%60in_breaking%3Dtrue%60%20before%20ever%20reaching%20the%20%60normalize_kac_section%60%20call%2C%20so%20the%20%60%22Breaking%20Changes%22%60%20case%20in%20the%20%60case%60%20statement%20is%20never%20exercised%20from%20that%20code%20path.%20It%20does%20fire%20when%20the%20function%20is%20called%20directly%20%28as%20the%20%60normalize_kac_section%3A%20maps%20Changed%20aliases%20to%20Changed%60%20unit%20test%20shows%29%2C%20which%20makes%20the%20function's%20standalone%20contract%20correct%2C%20but%20the%20comment%20or%20the%20case%20statement%20ordering%20could%20be%20clarified%20to%20document%20this%20intentional%20dual%20behavior.%0A%0A&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Flib%2Frelease%2Fchangelog_merge.sh%3A103-109%0A**Trailing%20blank%20lines%20accumulate%20in%20%60_MERGE_BREAKING%60**%0A%0AWhen%20a%20blank%20line%20appears%20inside%20a%20%60%23%23%23%20Breaking%20changes%60%20block%20%28e.g.%2C%20between%20a%20table%20row%20and%20the%20next%20section%29%2C%20the%20%60in_breaking%60%20accumulation%20path%20appends%20the%20empty%20%60%24line%60%20unconditionally%20after%20a%20%60%24'%5Cn'%60%20separator.%20This%20means%20%60_MERGE_BREAKING%60%20picks%20up%20trailing%20%60%5Cn%60%20characters%20from%20blank%20lines%20that%20precede%20the%20next%20%60%23%23%23%60%20heading.%20When%20two%20breaking%20blocks%20are%20later%20joined%20with%20%60%24'%5Cn'%60%20in%20%60merge_changelog_sections%60%2C%20the%20result%20can%20have%20two%20or%20three%20consecutive%20blank%20lines%20between%20bullet%20items%2C%20which%20some%20linters%20flag.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Flib%2Frelease%2Fchangelog_merge.sh%3A29-38%0A**%60%22Breaking%20Changes%22%60%20arm%20in%20%60normalize_kac_section%60%20is%20dead%20code%20when%20called%20from%20%60parse_changelog_body%60**%0A%0A%60parse_changelog_body%60%20intercepts%20%60%5BBb%5Dreaking%20%5BCc%5Dhanges%60%20headings%20at%20line%2081%20and%20sets%20%60in_breaking%3Dtrue%60%20before%20ever%20reaching%20the%20%60normalize_kac_section%60%20call%2C%20so%20the%20%60%22Breaking%20Changes%22%60%20case%20in%20the%20%60case%60%20statement%20is%20never%20exercised%20from%20that%20code%20path.%20It%20does%20fire%20when%20the%20function%20is%20called%20directly%20%28as%20the%20%60normalize_kac_section%3A%20maps%20Changed%20aliases%20to%20Changed%60%20unit%20test%20shows%29%2C%20which%20makes%20the%20function's%20standalone%20contract%20correct%2C%20but%20the%20comment%20or%20the%20case%20statement%20ordering%20could%20be%20clarified%20to%20document%20this%20intentional%20dual%20behavior.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22fix%2F343-align-changelog-generator-kac-sections%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F343-align-changelog-generator-kac-sections%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Flib%2Frelease%2Fchangelog_merge.sh%3A103-109%0A**Trailing%20blank%20lines%20accumulate%20in%20%60_MERGE_BREAKING%60**%0A%0AWhen%20a%20blank%20line%20appears%20inside%20a%20%60%23%23%23%20Breaking%20changes%60%20block%20%28e.g.%2C%20between%20a%20table%20row%20and%20the%20next%20section%29%2C%20the%20%60in_breaking%60%20accumulation%20path%20appends%20the%20empty%20%60%24line%60%20unconditionally%20after%20a%20%60%24'%5Cn'%60%20separator.%20This%20means%20%60_MERGE_BREAKING%60%20picks%20up%20trailing%20%60%5Cn%60%20characters%20from%20blank%20lines%20that%20precede%20the%20next%20%60%23%23%23%60%20heading.%20When%20two%20breaking%20blocks%20are%20later%20joined%20with%20%60%24'%5Cn'%60%20in%20%60merge_changelog_sections%60%2C%20the%20result%20can%20have%20two%20or%20three%20consecutive%20blank%20lines%20between%20bullet%20items%2C%20which%20some%20linters%20flag.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Flib%2Frelease%2Fchangelog_merge.sh%3A29-38%0A**%60%22Breaking%20Changes%22%60%20arm%20in%20%60normalize_kac_section%60%20is%20dead%20code%20when%20called%20from%20%60parse_changelog_body%60**%0A%0A%60parse_changelog_body%60%20intercepts%20%60%5BBb%5Dreaking%20%5BCc%5Dhanges%60%20headings%20at%20line%2081%20and%20sets%20%60in_breaking%3Dtrue%60%20before%20ever%20reaching%20the%20%60normalize_kac_section%60%20call%2C%20so%20the%20%60%22Breaking%20Changes%22%60%20case%20in%20the%20%60case%60%20statement%20is%20never%20exercised%20from%20that%20code%20path.%20It%20does%20fire%20when%20the%20function%20is%20called%20directly%20%28as%20the%20%60normalize_kac_section%3A%20maps%20Changed%20aliases%20to%20Changed%60%20unit%20test%20shows%29%2C%20which%20makes%20the%20function's%20standalone%20contract%20correct%2C%20but%20the%20comment%20or%20the%20case%20statement%20ordering%20could%20be%20clarified%20to%20document%20this%20intentional%20dual%20behavior.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (7): Last reviewed commit: ["fix(release): recognize indented bullets..."](https://github.com/lgtm-hq/lgtm-ci/commit/579b9d1b261022f15d3f868030f6f42a5182fc16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36550335)</sub>

<!-- /greptile_comment -->