### PR TITLE
fix(homebrew): restore deprecated updaters and correct formula arg order

### DIFF
--- a/.github/actions/update-homebrew/action.yml
+++ b/.github/actions/update-homebrew/action.yml
@@ -1,0 +1,127 @@
+# DEPRECATION: Org repos publishing to lgtm-hq/homebrew-tap should use
+# trigger-homebrew-update (repository_dispatch model) instead. This action
+# remains for simple same-repo tap use cases where the caller owns the tap.
+---
+name: "Update Homebrew Formula"
+description: "Update a Homebrew formula with new version from PyPI"
+author: "lgtm-hq"
+
+inputs:
+  tap-repository:
+    description: "Homebrew tap repository (owner/repo)"
+    required: true
+  formula:
+    description: "Formula name"
+    required: true
+  package-name:
+    description: "PyPI package name"
+    required: true
+  version:
+    description: "Version to update to"
+    required: true
+  wait-for-availability:
+    description: "Wait for package to be available on PyPI"
+    required: false
+    default: "true"
+  max-wait-minutes:
+    description: "Maximum wait time in minutes"
+    required: false
+    default: "10"
+  test-pypi:
+    description: "Use TestPyPI instead of PyPI"
+    required: false
+    default: "false"
+  push:
+    description: "Push changes to tap repository"
+    required: false
+    default: "true"
+  create-pr:
+    description: "Create PR instead of direct push"
+    required: false
+    default: "false"
+
+outputs:
+  updated:
+    description: "Whether the formula was updated"
+    value: ${{ steps.commit.outputs.updated || 'false' }}
+  commit-sha:
+    description: "Commit SHA of the update"
+    value: ${{ steps.commit.outputs.commit-sha }}
+  pr-url:
+    description: "Pull request URL (if create-pr is true)"
+    value: ${{ steps.pr.outputs.pr-url }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
+          >> "$GITHUB_ENV"
+
+    - name: Wait for package availability
+      if: inputs.wait-for-availability == 'true'
+      shell: bash
+      env:
+        STEP: wait
+        PACKAGE: ${{ inputs.package-name }}
+        VERSION: ${{ inputs.version }}
+        MAX_WAIT: ${{ inputs.max-wait-minutes }}
+        TEST_PYPI: ${{ inputs.test-pypi }}
+      run: $SCRIPTS_DIR/ci/actions/update-homebrew.sh
+
+    - name: Generate formula
+      id: generate
+      shell: bash
+      env:
+        STEP: generate
+        TAP_REPOSITORY: ${{ inputs.tap-repository }}
+        FORMULA: ${{ inputs.formula }}
+        PACKAGE: ${{ inputs.package-name }}
+        VERSION: ${{ inputs.version }}
+        TEST_PYPI: ${{ inputs.test-pypi }}
+      run: $SCRIPTS_DIR/ci/actions/update-homebrew.sh
+
+    - name: Commit changes
+      id: commit
+      if: inputs.push == 'true' || inputs.create-pr == 'true'
+      shell: bash
+      env:
+        STEP: commit
+        TAP_REPOSITORY: ${{ inputs.tap-repository }}
+        FORMULA: ${{ inputs.formula }}
+        VERSION: ${{ inputs.version }}
+        PUSH: ${{ inputs.push }}
+        CREATE_PR: ${{ inputs.create-pr }}
+        GH_TOKEN: ${{ github.token }}
+      run: $SCRIPTS_DIR/ci/actions/update-homebrew.sh
+
+    - name: Create pull request
+      id: pr
+      if: inputs.create-pr == 'true'
+      shell: bash
+      env:
+        STEP: pr
+        TAP_REPOSITORY: ${{ inputs.tap-repository }}
+        FORMULA: ${{ inputs.formula }}
+        VERSION: ${{ inputs.version }}
+        GH_TOKEN: ${{ github.token }}
+      run: $SCRIPTS_DIR/ci/actions/update-homebrew.sh
+
+    - name: Generate summary
+      shell: bash
+      env:
+        STEP: summary
+        TAP_REPOSITORY: ${{ inputs.tap-repository }}
+        FORMULA: ${{ inputs.formula }}
+        PACKAGE: ${{ inputs.package-name }}
+        VERSION: ${{ inputs.version }}
+        UPDATED: ${{ steps.commit.outputs.updated || 'false' }}
+        COMMIT_SHA: ${{ steps.commit.outputs.commit-sha }}
+        PR_URL: ${{ steps.pr.outputs.pr-url }}
+      run: $SCRIPTS_DIR/ci/actions/update-homebrew.sh
+
+branding:
+  icon: "download"
+  color: "yellow"

--- a/.github/workflows/reusable-publish-homebrew.yml
+++ b/.github/workflows/reusable-publish-homebrew.yml
@@ -1,0 +1,163 @@
+# DEPRECATION: Org repos publishing to lgtm-hq/homebrew-tap should use
+# trigger-homebrew-update (repository_dispatch model) instead. This reusable
+# remains for simple same-repo tap use cases where the caller owns the tap.
+---
+name: Reusable Homebrew Formula Update Workflow
+
+on:
+  workflow_call:
+    inputs:
+      tap-repository:
+        description: "Homebrew tap repository (owner/repo)"
+        required: true
+        type: string
+      formula:
+        description: "Formula name"
+        required: true
+        type: string
+      package-name:
+        description: "PyPI package name"
+        required: true
+        type: string
+      version:
+        description: "Version to update to"
+        required: true
+        type: string
+      wait-for-availability:
+        description: "Wait for package to be available on PyPI"
+        required: false
+        type: boolean
+        default: true
+      max-wait-minutes:
+        description: "Maximum wait time in minutes"
+        required: false
+        type: number
+        default: 10
+      test-pypi:
+        description: "Use TestPyPI instead of PyPI"
+        required: false
+        type: boolean
+        default: false
+      create-pr:
+        description: "Create PR instead of direct push"
+        required: false
+        type: boolean
+        default: false
+      tooling-ref:
+        description: "Git ref to use when checking out lgtm-ci tooling scripts"
+        required: false
+        type: string
+        default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "block"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
+      egress-preset:
+        description: >-
+          Named allowlist when allowed-endpoints is empty and egress-policy is
+          block (github-minimal, github-pages, github-tooling, docker, playwright, pypi,
+          rubygems, npm-publish, quality, sbom, scorecard)
+        required: false
+        type: string
+        default: "pypi"
+      job-name:
+        description: "GitHub check name for the publish job"
+        required: false
+        type: string
+        default: "Update Homebrew Formula"
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 15
+
+    outputs:
+      updated:
+        description: "Whether the formula was updated"
+        value: ${{ jobs.update.outputs.updated }}
+      commit-sha:
+        description: "Commit SHA of the update"
+        value: ${{ jobs.update.outputs.commit-sha }}
+      pr-url:
+        description: "Pull request URL (if create-pr is true)"
+        value: ${{ jobs.update.outputs.pr-url }}
+
+jobs:
+  update:
+    name: ${{ inputs.job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: write
+
+    outputs:
+      updated: ${{ steps.homebrew.outputs.updated || 'false' }}
+      commit-sha: ${{ steps.homebrew.outputs.commit-sha }}
+      pr-url: ${{ steps.homebrew.outputs.pr-url }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+
+      - name: Update Homebrew formula
+        id: homebrew
+        uses: ./.lgtm-ci-tooling/.github/actions/update-homebrew
+        with:
+          tap-repository: ${{ inputs.tap-repository }}
+          formula: ${{ inputs.formula }}
+          package-name: ${{ inputs.package-name }}
+          version: ${{ inputs.version }}
+          wait-for-availability: ${{ inputs.wait-for-availability }}
+          max-wait-minutes: ${{ inputs.max-wait-minutes }}
+          test-pypi: ${{ inputs.test-pypi }}
+          create-pr: ${{ inputs.create-pr }}

--- a/scripts/ci/actions/update-homebrew.sh
+++ b/scripts/ci/actions/update-homebrew.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Update Homebrew formula with new version from PyPI
+#
+# Environment variables:
+#   STEP: wait | generate | commit | pr | summary
+#   TAP_REPOSITORY: Homebrew tap repository (owner/repo)
+#   FORMULA: Formula name
+#   PACKAGE: PyPI package name
+#   VERSION: Version to update to
+#   TEST_PYPI: Use TestPyPI instead of PyPI
+#   MAX_WAIT: Maximum wait time in minutes (for wait step)
+#   PUSH: Push changes to tap repository
+#   CREATE_PR: Create PR instead of direct push
+set -euo pipefail
+
+: "${STEP:?STEP is required}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+source "$SCRIPT_DIR/../lib/actions.sh"
+source "$SCRIPT_DIR/../lib/publish.sh"
+
+# Working directory for tap clone
+TAP_DIR="${RUNNER_TEMP:-/tmp}/homebrew-tap"
+
+case "$STEP" in
+wait)
+	: "${PACKAGE:?PACKAGE is required}"
+	: "${VERSION:?VERSION is required}"
+	: "${MAX_WAIT:=10}"
+	: "${TEST_PYPI:=false}"
+
+	max_wait_seconds=$((MAX_WAIT * 60))
+
+	log_info "Waiting for $PACKAGE@$VERSION on PyPI..."
+
+	if wait_for_package "pypi" "$PACKAGE" "$VERSION" "$max_wait_seconds" "$TEST_PYPI"; then
+		log_success "Package is available"
+	else
+		die "Timeout waiting for package availability"
+	fi
+	;;
+
+generate)
+	: "${TAP_REPOSITORY:?TAP_REPOSITORY is required}"
+	: "${FORMULA:?FORMULA is required}"
+	: "${PACKAGE:?PACKAGE is required}"
+	: "${VERSION:?VERSION is required}"
+	: "${TEST_PYPI:=false}"
+
+	log_info "Generating/updating formula for $PACKAGE@$VERSION..."
+
+	# Clone tap repository
+	clone_homebrew_tap "$TAP_REPOSITORY" "$TAP_DIR"
+
+	# Get download URL and SHA256 from PyPI
+	download_url=$(get_pypi_download_url "$PACKAGE" "$VERSION" "$TEST_PYPI")
+	if [[ -z "$download_url" ]]; then
+		die "Could not get download URL from PyPI"
+	fi
+
+	sha256=$(get_pypi_sha256 "$PACKAGE" "$VERSION" "$TEST_PYPI")
+	if [[ -z "$sha256" ]]; then
+		die "Could not get SHA256 from PyPI"
+	fi
+
+	log_info "Download URL: $download_url"
+	log_info "SHA256: $sha256"
+
+	# Find or create formula file
+	formula_file=""
+	if [[ -f "$TAP_DIR/Formula/$FORMULA.rb" ]]; then
+		formula_file="$TAP_DIR/Formula/$FORMULA.rb"
+	elif [[ -f "$TAP_DIR/$FORMULA.rb" ]]; then
+		formula_file="$TAP_DIR/$FORMULA.rb"
+	fi
+
+	if [[ -n "$formula_file" ]]; then
+		log_info "Updating existing formula: $formula_file"
+		update_formula_version "$formula_file" "$download_url" "$sha256" "$VERSION"
+	else
+		log_info "Creating new formula..."
+		mkdir -p "$TAP_DIR/Formula"
+		formula_file="$TAP_DIR/Formula/$FORMULA.rb"
+
+		# Generate new formula
+		generate_formula_from_pypi "$PACKAGE" "$VERSION" "A Python package" "$TEST_PYPI" >"$formula_file"
+	fi
+
+	log_success "Formula updated: $formula_file"
+	set_github_output "formula-file" "$formula_file"
+	;;
+
+commit)
+	: "${TAP_REPOSITORY:?TAP_REPOSITORY is required}"
+	: "${FORMULA:?FORMULA is required}"
+	: "${VERSION:?VERSION is required}"
+	: "${PUSH:=true}"
+	: "${CREATE_PR:=false}"
+
+	log_info "Committing formula update..."
+
+	cd "$TAP_DIR"
+
+	# Configure git
+	configure_git_ci_user
+
+	# Stage changes
+	git add -A
+
+	# Check if there are changes
+	if git diff --cached --quiet; then
+		log_warn "No changes to commit"
+		set_github_output "updated" "false"
+		exit 0
+	fi
+
+	# Create branch for PR if needed
+	if [[ "$CREATE_PR" == "true" ]]; then
+		branch_name="update-$FORMULA-$VERSION"
+		git checkout -b "$branch_name"
+	fi
+
+	# Commit
+	git commit -m "Update $FORMULA to $VERSION"
+	commit_sha=$(git rev-parse HEAD)
+
+	log_success "Committed: $commit_sha"
+
+	# Push if requested
+	if [[ "$PUSH" == "true" ]] || [[ "$CREATE_PR" == "true" ]]; then
+		if [[ "$CREATE_PR" == "true" ]]; then
+			git push -u origin "$branch_name"
+		else
+			git push origin HEAD
+		fi
+		log_success "Pushed to $TAP_REPOSITORY"
+	fi
+
+	set_github_output "updated" "true"
+	set_github_output "commit-sha" "$commit_sha"
+	;;
+
+pr)
+	: "${TAP_REPOSITORY:?TAP_REPOSITORY is required}"
+	: "${FORMULA:?FORMULA is required}"
+	: "${VERSION:?VERSION is required}"
+
+	log_info "Creating pull request..."
+
+	cd "$TAP_DIR"
+
+	branch_name="update-$FORMULA-$VERSION"
+
+	# Create PR using gh CLI
+	pr_url=$(gh pr create \
+		--repo "$TAP_REPOSITORY" \
+		--title "Update $FORMULA to $VERSION" \
+		--body "Automated formula update for $FORMULA version $VERSION." \
+		--head "$branch_name" \
+		--base main 2>/dev/null ||
+		gh pr create \
+			--repo "$TAP_REPOSITORY" \
+			--title "Update $FORMULA to $VERSION" \
+			--body "Automated formula update for $FORMULA version $VERSION." \
+			--head "$branch_name" \
+			--base master)
+
+	log_success "Created PR: $pr_url"
+	set_github_output "pr-url" "$pr_url"
+	;;
+
+summary)
+	: "${TAP_REPOSITORY:=}"
+	: "${FORMULA:=}"
+	: "${PACKAGE:=}"
+	: "${VERSION:=}"
+	: "${UPDATED:=false}"
+	: "${COMMIT_SHA:=}"
+	: "${PR_URL:=}"
+
+	add_github_summary "## Homebrew Formula Update"
+	add_github_summary ""
+	add_github_summary "| Property | Value |"
+	add_github_summary "| -------- | ----- |"
+	add_github_summary "| Tap | $TAP_REPOSITORY |"
+	add_github_summary "| Formula | $FORMULA |"
+	add_github_summary "| Package | $PACKAGE |"
+	add_github_summary "| Version | $VERSION |"
+
+	if [[ "$UPDATED" == "true" ]]; then
+		add_github_summary "| Status | :white_check_mark: Updated |"
+		if [[ -n "$COMMIT_SHA" ]]; then
+			add_github_summary "| Commit | \`$COMMIT_SHA\` |"
+		fi
+		if [[ -n "$PR_URL" ]]; then
+			add_github_summary "| PR | $PR_URL |"
+		fi
+	else
+		add_github_summary "| Status | :x: Not Updated |"
+	fi
+	;;
+
+*)
+	die_unknown_step "$STEP"
+	;;
+esac

