### PR TITLE
fix(ci): map pytest coverage formats for publish-test-summary

### DIFF
--- a/.github/workflows/reusable-test-python.yml
+++ b/.github/workflows/reusable-test-python.yml
@@ -556,5 +556,8 @@ jobs:
       coverage-file: >-
         ${{ inputs.coverage-format == 'xml' && 'coverage.xml' ||
         (inputs.coverage-format == 'lcov' && 'coverage.lcov' || 'coverage.json') }}
-      coverage-format: ${{ inputs.coverage-format }}
+      coverage-format: >-
+        ${{ inputs.coverage-format == 'lcov' && 'lcov' ||
+        (inputs.coverage-format == 'xml' && 'cobertura' ||
+        'coverage-py') }}
       tooling-ref: ${{ inputs.tooling-ref }}

--- a/scripts/ci/actions/generate-coverage-comment.sh
+++ b/scripts/ci/actions/generate-coverage-comment.sh
@@ -125,6 +125,7 @@ if [[ "$FORMAT" == "auto" ]]; then
 		case "$(detect_coverage_format "$COVERAGE_FILE")" in
 		lcov) FORMAT="lcov" ;;
 		cobertura) FORMAT="cobertura" ;;
+		coverage-py) FORMAT="coverage-py" ;;
 		*) FORMAT="istanbul" ;;
 		esac
 	else

--- a/scripts/ci/actions/generate-coverage-comment.sh
+++ b/scripts/ci/actions/generate-coverage-comment.sh
@@ -126,6 +126,7 @@ if [[ "$FORMAT" == "auto" ]]; then
 		lcov) FORMAT="lcov" ;;
 		cobertura) FORMAT="cobertura" ;;
 		coverage-py) FORMAT="coverage-py" ;;
+		istanbul) FORMAT="istanbul" ;;
 		*) FORMAT="istanbul" ;;
 		esac
 	else

--- a/scripts/ci/actions/generate-coverage-comment.sh
+++ b/scripts/ci/actions/generate-coverage-comment.sh
@@ -4,7 +4,7 @@
 #
 # Required environment variables:
 #   COVERAGE_FILE - Path to coverage summary JSON file
-#   FORMAT - Coverage format: istanbul, coverage-py, lcov, or auto
+#   FORMAT - Coverage format: istanbul, coverage-py, cobertura, lcov, or auto
 #   REPORT_URL - URL to full report (optional)
 #   THRESHOLD_LINES - Minimum line coverage percentage
 #   THRESHOLD_BRANCHES - Minimum branch coverage percentage
@@ -121,8 +121,12 @@ if [[ "$FORMAT" == "auto" ]]; then
 		FORMAT="istanbul"
 	elif jq -e '.totals' "$COVERAGE_FILE" >/dev/null 2>&1; then
 		FORMAT="coverage-py"
-	elif declare -f detect_coverage_format &>/dev/null && [[ "$(detect_coverage_format "$COVERAGE_FILE")" == "lcov" ]]; then
-		FORMAT="lcov"
+	elif declare -f detect_coverage_format &>/dev/null; then
+		case "$(detect_coverage_format "$COVERAGE_FILE")" in
+		lcov) FORMAT="lcov" ;;
+		cobertura) FORMAT="cobertura" ;;
+		*) FORMAT="istanbul" ;;
+		esac
 	else
 		FORMAT="istanbul"
 	fi
@@ -152,6 +156,17 @@ lcov)
 	BRANCHES_RAW=${COVERAGE_BRANCHES:-0}
 	FUNCTIONS_RAW=${COVERAGE_FUNCTIONS:-0}
 	STATEMENTS_RAW=${COVERAGE_STATEMENTS:-$LINES_RAW}
+	;;
+cobertura)
+	if ! declare -f extract_coverage_details &>/dev/null; then
+		echo "::error::Cobertura support requires scripts/ci/lib/testing/coverage/extract.sh"
+		exit 1
+	fi
+	extract_coverage_details "$COVERAGE_FILE"
+	LINES_RAW=${COVERAGE_LINES:-0}
+	BRANCHES_RAW=${COVERAGE_BRANCHES:-0}
+	FUNCTIONS_RAW=${COVERAGE_LINES:-0}
+	STATEMENTS_RAW=${COVERAGE_LINES:-0}
 	;;
 *)
 	echo "::error::Unknown coverage format: $FORMAT"

