### PR TITLE
fix: preserve monorepo paths in node-coverage test-summary artifacts

### DIFF
--- a/.github/workflows/reusable-test-node-custom.yml
+++ b/.github/workflows/reusable-test-node-custom.yml
@@ -338,10 +338,8 @@ jobs:
         env:
           WORKING_DIRECTORY: ${{ inputs.working-directory }}
           COVERAGE_SUMMARY_FILE: ${{ inputs.coverage-summary-file }}
-        run: |
-          dest="node-coverage-staged/${WORKING_DIRECTORY}/${COVERAGE_SUMMARY_FILE}"
-          mkdir -p "$(dirname "$dest")"
-          cp "${WORKING_DIRECTORY}/${COVERAGE_SUMMARY_FILE}" "$dest"
+        run: >-
+          bash .lgtm-ci-tooling/scripts/ci/actions/stage-node-coverage-test-summary.sh
 
       - name: Upload coverage for test summary
         if: >-

--- a/.github/workflows/reusable-test-node-custom.yml
+++ b/.github/workflows/reusable-test-node-custom.yml
@@ -326,6 +326,23 @@ jobs:
           WORKING_DIRECTORY: ${{ inputs.working-directory }}
         run: bash .lgtm-ci-tooling/scripts/ci/actions/run-command.sh
 
+      - name: Stage coverage for test summary
+        if: >-
+          always()
+          && inputs.coverage
+          && inputs.publish-test-summary
+          && inputs.node-versions == ''
+          && github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.fork == false
+        shell: bash
+        env:
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+          COVERAGE_SUMMARY_FILE: ${{ inputs.coverage-summary-file }}
+        run: |
+          dest="node-coverage-staged/${WORKING_DIRECTORY}/${COVERAGE_SUMMARY_FILE}"
+          mkdir -p "$(dirname "$dest")"
+          cp "${WORKING_DIRECTORY}/${COVERAGE_SUMMARY_FILE}" "$dest"
+
       - name: Upload coverage for test summary
         if: >-
           always()
@@ -337,7 +354,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: node-coverage
-          path: ${{ inputs.working-directory }}/${{ inputs.coverage-summary-file }}
+          path: node-coverage-staged/
           retention-days: 7
           if-no-files-found: ignore
 

--- a/.github/workflows/reusable-test-node.yml
+++ b/.github/workflows/reusable-test-node.yml
@@ -454,6 +454,23 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
+      - name: Stage coverage for test summary
+        if: >-
+          always()
+          && inputs.coverage
+          && inputs.publish-test-summary
+          && inputs.node-versions == ''
+          && github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.fork == false
+        shell: bash
+        env:
+          WORKING_DIRECTORY: ${{ inputs.working-directory }}
+          COVERAGE_SUMMARY_FILE: ${{ inputs.coverage-summary-file }}
+        run: |
+          dest="node-coverage-staged/${WORKING_DIRECTORY}/${COVERAGE_SUMMARY_FILE}"
+          mkdir -p "$(dirname "$dest")"
+          cp "${WORKING_DIRECTORY}/${COVERAGE_SUMMARY_FILE}" "$dest"
+
       - name: Upload coverage for test summary
         if: >-
           always()
@@ -465,7 +482,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: node-coverage
-          path: ${{ inputs.working-directory }}/${{ inputs.coverage-summary-file }}
+          path: node-coverage-staged/
           retention-days: 7
           if-no-files-found: ignore
 

--- a/.github/workflows/reusable-test-node.yml
+++ b/.github/workflows/reusable-test-node.yml
@@ -466,10 +466,8 @@ jobs:
         env:
           WORKING_DIRECTORY: ${{ inputs.working-directory }}
           COVERAGE_SUMMARY_FILE: ${{ inputs.coverage-summary-file }}
-        run: |
-          dest="node-coverage-staged/${WORKING_DIRECTORY}/${COVERAGE_SUMMARY_FILE}"
-          mkdir -p "$(dirname "$dest")"
-          cp "${WORKING_DIRECTORY}/${COVERAGE_SUMMARY_FILE}" "$dest"
+        run: >-
+          bash .lgtm-ci-tooling/scripts/ci/actions/stage-node-coverage-test-summary.sh
 
       - name: Upload coverage for test summary
         if: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **workflows**: stage `node-coverage` test-summary artifacts under