--- a/scripts/ci/lib/publish.sh
+++ b/scripts/ci/lib/publish.sh
@@ -9,6 +9,7 @@
 #   - publish/version.sh (version extraction)
 #   - publish/validate.sh (package validation)
 #   - publish/registry.sh (registry availability)
+#   - publish/homebrew.sh (Homebrew formula generation)
 
 # Prevent multiple sourcing
 [[ -n "${_LGTM_CI_PUBLISH_LOADED:-}" ]] && return 0
@@ -32,3 +33,6 @@ fi
 
 # shellcheck source=publish/registry.sh
 [[ -f "$_LGTM_CI_PUBLISH_LIB_DIR/publish/registry.sh" ]] && source "$_LGTM_CI_PUBLISH_LIB_DIR/publish/registry.sh"
+
+# shellcheck source=publish/homebrew.sh
+[[ -f "$_LGTM_CI_PUBLISH_LIB_DIR/publish/homebrew.sh" ]] && source "$_LGTM_CI_PUBLISH_LIB_DIR/publish/homebrew.sh"

--- a/scripts/ci/lib/publish/homebrew.sh
+++ b/scripts/ci/lib/publish/homebrew.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Homebrew formula generation utilities
+#
+# Provides functions to generate and update Homebrew formulas for Python packages.
+
+# Guard against multiple sourcing
+[[ -n "${_PUBLISH_HOMEBREW_LOADED:-}" ]] && return 0
+readonly _PUBLISH_HOMEBREW_LOADED=1
+
+# Source registry functions if not already loaded
+if [[ -z "${_PUBLISH_REGISTRY_LOADED:-}" ]]; then
+	_HOMEBREW_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+	# shellcheck source=registry.sh
+	source "$_HOMEBREW_LIB_DIR/registry.sh"
+fi
+
+# Escape a string for use in Ruby double-quoted strings
+# Escapes backslashes and double quotes
+# Usage: escape_ruby_string "string with \"quotes\" and \\backslashes"
+escape_ruby_string() {
+	local str="${1:-}"
+	# Escape backslashes first, then double quotes
+	str="${str//\\/\\\\}"
+	str="${str//\"/\\\"}"
+	echo "$str"
+}
+
+# Generate a Homebrew formula from PyPI package
+# Usage: generate_formula_from_pypi "package-name" "1.2.3" "Formula description" [test-pypi] [homepage] [license] [python-version] [test-cmd]
+# Outputs formula content to stdout
+generate_formula_from_pypi() {
+	local package="${1:?Package name required}"
+	local version="${2:?Version required}"
+	local description="${3:-A Python package}"
+	local test_pypi="${4:-false}"
+	local homepage="${5:-}"
+	local license="${6:-}"
+	local python_version="${7:-3.12}"
+	local test_cmd="${8:-}"
+
+	# Escape description for Ruby string
+	description=$(escape_ruby_string "$description")
+
+	# Get download URL and SHA256
+	local download_url sha256
+	download_url=$(get_pypi_download_url "$package" "$version" "$test_pypi")
+	if [[ -z "$download_url" ]]; then
+		log_error "Could not get download URL for $package@$version"
+		return 1
+	fi
+
+	sha256=$(get_pypi_sha256 "$package" "$version" "$test_pypi")
+	if [[ -z "$sha256" ]]; then
+		log_error "Could not get SHA256 for $package@$version"
+		return 1
+	fi
+
+	# Generate formula class name (CamelCase)
+	# Normalize all non-alphanumeric characters to underscores, then convert to CamelCase
+	local class_name
+	class_name=$(echo "$package" | sed 's/[^A-Za-z0-9]/_/g' | awk -F_ '{for(i=1;i<=NF;i++) $i=toupper(substr($i,1,1)) tolower(substr($i,2))}1' OFS='')
+	# Ruby class names cannot start with a digit
+	if [[ "$class_name" =~ ^[0-9] ]]; then
+		class_name="Pkg$class_name"
+	fi
+
+	# Set homepage
+	if [[ -z "$homepage" ]]; then
+		homepage="https://pypi.org/project/$package/"
+	fi
+
+	# Try to get license from PyPI if not provided
+	local license_line
+	if [[ -z "$license" ]]; then
+		local api_url="$PYPI_API_URL"
+		if [[ "$test_pypi" == "true" ]]; then
+			api_url="$TEST_PYPI_API_URL"
+		fi
+		license=$(curl -s "$api_url/$package/$version/json" 2>/dev/null |
+			grep -o '"license":"[^"]*"' | head -1 | sed 's/"license":"\([^"]*\)"/\1/')
+	fi
+
+	# Build license line - use comment placeholder if not found
+	if [[ -n "$license" ]] && [[ "$license" != "null" ]]; then
+		# Escape license for Ruby string
+		local escaped_license
+		escaped_license=$(escape_ruby_string "$license")
+		license_line="license \"$escaped_license\""
+	else
+		log_warn "Could not determine license for $package@$version"
+		log_warn "Please provide license explicitly or verify the generated formula"
+		license_line="# license not detected; please verify and add an SPDX identifier"
+	fi
+
+	# Set default test command if not provided
+	if [[ -z "$test_cmd" ]]; then
+		test_cmd="bin/\"$package\", \"--version\""
+	fi
+
+	# Output formula
+	cat <<EOF
+# frozen_string_literal: true
+
+class $class_name < Formula
+  include Language::Python::Virtualenv
+
+  desc "$description"
+  homepage "$homepage"
+  url "$download_url"
+  sha256 "$sha256"
+  $license_line
+
+  depends_on "python@$python_version"
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    system $test_cmd
+  end
+end
+EOF
+}
+
+# Update version and SHA256 in existing Homebrew formula
+# Usage: update_formula_version "formula_path" "new_url" "new_sha256" [new_version]
+# Returns 0 on success, 1 on failure
+update_formula_version() {
+	local formula_path="${1:?Formula path required}"
+	local new_url="${2:?New URL required}"
+	local new_sha256="${3:?New SHA256 required}"
+	local new_version="${4:-}" # Optional for logging
+
+	if [[ ! -f "$formula_path" ]]; then
+		log_error "Formula not found: $formula_path"
+		return 1
+	fi
+
+	# Create backup
+	cp "$formula_path" "$formula_path.bak"
+
+	# Update URL (only first top-level occurrence with 2-space indent, not resource blocks)
+	# Uses match()+substr() instead of sub() to treat new_val as literal text
+	if ! awk -v new_val="$new_url" '/^  url "/ && !done { match($0, /url "[^"]*"/); prefix = substr($0, 1, RSTART - 1); suffix = substr($0, RSTART + RLENGTH); print prefix "url \"" new_val "\"" suffix; done=1; next } { print }' "$formula_path" >"${formula_path}.tmp"; then
+		mv "$formula_path.bak" "$formula_path"
+		log_error "Failed to update URL"
+		return 1
+	fi
+	mv "${formula_path}.tmp" "$formula_path"
+
+	# Update SHA256 (only first top-level occurrence with 2-space indent, not resource blocks)
+	if ! awk -v new_val="$new_sha256" '/^  sha256 "/ && !done { match($0, /sha256 "[^"]*"/); prefix = substr($0, 1, RSTART - 1); suffix = substr($0, RSTART + RLENGTH); print prefix "sha256 \"" new_val "\"" suffix; done=1; next } { print }' "$formula_path" >"${formula_path}.tmp"; then
+		mv "$formula_path.bak" "$formula_path"
+		log_error "Failed to update SHA256"
+		return 1
+	fi
+	mv "${formula_path}.tmp" "$formula_path"
+
+	# Clean up backup on success
+	rm -f "$formula_path.bak"
+
+	if [[ -n "$new_version" ]]; then
+		log_success "Updated formula to version $new_version"
+	else
+		log_success "Updated formula"
+	fi
+	return 0
+}
+
+# Calculate SHA256 for a URL (downloads and hashes)
+# Usage: calculate_sha256_from_url "https://..."
+# Returns SHA256 hash
+calculate_sha256_from_url() {
+	local url="${1:?URL required}"
+	local tmpfile
+
+	tmpfile=$(mktemp)
+	trap 'rm -f "$tmpfile"' RETURN
+
+	if ! curl -sL --fail "$url" -o "$tmpfile"; then
+		log_error "Failed to download: $url"
+		return 1
+	fi
+
+	if command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$tmpfile" | awk '{print $1}'
+	elif command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$tmpfile" | awk '{print $1}'
+	else
+		log_error "No SHA256 tool available"
+		return 1
+	fi
+}
+
+# Generate resource blocks for Python dependencies
+# Usage: calculate_resource_checksums "requirements.txt"
+# Outputs Homebrew resource blocks
+calculate_resource_checksums() {
+	local requirements_file="${1:?Requirements file required}"
+
+	if [[ ! -f "$requirements_file" ]]; then
+		log_error "Requirements file not found: $requirements_file"
+		return 1
+	fi
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		# Skip comment-only lines
+		[[ "$line" =~ ^[[:space:]]*# ]] && continue
+		[[ -z "${line// /}" ]] && continue
+
+		# Strip inline comments and trim whitespace
+		local pkg_spec="${line%%#*}"
+		pkg_spec="${pkg_spec%"${pkg_spec##*[![:space:]]}"}" # Trim trailing whitespace
+		pkg_spec="${pkg_spec#"${pkg_spec%%[![:space:]]*}"}" # Trim leading whitespace
+
+		# Skip empty after stripping comments
+		[[ -z "$pkg_spec" ]] && continue
+
+		# Skip lines with environment markers (e.g., package==1.0; python_version<"3.9")
+		if [[ "$pkg_spec" == *";"* ]]; then
+			log_warn "Skipping requirement with environment markers: $pkg_spec (not supported)"
+			continue
+		fi
+
+		# Parse package==version (capture only the version token, excluding any trailing chars)
+		local pkg_name pkg_version
+
+		if [[ "$pkg_spec" =~ ^([^=\<\>![:space:]]+)[[:space:]]*==[[:space:]]*([^[:space:]\;\#,]+) ]]; then
+			pkg_name="${BASH_REMATCH[1]}"
+			pkg_version="${BASH_REMATCH[2]}"
+		else
+			log_warn "Skipping unparseable requirement: $pkg_spec (only '==' pinned versions supported)"
+			continue
+		fi
+
+		# Clean package name (remove extras like [dev])
+		pkg_name="${pkg_name%%\[*}"
+		pkg_name="${pkg_name// /}"
+
+		# Get PyPI info
+		local url sha256
+		url=$(get_pypi_download_url "$pkg_name" "$pkg_version")
+		sha256=$(get_pypi_sha256 "$pkg_name" "$pkg_version")
+
+		if [[ -z "$url" ]]; then
+			log_warn "Could not get download URL for $pkg_name - dependency will be omitted from formula"
+			continue
+		fi
+		if [[ -z "$sha256" ]]; then
+			log_warn "Could not get SHA256 for $pkg_name - dependency will be omitted from formula"
+			continue
+		fi
+
+		cat <<EOF
+
+  resource "$pkg_name" do
+    url "$url"
+    sha256 "$sha256"
+  end
+EOF
+	done <"$requirements_file"
+}
+
+# Clone a Homebrew tap repository
+# Usage: clone_homebrew_tap "owner/repo" "target_dir"
+# Returns 0 on success, 1 on failure
+clone_homebrew_tap() {
+	local tap_repo="${1:?Tap repository required (owner/repo)}"
+	local target_dir="${2:?Target directory required}"
+
+	local repo_url="https://github.com/$tap_repo.git"
+
+	if [[ -d "$target_dir/.git" ]]; then
+		log_info "Updating existing tap clone..."
+		if ! git -C "$target_dir" fetch origin; then
+			log_error "Failed to fetch from $repo_url"
+			return 1
+		fi
+		# Try main first, then master; fail if both don't exist
+		if ! git -C "$target_dir" reset --hard origin/main 2>/dev/null; then
+			if ! git -C "$target_dir" reset --hard origin/master 2>/dev/null; then
+				log_error "Failed to reset $target_dir to origin/main or origin/master"
+				return 1
+			fi
+		fi
+	else
+		log_info "Cloning tap repository..."
+		if ! git clone --depth 1 "$repo_url" "$target_dir"; then
+			log_error "Failed to clone $repo_url to $target_dir"
+			return 1
+		fi
+	fi
+
+	return 0
+}
+
+# Commit and push formula update
+# Usage: commit_formula_update "tap_dir" "formula_name" "version"
+# Returns 0 on success, 1 on failure
+commit_formula_update() {
+	local tap_dir="${1:?Tap directory required}"
+	local formula_name="${2:?Formula name required}"
+	local version="${3:?Version required}"
+
+	# Use subshell to isolate directory change
+	(
+		cd "$tap_dir" || exit 1
+
+		# Configure git for CI
+		if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+			git config user.name "github-actions[bot]"
+			git config user.email "github-actions[bot]@users.noreply.github.com"
+		fi
+
+		# Add and commit
+		git add "Formula/$formula_name.rb" 2>/dev/null || git add "$formula_name.rb"
+
+		if ! git diff --cached --quiet; then
+			git commit -m "Update $formula_name to $version"
+			log_success "Committed formula update"
+		else
+			log_warn "No changes to commit"
+		fi
+	)
+	local status=$?
+	if [[ $status -ne 0 ]]; then
+		log_error "Failed to commit formula update in $tap_dir"
+		return $status
+	fi
+	return 0
+}
+
+# =============================================================================
+# Export functions
+# =============================================================================
+export -f generate_formula_from_pypi update_formula_version
+export -f calculate_sha256_from_url calculate_resource_checksums
+export -f clone_homebrew_tap commit_formula_update

--- a/tests/bats/unit/lib/publish/test_homebrew.bats
+++ b/tests/bats/unit/lib/publish/test_homebrew.bats
@@ -1,0 +1,751 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/lib/publish/homebrew.sh
+
+load "../../../../helpers/common"
+load "../../../../helpers/github_env"
+load "../../../../helpers/mocks"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+	save_path
+	export LIB_DIR
+	export BATS_TEST_TMPDIR
+
+	# Source log functions for mocking
+	# shellcheck source=/dev/null
+	source "$LIB_DIR/log.sh" 2>/dev/null || true
+}
+
+teardown() {
+	restore_path
+	teardown_github_env
+	teardown_temp_dir
+}
+
+# =============================================================================
+# escape_ruby_string tests
+# =============================================================================
+
+@test "escape_ruby_string: returns empty string for empty input" {
+	run bash -c 'source "$LIB_DIR/publish/homebrew.sh" && escape_ruby_string ""'
+	assert_success
+	assert_output ""
+}
+
+@test "escape_ruby_string: returns unchanged string without special chars" {
+	run bash -c 'source "$LIB_DIR/publish/homebrew.sh" && escape_ruby_string "simple text"'
+	assert_success
+	assert_output "simple text"
+}
+
+@test "escape_ruby_string: escapes double quotes" {
+	run bash -c 'source "$LIB_DIR/publish/homebrew.sh" && escape_ruby_string "say \"hello\""'
+	assert_success
+	assert_output 'say \"hello\"'
+}
+
+@test "escape_ruby_string: escapes backslashes" {
+	run bash -c 'source "$LIB_DIR/publish/homebrew.sh" && escape_ruby_string "path\\to\\file"'
+	assert_success
+	assert_output 'path\\to\\file'
+}
+
+@test "escape_ruby_string: escapes both quotes and backslashes" {
+	run bash -c 'source "$LIB_DIR/publish/homebrew.sh" && escape_ruby_string "say \"hello\\world\""'
+	assert_success
+	assert_output 'say \"hello\\world\"'
+}
+
+# =============================================================================
+# update_formula_version tests
+# =============================================================================
+
+@test "update_formula_version: fails when formula file missing" {
+	run bash -c '
+		source "$LIB_DIR/publish/homebrew.sh"
+		update_formula_version "/nonexistent/formula.rb" "http://new-url" "abc123" 2>&1
+	'
+	assert_failure
+	assert_output --partial "Formula not found"
+}
+
+@test "update_formula_version: updates url in formula" {
+	local formula="${BATS_TEST_TMPDIR}/test.rb"
+	cat >"$formula" <<'EOF'
+class Test < Formula
+  desc "Test formula"
+  homepage "https://example.com"
+  url "https://old.example.com/test-1.0.0.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+end
+EOF
+
+	run bash -c "
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		update_formula_version '$formula' 'https://new.example.com/test-2.0.0.tar.gz' 'abc123def456' '2.0.0' 2>&1
+	"
+	assert_success
+
+	# Verify the URL was updated
+	run grep 'url "https://new.example.com/test-2.0.0.tar.gz"' "$formula"
+	assert_success
+}
+
+@test "update_formula_version: updates sha256 in formula" {
+	local formula="${BATS_TEST_TMPDIR}/test.rb"
+	cat >"$formula" <<'EOF'
+class Test < Formula
+  desc "Test formula"
+  url "https://example.com/test-1.0.0.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+end
+EOF
+
+	run bash -c "
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		update_formula_version '$formula' 'https://new.example.com/test.tar.gz' 'newsha256hash' 2>&1
+	"
+	assert_success
+
+	# Verify SHA256 was updated
+	run grep 'sha256 "newsha256hash"' "$formula"
+	assert_success
+}
+
+@test "update_formula_version: only updates first url (not resource blocks)" {
+	local formula="${BATS_TEST_TMPDIR}/test.rb"
+	cat >"$formula" <<'EOF'
+class Test < Formula
+  desc "Test formula"
+  url "https://example.com/main-1.0.0.tar.gz"
+  sha256 "main000000000000000000000000000000000000000000000000000000000000"
+
+  resource "dep" do
+    url "https://example.com/dep-1.0.0.tar.gz"
+    sha256 "dep0000000000000000000000000000000000000000000000000000000000"
+  end
+end
+EOF
+
+	run bash -c "
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		update_formula_version '$formula' 'https://new.example.com/main-2.0.0.tar.gz' 'newmainsha' 2>&1
+	"
+	assert_success
+
+	# Resource URL should remain unchanged
+	run grep 'url "https://example.com/dep-1.0.0.tar.gz"' "$formula"
+	assert_success
+}
+
+@test "update_formula_version: restores backup on failure" {
+	local formula="${BATS_TEST_TMPDIR}/test.rb"
+	local original_content='class Test < Formula
+  url "https://example.com/test.tar.gz"
+  sha256 "original"
+end'
+	echo "$original_content" >"$formula"
+
+	# Force awk to fail by replacing it with a command that always fails
+	run bash -c "
+		awk() { return 1; }
+		export -f awk
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		update_formula_version '$formula' 'https://new.example.com/test.tar.gz' 'newhash' 2>&1
+	"
+	assert_failure
+
+	# Verify original content was preserved via backup restore
+	local current_content
+	current_content=$(cat "$formula")
+	[[ "$current_content" == "$original_content" ]]
+}
+
+# =============================================================================
+# calculate_sha256_from_url tests
+# =============================================================================
+
+@test "calculate_sha256_from_url: fails on download error" {
+	mock_command "curl" "" 1
+
+	run bash -c '
+		source "$LIB_DIR/publish/homebrew.sh"
+		calculate_sha256_from_url "https://example.com/nonexistent.tar.gz" 2>&1
+	'
+	assert_failure
+	assert_output --partial "Failed to download"
+}
+
+@test "calculate_sha256_from_url: returns sha256 hash" {
+	# Create mock that writes known content
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+
+	cat >"${mock_bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+# Find -o argument and write known content
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -o) echo "test content" > "$2"; exit 0;;
+        *) shift;;
+    esac
+done
+exit 0
+EOF
+	chmod +x "${mock_bin}/curl"
+	export PATH="${mock_bin}:$PATH"
+
+	run bash -c '
+		source "$LIB_DIR/publish/homebrew.sh"
+		calculate_sha256_from_url "https://example.com/test.tar.gz"
+	'
+	assert_success
+	# Output should be a 64-character hex string (SHA256)
+	[[ ${#output} -eq 64 ]]
+}
+
+# =============================================================================
+# calculate_resource_checksums tests
+# =============================================================================
+
+@test "calculate_resource_checksums: fails when requirements file missing" {
+	run bash -c '
+		source "$LIB_DIR/publish/homebrew.sh"
+		calculate_resource_checksums "/nonexistent/requirements.txt" 2>&1
+	'
+	assert_failure
+	assert_output --partial "Requirements file not found"
+}
+
+@test "calculate_resource_checksums: skips comment lines" {
+	local req_file="${BATS_TEST_TMPDIR}/requirements.txt"
+	cat >"$req_file" <<'EOF'
+# This is a comment
+   # Indented comment
+EOF
+
+	run bash -c "
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		calculate_resource_checksums '$req_file' 2>&1
+	"
+	assert_success
+	# Output should be empty (no resource blocks)
+	refute_output --partial "resource"
+}
+
+@test "calculate_resource_checksums: skips empty lines" {
+	local req_file="${BATS_TEST_TMPDIR}/requirements.txt"
+	cat >"$req_file" <<'EOF'
+
+
+
+EOF
+
+	run bash -c "
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		calculate_resource_checksums '$req_file' 2>&1
+	"
+	assert_success
+	refute_output --partial "resource"
+}
+
+@test "calculate_resource_checksums: skips lines with environment markers" {
+	local req_file="${BATS_TEST_TMPDIR}/requirements.txt"
+	cat >"$req_file" <<'EOF'
+package==1.0.0; python_version<"3.9"
+EOF
+
+	run bash -c "
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		calculate_resource_checksums '$req_file' 2>&1
+	"
+	# Should warn and skip, not error
+	assert_success
+	assert_output --partial "Skipping requirement with environment markers"
+}
+
+@test "calculate_resource_checksums: skips unparseable requirements" {
+	local req_file="${BATS_TEST_TMPDIR}/requirements.txt"
+	cat >"$req_file" <<'EOF'
+package>=1.0.0
+another~=2.0
+EOF
+
+	run bash -c "
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		calculate_resource_checksums '$req_file' 2>&1
+	"
+	assert_success
+	assert_output --partial "Skipping unparseable requirement"
+}
+
+@test "calculate_resource_checksums: strips inline comments" {
+	local req_file="${BATS_TEST_TMPDIR}/requirements.txt"
+	cat >"$req_file" <<'EOF'
+package==1.0.0  # inline comment
+EOF
+
+	# Mock get_pypi_download_url and get_pypi_sha256
+	mock_command "curl" '{"urls":[{"packagetype":"sdist","url":"https://pypi.org/test.tar.gz","digests":{"sha256":"abc123"}}]}' 0
+
+	run bash -c "
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		calculate_resource_checksums '$req_file' 2>&1
+	"
+	# Should attempt to process 'package' not 'package # inline comment'
+	assert_success
+}
+
+@test "calculate_resource_checksums: removes extras from package name" {
+	local req_file="${BATS_TEST_TMPDIR}/requirements.txt"
+	cat >"$req_file" <<'EOF'
+package[dev,test]==1.0.0
+EOF
+
+	# Mock curl to return valid PyPI response
+	mock_command "curl" '{"urls":[{"packagetype":"sdist","url":"https://pypi.org/package-1.0.0.tar.gz","digests":{"sha256":"abc123"}}]}' 0
+
+	run bash -c "
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		calculate_resource_checksums '$req_file' 2>&1
+	"
+	# Should use 'package' not 'package[dev,test]'
+	assert_success
+}
+
+# =============================================================================
+# clone_homebrew_tap tests
+# =============================================================================
+
+@test "clone_homebrew_tap: clones new repository" {
+	mock_command_record "git" "" 0
+
+	local target_dir="${BATS_TEST_TMPDIR}/tap"
+
+	run bash -c "
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		clone_homebrew_tap 'owner/homebrew-tap' '$target_dir' 2>&1
+	"
+	assert_success
+
+	# Verify git clone was called
+	local calls
+	calls=$(cat "$BATS_TEST_TMPDIR/mock_calls_git")
+	[[ "$calls" == *"clone"* ]]
+	[[ "$calls" == *"https://github.com/owner/homebrew-tap.git"* ]]
+}
+
+@test "clone_homebrew_tap: updates existing repository" {
+	local target_dir="${BATS_TEST_TMPDIR}/tap"
+	mkdir -p "$target_dir/.git"
+
+	mock_command_record "git" "" 0
+
+	run bash -c "
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		clone_homebrew_tap 'owner/homebrew-tap' '$target_dir' 2>&1
+	"
+	assert_success
+
+	# Verify git fetch was called instead of clone
+	local calls
+	calls=$(cat "$BATS_TEST_TMPDIR/mock_calls_git")
+	[[ "$calls" == *"fetch"* ]]
+}
+
+@test "clone_homebrew_tap: fails on clone error" {
+	mock_command "git" "" 1
+
+	local target_dir="${BATS_TEST_TMPDIR}/tap"
+
+	run bash -c "
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		clone_homebrew_tap 'owner/homebrew-tap' '$target_dir' 2>&1
+	"
+	assert_failure
+	assert_output --partial "Failed to clone"
+}
+
+# =============================================================================
+# commit_formula_update tests
+# =============================================================================
+
+@test "commit_formula_update: commits formula changes" {
+	setup_mock_git_repo
+	local tap_dir="$MOCK_GIT_REPO"
+
+	# Create formula file
+	mkdir -p "$tap_dir/Formula"
+	echo 'class Test < Formula; end' >"$tap_dir/Formula/test.rb"
+
+	run bash -c "
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		commit_formula_update '$tap_dir' 'test' '1.2.3' 2>&1
+	"
+	assert_success
+	assert_output --partial "Committed formula update"
+}
+
+@test "commit_formula_update: configures git in CI environment" {
+	setup_mock_git_repo
+	local tap_dir="$MOCK_GIT_REPO"
+
+	mkdir -p "$tap_dir/Formula"
+	echo 'class Test < Formula; end' >"$tap_dir/Formula/test.rb"
+
+	run bash -c "
+		export GITHUB_ACTIONS=true
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		commit_formula_update '$tap_dir' 'test' '1.2.3' 2>&1
+	"
+	assert_success
+}
+
+@test "commit_formula_update: warns when no changes to commit" {
+	setup_mock_git_repo
+	local tap_dir="$MOCK_GIT_REPO"
+
+	# Create and commit formula file first
+	mkdir -p "$tap_dir/Formula"
+	echo 'class Test < Formula; end' >"$tap_dir/Formula/test.rb"
+	(cd "$tap_dir" && git add Formula/test.rb && git commit -q -m "Add formula")
+
+	run bash -c "
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		commit_formula_update '$tap_dir' 'test' '1.2.3' 2>&1
+	"
+	assert_success
+	assert_output --partial "No changes to commit"
+}
+
+@test "commit_formula_update: uses correct commit message" {
+	setup_mock_git_repo
+	local tap_dir="$MOCK_GIT_REPO"
+
+	mkdir -p "$tap_dir/Formula"
+	echo 'class Myformula < Formula; end' >"$tap_dir/Formula/myformula.rb"
+
+	run bash -c "
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		commit_formula_update '$tap_dir' 'myformula' '2.0.0' 2>&1
+	"
+	assert_success
+
+	# Check commit message
+	run bash -c "cd '$tap_dir' && git log -1 --format=%s"
+	assert_output "Update myformula to 2.0.0"
+}
+
+# =============================================================================
+# generate_formula_from_pypi tests (mocked)
+# =============================================================================
+
+@test "generate_formula_from_pypi: fails when download URL unavailable" {
+	# Mock curl to return empty response
+	mock_command "curl" "" 0
+
+	run bash -c '
+		source "$LIB_DIR/publish/homebrew.sh"
+		generate_formula_from_pypi "nonexistent-package" "1.0.0" "Test package" 2>&1
+	'
+	assert_failure
+	assert_output --partial "Could not get download URL"
+}
+
+@test "generate_formula_from_pypi: generates valid formula structure" {
+	# Mock PyPI API response
+	local pypi_response='{"urls":[{"packagetype":"sdist","url":"https://files.pythonhosted.org/packages/test-1.0.0.tar.gz","digests":{"sha256":"abc123def456"}}]}'
+	mock_command "curl" "$pypi_response" 0
+
+	run bash -c '
+		source "$LIB_DIR/publish/homebrew.sh"
+		generate_formula_from_pypi "test-package" "1.0.0" "A test package" 2>&1
+	'
+	assert_success
+	assert_output --partial "class TestPackage < Formula"
+	assert_output --partial 'desc "A test package"'
+	assert_output --partial 'depends_on "python@'
+	assert_output --partial "virtualenv_install_with_resources"
+}
+
+@test "generate_formula_from_pypi: handles package names starting with digits" {
+	local pypi_response='{"urls":[{"packagetype":"sdist","url":"https://pypi.org/2to3-1.0.0.tar.gz","digests":{"sha256":"abc123"}}]}'
+	mock_command "curl" "$pypi_response" 0
+
+	run bash -c '
+		source "$LIB_DIR/publish/homebrew.sh"
+		generate_formula_from_pypi "2to3" "1.0.0" "Python 2 to 3 converter" 2>&1
+	'
+	assert_success
+	# Class name should be prefixed with Pkg since it starts with a digit
+	assert_output --partial "class Pkg2to3 < Formula"
+}
+
+@test "generate_formula_from_pypi: escapes description with quotes" {
+	local pypi_response='{"urls":[{"packagetype":"sdist","url":"https://pypi.org/test-1.0.0.tar.gz","digests":{"sha256":"abc123"}}]}'
+	mock_command "curl" "$pypi_response" 0
+
+	run bash -c '
+		source "$LIB_DIR/publish/homebrew.sh"
+		generate_formula_from_pypi "test" "1.0.0" "A \"quoted\" description" 2>&1
+	'
+	assert_success
+	assert_output --partial 'desc "A \"quoted\" description"'
+}
+
+@test "generate_formula_from_pypi: uses custom homepage" {
+	local pypi_response='{"urls":[{"packagetype":"sdist","url":"https://pypi.org/test-1.0.0.tar.gz","digests":{"sha256":"abc123"}}]}'
+	mock_command "curl" "$pypi_response" 0
+
+	run bash -c '
+		source "$LIB_DIR/publish/homebrew.sh"
+		generate_formula_from_pypi "test" "1.0.0" "Test" "false" "https://custom.example.com" 2>&1
+	'
+	assert_success
+	assert_output --partial 'homepage "https://custom.example.com"'
+}
+
+@test "generate_formula_from_pypi: uses explicit license" {
+	local pypi_response='{"urls":[{"packagetype":"sdist","url":"https://pypi.org/test-1.0.0.tar.gz","digests":{"sha256":"abc123"}}]}'
+	mock_command "curl" "$pypi_response" 0
+
+	run bash -c '
+		source "$LIB_DIR/publish/homebrew.sh"
+		generate_formula_from_pypi "test" "1.0.0" "Test" "false" "" "MIT" 2>&1
+	'
+	assert_success
+	assert_output --partial 'license "MIT"'
+}
+
+@test "generate_formula_from_pypi: uses custom python version" {
+	local pypi_response='{"urls":[{"packagetype":"sdist","url":"https://pypi.org/test-1.0.0.tar.gz","digests":{"sha256":"abc123"}}]}'
+	mock_command "curl" "$pypi_response" 0
+
+	run bash -c '
+		source "$LIB_DIR/publish/homebrew.sh"
+		generate_formula_from_pypi "test" "1.0.0" "Test" "false" "" "MIT" "3.11" 2>&1
+	'
+	assert_success
+	assert_output --partial 'depends_on "python@3.11"'
+}
+
+@test "generate_formula_from_pypi: uses custom test command" {
+	local pypi_response='{"urls":[{"packagetype":"sdist","url":"https://pypi.org/test-1.0.0.tar.gz","digests":{"sha256":"abc123"}}]}'
+	mock_command "curl" "$pypi_response" 0
+
+	run bash -c '
+		source "$LIB_DIR/publish/homebrew.sh"
+		generate_formula_from_pypi "test" "1.0.0" "Test" "false" "" "MIT" "3.12" "system bin/\"test\", \"--help\"" 2>&1
+	'
+	assert_success
+	assert_output --partial 'system bin/"test", "--help"'
+}
+
+@test "generate_formula_from_pypi: warns when no license found" {
+	local pypi_response='{"urls":[{"packagetype":"sdist","url":"https://pypi.org/test-1.0.0.tar.gz","digests":{"sha256":"abc123"}}]}'
+	mock_command "curl" "$pypi_response" 0
+
+	run bash -c '
+		source "$LIB_DIR/publish/homebrew.sh"
+		generate_formula_from_pypi "test" "1.0.0" "Test" "false" "" "" 2>&1
+	'
+	assert_success
+	assert_output --partial "license not detected"
+}
+
+@test "generate_formula_from_pypi: fails when SHA256 unavailable" {
+	# sdist present (so download URL succeeds) but sha256 is empty string
+	# jq -r on "" returns empty, making -z check pass → "Could not get SHA256"
+	local pypi_response='{"urls":[{"packagetype":"sdist","url":"https://pypi.org/test-1.0.0.tar.gz","digests":{"sha256":""}}]}'
+	mock_command "curl" "$pypi_response" 0
+
+	run bash -c '
+		source "$LIB_DIR/publish/homebrew.sh"
+		generate_formula_from_pypi "test" "1.0.0" "Test" 2>&1
+	'
+	assert_failure
+	assert_output --partial "Could not get SHA256"
+}
+
+@test "update_formula_version: logs success with version" {
+	local formula="${BATS_TEST_TMPDIR}/test.rb"
+	cat >"$formula" <<'EOF'
+class Test < Formula
+  url "https://old.example.com/test-1.0.0.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+end
+EOF
+
+	run bash -c "
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		update_formula_version '$formula' 'https://new.example.com/test.tar.gz' 'newhash' '3.0.0' 2>&1
+	"
+	assert_success
+	assert_output --partial "Updated formula to version 3.0.0"
+}
+
+@test "update_formula_version: logs success without version" {
+	local formula="${BATS_TEST_TMPDIR}/test.rb"
+	cat >"$formula" <<'EOF'
+class Test < Formula
+  url "https://old.example.com/test.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+end
+EOF
+
+	run bash -c "
+		source \"\$LIB_DIR/publish/homebrew.sh\"
+		update_formula_version '$formula' 'https://new.example.com/test.tar.gz' 'newhash' 2>&1
+	"
+	assert_success
+	assert_output --partial "Updated formula"
+}
+
+# =============================================================================
+# Function export tests
+# =============================================================================
+
+@test "homebrew.sh: exports escape_ruby_string function" {
+	run bash -c 'source "$LIB_DIR/publish/homebrew.sh" && declare -F escape_ruby_string'
+	assert_success
+}
+
+@test "homebrew.sh: exports generate_formula_from_pypi function" {
+	run bash -c 'source "$LIB_DIR/publish/homebrew.sh" && declare -F generate_formula_from_pypi'
+	assert_success
+}
+
+@test "homebrew.sh: exports update_formula_version function" {
+	run bash -c 'source "$LIB_DIR/publish/homebrew.sh" && declare -F update_formula_version'
+	assert_success
+}
+
+@test "homebrew.sh: exports calculate_sha256_from_url function" {
+	run bash -c 'source "$LIB_DIR/publish/homebrew.sh" && declare -F calculate_sha256_from_url'
+	assert_success
+}
+
+@test "homebrew.sh: exports calculate_resource_checksums function" {
+	run bash -c 'source "$LIB_DIR/publish/homebrew.sh" && declare -F calculate_resource_checksums'
+	assert_success
+}
+
+@test "homebrew.sh: exports clone_homebrew_tap function" {
+	run bash -c 'source "$LIB_DIR/publish/homebrew.sh" && declare -F clone_homebrew_tap'
+	assert_success
+}
+
+@test "homebrew.sh: exports commit_formula_update function" {
+	run bash -c 'source "$LIB_DIR/publish/homebrew.sh" && declare -F commit_formula_update'
+	assert_success
+}
+
+# =============================================================================
+# Guard pattern tests
+# =============================================================================
+
+@test "homebrew.sh: can be sourced multiple times without error" {
+	run bash -c '
+		source "$LIB_DIR/publish/homebrew.sh"
+		source "$LIB_DIR/publish/homebrew.sh"
+		source "$LIB_DIR/publish/homebrew.sh"
+		declare -F escape_ruby_string >/dev/null && echo "ok"
+	'
+	assert_success
+	assert_output "ok"
+}
+
+@test "homebrew.sh: sets _PUBLISH_HOMEBREW_LOADED guard" {
+	run bash -c 'source "$LIB_DIR/publish/homebrew.sh" && echo "${_PUBLISH_HOMEBREW_LOADED}"'
+	assert_success
+	assert_output "1"
+}
+
+# =============================================================================
+# update-homebrew.sh generate regression tests
+# =============================================================================
+
+_mock_git_clone_tap_fixture() {
+	local fixture_tap="$1"
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+
+	cat >"${mock_bin}/git" <<EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "clone" ]]; then
+	target="\${@: -1}"
+	mkdir -p "\$target"
+	cp -R "${fixture_tap}/." "\$target/"
+	exit 0
+fi
+if command -v /usr/bin/git >/dev/null 2>&1; then
+	exec /usr/bin/git "\$@"
+fi
+if command -v /usr/local/bin/git >/dev/null 2>&1; then
+	exec /usr/local/bin/git "\$@"
+fi
+exit 0
+EOF
+	chmod +x "${mock_bin}/git"
+
+	if [[ ":$PATH:" != *":${mock_bin}:"* ]]; then
+		export PATH="${mock_bin}:$PATH"
+	fi
+}
+
+@test "update-homebrew.sh generate: updates existing formula url and sha256" {
+	local fixture_tap="${BATS_TEST_TMPDIR}/fixture-tap"
+	mkdir -p "$fixture_tap/Formula"
+	cat >"$fixture_tap/Formula/winnow.rb" <<'EOF'
+class Winnow < Formula
+  desc "Winnow"
+  homepage "https://example.com"
+  url "https://files.pythonhosted.org/packages/old/winnow-1.0.0.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+end
+EOF
+
+	local new_url="https://files.pythonhosted.org/packages/new/winnow-2.0.0.tar.gz"
+	local new_sha="aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd001122"
+	local pypi_json
+	pypi_json=$(
+		jq -n \
+			--arg url "$new_url" \
+			--arg sha "$new_sha" \
+			'{urls:[{packagetype:"sdist",url:$url,digests:{sha256:$sha}}]}'
+	)
+
+	_mock_git_clone_tap_fixture "$fixture_tap"
+	mock_command "curl" "$pypi_json" 0
+
+	local tap_target="${BATS_TEST_TMPDIR}/homebrew-tap"
+
+	run env \
+		STEP=generate \
+		TAP_REPOSITORY=lgtm-hq/homebrew-tap \
+		FORMULA=winnow \
+		PACKAGE=winnow \
+		VERSION=2.0.0 \
+		RUNNER_TEMP="$BATS_TEST_TMPDIR" \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/update-homebrew.sh"
+
+	assert_success
+
+	run grep "url \"${new_url}\"" "${tap_target}/Formula/winnow.rb"
+	assert_success
+
+	run grep "sha256 \"${new_sha}\"" "${tap_target}/Formula/winnow.rb"
+	assert_success
+}
+
+# =============================================================================
+# Integration tests
+# =============================================================================
+
+@test "homebrew.sh: sources registry.sh automatically" {
+	require_bash4
+	run bash -c 'source "$LIB_DIR/publish/homebrew.sh" && declare -F get_pypi_download_url'
+	assert_success
+}

--- a/tests/bats/unit/lib/test_publish.bats
+++ b/tests/bats/unit/lib/test_publish.bats
@@ -36,6 +36,12 @@ teardown() {
 	assert_output "loaded"
 }
 
+@test "publish.sh: sources publish/homebrew.sh" {
+	run bash -c 'source "$LIB_DIR/publish.sh" && declare -f generate_formula_from_pypi >/dev/null && echo "loaded"'
+	assert_success
+	assert_output "loaded"
+}
+
 # =============================================================================
 # Guard pattern tests
 # =============================================================================


### PR DESCRIPTION
## Summary

Restores the legacy `update-homebrew` composite action and `reusable-publish-homebrew` workflow (removed in #351) with deprecation comments directing org repos to `trigger-homebrew-update` and `lgtm-hq/homebrew-tap`. Fixes the `update_formula_version` argument order bug in the generate step and adds a BATS regression test that exercises the full generate path.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Changes Made

- Add deprecation comment blocks to `.github/actions/update-homebrew/action.yml` and `.github/workflows/reusable-publish-homebrew.yml`
- Restore `scripts/ci/actions/update-homebrew.sh`, `scripts/ci/lib/publish/homebrew.sh`, and related publish aggregator wiring
- Fix `update_formula_version` call: pass `(formula_file, download_url, sha256, version)` instead of `(formula_file, version, download_url, sha256)`
- Add BATS regression test in `tests/bats/unit/lib/publish/test_homebrew.bats` for the generate step

## Breaking Changes

None

## Closes

- Relates to [homebrew-tap#44](https://github.com/lgtm-hq/homebrew-tap/issues/44)

## Test plan

- [x] `uv run lintro chk` — zero issues
- [x] `uv run lintro fmt` — zero issues
- [x] `uv run lintro tst` — all tests pass
- [x] BATS: `tests/bats/unit/lib/publish/test_homebrew.bats`, `test_trigger_homebrew_update.bats`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore deprecated Homebrew updaters and fix formula argument order in CI scripts
> - Adds [publish/homebrew.sh](https://github.com/lgtm-hq/lgtm-ci/pull/355/files#diff-111f6c84e721faa12f28597342c4b63100b4506143d17b3e4f1829adf0b38eea) with functions to generate a full Homebrew formula from PyPI metadata, update an existing formula's `url`/`sha256`, compute SHA256 from a URL, produce resource blocks from a requirements file, clone a tap, and commit changes.
> - Adds [update-homebrew.sh](https://github.com/lgtm-hq/lgtm-ci/pull/355/files#diff-91c6e39961abf1641a664be05fd0415a0f0b1de6476b71192f14bf1dcb7dafd0), a step-dispatched script covering wait, generate, commit, PR creation, and summary phases, communicating results via GitHub Actions outputs.
> - Wraps the above in a composite action ([action.yml](https://github.com/lgtm-hq/lgtm-ci/pull/355/files#diff-43c986647d0d431fb694c30d8f1e50cf21f1bafb3bcf56323709d9a51bdec704)) and a reusable workflow ([reusable-publish-homebrew.yml](https://github.com/lgtm-hq/lgtm-ci/pull/355/files#diff-5be5db876abdd7fb08d2c684b9d5a95d707d9b44fe22fb3cfbff27902c2f61d5)) with hardened network egress support.
> - Adds a Bats test suite in [test_homebrew.bats](https://github.com/lgtm-hq/lgtm-ci/pull/355/files#diff-623c67802a514506c619150f586ef6e7a6acfd58cbb820734ca9940278362c8c) covering all new library functions and the generate step integration.
> - [publish.sh](https://github.com/lgtm-hq/lgtm-ci/pull/355/files#diff-8835b26f7418301dd86d584b7b47f3e9c55963b6a0f3e7bb30c6a60db3812274) is updated to source `publish/homebrew.sh` so callers get Homebrew functions automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43c4799.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Homebrew formula publication infrastructure with version management and dependency resolution.
  * Enhanced security for Homebrew publishing workflows with egress policy controls and allowlist management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores the deprecated `update-homebrew` composite action and `reusable-publish-homebrew` workflow with deprecation notices, adds the `publish/homebrew.sh` helper library, and fixes the `update_formula_version` argument-order bug.

- **Bug fix confirmed**: The `update_formula_version` call now correctly passes `(formula_file, download_url, sha256, VERSION)`, matching the function signature.
- **New BATS suite** covers all public functions and adds an end-to-end regression test for the generate step.
- **Credential gap**: `clone_homebrew_tap` clones the tap repository over plain HTTPS without credentials; the subsequent `git push` will fail with a 403. `escape_ruby_string` is also missing from the `export -f` block despite being a dependency of the exported `generate_formula_from_pypi`.
</details>

<h3>Confidence Score: 3/5</h3>

The core argument-order fix is correct, but the restored push path will always fail with an authentication error against the tap repository — the feature cannot complete a push or PR-branch creation until credential injection is added to the clone step.

The tap clone URL carries no credentials and git does not pick up `GH_TOKEN` automatically, so every call to this action that attempts a push will fail at runtime. This affects the primary purpose of the restored code.

scripts/ci/lib/publish/homebrew.sh (clone_homebrew_tap / export block) and scripts/ci/actions/update-homebrew.sh (commit step push)

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/lib/publish/homebrew.sh | New library providing Homebrew formula generation/update utilities. The `update_formula_version` arg-order fix is correct. However, `clone_homebrew_tap` always clones without credentials, causing `git push` to fail at runtime; and `escape_ruby_string` is missing from the `export -f` block. |
| scripts/ci/actions/update-homebrew.sh | Restored action driver. Argument-order fix is correct. The `commit` step's `git push` will fail due to missing credential injection in `clone_homebrew_tap`. |
| .github/actions/update-homebrew/action.yml | Restored composite action with deprecation comment. `GH_TOKEN` passed to commit/pr steps but not used to authenticate the git remote; only the `git push` path is broken. |
| .github/workflows/reusable-publish-homebrew.yml | Restored reusable workflow with SHA-pinned checkout and harden-runner. No `tap-token` secret input defined. |
| scripts/ci/lib/publish.sh | Minimal aggregator change: adds conditional source for `publish/homebrew.sh`. |
| tests/bats/unit/lib/publish/test_homebrew.bats | Comprehensive BATS suite; the 'exports escape_ruby_string' test only checks declaration, not export. The generate regression test is solid. |
| tests/bats/unit/lib/test_publish.bats | Adds sourcing verification test for `publish/homebrew.sh`. |

</details>

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Flib%2Fpublish%2Fhomebrew.sh%3A273%0A**Git%20push%20will%20fail%20%E2%80%94%20clone%20URL%20carries%20no%20credentials**%0A%0A%60clone_homebrew_tap%60%20builds%20a%20plain%20HTTPS%20URL%20for%20the%20tap%20repository.%20When%20the%20%60commit%60%20step%20in%20%60update-homebrew.sh%60%20later%20runs%20%60git%20push%20origin%20HEAD%60%20%28or%20%60git%20push%20-u%20origin%20%22%24branch_name%22%60%29%2C%20git%20has%20no%20authentication%20for%20that%20remote%20and%20will%20be%20rejected%20with%20a%20403.%20%60GH_TOKEN%60%20is%20exported%20to%20the%20environment%20by%20the%20action's%20%60commit%60%20step%2C%20but%20git%20does%20not%20consume%20it%20automatically.%20The%20token%20must%20be%20injected%20into%20the%20remote%20URL%20at%20clone%20time%20%28e.g.%20via%20a%20token-prefixed%20HTTPS%20URL%29%20or%20the%20credential%20stack%20must%20be%20primed%20before%20the%20push%20%28e.g.%20%60gh%20auth%20setup-git%60%29.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Flib%2Fpublish%2Fhomebrew.sh%3A338-340%0A%60escape_ruby_string%60%20is%20called%20inside%20the%20exported%20%60generate_formula_from_pypi%60%2C%20but%20it%20is%20absent%20from%20the%20%60export%20-f%60%20block.%20If%20a%20child%20process%20inherits%20only%20the%20exported%20functions%20%28without%20re-sourcing%20%60homebrew.sh%60%29%2C%20calling%20%60generate_formula_from_pypi%60%20there%20will%20fail%20with%20%60command%20not%20found%3A%20escape_ruby_string%60.%20The%20test%20named%20%22exports%20escape_ruby_string%20function%22%20passes%20only%20because%20it%20sources%20the%20file%20first%2C%20so%20it%20does%20not%20catch%20this%20gap.%0A%0A%60%60%60suggestion%0Aexport%20-f%20escape_ruby_string%0Aexport%20-f%20generate_formula_from_pypi%20update_formula_version%0Aexport%20-f%20calculate_sha256_from_url%20calculate_resource_checksums%0Aexport%20-f%20clone_homebrew_tap%20commit_formula_update%0A%60%60%60%0A%0A&pr=355&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Flib%2Fpublish%2Fhomebrew.sh%3A273%0A**Git%20push%20will%20fail%20%E2%80%94%20clone%20URL%20carries%20no%20credentials**%0A%0A%60clone_homebrew_tap%60%20builds%20a%20plain%20HTTPS%20URL%20for%20the%20tap%20repository.%20When%20the%20%60commit%60%20step%20in%20%60update-homebrew.sh%60%20later%20runs%20%60git%20push%20origin%20HEAD%60%20%28or%20%60git%20push%20-u%20origin%20%22%24branch_name%22%60%29%2C%20git%20has%20no%20authentication%20for%20that%20remote%20and%20will%20be%20rejected%20with%20a%20403.%20%60GH_TOKEN%60%20is%20exported%20to%20the%20environment%20by%20the%20action's%20%60commit%60%20step%2C%20but%20git%20does%20not%20consume%20it%20automatically.%20The%20token%20must%20be%20injected%20into%20the%20remote%20URL%20at%20clone%20time%20%28e.g.%20via%20a%20token-prefixed%20HTTPS%20URL%29%20or%20the%20credential%20stack%20must%20be%20primed%20before%20the%20push%20%28e.g.%20%60gh%20auth%20setup-git%60%29.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Flib%2Fpublish%2Fhomebrew.sh%3A338-340%0A%60escape_ruby_string%60%20is%20called%20inside%20the%20exported%20%60generate_formula_from_pypi%60%2C%20but%20it%20is%20absent%20from%20the%20%60export%20-f%60%20block.%20If%20a%20child%20process%20inherits%20only%20the%20exported%20functions%20%28without%20re-sourcing%20%60homebrew.sh%60%29%2C%20calling%20%60generate_formula_from_pypi%60%20there%20will%20fail%20with%20%60command%20not%20found%3A%20escape_ruby_string%60.%20The%20test%20named%20%22exports%20escape_ruby_string%20function%22%20passes%20only%20because%20it%20sources%20the%20file%20first%2C%20so%20it%20does%20not%20catch%20this%20gap.%0A%0A%60%60%60suggestion%0Aexport%20-f%20escape_ruby_string%0Aexport%20-f%20generate_formula_from_pypi%20update_formula_version%0Aexport%20-f%20calculate_sha256_from_url%20calculate_resource_checksums%0Aexport%20-f%20clone_homebrew_tap%20commit_formula_update%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=355&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2Ftrigger-homebrew-update%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ftrigger-homebrew-update%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fci%2Flib%2Fpublish%2Fhomebrew.sh%3A273%0A**Git%20push%20will%20fail%20%E2%80%94%20clone%20URL%20carries%20no%20credentials**%0A%0A%60clone_homebrew_tap%60%20builds%20a%20plain%20HTTPS%20URL%20for%20the%20tap%20repository.%20When%20the%20%60commit%60%20step%20in%20%60update-homebrew.sh%60%20later%20runs%20%60git%20push%20origin%20HEAD%60%20%28or%20%60git%20push%20-u%20origin%20%22%24branch_name%22%60%29%2C%20git%20has%20no%20authentication%20for%20that%20remote%20and%20will%20be%20rejected%20with%20a%20403.%20%60GH_TOKEN%60%20is%20exported%20to%20the%20environment%20by%20the%20action's%20%60commit%60%20step%2C%20but%20git%20does%20not%20consume%20it%20automatically.%20The%20token%20must%20be%20injected%20into%20the%20remote%20URL%20at%20clone%20time%20%28e.g.%20via%20a%20token-prefixed%20HTTPS%20URL%29%20or%20the%20credential%20stack%20must%20be%20primed%20before%20the%20push%20%28e.g.%20%60gh%20auth%20setup-git%60%29.%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fci%2Flib%2Fpublish%2Fhomebrew.sh%3A338-340%0A%60escape_ruby_string%60%20is%20called%20inside%20the%20exported%20%60generate_formula_from_pypi%60%2C%20but%20it%20is%20absent%20from%20the%20%60export%20-f%60%20block.%20If%20a%20child%20process%20inherits%20only%20the%20exported%20functions%20%28without%20re-sourcing%20%60homebrew.sh%60%29%2C%20calling%20%60generate_formula_from_pypi%60%20there%20will%20fail%20with%20%60command%20not%20found%3A%20escape_ruby_string%60.%20The%20test%20named%20%22exports%20escape_ruby_string%20function%22%20passes%20only%20because%20it%20sources%20the%20file%20first%2C%20so%20it%20does%20not%20catch%20this%20gap.%0A%0A%60%60%60suggestion%0Aexport%20-f%20escape_ruby_string%0Aexport%20-f%20generate_formula_from_pypi%20update_formula_version%0Aexport%20-f%20calculate_sha256_from_url%20calculate_resource_checksums%0Aexport%20-f%20clone_homebrew_tap%20commit_formula_update%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=355&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(homebrew): restore deprecated update..."](https://github.com/lgtm-hq/lgtm-ci/commit/43c479927138c6c369da7b9c082e1d9f5e39b0c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37296011)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->