--- a/scripts/ci/actions/generate-coverage-comment.sh
+++ b/scripts/ci/actions/generate-coverage-comment.sh
@@ -165,8 +165,8 @@ cobertura)
 	extract_coverage_details "$COVERAGE_FILE"
 	LINES_RAW=${COVERAGE_LINES:-0}
 	BRANCHES_RAW=${COVERAGE_BRANCHES:-0}
-	FUNCTIONS_RAW=${COVERAGE_LINES:-0}
-	STATEMENTS_RAW=${COVERAGE_LINES:-0}
+	FUNCTIONS_RAW=$LINES_RAW # Cobertura XML only exposes line/branch rates
+	STATEMENTS_RAW=$LINES_RAW
 	;;
 *)
 	echo "::error::Unknown coverage format: $FORMAT"

--- a/tests/bats/integration/test_reusable_test_python_workflow.bats
+++ b/tests/bats/integration/test_reusable_test_python_workflow.bats
@@ -76,13 +76,19 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-python.yml"
 
 @test "reusable-test-python: publish-test-summary maps pytest formats to comment semantics" {
 	run awk '
-		/^  publish-test-summary:/ { in_publish = 1; in_cov = 0; passthrough = 0; semantic = 0 }
+		/^  publish-test-summary:/ {
+			in_publish = 1
+			in_cov = 0
+			passthrough = 0
+			has_coverage_py = 0
+			has_cobertura = 0
+		}
 		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ { in_publish = 0 }
 		in_publish && /coverage-format:/ { in_cov = 1 }
-		in_publish && in_cov && /coverage-py/ { semantic = 1 }
-		in_publish && in_cov && /cobertura/ { semantic = 1 }
+		in_publish && in_cov && /coverage-py/ { has_coverage_py = 1 }
+		in_publish && in_cov && /cobertura/ { has_cobertura = 1 }
 		in_publish && in_cov && /coverage-format: \$\{\{ inputs\.coverage-format \}\}/ { passthrough = 1 }
-		END { exit !(semantic && !passthrough) }
+		END { exit !(has_coverage_py && has_cobertura && !passthrough) }
 	' "$WORKFLOW"
 	assert_success
 }

--- a/tests/bats/integration/test_reusable_test_python_workflow.bats
+++ b/tests/bats/integration/test_reusable_test_python_workflow.bats
@@ -73,3 +73,16 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-python.yml"
 	' "$WORKFLOW"
 	assert_success
 }
+
+@test "reusable-test-python: publish-test-summary maps pytest formats to comment semantics" {
+	run awk '
+		/^  publish-test-summary:/ { in_publish = 1; in_cov = 0; passthrough = 0; semantic = 0 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ { in_publish = 0 }
+		in_publish && /coverage-format:/ { in_cov = 1 }
+		in_publish && in_cov && /coverage-py/ { semantic = 1 }
+		in_publish && in_cov && /cobertura/ { semantic = 1 }
+		in_publish && in_cov && /coverage-format: \$\{\{ inputs\.coverage-format \}\}/ { passthrough = 1 }
+		END { exit !(semantic && !passthrough) }
+	' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_test_python_workflow.bats
+++ b/tests/bats/integration/test_reusable_test_python_workflow.bats
@@ -82,13 +82,15 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-python.yml"
 			passthrough = 0
 			has_coverage_py = 0
 			has_cobertura = 0
+			has_lcov = 0
 		}
 		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ { in_publish = 0 }
 		in_publish && /coverage-format:/ { in_cov = 1 }
 		in_publish && in_cov && /coverage-py/ { has_coverage_py = 1 }
 		in_publish && in_cov && /cobertura/ { has_cobertura = 1 }
+		in_publish && in_cov && /'\''lcov'\'' && '\''lcov'\''/ { has_lcov = 1 }
 		in_publish && in_cov && /coverage-format: \$\{\{ inputs\.coverage-format \}\}/ { passthrough = 1 }
-		END { exit !(has_coverage_py && has_cobertura && !passthrough) }
+		END { exit !(has_coverage_py && has_cobertura && has_lcov && !passthrough) }
 	' "$WORKFLOW"
 	assert_success
 }

--- a/tests/bats/unit/actions/test_generate_coverage_comment.bats
+++ b/tests/bats/unit/actions/test_generate_coverage_comment.bats
@@ -243,3 +243,27 @@ EOF
 	assert_file_contains "$GITHUB_OUTPUT" "passed=true"
 	assert_file_contains "$GITHUB_OUTPUT" "Code Coverage Report"
 }