+  `node-coverage-staged/` so monorepo `working-directory` paths are preserved
+  when downloaded by `reusable-publish-test-summary.yml`
+
 ### Security
 
 ## [0.45.0] - 2026-06-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **workflows**: stage `node-coverage` test-summary artifacts under
   `node-coverage-staged/` so monorepo `working-directory` paths are preserved
   when downloaded by `reusable-publish-test-summary.yml`
+- **scripts**: add `stage-node-coverage-test-summary.sh` with missing-file skip
+  so failed test runs do not error when coverage was never written
 
 ### Security
 

--- a/scripts/ci/actions/stage-node-coverage-test-summary.sh
+++ b/scripts/ci/actions/stage-node-coverage-test-summary.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Stage Node.js coverage summary for publish-test-summary artifact upload.
+
+set -euo pipefail
+
+: "${WORKING_DIRECTORY:=.}"
+: "${COVERAGE_SUMMARY_FILE:?COVERAGE_SUMMARY_FILE is required}"
+
+source_file="${WORKING_DIRECTORY}/${COVERAGE_SUMMARY_FILE}"
+
+if [[ ! -f "$source_file" ]]; then
+	echo "Coverage summary missing (${source_file}), skipping staging"
+	exit 0
+fi
+
+dest="node-coverage-staged/${WORKING_DIRECTORY}/${COVERAGE_SUMMARY_FILE}"
+mkdir -p "$(dirname "$dest")"
+cp "$source_file" "$dest"
+echo "Staged ${source_file} -> ${dest}"

