### PR TITLE
fix: thread working-directory into node-coverage summary path

### DIFF
--- a/.github/workflows/reusable-test-node-custom.yml
+++ b/.github/workflows/reusable-test-node-custom.yml
@@ -559,6 +559,8 @@ jobs:
       job-result: ${{ needs.aggregate-tests.outputs.passed == 'true' && 'success' || 'failure' }}
       rich-coverage-comment: ${{ inputs.coverage }}
       coverage-artifact-name: ${{ inputs.coverage && 'node-coverage' || '' }}
-      coverage-file: ${{ inputs.coverage-summary-file }}
+      coverage-file: >-
+        ${{ inputs.working-directory == '.' && inputs.coverage-summary-file ||
+        format('{0}/{1}', inputs.working-directory, inputs.coverage-summary-file) }}
       coverage-format: istanbul
       tooling-ref: ${{ inputs.tooling-ref }}

--- a/.github/workflows/reusable-test-node.yml
+++ b/.github/workflows/reusable-test-node.yml
@@ -715,6 +715,8 @@ jobs:
       job-result: ${{ needs.aggregate-tests.outputs.passed == 'true' && 'success' || 'failure' }}
       rich-coverage-comment: ${{ inputs.coverage }}
       coverage-artifact-name: ${{ inputs.coverage && 'node-coverage' || '' }}
-      coverage-file: ${{ inputs.coverage-summary-file }}
+      coverage-file: >-
+        ${{ inputs.working-directory == '.' && inputs.coverage-summary-file ||
+        format('{0}/{1}', inputs.working-directory, inputs.coverage-summary-file) }}
       coverage-format: istanbul
       tooling-ref: ${{ inputs.tooling-ref }}

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -153,6 +153,13 @@ Rich coverage comments use `generate-coverage-comment` with an optional
 `## 📊 Code Coverage Report — {test-suite-name}`; `comment-marker` remains the
 upsert identity.
 
+Node test reusables (`reusable-test-node`, `reusable-test-node-custom`) upload the
+`node-coverage` artifact from `{working-directory}/{coverage-summary-file}`.
+`publish-test-summary` must pass the same path (including the `working-directory`
+prefix when it is not `.`) as `coverage-file` to
+`reusable-publish-test-summary.yml` so `download-artifact` resolves the summary
+inside `coverage-test-summary/`.
+
 ### Compat vs coverage contract (#340)
 
 Rust, Node, and Python test reusables share a **two-mode contract**:

--- a/tests/bats/integration/test_reusable_test_node.bats
+++ b/tests/bats/integration/test_reusable_test_node.bats
@@ -47,8 +47,10 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node.yml"
 
 @test "reusable-test-node: node-coverage artifact upload uses working-directory prefix" {
 	run awk '
-		/Upload coverage for test summary/ { in_step = 1 }
-		in_step && /path: \$\{\{ inputs\.working-directory \}\}\/\$\{\{ inputs\.coverage-summary-file \}\}/ {
+		/^  test-vitest:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  test-vitest:/ { in_job = 0 }
+		in_job && /Upload coverage for test summary/ { in_step = 1 }
+		in_job && in_step && /path: \$\{\{ inputs\.working-directory \}\}\/\$\{\{ inputs\.coverage-summary-file \}\}/ {
 			found = 1
 			exit
 		}
@@ -59,8 +61,10 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node.yml"
 
 @test "reusable-test-node: publish-test-summary coverage-file matches node-coverage upload layout" {
 	run awk '
-		/Upload coverage for test summary/ { in_upload = 1 }
-		in_upload && /path: \$\{\{ inputs\.working-directory \}\}\/\$\{\{ inputs\.coverage-summary-file \}\}/ {
+		/^  test-vitest:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  test-vitest:/ { in_job = 0 }
+		in_job && /Upload coverage for test summary/ { in_upload = 1 }
+		in_job && in_upload && /path: \$\{\{ inputs\.working-directory \}\}\/\$\{\{ inputs\.coverage-summary-file \}\}/ {
 			upload = 1
 		}
 		/^  publish-test-summary:/ { in_publish = 1 }

--- a/tests/bats/integration/test_reusable_test_node.bats
+++ b/tests/bats/integration/test_reusable_test_node.bats
@@ -68,9 +68,12 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node.yml"
 			upload = 1
 		}
 		/^  publish-test-summary:/ { in_publish = 1 }
-		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ { in_publish = 0 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ {
+			in_publish = 0
+			in_cov = 0
+		}
 		in_publish && /coverage-file:/ { in_cov = 1 }
-		in_cov && /inputs\.working-directory/ && /inputs\.coverage-summary-file/ {
+		in_publish && in_cov && /inputs\.working-directory/ && /inputs\.coverage-summary-file/ {
 			publish = 1
 		}
 		END { exit !(upload && publish) }

--- a/tests/bats/integration/test_reusable_test_node.bats
+++ b/tests/bats/integration/test_reusable_test_node.bats
@@ -44,3 +44,44 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node.yml"
 	run grep -Fq "steps.stage-pages-coverage.outcome == 'success'" "$WORKFLOW"
 	assert_success
 }
+
+@test "reusable-test-node: node-coverage artifact upload uses working-directory prefix" {
+	run awk '
+		/Upload coverage for test summary/ { in_step = 1 }
+		in_step && /path: \$\{\{ inputs\.working-directory \}\}\/\$\{\{ inputs\.coverage-summary-file \}\}/ {
+			found = 1
+			exit
+		}
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-test-node: publish-test-summary coverage-file matches node-coverage upload layout" {
+	run awk '
+		/Upload coverage for test summary/ { in_upload = 1 }
+		in_upload && /path: \$\{\{ inputs\.working-directory \}\}\/\$\{\{ inputs\.coverage-summary-file \}\}/ {
+			upload = 1
+		}
+		/^  publish-test-summary:/ { in_publish = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ { in_publish = 0 }
+		in_publish && /coverage-file:/ { in_cov = 1 }
+		in_cov && /inputs\.working-directory/ && /inputs\.coverage-summary-file/ {
+			publish = 1
+		}
+		END { exit !(upload && publish) }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-test-node: publish-test-summary rejects bare coverage-summary-file path" {
+	run awk '
+		/^  publish-test-summary:/ { in_publish = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ { in_publish = 0 }
+		in_publish && /^      coverage-file: \$\{\{ inputs\.coverage-summary-file \}\}$/ {
+			bare = 1
+		}
+		END { exit bare }
+	' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_test_node_custom.bats
+++ b/tests/bats/integration/test_reusable_test_node_custom.bats
@@ -47,3 +47,48 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node-custom.yml"
 	' "$WORKFLOW"
 	assert_success
 }
+
+@test "reusable-test-node-custom: node-coverage artifact upload uses working-directory prefix" {
+	run awk '
+		/^  test:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  test:/ { in_job = 0 }
+		in_job && /Upload coverage for test summary/ { in_step = 1 }
+		in_job && in_step && /path: \$\{\{ inputs\.working-directory \}\}\/\$\{\{ inputs\.coverage-summary-file \}\}/ {
+			found = 1
+			exit
+		}
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-test-node-custom: publish-test-summary coverage-file matches node-coverage upload layout" {
+	run awk '
+		/^  test:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  test:/ { in_job = 0 }
+		in_job && /Upload coverage for test summary/ { in_upload = 1 }
+		in_job && in_upload && /path: \$\{\{ inputs\.working-directory \}\}\/\$\{\{ inputs\.coverage-summary-file \}\}/ {
+			upload = 1
+		}
+		/^  publish-test-summary:/ { in_publish = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ { in_publish = 0 }
+		in_publish && /coverage-file:/ { in_cov = 1 }
+		in_cov && /inputs\.working-directory/ && /inputs\.coverage-summary-file/ {
+			publish = 1
+		}
+		END { exit !(upload && publish) }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-test-node-custom: publish-test-summary rejects bare coverage-summary-file path" {
+	run awk '
+		/^  publish-test-summary:/ { in_publish = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ { in_publish = 0 }
+		in_publish && /^      coverage-file: \$\{\{ inputs\.coverage-summary-file \}\}$/ {
+			bare = 1
+		}
+		END { exit bare }
+	' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_test_node_custom.bats
+++ b/tests/bats/integration/test_reusable_test_node_custom.bats
@@ -71,9 +71,12 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node-custom.yml"
 			upload = 1
 		}
 		/^  publish-test-summary:/ { in_publish = 1 }
-		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ { in_publish = 0 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ {
+			in_publish = 0
+			in_cov = 0
+		}
 		in_publish && /coverage-file:/ { in_cov = 1 }
-		in_cov && /inputs\.working-directory/ && /inputs\.coverage-summary-file/ {
+		in_publish && in_cov && /inputs\.working-directory/ && /inputs\.coverage-summary-file/ {
 			publish = 1
 		}
 		END { exit !(upload && publish) }


### PR DESCRIPTION
## Summary

Fix a path mismatch in `reusable-test-node.yml` where the `node-coverage` artifact is uploaded from `${{ inputs.working-directory }}/${{ inputs.coverage-summary-file }}` but `publish-test-summary` passed only `${{ inputs.coverage-summary-file }}` to `reusable-publish-test-summary`. After `download-artifact` strips the upload prefix, the rich coverage comment could not find the summary file in monorepo layouts (e.g. `working-directory: apps/web`).

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #348

## Changes Made

- Thread `working-directory` into `publish-test-summary` `coverage-file` using the same conditional prefix pattern as other workflows (`'.'` keeps the bare summary path; otherwise `format('{0}/{1}', ...)`).
- Add BATS contract tests ensuring upload and publish paths stay aligned and rejecting the bare `coverage-summary-file` regression.

## Testing

- [x] `uv run lintro chk` — zero issues
- [x] `make test-bats` — 2245 tests passed (including 3 new integration tests)
- [x] Verified consumer contract: `Rustume` uses `working-directory: apps/web`, `coverage: true`, `publish-test-summary: true`; resolved path is now `apps/web/coverage/coverage-summary.json` on both upload and publish sides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests verifying coverage file path handling and validation for test workflows.

* **Chores**
  * Adjusted test workflow wiring to resolve coverage-summary file paths correctly when a working directory is configured.

* **Documentation**
  * Updated workflow contract docs to clarify how coverage summary paths must be resolved and consumed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix coverage-file path in node test workflows to include working-directory prefix
> - When `inputs.working-directory` is not `.`, the `publish-test-summary` step in [`reusable-test-node.yml`](https://github.com/lgtm-hq/lgtm-ci/pull/349/files#diff-cfb6bc8637ac27e7e0117be0e18a78ae566c2239523a9ef5c4fa80b8db205c55) and [`reusable-test-node-custom.yml`](https://github.com/lgtm-hq/lgtm-ci/pull/349/files#diff-322e9b337c29367ec000da880cb676272f151fac9b2580e4bc40034fa72d0d70) now prefixes `coverage-summary-file` with `working-directory`, matching the path used when uploading the artifact.
> - Without this fix, `download-artifact` in `publish-test-summary` fails to resolve the coverage summary because the upload path includes the working-directory prefix but the download path did not.
> - Integration tests are added for both workflows to assert correct artifact path construction and reject bare `inputs.coverage-summary-file` usage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4acc44.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a path mismatch where `node-coverage` artifacts were uploaded from `{working-directory}/{coverage-summary-file}` but `publish-test-summary` received only the bare `coverage-summary-file`, causing `generate-coverage-comment` to look for the file at the wrong location inside `coverage-test-summary/` in monorepo layouts.

- **Workflow fix** (`reusable-test-node.yml`, `reusable-test-node-custom.yml`): `coverage-file` is now computed with the same conditional prefix pattern used elsewhere — returning the bare `coverage-summary-file` when `working-directory` is `.`, and `format('{0}/{1}', working-directory, coverage-summary-file)` otherwise.
- **BATS contract tests**: Three AWK-based integration tests verify the upload path, the publish path, and absence of the bare-path regression in each workflow variant.
- **Documentation**: `docs/workflow-contract.md` gains a prose description of the two-sided upload/publish path contract for node test reusables.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, well-understood path alignment fix with no side effects on non-monorepo consumers.

Both workflow files receive an identical, minimal one-expression change; the default `working-directory: .` case preserves existing behaviour exactly, and the `format('{0}/{1}', ...)` branch correctly mirrors the already-correct artifact upload path. The BATS tests lock down both sides of the contract. No unrelated code is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-test-node.yml | Replaces bare `inputs.coverage-summary-file` with a conditional that prefixes `working-directory` when it is not `.`, aligning `coverage-file` with the artifact upload path. |
| .github/workflows/reusable-test-node-custom.yml | Applies the identical `working-directory` prefix fix to the custom-runner variant, keeping it in parity with the standard workflow. |
| tests/bats/integration/test_reusable_test_node.bats | Adds three AWK-based contract tests: verifies upload uses the working-directory prefix, verifies publish-test-summary mirrors that layout, and rejects the bare regression path. |
| tests/bats/integration/test_reusable_test_node_custom.bats | Mirrors the three new contract tests for the custom-runner workflow, with correct job-name anchors (`test:` instead of `test-vitest:`). |
| docs/workflow-contract.md | Documents the upload/publish path contract for node test reusables, clarifying that `working-directory` must be threaded through both sides. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant TJ as test-vitest job
    participant UA as upload-artifact
    participant ART as node-coverage artifact
    participant DA as download-artifact
    participant PTS as publish-test-summary job
    participant GCC as generate-coverage-comment

    TJ->>UA: "path: {working-directory}/{coverage-summary-file}"
    UA->>ART: stores file at apps/web/coverage/coverage-summary.json

    Note over PTS: coverage-file = working-directory == '.' ?<br/>coverage-summary-file :<br/>format('{0}/{1}', working-directory, coverage-summary-file)

    PTS->>DA: "download name=node-coverage to coverage-test-summary/"
    DA->>PTS: coverage-test-summary/apps/web/coverage/coverage-summary.json

    PTS->>GCC: "coverage-file: coverage-test-summary/{coverage-file}"
    Note over GCC: resolves to coverage-test-summary/apps/web/coverage/coverage-summary.json ✓
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test: scope coverage-file assertions to ..."](https://github.com/lgtm-hq/lgtm-ci/commit/d4acc44c9a4ed6e1ed64e4bf1b2c65cd8bcd18d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36904336)</sub>

<!-- /greptile_comment -->