+
+@test "generate-coverage-comment: extracts cobertura coverage from pytest xml" {
+	local coverage_file="${BATS_TEST_TMPDIR}/coverage.xml"
+	cat >"$coverage_file" <<'EOF'
+<?xml version="1.0" ?>
+<coverage line-rate="0.88" branch-rate="0.77" lines-covered="880" lines-valid="1000" branches-covered="77" branches-valid="100" version="7.6.1">
+</coverage>
+EOF
+
+	run env \
+		GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+		COVERAGE_FILE="$coverage_file" \
+		FORMAT="cobertura" \
+		THRESHOLD_LINES="80" \
+		THRESHOLD_BRANCHES="70" \
+		THRESHOLD_FUNCTIONS="80" \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/generate-coverage-comment.sh"
+
+	assert_success
+	assert_file_contains "$GITHUB_OUTPUT" "lines=88"
+	assert_file_contains "$GITHUB_OUTPUT" "branches=77"
+	assert_file_contains "$GITHUB_OUTPUT" "passed=true"
+	assert_file_contains "$GITHUB_OUTPUT" "Code Coverage Report"
+}

--- a/tests/bats/unit/actions/test_generate_coverage_comment.bats
+++ b/tests/bats/unit/actions/test_generate_coverage_comment.bats
@@ -264,6 +264,7 @@ EOF
 	assert_success
 	assert_file_contains "$GITHUB_OUTPUT" "lines=88"
 	assert_file_contains "$GITHUB_OUTPUT" "branches=77"
+	assert_file_contains "$GITHUB_OUTPUT" "functions=88"
 	assert_file_contains "$GITHUB_OUTPUT" "passed=true"
 	assert_file_contains "$GITHUB_OUTPUT" "Code Coverage Report"
 }


### PR DESCRIPTION
## Summary

Fixes a contract mismatch in `reusable-test-python.yml` where pytest output format names (`json`, `xml`, `lcov`) were passed verbatim to `reusable-publish-test-summary.yml`, causing `generate-coverage-comment.sh` to fail with `Unknown coverage format` when callers enable `publish-test-summary: true`.

The fix maps pytest formats to comment semantic formats at the reusable boundary, following the same pattern as `reusable-test-node.yml` (`istanbul`) and `reusable-rust-test.yml` (`lcov`).

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [ ] YAML files pass `yamllint`
- [ ] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #360

## Changes Made

- Map pytest `json` → `coverage-py`, `xml` → `cobertura`, `lcov` → `lcov` in `publish-test-summary` delegation
- Add `cobertura` parsing branch to `generate-coverage-comment.sh` using existing `extract_coverage_details`
- Improve `auto` format detection to recognize cobertura before defaulting to istanbul
- Add BATS contract test for publish wiring and unit test for cobertura XML extraction

## Testing