--- a/tests/bats/integration/test_reusable_test_node.bats
+++ b/tests/bats/integration/test_reusable_test_node.bats
@@ -49,11 +49,16 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node.yml"
 	run awk '
 		/^  test-vitest:/ { in_job = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  test-vitest:/ { in_job = 0 }
-		in_job && /Stage coverage for test summary/ { in_step = 1 }
-		in_job && in_step && /node-coverage-staged/ && /WORKING_DIRECTORY/ && /COVERAGE_SUMMARY_FILE/ {
-			found = 1
+		in_job && /Stage coverage for test summary/ {
+			in_step = 1
+			script = 0
+			env_wd = 0
+			env_cov = 0
 		}
-		END { exit !found }
+		in_job && in_step && /stage-node-coverage-test-summary\.sh/ { script = 1 }
+		in_job && in_step && /WORKING_DIRECTORY:/ { env_wd = 1 }
+		in_job && in_step && /COVERAGE_SUMMARY_FILE:/ { env_cov = 1 }
+		END { exit !(script && env_wd && env_cov) }
 	' "$WORKFLOW"
 	assert_success
 }
@@ -76,10 +81,15 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node.yml"
 	run awk '
 		/^  test-vitest:/ { in_job = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  test-vitest:/ { in_job = 0 }
-		in_job && /Stage coverage for test summary/ { in_stage = 1 }
-		in_job && in_stage && /node-coverage-staged/ && /WORKING_DIRECTORY/ && /COVERAGE_SUMMARY_FILE/ {
-			stage = 1
+		in_job && /Stage coverage for test summary/ {
+			in_stage = 1
+			script = 0
+			env_wd = 0
+			env_cov = 0
 		}
+		in_job && in_stage && /stage-node-coverage-test-summary\.sh/ { script = 1 }
+		in_job && in_stage && /WORKING_DIRECTORY:/ { env_wd = 1 }
+		in_job && in_stage && /COVERAGE_SUMMARY_FILE:/ { env_cov = 1 }
 		/^  publish-test-summary:/ { in_publish = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ {
 			in_publish = 0
@@ -89,7 +99,7 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node.yml"
 		in_publish && in_cov && /inputs\.working-directory/ && /inputs\.coverage-summary-file/ {
 			publish = 1
 		}
-		END { exit !(stage && publish) }
+		END { exit !(script && env_wd && env_cov && publish) }
 	' "$WORKFLOW"
 	assert_success
 }

--- a/tests/bats/integration/test_reusable_test_node.bats
+++ b/tests/bats/integration/test_reusable_test_node.bats
@@ -45,27 +45,40 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node.yml"
 	assert_success
 }
 
-@test "reusable-test-node: node-coverage artifact upload uses working-directory prefix" {
+@test "reusable-test-node: stages node-coverage artifact preserving working-directory prefix" {
 	run awk '
 		/^  test-vitest:/ { in_job = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  test-vitest:/ { in_job = 0 }
-		in_job && /Upload coverage for test summary/ { in_step = 1 }
-		in_job && in_step && /path: \$\{\{ inputs\.working-directory \}\}\/\$\{\{ inputs\.coverage-summary-file \}\}/ {
+		in_job && /Stage coverage for test summary/ { in_step = 1 }
+		in_job && in_step && /node-coverage-staged/ && /WORKING_DIRECTORY/ && /COVERAGE_SUMMARY_FILE/ {
 			found = 1
-			exit
 		}
 		END { exit !found }
 	' "$WORKFLOW"
 	assert_success
 }
 
-@test "reusable-test-node: publish-test-summary coverage-file matches node-coverage upload layout" {
+@test "reusable-test-node: node-coverage artifact upload uses staged directory" {
 	run awk '
 		/^  test-vitest:/ { in_job = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  test-vitest:/ { in_job = 0 }
 		in_job && /Upload coverage for test summary/ { in_upload = 1 }
+		in_job && in_upload && /path: node-coverage-staged\// { dir = 1 }
 		in_job && in_upload && /path: \$\{\{ inputs\.working-directory \}\}\/\$\{\{ inputs\.coverage-summary-file \}\}/ {
-			upload = 1
+			single = 1
+		}
+		END { exit !(dir && !single) }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-test-node: publish-test-summary coverage-file matches node-coverage staged layout" {
+	run awk '
+		/^  test-vitest:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  test-vitest:/ { in_job = 0 }
+		in_job && /Stage coverage for test summary/ { in_stage = 1 }
+		in_job && in_stage && /node-coverage-staged/ && /WORKING_DIRECTORY/ && /COVERAGE_SUMMARY_FILE/ {
+			stage = 1
 		}
 		/^  publish-test-summary:/ { in_publish = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ {
@@ -76,7 +89,7 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node.yml"
 		in_publish && in_cov && /inputs\.working-directory/ && /inputs\.coverage-summary-file/ {
 			publish = 1
 		}
-		END { exit !(upload && publish) }
+		END { exit !(stage && publish) }
 	' "$WORKFLOW"
 	assert_success
 }

--- a/tests/bats/integration/test_reusable_test_node_custom.bats
+++ b/tests/bats/integration/test_reusable_test_node_custom.bats
@@ -52,11 +52,16 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node-custom.yml"
 	run awk '
 		/^  test:/ { in_job = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  test:/ { in_job = 0 }
-		in_job && /Stage coverage for test summary/ { in_step = 1 }
-		in_job && in_step && /node-coverage-staged/ && /WORKING_DIRECTORY/ && /COVERAGE_SUMMARY_FILE/ {
-			found = 1
+		in_job && /Stage coverage for test summary/ {
+			in_step = 1
+			script = 0
+			env_wd = 0
+			env_cov = 0
 		}
-		END { exit !found }
+		in_job && in_step && /stage-node-coverage-test-summary\.sh/ { script = 1 }
+		in_job && in_step && /WORKING_DIRECTORY:/ { env_wd = 1 }
+		in_job && in_step && /COVERAGE_SUMMARY_FILE:/ { env_cov = 1 }
+		END { exit !(script && env_wd && env_cov) }
 	' "$WORKFLOW"
 	assert_success
 }
@@ -79,10 +84,15 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node-custom.yml"
 	run awk '
 		/^  test:/ { in_job = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  test:/ { in_job = 0 }
-		in_job && /Stage coverage for test summary/ { in_stage = 1 }
-		in_job && in_stage && /node-coverage-staged/ && /WORKING_DIRECTORY/ && /COVERAGE_SUMMARY_FILE/ {
-			stage = 1
+		in_job && /Stage coverage for test summary/ {
+			in_stage = 1
+			script = 0
+			env_wd = 0
+			env_cov = 0
 		}
+		in_job && in_stage && /stage-node-coverage-test-summary\.sh/ { script = 1 }
+		in_job && in_stage && /WORKING_DIRECTORY:/ { env_wd = 1 }
+		in_job && in_stage && /COVERAGE_SUMMARY_FILE:/ { env_cov = 1 }
 		/^  publish-test-summary:/ { in_publish = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ {
 			in_publish = 0
@@ -92,7 +102,7 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node-custom.yml"
 		in_publish && in_cov && /inputs\.working-directory/ && /inputs\.coverage-summary-file/ {
 			publish = 1
 		}
-		END { exit !(stage && publish) }
+		END { exit !(script && env_wd && env_cov && publish) }
 	' "$WORKFLOW"
 	assert_success
 }

--- a/tests/bats/integration/test_reusable_test_node_custom.bats
+++ b/tests/bats/integration/test_reusable_test_node_custom.bats
@@ -48,27 +48,40 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node-custom.yml"
 	assert_success
 }
 
-@test "reusable-test-node-custom: node-coverage artifact upload uses working-directory prefix" {
+@test "reusable-test-node-custom: stages node-coverage artifact preserving working-directory prefix" {
 	run awk '
 		/^  test:/ { in_job = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  test:/ { in_job = 0 }
-		in_job && /Upload coverage for test summary/ { in_step = 1 }
-		in_job && in_step && /path: \$\{\{ inputs\.working-directory \}\}\/\$\{\{ inputs\.coverage-summary-file \}\}/ {
+		in_job && /Stage coverage for test summary/ { in_step = 1 }
+		in_job && in_step && /node-coverage-staged/ && /WORKING_DIRECTORY/ && /COVERAGE_SUMMARY_FILE/ {
 			found = 1
-			exit
 		}
 		END { exit !found }
 	' "$WORKFLOW"
 	assert_success
 }
 
-@test "reusable-test-node-custom: publish-test-summary coverage-file matches node-coverage upload layout" {
+@test "reusable-test-node-custom: node-coverage artifact upload uses staged directory" {
 	run awk '
 		/^  test:/ { in_job = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  test:/ { in_job = 0 }
 		in_job && /Upload coverage for test summary/ { in_upload = 1 }
+		in_job && in_upload && /path: node-coverage-staged\// { dir = 1 }
 		in_job && in_upload && /path: \$\{\{ inputs\.working-directory \}\}\/\$\{\{ inputs\.coverage-summary-file \}\}/ {
-			upload = 1
+			single = 1
+		}
+		END { exit !(dir && !single) }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-test-node-custom: publish-test-summary coverage-file matches node-coverage staged layout" {
+	run awk '
+		/^  test:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  test:/ { in_job = 0 }
+		in_job && /Stage coverage for test summary/ { in_stage = 1 }
+		in_job && in_stage && /node-coverage-staged/ && /WORKING_DIRECTORY/ && /COVERAGE_SUMMARY_FILE/ {
+			stage = 1
 		}
 		/^  publish-test-summary:/ { in_publish = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ {
@@ -79,7 +92,7 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node-custom.yml"
 		in_publish && in_cov && /inputs\.working-directory/ && /inputs\.coverage-summary-file/ {
 			publish = 1
 		}
-		END { exit !(upload && publish) }
+		END { exit !(stage && publish) }
 	' "$WORKFLOW"
 	assert_success
 }

--- a/tests/bats/unit/actions/test_stage_node_coverage_test_summary.bats
+++ b/tests/bats/unit/actions/test_stage_node_coverage_test_summary.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for stage-node-coverage-test-summary.sh
+
+load "../../../helpers/common"
+
+setup() {
+	setup_temp_dir
+	cd "$BATS_TEST_TMPDIR" || return 1
+	export SCRIPT="$PROJECT_ROOT/scripts/ci/actions/stage-node-coverage-test-summary.sh"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "stage-node-coverage-test-summary: preserves working-directory prefix" {
+	mkdir -p apps/web/coverage
+	echo '{"total":{}}' >apps/web/coverage/coverage-summary.json
+
+	WORKING_DIRECTORY=apps/web \
+		COVERAGE_SUMMARY_FILE=coverage/coverage-summary.json \
+		run bash "$SCRIPT"
+	assert_success
+	assert_file_exists node-coverage-staged/apps/web/coverage/coverage-summary.json
+}
+
+@test "stage-node-coverage-test-summary: skips when coverage summary is missing" {
+	WORKING_DIRECTORY=apps/web \
+		COVERAGE_SUMMARY_FILE=coverage/coverage-summary.json \
+		run bash "$SCRIPT"
+	assert_success
+	run test ! -e node-coverage-staged
+	assert_success
+}


### PR DESCRIPTION
## Summary

Fixes a path-flattening bug where `upload-artifact` uploaded a single coverage
summary file, stripping the monorepo `working-directory` prefix. Coverage PR
comments failed for packages like `apps/web` because
`reusable-publish-test-summary.yml` could not locate the file after download.

Both Node test reusables now stage coverage into `node-coverage-staged/` before
upload, preserving the full relative path inside the artifact.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve monorepo paths in node-coverage test-summary artifacts
> - Adds [`stage-node-coverage-test-summary.sh`](https://github.com/lgtm-hq/lgtm-ci/pull/354/files#diff-fbb60c773c34b8accc6b2f76e39e89d09e4702c3283e2194cefb03735f25d578) to copy coverage summaries into `node-coverage-staged/<working-directory>/` before upload, preserving monorepo subdirectory structure.
> - Updates [`reusable-test-node.yml`](https://github.com/lgtm-hq/lgtm-ci/pull/354/files#diff-cfb6bc8637ac27e7e0117be0e18a78ae566c2239523a9ef5c4fa80b8db205c55) and [`reusable-test-node-custom.yml`](https://github.com/lgtm-hq/lgtm-ci/pull/354/files#diff-322e9b337c29367ec000da880cb676272f151fac9b2580e4bc40034fa72d0d70) to run the staging step and upload `node-coverage-staged/` instead of a single flat file path.
> - The staging script skips silently if the coverage summary file is missing, avoiding failures for jobs that produce no coverage.
> - Behavioral Change: the uploaded artifact now contains a directory tree rooted at `node-coverage-staged/` rather than a single file, which may affect any downstream steps that reference the artifact by the old path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf913ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated test-summary coverage artifact staging in continuous integration workflows to preserve monorepo working-directory paths when artifacts are downloaded and published.
  * Coverage summary files are now organized under a dedicated staging directory structure before being uploaded.
  * Automated test validation has been updated to confirm proper artifact staging behavior across test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a path-flattening bug where `upload-artifact` stripped monorepo `working-directory` prefixes from coverage summary artifacts, causing `reusable-publish-test-summary.yml` to fail locating the file after download.

- Introduces `stage-node-coverage-test-summary.sh`, which copies the coverage summary into `node-coverage-staged/${WORKING_DIRECTORY}/${COVERAGE_SUMMARY_FILE}` before upload; the script exits `0` gracefully when the coverage file is absent (e.g., after a test-runner crash), restoring the silent-skip semantics previously provided by `if-no-files-found: ignore`.
- Both `reusable-test-node.yml` and `reusable-test-node-custom.yml` gain a staging step with the same condition guard as the upload step, and the upload `path` changes from a single flat file to the `node-coverage-staged/` directory so the artifact preserves the full sub-path that `reusable-publish-test-summary.yml` constructs via `format('coverage-test-summary/{0}', inputs.coverage-file)`.
- Integration and unit tests are added/updated to assert the new staging step, env vars, directory-based upload path, and correct skip behaviour on missing files.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the staging script correctly preserves paths for all cases including the WORKING_DIRECTORY=. default, and the missing-file guard restores the previous silent-skip behaviour.

The core fix — staging into a directory that preserves the monorepo sub-path before upload — is correct and the downstream coverage-file formula in reusable-publish-test-summary.yml aligns exactly with the new artifact layout. The missing-file guard addresses the previously raised concern about cp failing on absent coverage files. No logic errors were found in the changed paths.

The unit test suite for stage-node-coverage-test-summary.sh omits a test for the WORKING_DIRECTORY=. default, but the behaviour is correct; no files require blocking attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/actions/stage-node-coverage-test-summary.sh | New staging script: correctly handles missing coverage file with an early exit, constructs the node-coverage-staged/${WORKING_DIRECTORY}/${COVERAGE_SUMMARY_FILE} destination, and creates parent directories with mkdir -p. |
| .github/workflows/reusable-test-node.yml | Adds staging step before the upload step (same condition guard); upload path changed from a single flat file to node-coverage-staged/ directory, preserving monorepo sub-paths inside the artifact. |
| .github/workflows/reusable-test-node-custom.yml | Mirrors the same staging-step addition and upload-path change as reusable-test-node.yml; conditions are identical, change is symmetric. |
| tests/bats/unit/actions/test_stage_node_coverage_test_summary.bats | Two unit tests cover happy-path (with apps/web prefix) and missing-file skip; the WORKING_DIRECTORY=. default case is not covered. |
| tests/bats/integration/test_reusable_test_node.bats | Integration tests updated to assert staging script presence, env vars, new node-coverage-staged/ upload path, and absence of the old flat-file path; logic is correct. |
| tests/bats/integration/test_reusable_test_node_custom.bats | Symmetric counterpart to test_reusable_test_node.bats; same test structure applied to the custom-workflow job block. |
| CHANGELOG.md | Changelog entry placed correctly in the Fixed section for the current unreleased version; accurately describes both the workflow change and the new script. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant T as test-vitest job
    participant S as stage-node-coverage-test-summary.sh
    participant A as actions/upload-artifact
    participant P as publish-test-summary job
    participant D as actions/download-artifact
    participant G as generate-coverage-comment

    T->>S: run (WORKING_DIRECTORY, COVERAGE_SUMMARY_FILE)
    alt coverage file exists
        S->>S: mkdir -p node-coverage-staged/WORKING_DIR/
        S->>S: cp source → node-coverage-staged/WORKING_DIR/FILE
    else coverage file missing
        S->>S: echo skip, exit 0
    end
    T->>A: "upload path=node-coverage-staged/ → artifact node-coverage"
    Note over A: artifact preserves WORKING_DIR/FILE structure
    P->>D: download artifact node-coverage → coverage-test-summary/
    Note over D: file at coverage-test-summary/WORKING_DIR/FILE
    P->>G: "coverage-file = coverage-test-summary/WORKING_DIR/FILE"
    G->>P: rich coverage comment
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fbats%2Funit%2Factions%2Ftest_stage_node_coverage_test_summary.bats%3A17-35%0A**Missing%20unit%20test%20for%20%60WORKING_DIRECTORY%3D.%60%20%28default%20case%29**%0A%0AThe%20script%20defaults%20%60WORKING_DIRECTORY%60%20to%20%60.%60%20when%20unset%2C%20which%20makes%20the%20staging%20destination%20%60node-coverage-staged%2F.%2Fcoverage%2Fcoverage-summary.json%60.%20The%20OS%20normalises%20the%20%60.%2F%60%20transparently%2C%20so%20the%20file%20lands%20at%20%60node-coverage-staged%2Fcoverage%2Fcoverage-summary.json%60%20%E2%80%94%20matching%20the%20%60coverage-file%60%20formula%20in%20%60publish-test-summary%60%20for%20the%20root-package%20case.%20Adding%20a%20test%20here%20would%20lock%20in%20that%20behaviour%20and%20catch%20any%20future%20regression%20where%20the%20path%20expression%20changes.%0A%0A&pr=354&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fbats%2Funit%2Factions%2Ftest_stage_node_coverage_test_summary.bats%3A17-35%0A**Missing%20unit%20test%20for%20%60WORKING_DIRECTORY%3D.%60%20%28default%20case%29**%0A%0AThe%20script%20defaults%20%60WORKING_DIRECTORY%60%20to%20%60.%60%20when%20unset%2C%20which%20makes%20the%20staging%20destination%20%60node-coverage-staged%2F.%2Fcoverage%2Fcoverage-summary.json%60.%20The%20OS%20normalises%20the%20%60.%2F%60%20transparently%2C%20so%20the%20file%20lands%20at%20%60node-coverage-staged%2Fcoverage%2Fcoverage-summary.json%60%20%E2%80%94%20matching%20the%20%60coverage-file%60%20formula%20in%20%60publish-test-summary%60%20for%20the%20root-package%20case.%20Adding%20a%20test%20here%20would%20lock%20in%20that%20behaviour%20and%20catch%20any%20future%20regression%20where%20the%20path%20expression%20changes.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=354&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22fix%2Fnode-coverage-artifact-path-flattening%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fnode-coverage-artifact-path-flattening%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fbats%2Funit%2Factions%2Ftest_stage_node_coverage_test_summary.bats%3A17-35%0A**Missing%20unit%20test%20for%20%60WORKING_DIRECTORY%3D.%60%20%28default%20case%29**%0A%0AThe%20script%20defaults%20%60WORKING_DIRECTORY%60%20to%20%60.%60%20when%20unset%2C%20which%20makes%20the%20staging%20destination%20%60node-coverage-staged%2F.%2Fcoverage%2Fcoverage-summary.json%60.%20The%20OS%20normalises%20the%20%60.%2F%60%20transparently%2C%20so%20the%20file%20lands%20at%20%60node-coverage-staged%2Fcoverage%2Fcoverage-summary.json%60%20%E2%80%94%20matching%20the%20%60coverage-file%60%20formula%20in%20%60publish-test-summary%60%20for%20the%20root-package%20case.%20Adding%20a%20test%20here%20would%20lock%20in%20that%20behaviour%20and%20catch%20any%20future%20regression%20where%20the%20path%20expression%20changes.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=354&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: extract node-coverage staging scrip..."](https://github.com/lgtm-hq/lgtm-ci/commit/cf913bac23bdd7ff78987ee6572c8e532e5bd067) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37294581)</sub>

<!-- /greptile_comment -->