- [x] `bats tests/bats/integration/test_reusable_test_python_workflow.bats`
- [x] `bats tests/bats/unit/actions/test_generate_coverage_comment.bats`
- [x] `shellcheck scripts/ci/actions/generate-coverage-comment.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended automated coverage comment generation to recognize and parse Cobertura coverage reports.
* **Bug Fixes**
  * Improved `coverage-format` handling in `auto` mode by explicitly mapping supported formats (including Cobertura) and falling back to safe defaults when detection is unclear.
  * Updated reusable test publishing workflow to normalize `coverage-format` inputs for consistent reporting.
* **Tests**
  * Added integration coverage-format handling checks for both coverage-py and Cobertura.
  * Added unit coverage extraction test for Cobertura to validate reported metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a contract mismatch where pytest coverage format names (`json`, `xml`, `lcov`) were passed verbatim to `reusable-publish-test-summary.yml`, causing `generate-coverage-comment.sh` to exit with `Unknown coverage format`. The fix translates those names to semantic formats (`coverage-py`, `cobertura`, `lcov`) at the reusable-workflow boundary, adds a `cobertura` parsing branch to the shell script, and improves `auto` detection to handle all known formats via a `case` dispatch.

- **`reusable-test-python.yml`**: adds a ternary expression mapping pytest format names to the comment-semantic equivalents before delegating to `publish-test-summary`.
- **`generate-coverage-comment.sh`**: adds a `cobertura` case that calls the existing `extract_coverage_details` helper and proxies `functions`/`statements` from the line rate (correct, since Cobertura XML exposes only `line-rate` and `branch-rate`); the `auto` path is also widened from a single LCOV guard to a full `case` statement.
- **Tests**: a BATS integration contract test verifies the format-mapping expression in the workflow, and a unit test exercises Cobertura XML extraction end-to-end.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted bug fix with a narrow blast radius, backed by both unit and integration tests.

The format-mapping expression in the workflow is straightforward, the new cobertura branch in the shell script follows the identical pattern already used by lcov and coverage-py, and extract_coverage_details already had a working cobertura implementation in the shared library. No existing behaviour is modified; all new paths are covered by the added tests.

The unit test file is missing a statements=88 assertion for the cobertura fixture, and reusable-publish-test-summary.yml's input description still omits cobertura from its documented values — both are minor gaps and do not affect runtime correctness.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-test-python.yml | Adds format mapping at the reusable boundary: `json`→`coverage-py`, `xml`→`cobertura`, `lcov`→`lcov`, fixing the contract mismatch with `generate-coverage-comment.sh`. |
| scripts/ci/actions/generate-coverage-comment.sh | Adds `cobertura` case using `extract_coverage_details`, proxying functions/statements from line rate (correct, since Cobertura XML exposes only line/branch rates). Improves `auto` detection to dispatch all formats via a `case` statement instead of a single LCOV guard. |
| tests/bats/integration/test_reusable_test_python_workflow.bats | New awk-based contract test verifies that the `publish-test-summary` job's `coverage-format` block maps to `coverage-py`, `cobertura`, and `lcov` without verbatim passthrough. |
| tests/bats/unit/actions/test_generate_coverage_comment.bats | New unit test validates cobertura XML extraction against a minimal fixture; correctly asserts `lines`, `branches`, `functions`, and `passed`, but is missing a `statements=88` assertion. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["reusable-test-python.yml\ninputs.coverage-format"] -->|json| B["coverage-py"]
    A -->|xml| C["cobertura"]
    A -->|lcov| D["lcov"]
    B --> E["reusable-publish-test-summary.yml\ncoverage-format input"]
    C --> E
    D --> E
    E --> F["generate-coverage-comment.sh\nFORMAT env var"]
    F -->|coverage-py| G["jq .totals\nFUNCTIONS_RAW = LINES_RAW"]
    F -->|cobertura| H["extract_coverage_details\nFUNCTIONS_RAW = LINES_RAW\nnew in this PR"]
    F -->|lcov| I["extract_coverage_details\nFUNCTIONS_RAW = COVERAGE_FUNCTIONS"]
    F -->|istanbul| J["jq .total.*"]
    F -->|auto| K{detect_coverage_format}
    K -->|cobertura| H
    K -->|lcov| I
    K -->|coverage-py| G
    K -->|istanbul| J
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["reusable-test-python.yml\ninputs.coverage-format"] -->|json| B["coverage-py"]
    A -->|xml| C["cobertura"]
    A -->|lcov| D["lcov"]
    B --> E["reusable-publish-test-summary.yml\ncoverage-format input"]
    C --> E
    D --> E
    E --> F["generate-coverage-comment.sh\nFORMAT env var"]
    F -->|coverage-py| G["jq .totals\nFUNCTIONS_RAW = LINES_RAW"]
    F -->|cobertura| H["extract_coverage_details\nFUNCTIONS_RAW = LINES_RAW\nnew in this PR"]
    F -->|lcov| I["extract_coverage_details\nFUNCTIONS_RAW = COVERAGE_FUNCTIONS"]
    F -->|istanbul| J["jq .total.*"]
    F -->|auto| K{detect_coverage_format}
    K -->|cobertura| H
    K -->|lcov| I
    K -->|coverage-py| G
    K -->|istanbul| J
```

</a>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atests%2Fbats%2Funit%2Factions%2Ftest_generate_coverage_comment.bats%3A264-269%0A**Missing%20%60statements%60%20assertion%20in%20cobertura%20test**%0A%0AThe%20cobertura%20case%20sets%20%60STATEMENTS_RAW%3D%24LINES_RAW%60%2C%20so%20%60statements%3D88%60%20is%20written%20to%20%60GITHUB_OUTPUT%60.%20The%20test%20verifies%20%60lines%60%2C%20%60branches%60%2C%20and%20%60functions%60%20%28the%20latter%20in%20response%20to%20the%20prior%20review%20thread%29%2C%20but%20omits%20the%20corresponding%20%60statements%3D88%60%20check.%20A%20future%20regression%20that%20inadvertently%20drops%20or%20miscalculates%20%60statements%60%20would%20go%20undetected%20here.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Freusable-publish-test-summary.yml%3A57-58%0AThe%20%60coverage-format%60%20input%20description%20was%20not%20updated%20alongside%20the%20script%20change%3B%20%60cobertura%60%20is%20now%20a%20valid%20value%20that%20callers%20%28including%20%60reusable-test-python.yml%60%29%20will%20pass%2C%20but%20it%20is%20absent%20from%20the%20description.%20This%20can%20mislead%20anyone%20reading%20the%20workflow%20interface.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20coverage-format%3A%0A%20%20%20%20%20%20%20%20description%3A%20%22Coverage%20format%3A%20istanbul%2C%20coverage-py%2C%20cobertura%2C%20lcov%2C%20or%20auto%22%0A%60%60%60%0A%0A&pr=361&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atests%2Fbats%2Funit%2Factions%2Ftest_generate_coverage_comment.bats%3A264-269%0A**Missing%20%60statements%60%20assertion%20in%20cobertura%20test**%0A%0AThe%20cobertura%20case%20sets%20%60STATEMENTS_RAW%3D%24LINES_RAW%60%2C%20so%20%60statements%3D88%60%20is%20written%20to%20%60GITHUB_OUTPUT%60.%20The%20test%20verifies%20%60lines%60%2C%20%60branches%60%2C%20and%20%60functions%60%20%28the%20latter%20in%20response%20to%20the%20prior%20review%20thread%29%2C%20but%20omits%20the%20corresponding%20%60statements%3D88%60%20check.%20A%20future%20regression%20that%20inadvertently%20drops%20or%20miscalculates%20%60statements%60%20would%20go%20undetected%20here.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Freusable-publish-test-summary.yml%3A57-58%0AThe%20%60coverage-format%60%20input%20description%20was%20not%20updated%20alongside%20the%20script%20change%3B%20%60cobertura%60%20is%20now%20a%20valid%20value%20that%20callers%20%28including%20%60reusable-test-python.yml%60%29%20will%20pass%2C%20but%20it%20is%20absent%20from%20the%20description.%20This%20can%20mislead%20anyone%20reading%20the%20workflow%20interface.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20coverage-format%3A%0A%20%20%20%20%20%20%20%20description%3A%20%22Coverage%20format%3A%20istanbul%2C%20coverage-py%2C%20cobertura%2C%20lcov%2C%20or%20auto%22%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=361&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22fix%2F360-python-publish-coverage-format-mapping%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F360-python-publish-coverage-format-mapping%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atests%2Fbats%2Funit%2Factions%2Ftest_generate_coverage_comment.bats%3A264-269%0A**Missing%20%60statements%60%20assertion%20in%20cobertura%20test**%0A%0AThe%20cobertura%20case%20sets%20%60STATEMENTS_RAW%3D%24LINES_RAW%60%2C%20so%20%60statements%3D88%60%20is%20written%20to%20%60GITHUB_OUTPUT%60.%20The%20test%20verifies%20%60lines%60%2C%20%60branches%60%2C%20and%20%60functions%60%20%28the%20latter%20in%20response%20to%20the%20prior%20review%20thread%29%2C%20but%20omits%20the%20corresponding%20%60statements%3D88%60%20check.%20A%20future%20regression%20that%20inadvertently%20drops%20or%20miscalculates%20%60statements%60%20would%20go%20undetected%20here.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Freusable-publish-test-summary.yml%3A57-58%0AThe%20%60coverage-format%60%20input%20description%20was%20not%20updated%20alongside%20the%20script%20change%3B%20%60cobertura%60%20is%20now%20a%20valid%20value%20that%20callers%20%28including%20%60reusable-test-python.yml%60%29%20will%20pass%2C%20but%20it%20is%20absent%20from%20the%20description.%20This%20can%20mislead%20anyone%20reading%20the%20workflow%20interface.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20coverage-format%3A%0A%20%20%20%20%20%20%20%20description%3A%20%22Coverage%20format%3A%20istanbul%2C%20coverage-py%2C%20cobertura%2C%20lcov%2C%20or%20auto%22%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=361&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["fix(ci): make auto-detect formats explic..."](https://github.com/lgtm-hq/lgtm-ci/commit/48cfa10b66cefc75fc8b54a149fc8e3b6c92167e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38662308)</sub>

<!-- /greptile_comment -->