### PR TITLE
feat(ci): close adoption gaps blocking py-lintro reusable workflow migration

### DIFF
--- a/.github/actions/attest-build/action.yml
+++ b/.github/actions/attest-build/action.yml
@@ -37,8 +37,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Prepare attestation
       id: prepare

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -75,8 +75,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Setup Docker environment
       shell: bash

--- a/.github/actions/bundle-workflow-artifacts/action.yml
+++ b/.github/actions/bundle-workflow-artifacts/action.yml
@@ -41,8 +41,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Bundle workflow artifacts
       id: bundle

--- a/.github/actions/calculate-version/action.yml
+++ b/.github/actions/calculate-version/action.yml
@@ -37,8 +37,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Calculate next version
       id: calculate

--- a/.github/actions/collect-coverage/action.yml
+++ b/.github/actions/collect-coverage/action.yml
@@ -52,8 +52,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Detect coverage files
       id: detect

--- a/.github/actions/create-github-release/action.yml
+++ b/.github/actions/create-github-release/action.yml
@@ -55,8 +55,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Create GitHub release
       id: release

--- a/.github/actions/create-release-tag/action.yml
+++ b/.github/actions/create-release-tag/action.yml
@@ -44,8 +44,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Create release tag
       id: tag

--- a/.github/actions/deploy-pages/action.yml
+++ b/.github/actions/deploy-pages/action.yml
@@ -31,8 +31,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Prepare content
       id: prepare

--- a/.github/actions/egress-audit/action.yml
+++ b/.github/actions/egress-audit/action.yml
@@ -49,8 +49,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Setup egress monitoring
       id: setup

--- a/.github/actions/generate-changelog/action.yml
+++ b/.github/actions/generate-changelog/action.yml
@@ -36,8 +36,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Generate changelog
       id: generate

--- a/.github/actions/generate-coverage-comment/action.yml
+++ b/.github/actions/generate-coverage-comment/action.yml
@@ -69,8 +69,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Generate comment
       id: generate

--- a/.github/actions/generate-lighthouse-comment/action.yml
+++ b/.github/actions/generate-lighthouse-comment/action.yml
@@ -54,8 +54,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Generate comment
       id: generate

--- a/.github/actions/generate-playwright-comment/action.yml
+++ b/.github/actions/generate-playwright-comment/action.yml
@@ -47,8 +47,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Generate comment
       id: generate

--- a/.github/actions/generate-sbom/action.yml
+++ b/.github/actions/generate-sbom/action.yml
@@ -46,8 +46,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Generate SBOM
       id: generate

--- a/.github/actions/merge-playwright-reports/action.yml
+++ b/.github/actions/merge-playwright-reports/action.yml
@@ -40,8 +40,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Collect reports
       id: collect

--- a/.github/actions/post-pr-comment/action.yml
+++ b/.github/actions/post-pr-comment/action.yml
@@ -49,8 +49,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Detect PR number
       id: pr

--- a/.github/actions/publish-gem/action.yml
+++ b/.github/actions/publish-gem/action.yml
@@ -37,8 +37,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Validate gemspec
       id: validate

--- a/.github/actions/publish-npm/action.yml
+++ b/.github/actions/publish-npm/action.yml
@@ -49,8 +49,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Validate package
       id: validate

--- a/.github/actions/run-lighthouse/action.yml
+++ b/.github/actions/run-lighthouse/action.yml
@@ -72,8 +72,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Setup Node.js
       uses: ./.github/actions/setup-node

--- a/.github/actions/run-playwright/action.yml
+++ b/.github/actions/run-playwright/action.yml
@@ -59,8 +59,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Setup Node.js
       uses: ./.github/actions/setup-node

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -58,8 +58,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Detect test runner
       id: detect

--- a/.github/actions/scan-vulnerabilities/action.yml
+++ b/.github/actions/scan-vulnerabilities/action.yml
@@ -54,8 +54,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Determine scan target
       id: target

--- a/.github/actions/secure-checkout/action.yml
+++ b/.github/actions/secure-checkout/action.yml
@@ -91,8 +91,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Checkout repository
       id: checkout

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -33,8 +33,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Setup environment
       id: setup

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -48,8 +48,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Setup Ruby
       # Pinned to SHA for supply chain security

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -46,8 +46,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Install Rust toolchain
       # Pinned to SHA for supply chain security

--- a/.github/actions/sign-artifact/action.yml
+++ b/.github/actions/sign-artifact/action.yml
@@ -44,8 +44,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Install Cosign
       # Pinned to SHA for supply chain security

--- a/.github/actions/trigger-homebrew-update/action.yml
+++ b/.github/actions/trigger-homebrew-update/action.yml
@@ -51,8 +51,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Dispatch formula update
       id: dispatch

--- a/.github/actions/validate-action-pinning/action.yml
+++ b/.github/actions/validate-action-pinning/action.yml
@@ -50,8 +50,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Validate action pinning
       id: validate

--- a/.github/actions/validate-package/action.yml
+++ b/.github/actions/validate-package/action.yml
@@ -29,8 +29,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Detect package type
       shell: bash

--- a/.github/actions/verify-attestation/action.yml
+++ b/.github/actions/verify-attestation/action.yml
@@ -34,8 +34,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Verify attestation
       id: verify

--- a/.github/actions/verify-signature/action.yml
+++ b/.github/actions/verify-signature/action.yml
@@ -32,8 +32,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Install Cosign
       # Pinned to SHA for supply chain security

--- a/.github/actions/wait-for-package/action.yml
+++ b/.github/actions/wait-for-package/action.yml
@@ -38,8 +38,8 @@ runs:
     - name: Resolve scripts directory
       shell: bash
       run: |
-        echo "SCRIPTS_DIR=${GITHUB_ACTION_PATH//\\//}/../../../scripts" \
-          >> "$GITHUB_ENV"
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
     - name: Check initial availability
       id: check

--- a/.github/workflows/reusable-ghcr-cleanup.yml
+++ b/.github/workflows/reusable-ghcr-cleanup.yml
@@ -17,7 +17,26 @@ on:
         description: "Always keep N most recent untagged versions"
         required: false
         type: number
-        default: 5
+        default: 0
+      build-cache-pr-age-days:
+        description: >-
+          Minimum age in days before deleting ephemeral pr-*/mq-*/dispatch-*
+          build-cache tags
+        required: false
+        type: number
+        default: 14
+      protect-referenced:
+        description: >-
+          Collect digests referenced by tagged manifest indexes and skip prune
+          when collection is incomplete
+        required: false
+        type: boolean
+        default: true
+      prune-buildcache:
+        description: "Delete aged ephemeral build-cache tags (pr-*, mq-*, dispatch-*)"
+        required: false
+        type: boolean
+        default: true
       dry-run:
         description: "Log only, no deletions"
         required: false
@@ -121,6 +140,9 @@ jobs:
           PACKAGE_NAME: ${{ inputs.package-name }}
           MIN_AGE_DAYS: ${{ inputs.min-age-days }}
           KEEP_LATEST: ${{ inputs.keep-latest }}
+          BUILD_CACHE_PR_AGE_DAYS: ${{ inputs.build-cache-pr-age-days }}
+          PROTECT_REFERENCED: ${{ inputs.protect-referenced }}
+          PRUNE_BUILDCACHE: ${{ inputs.prune-buildcache }}
           DRY_RUN: ${{ inputs.dry-run }}
           GITHUB_ORG: ${{ github.repository_owner }}
         run: .lgtm-ci-tooling/scripts/ci/actions/ghcr-cleanup.sh

--- a/.github/workflows/reusable-vuln-suppression-check.yml
+++ b/.github/workflows/reusable-vuln-suppression-check.yml
@@ -40,6 +40,12 @@ on:
         required: false
         type: string
         default: ""
+      cleanup-pr-labels:
+        description: >-
+          Comma-separated labels for auto-created cleanup PRs
+        required: false
+        type: string
+        default: "security,dependencies,automation"
       tooling-ref:
         description: "Git ref to use when checking out lgtm-ci tooling scripts"
         required: false
@@ -147,5 +153,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           CONFIG_PATH: ${{ inputs.config-path }}
           WORKFLOW_FILE: ${{ inputs.workflow-file }}
+          CLEANUP_PR_LABELS: ${{ inputs.cleanup-pr-labels }}
           CHECK_SCRIPT: ${{ inputs.check-script }}
         run: bash "$GITHUB_WORKSPACE/$CHECK_SCRIPT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ghcr**: referenced-digest protection and ephemeral build-cache tag pruning in
+  `reusable-ghcr-cleanup.yml` (#363)
+- **workflows**: `cleanup-pr-labels` input on `reusable-vuln-suppression-check.yml`
+  (#363)
+
 ### Changed
+
+- **ghcr**: `keep-latest` default is now `0` (delete all eligible untagged versions)
+  (#363)
+- **security**: vuln suppression cleanup removes stale and expired entries via PR
+  (#363)
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- **actions**: fix `SCRIPTS_DIR` resolution across composite actions using
+  `GITHUB_ACTION_PATH` (#363)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **ghcr**: `keep-latest` default is now `0` (delete all eligible untagged versions)
   (#363)
-- **security**: vuln suppression cleanup removes stale and expired entries via PR
-  (#363)
+- **ghcr**: use `updated_at` for age and keep-latest sorting to avoid
+  deleting recently refreshed versions (#363)
+- **ghcr**: ephemeral tag pattern matches any suffix, not just numeric (#363)
+- **security**: vuln suppression cleanup removes stale and expired entries via PR;
+  expired entries cause workflow failure for manual review (#363)
 
 ### Deprecated
 
@@ -29,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **actions**: fix `SCRIPTS_DIR` resolution across composite actions using
   `GITHUB_ACTION_PATH` (#363)
+- **ghcr**: protect root tagged digest in referenced-digest collection (#363)
+- **ghcr**: fix empty referenced-digests array producing `[""]` in jq filter (#363)
+- **security**: fail workflow when existing cleanup PR masks new expired
+  suppressions (#363)
 
 ### Security
 

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -779,7 +779,7 @@ stale (vulnerability resolved upstream) or expired (past `ignoreUntil`).
 | `osv-version`            | `2.3.5`                 | osv-scanner release version                |
 | `config-path`            | `.osv-scanner.toml`     | Suppression TOML path                      |
 | `check-script`           | tooling default         | Repo-local override supported              |
-| `cleanup-pr-labels`      | `security,dependencies,automation` | Labels on auto-created cleanup PR |
+| `cleanup-pr-labels`      | see below | Labels on cleanup PR |
 | `egress-preset`          | `osv-scanner`           | Includes GitHub tooling + OSV API hosts    |
 | `allowed-endpoints-mode` | `append`                | Merge preset with caller endpoints         |
 | `workflow-file`          | empty                   | Caller workflow filename for PR footer     |
@@ -818,21 +818,21 @@ versions it collects digests referenced by tagged manifest indexes (multi-arch
 children, cosign/SLSA attestations) and skips the entire prune when that
 collection is incomplete.
 
-| Input                     | Default | Notes                                                       |
-| ------------------------- | ------- | ----------------------------------------------------------- |
-| `package-name`            | —       | Required GHCR package name                                  |
-| `min-age-days`            | `7`     | Minimum age before untagged deletion                        |
-| `keep-latest`             | `0`     | Keep N most recent eligible untagged versions               |
-| `build-cache-pr-age-days` | `14`    | Minimum age before ephemeral build-cache tag deletion       |
-| `protect-referenced`      | `true`  | Skip prune when referenced-digest collection is incomplete  |
-| `prune-buildcache`        | `true`  | Delete aged `pr-*` / `mq-*` / `dispatch-*` tags             |
-| `dry-run`                 | `false` | Log only, no deletions                                      |
-| `egress-policy`           | `block` | Pass `block` (not `audit`) for production maintenance       |
-| `egress-preset`           | `github-tooling` | Includes GitHub API + GHCR registry hosts          |
-| `allowed-endpoints`       | `""`    | Custom endpoints when `egress-policy` is `block`              |
-| `allowed-endpoints-mode`  | `replace` | Merge or replace preset endpoints (`replace`/`append`)    |
-| `tooling-ref`             | `""`    | Git ref for lgtm-ci tooling sparse checkout                 |
-| `runner-image`            | `ubuntu-24.04` | GitHub-hosted runner image label                     |
+| Input | Default | Notes |
+| --- | --- | --- |
+| `package-name` | — | Required GHCR package name |
+| `min-age-days` | `7` | Min age before untagged deletion |
+| `keep-latest` | `0` | Keep N most recent untagged |
+| `build-cache-pr-age-days` | `14` | Min age before cache deletion |
+| `protect-referenced` | `true` | Skip when refs incomplete |
+| `prune-buildcache` | `true` | Delete aged ephemeral tags |
+| `dry-run` | `false` | Log only, no deletions |
+| `egress-policy` | `block` | `audit` or `block` |
+| `egress-preset` | `github-tooling` | API + GHCR hosts |
+| `allowed-endpoints` | `""` | Custom endpoints |
+| `allowed-endpoints-mode` | `replace` | `replace` or `append` |
+| `tooling-ref` | `""` | lgtm-ci tooling git ref |
+| `runner-image` | `ubuntu-24.04` | Runner image label |
 
 Grant `contents: read` and `packages: write` on the caller job. Forward a token with
 `packages:write` via `secrets.token` (or `secrets: inherit`).

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -829,8 +829,12 @@ collection is incomplete.
 | `dry-run`                 | `false` | Log only, no deletions                                      |
 | `egress-policy`           | `block` | Pass `block` (not `audit`) for production maintenance       |
 | `egress-preset`           | `github-tooling` | Includes GitHub API + GHCR registry hosts          |
+| `allowed-endpoints`       | `""`    | Custom endpoints when `egress-policy` is `block`              |
+| `allowed-endpoints-mode`  | `replace` | Merge or replace preset endpoints (`replace`/`append`)    |
+| `tooling-ref`             | `""`    | Git ref for lgtm-ci tooling sparse checkout                 |
+| `runner-image`            | `ubuntu-24.04` | GitHub-hosted runner image label                     |
 
-Grant `packages: write` on the caller job. Forward a token with
+Grant `contents: read` and `packages: write` on the caller job. Forward a token with
 `packages:write` via `secrets.token` (or `secrets: inherit`).
 
 ```yaml

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -772,13 +772,14 @@ For push/schedule workflows, omit the publish job and pass
 
 `reusable-vuln-suppression-check.yml` installs `osv-scanner` directly (no Docker),
 probes the repository without suppressions, and opens a cleanup PR when entries are
-stale (vulnerability resolved upstream). Expired suppressions fail the job.
+stale (vulnerability resolved upstream) or expired (past `ignoreUntil`).
 
 | Input                    | Default                 | Notes                                      |
 | ------------------------ | ----------------------- | ------------------------------------------ |
 | `osv-version`            | `2.3.5`                 | osv-scanner release version                |
 | `config-path`            | `.osv-scanner.toml`     | Suppression TOML path                      |
 | `check-script`           | tooling default         | Repo-local override supported              |
+| `cleanup-pr-labels`      | `security,dependencies,automation` | Labels on auto-created cleanup PR |
 | `egress-preset`          | `osv-scanner`           | Includes GitHub tooling + OSV API hosts    |
 | `allowed-endpoints-mode` | `append`                | Merge preset with caller endpoints         |
 | `workflow-file`          | empty                   | Caller workflow filename for PR footer     |
@@ -807,6 +808,55 @@ jobs:
       workflow-file: vuln-suppression-check.yml
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### GHCR cleanup
+
+`reusable-ghcr-cleanup.yml` prunes aged untagged container versions and ephemeral
+build-cache tags (`pr-*`, `mq-*`, `dispatch-*`). Before deleting untagged
+versions it collects digests referenced by tagged manifest indexes (multi-arch
+children, cosign/SLSA attestations) and skips the entire prune when that
+collection is incomplete.
+
+| Input                     | Default | Notes                                                       |
+| ------------------------- | ------- | ----------------------------------------------------------- |
+| `package-name`            | —       | Required GHCR package name                                  |
+| `min-age-days`            | `7`     | Minimum age before untagged deletion                        |
+| `keep-latest`             | `0`     | Keep N most recent eligible untagged versions               |
+| `build-cache-pr-age-days` | `14`    | Minimum age before ephemeral build-cache tag deletion       |
+| `protect-referenced`      | `true`  | Skip prune when referenced-digest collection is incomplete  |
+| `prune-buildcache`        | `true`  | Delete aged `pr-*` / `mq-*` / `dispatch-*` tags             |
+| `dry-run`                 | `false` | Log only, no deletions                                      |
+| `egress-policy`           | `block` | Pass `block` (not `audit`) for production maintenance       |
+| `egress-preset`           | `github-tooling` | Includes GitHub API + GHCR registry hosts          |
+
+Grant `packages: write` on the caller job. Forward a token with
+`packages:write` via `secrets.token` (or `secrets: inherit`).
+
+```yaml
+'on':
+  schedule:
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+    inputs:
+      min_age_days:
+        description: Minimum age in days
+        type: number
+        default: 7
+
+permissions: {}
+
+jobs:
+  ghcr-cleanup:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ghcr-cleanup.yml@<sha>
+    permissions:
+      contents: read
+      packages: write
+    with:
+      package-name: my-image
+      min-age-days: ${{ github.event_name != 'workflow_dispatch' && 7 || inputs.min_age_days }}
+      keep-latest: 0
+    secrets: inherit
 ```
 
 ### Documentation site quality

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -908,10 +908,14 @@ or manifest collection is incomplete.
 | `protect-referenced`      | `true`           | Skip prune when reference protection is incomplete |
 | `prune-buildcache`        | `true`           | Delete aged `pr-*` / `mq-*` / `dispatch-*` tags    |
 | `dry-run`                 | `false`          | Log only                                           |
-| `egress-policy`           | `block`          | Use `block` for production maintenance             |
-| `egress-preset`           | `github-tooling` | GitHub API + GHCR registry hosts                   |
+| `egress-policy`           | `block`          | `audit` or `block`                                 |
+| `egress-preset`           | `github-tooling` | `github-minimal`, `github-tooling`, `docker`, etc. |
+| `allowed-endpoints`       | `""`             | Custom endpoints when `egress-policy` is `block`   |
+| `allowed-endpoints-mode`  | `replace`        | `replace` or `append` with preset endpoints        |
+| `tooling-ref`             | `""`             | Git ref for lgtm-ci tooling sparse checkout        |
+| `runner-image`            | `ubuntu-24.04`   | GitHub-hosted runner image label                   |
 
-Grant `packages: write` on the caller job. Forward `secrets.token` with
+Grant `contents: read` and `packages: write` on the caller job. Forward `secrets.token` with
 `packages:write` scope (or `secrets: inherit`).
 
 ## Documentation site quality

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -899,21 +899,21 @@ build-cache tags. Referenced-digest protection walks tagged manifest indexes and
 OCI Referrers before untagged deletion; the job skips pruning when registry auth
 or manifest collection is incomplete.
 
-| Input                     | Default          | Notes                                              |
-| ------------------------- | ---------------- | -------------------------------------------------- |
-| `package-name`            | required         | GHCR package name                                  |
-| `min-age-days`            | `7`              | Minimum age before untagged deletion               |
-| `keep-latest`             | `0`              | Keep N most recent eligible untagged versions      |
-| `build-cache-pr-age-days` | `14`             | Minimum age before ephemeral tag deletion          |
-| `protect-referenced`      | `true`           | Skip prune when reference protection is incomplete |
-| `prune-buildcache`        | `true`           | Delete aged `pr-*` / `mq-*` / `dispatch-*` tags    |
-| `dry-run`                 | `false`          | Log only                                           |
-| `egress-policy`           | `block`          | `audit` or `block`                                 |
-| `egress-preset`           | `github-tooling` | `github-minimal`, `github-tooling`, `docker`, etc. |
-| `allowed-endpoints`       | `""`             | Custom endpoints when `egress-policy` is `block`   |
-| `allowed-endpoints-mode`  | `replace`        | `replace` or `append` with preset endpoints        |
-| `tooling-ref`             | `""`             | Git ref for lgtm-ci tooling sparse checkout        |
-| `runner-image`            | `ubuntu-24.04`   | GitHub-hosted runner image label                   |
+| Input | Default | Notes |
+| --- | --- | --- |
+| `package-name` | required | GHCR package name |
+| `min-age-days` | `7` | Min age before deletion |
+| `keep-latest` | `0` | Keep N most recent |
+| `build-cache-pr-age-days` | `14` | Min cache age |
+| `protect-referenced` | `true` | Skip when incomplete |
+| `prune-buildcache` | `true` | Delete ephemeral tags |
+| `dry-run` | `false` | Log only |
+| `egress-policy` | `block` | `audit` or `block` |
+| `egress-preset` | `github-tooling` | Preset host list |
+| `allowed-endpoints` | `""` | Custom endpoints |
+| `allowed-endpoints-mode` | `replace` | `replace` / `append` |
+| `tooling-ref` | `""` | lgtm-ci git ref |
+| `runner-image` | `ubuntu-24.04` | Runner image label |
 
 Grant `contents: read` and `packages: write` on the caller job. Forward `secrets.token` with
 `packages:write` scope (or `secrets: inherit`).

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -868,7 +868,7 @@ Outputs: `exit-code`, `has-vulns`, `audit-failed`, `status`.
 suppression cleanup pattern used by Rustume, py-lintro, and turbo-themes. The job
 installs `osv-scanner` directly (no Docker), runs
 `scripts/ci/security/check-vuln-suppressions.sh`, and may open a cleanup PR
-removing stale entries. Expired suppressions fail the job for manual review.
+removing stale and expired entries.
 
 <!-- markdownlint-disable MD013 MD060 -- wide input reference table -->
 
@@ -877,6 +877,7 @@ removing stale entries. Expired suppressions fail the job for manual review.
 | `osv-version`            | `2.3.5`                                              | osv-scanner release to install                  |
 | `config-path`            | `.osv-scanner.toml`                                  | Suppression TOML relative to repo root          |
 | `check-script`           | `.lgtm-ci-tooling/scripts/ci/security/check-vuln-suppressions.sh` | Repo-local override supported |
+| `cleanup-pr-labels`      | `security,dependencies,automation`                   | Labels on auto-created cleanup PR               |
 | `egress-preset`          | `osv-scanner`                                        | `github-tooling` + release assets + OSV APIs    |
 | `allowed-endpoints-mode` | `append`                                             | Merge preset with caller-specific endpoints     |
 | `workflow-file`          | empty                                                | Caller workflow filename for auto-PR footer     |
@@ -890,6 +891,28 @@ Grant `contents: write` and `pull-requests: write` on the caller job. Forward
 `runner-image`; the install script downloads `linux_*` release binaries only.
 
 Required secrets: `GH_TOKEN`.
+
+## GHCR cleanup
+
+`reusable-ghcr-cleanup.yml` prunes aged untagged container versions and ephemeral
+build-cache tags. Referenced-digest protection walks tagged manifest indexes and
+OCI Referrers before untagged deletion; the job skips pruning when registry auth
+or manifest collection is incomplete.
+
+| Input                     | Default          | Notes                                              |
+| ------------------------- | ---------------- | -------------------------------------------------- |
+| `package-name`            | required         | GHCR package name                                  |
+| `min-age-days`            | `7`              | Minimum age before untagged deletion               |
+| `keep-latest`             | `0`              | Keep N most recent eligible untagged versions      |
+| `build-cache-pr-age-days` | `14`             | Minimum age before ephemeral tag deletion          |
+| `protect-referenced`      | `true`           | Skip prune when reference protection is incomplete |
+| `prune-buildcache`        | `true`           | Delete aged `pr-*` / `mq-*` / `dispatch-*` tags    |
+| `dry-run`                 | `false`          | Log only                                           |
+| `egress-policy`           | `block`          | Use `block` for production maintenance             |
+| `egress-preset`           | `github-tooling` | GitHub API + GHCR registry hosts                   |
+
+Grant `packages: write` on the caller job. Forward `secrets.token` with
+`packages:write` scope (or `secrets: inherit`).
 
 ## Documentation site quality
 

--- a/scripts/ci/actions/ghcr-cleanup.sh
+++ b/scripts/ci/actions/ghcr-cleanup.sh
@@ -1,21 +1,27 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
-# Purpose: Clean untagged container images from GitHub Container Registry
+# Purpose: Clean untagged and ephemeral build-cache images from GHCR
 #
 # Environment variables:
-#   PACKAGE_NAME  - GHCR package name to clean (required)
-#   GITHUB_ORG    - GitHub org or user owning the package (required)
-#   MIN_AGE_DAYS  - Minimum age in days before deletion (default: 7)
-#   KEEP_LATEST   - Always keep N most recent untagged versions (default: 5)
-#   DRY_RUN       - Log only, no deletions (default: false)
-#   GH_TOKEN      - GitHub token with packages:write scope
+#   PACKAGE_NAME          - GHCR package name to clean (required)
+#   GITHUB_ORG            - GitHub org or user owning the package (required)
+#   MIN_AGE_DAYS          - Minimum age in days before untagged deletion (default: 7)
+#   KEEP_LATEST           - Always keep N most recent untagged versions (default: 0)
+#   BUILD_CACHE_PR_AGE_DAYS - Minimum age before ephemeral tag deletion (default: 14)
+#   PROTECT_REFERENCED    - Skip prune when referenced-digest collection fails (default: true)
+#   PRUNE_BUILDCACHE      - Delete aged pr-*/mq-*/dispatch-* tags (default: true)
+#   DRY_RUN               - Log only, no deletions (default: false)
+#   GH_TOKEN              - GitHub token with packages:write scope
 
 set -euo pipefail
 
 : "${PACKAGE_NAME:?PACKAGE_NAME is required}"
 : "${GITHUB_ORG:?GITHUB_ORG is required}"
 : "${MIN_AGE_DAYS:=7}"
-: "${KEEP_LATEST:=5}"
+: "${KEEP_LATEST:=0}"
+: "${BUILD_CACHE_PR_AGE_DAYS:=14}"
+: "${PROTECT_REFERENCED:=true}"
+: "${PRUNE_BUILDCACHE:=true}"
 : "${DRY_RUN:=false}"
 
 [[ "$MIN_AGE_DAYS" =~ ^[0-9]+$ ]] || {
@@ -26,31 +32,135 @@ set -euo pipefail
 	echo "ERROR: KEEP_LATEST must be a non-negative integer, got: '$KEEP_LATEST'" >&2
 	exit 1
 }
+[[ "$BUILD_CACHE_PR_AGE_DAYS" =~ ^[0-9]+$ ]] || {
+	echo "ERROR: BUILD_CACHE_PR_AGE_DAYS must be a non-negative integer, got: '$BUILD_CACHE_PR_AGE_DAYS'" >&2
+	exit 1
+}
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
 # shellcheck source=../lib/actions.sh
 source "$SCRIPT_DIR/../lib/actions.sh"
+# shellcheck source=../lib/ghcr/registry.sh
+source "$SCRIPT_DIR/../lib/ghcr/registry.sh"
+# shellcheck source=../lib/ghcr/tags.sh
+source "$SCRIPT_DIR/../lib/ghcr/tags.sh"
+
+ghcr_fetch_versions() {
+	local api_err=""
+	all_versions=$(gh api --paginate \
+		"/orgs/${GITHUB_ORG}/packages/container/${PACKAGE_NAME}/versions" \
+		2>/dev/null | jq -s 'add // []') || {
+		all_versions=$(gh api --paginate \
+			"/users/${GITHUB_ORG}/packages/container/${PACKAGE_NAME}/versions" \
+			2>/dev/null | jq -s 'add // []') || die "Failed to fetch package versions"
+	}
+}
+
+ghcr_delete_version() {
+	local version_id="$1"
+	local api_err=""
+
+	if [[ "$DRY_RUN" == "true" ]]; then
+		return 0
+	fi
+
+	if api_err=$(gh api --method DELETE \
+		"/orgs/${GITHUB_ORG}/packages/container/${PACKAGE_NAME}/versions/${version_id}" \
+		2>&1); then
+		return 0
+	fi
+
+	if api_err=$(gh api --method DELETE \
+		"/users/${GITHUB_ORG}/packages/container/${PACKAGE_NAME}/versions/${version_id}" \
+		2>&1); then
+		return 0
+	fi
+
+	log_error "Failed to delete version ${version_id}: ${api_err}"
+	return 1
+}
+
+ghcr_version_timestamp() {
+	jq -r '.created_at // .updated_at // ""'
+}
+
+ghcr_is_older_than_days() {
+	local timestamp="$1"
+	local min_days="$2"
+	local cutoff_date
+
+	[[ -z "$timestamp" ]] && return 1
+
+	cutoff_date=$(date -u -v-"${min_days}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+		date -u -d "${min_days} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+		die "Could not compute cutoff date")
+
+	[[ "$timestamp" < "$cutoff_date" ]]
+}
 
 # =============================================================================
 # Fetch all package versions
 # =============================================================================
 log_info "Fetching versions for package: ${GITHUB_ORG}/${PACKAGE_NAME}"
 
-api_err=""
-all_versions=$(gh api --paginate \
-	"/orgs/${GITHUB_ORG}/packages/container/${PACKAGE_NAME}/versions" \
-	2>/dev/null | jq -s 'add // []') || {
-	# Try user endpoint if org endpoint fails
-	all_versions=$(gh api --paginate \
-		"/users/${GITHUB_ORG}/packages/container/${PACKAGE_NAME}/versions" \
-		2>/dev/null | jq -s 'add // []') || die "Failed to fetch package versions"
-}
+ghcr_fetch_versions
 
 total_count=$(echo "$all_versions" | jq 'length')
 log_info "Found $total_count total version(s)"
 
 # =============================================================================
-# Filter to untagged versions
+# Referenced-digest protection
+# =============================================================================
+referenced_digests=()
+referenced_complete=true
+protected_refs=0
+
+if [[ "$PROTECT_REFERENCED" == "true" && "$total_count" -gt 0 ]]; then
+	registry_token=""
+	if ! registry_token=$(ghcr_exchange_registry_token \
+		"$GITHUB_ORG" \
+		"$PACKAGE_NAME" \
+		"${GH_TOKEN:-}"); then
+		log_warning "Skipping prune for ${PACKAGE_NAME} (registry auth failed; cannot compute reference protection)"
+		add_github_summary "## GHCR Cleanup"
+		add_github_summary ""
+		add_github_summary "| Property | Value |"
+		add_github_summary "| -------- | ----- |"
+		add_github_summary "| Package | \`${GITHUB_ORG}/${PACKAGE_NAME}\` |"
+		add_github_summary "| Status | :warning: Skipped (registry auth failed) |"
+		exit 0
+	fi
+
+	referenced_digests_text=""
+	ghcr_collect_referenced_digests \
+		"$GITHUB_ORG" \
+		"$PACKAGE_NAME" \
+		"$all_versions" \
+		"$registry_token" \
+		referenced_complete \
+		referenced_digests_text
+
+	if [[ "$referenced_complete" != "true" ]]; then
+		log_warning "Skipping prune for ${PACKAGE_NAME} (referenced-digest collection incomplete)"
+		add_github_summary "## GHCR Cleanup"
+		add_github_summary ""
+		add_github_summary "| Property | Value |"
+		add_github_summary "| -------- | ----- |"
+		add_github_summary "| Package | \`${GITHUB_ORG}/${PACKAGE_NAME}\` |"
+		add_github_summary "| Status | :warning: Skipped (incomplete reference protection) |"
+		exit 0
+	fi
+
+	if [[ -n "$referenced_digests_text" ]]; then
+		while IFS= read -r digest; do
+			[[ -n "$digest" ]] && referenced_digests+=("$digest")
+		done <<<"$referenced_digests_text"
+		log_info "Collected ${#referenced_digests[@]} referenced digest(s) for protection"
+	fi
+fi
+
+# =============================================================================
+# Filter to untagged versions eligible for deletion
 # =============================================================================
 cutoff_date=$(date -u -v-"${MIN_AGE_DAYS}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
 	date -u -d "${MIN_AGE_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
@@ -58,14 +168,13 @@ cutoff_date=$(date -u -v-"${MIN_AGE_DAYS}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
 
 log_info "Cutoff date: $cutoff_date (older than $MIN_AGE_DAYS days)"
 
-# Get untagged versions older than cutoff, sorted newest first
-eligible_versions=$(echo "$all_versions" | jq --arg cutoff "$cutoff_date" '
+eligible_versions=$(echo "$all_versions" | jq --arg cutoff "$cutoff_date" --argjson refs "$(printf '%s\n' "${referenced_digests[@]}" | jq -R . | jq -s .)" '
+	def version_time: .created_at // .updated_at // "";
 	[ .[] |
-	  select(
-	    (.metadata.container.tags | length) == 0 and
-	    .updated_at < $cutoff
-	  )
-	] | sort_by(.updated_at) | reverse
+	  select((.metadata.container.tags | length) == 0) |
+	  select(version_time < $cutoff) |
+	  select(.name as $n | ($refs | index($n) | not))
+	] | sort_by(.created_at // .updated_at) | reverse
 ')
 
 eligible_count=$(echo "$eligible_versions" | jq 'length')
@@ -75,24 +184,64 @@ log_info "Found $eligible_count untagged version(s) older than $MIN_AGE_DAYS day
 # Apply keep-latest threshold
 # =============================================================================
 if [[ "$eligible_count" -le "$KEEP_LATEST" ]]; then
-	log_info "All $eligible_count eligible version(s) fall within keep-latest=$KEEP_LATEST — nothing to delete"
+	to_delete=$(echo '[]' | jq '.')
+	delete_count=0
+else
+	to_delete=$(echo "$eligible_versions" | jq --argjson skip "$KEEP_LATEST" '.[$skip:]')
+	delete_count=$(echo "$to_delete" | jq 'length')
+	log_info "Will delete $delete_count untagged version(s) (keeping $KEEP_LATEST most recent untagged)"
+fi
+
+# =============================================================================
+# Build-cache ephemeral tag pruning
+# =============================================================================
+buildcache_delete_count=0
+buildcache_to_delete='[]'
+
+if [[ "$PRUNE_BUILDCACHE" == "true" ]]; then
+	buildcache_cutoff=$(date -u -v-"${BUILD_CACHE_PR_AGE_DAYS}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+		date -u -d "${BUILD_CACHE_PR_AGE_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+		die "Could not compute buildcache cutoff date")
+
+	buildcache_candidates=$(echo "$all_versions" | jq --arg cutoff "$buildcache_cutoff" '
+		def version_time: .created_at // .updated_at // "";
+		[ .[] |
+		  select((.metadata.container.tags | length) > 0) |
+		  select(version_time < $cutoff)
+		]
+	')
+
+	buildcache_ids=()
+	while IFS=$'\t' read -r version_id tags_json version_name updated_at; do
+		if ghcr_is_ephemeral_only_tagged "$tags_json"; then
+			buildcache_ids+=("$version_id")
+			log_info "Buildcache eligible: version $version_id ($version_name, tags=$(jq -r 'join(",")' <<<"$tags_json"), updated $updated_at)"
+		fi
+	done < <(
+		echo "$buildcache_candidates" | jq -r '.[] | [.id, (.metadata.container.tags | @json), .name, (.created_at // .updated_at)] | @tsv'
+	)
+
+	if ((${#buildcache_ids[@]} > 0)); then
+		buildcache_to_delete=$(printf '%s\n' "${buildcache_ids[@]}" | jq -R . | jq -s .)
+		buildcache_delete_count=${#buildcache_ids[@]}
+		log_info "Will delete $buildcache_delete_count ephemeral build-cache version(s)"
+	fi
+fi
+
+if [[ "$delete_count" -eq 0 && "$buildcache_delete_count" -eq 0 ]]; then
+	log_info "nothing to delete for ${PACKAGE_NAME}"
 	add_github_summary "## GHCR Cleanup"
 	add_github_summary ""
 	add_github_summary "| Property | Value |"
 	add_github_summary "| -------- | ----- |"
 	add_github_summary "| Package | \`${GITHUB_ORG}/${PACKAGE_NAME}\` |"
 	add_github_summary "| Total versions | $total_count |"
-	add_github_summary "| Eligible for deletion | $eligible_count |"
+	add_github_summary "| Eligible untagged | $eligible_count |"
+	add_github_summary "| Eligible build-cache | $buildcache_delete_count |"
 	add_github_summary "| Deleted | 0 |"
 	add_github_summary "| Status | :white_check_mark: Nothing to clean |"
 	exit 0
 fi
-
-# Skip the first KEEP_LATEST entries (they're the newest untagged)
-to_delete=$(echo "$eligible_versions" | jq --argjson skip "$KEEP_LATEST" '.[$skip:]')
-delete_count=$(echo "$to_delete" | jq 'length')
-
-log_info "Will delete $delete_count version(s) (keeping $KEEP_LATEST most recent untagged)"
 
 # =============================================================================
 # Delete versions
@@ -102,26 +251,34 @@ failed=0
 
 while IFS=$'\t' read -r version_id version_name updated_at; do
 	if [[ "$DRY_RUN" == "true" ]]; then
-		log_info "[dry-run] Would delete version $version_id ($version_name, updated $updated_at)"
+		log_info "[dry-run] Would delete untagged version $version_id ($version_name, updated $updated_at)"
 		deleted=$((deleted + 1))
 		continue
 	fi
 
-	if api_err=$(gh api --method DELETE \
-		"/orgs/${GITHUB_ORG}/packages/container/${PACKAGE_NAME}/versions/${version_id}" \
-		2>&1); then
-		log_success "Deleted version $version_id ($version_name, updated $updated_at)"
-		deleted=$((deleted + 1))
-	elif api_err=$(gh api --method DELETE \
-		"/users/${GITHUB_ORG}/packages/container/${PACKAGE_NAME}/versions/${version_id}" \
-		2>&1); then
-		log_success "Deleted version $version_id ($version_name, updated $updated_at)"
+	if ghcr_delete_version "$version_id"; then
+		log_success "Deleted untagged version $version_id ($version_name, updated $updated_at)"
 		deleted=$((deleted + 1))
 	else
-		log_error "Failed to delete version $version_id ($version_name): $api_err"
 		failed=$((failed + 1))
 	fi
-done < <(echo "$to_delete" | jq -r '.[] | [.id, .name, .updated_at] | @tsv')
+done < <(echo "$to_delete" | jq -r '.[] | [.id, .name, (.created_at // .updated_at)] | @tsv')
+
+while IFS= read -r version_id; do
+	[[ -z "$version_id" ]] && continue
+	if [[ "$DRY_RUN" == "true" ]]; then
+		log_info "[dry-run] Would delete build-cache version $version_id"
+		deleted=$((deleted + 1))
+		continue
+	fi
+
+	if ghcr_delete_version "$version_id"; then
+		log_success "Deleted build-cache version $version_id"
+		deleted=$((deleted + 1))
+	else
+		failed=$((failed + 1))
+	fi
+done < <(echo "$buildcache_to_delete" | jq -r '.[]')
 
 # =============================================================================
 # Summary
@@ -138,8 +295,10 @@ add_github_summary "| Property | Value |"
 add_github_summary "| -------- | ----- |"
 add_github_summary "| Package | \`${GITHUB_ORG}/${PACKAGE_NAME}\` |"
 add_github_summary "| Total versions | $total_count |"
-add_github_summary "| Eligible for deletion | $eligible_count |"
-add_github_summary "| Kept (most recent) | $KEEP_LATEST |"
+add_github_summary "| Eligible untagged | $eligible_count |"
+add_github_summary "| Eligible build-cache | $buildcache_delete_count |"
+add_github_summary "| Kept (most recent untagged) | $KEEP_LATEST |"
+add_github_summary "| Referenced digests protected | ${#referenced_digests[@]} |"
 
 if [[ "$DRY_RUN" == "true" ]]; then
 	add_github_summary "| Would delete | $deleted |"

--- a/scripts/ci/actions/ghcr-cleanup.sh
+++ b/scripts/ci/actions/ghcr-cleanup.sh
@@ -163,6 +163,7 @@ eligible_versions=$(echo "$all_versions" | jq --arg cutoff "$cutoff_date" --argj
 	def version_time: .updated_at // .created_at // "";
 	[ .[] |
 	  select((.metadata.container.tags | length) == 0) |
+	  select(version_time != "") |
 	  select(version_time < $cutoff) |
 	  select(.name as $n | ($refs | index($n) | not))
 	] | sort_by(.updated_at // .created_at) | reverse
@@ -201,6 +202,7 @@ if [[ "$PRUNE_BUILDCACHE" == "true" ]]; then
 		def version_time: .updated_at // .created_at // "";
 		[ .[] |
 		  select((.metadata.container.tags | length) > 0) |
+		  select(version_time != "") |
 		  select(version_time < $cutoff) |
 		  select(.name as $n | ($refs | index($n) | not))
 		]

--- a/scripts/ci/actions/ghcr-cleanup.sh
+++ b/scripts/ci/actions/ghcr-cleanup.sh
@@ -57,25 +57,25 @@ ghcr_fetch_versions() {
 
 ghcr_delete_version() {
 	local version_id="$1"
-	local api_err=""
 
 	if [[ "$DRY_RUN" == "true" ]]; then
 		return 0
 	fi
 
-	if api_err=$(gh api --method DELETE \
+	local err=""
+	if err=$(gh api --method DELETE \
 		"/orgs/${GITHUB_ORG}/packages/container/${PACKAGE_NAME}/versions/${version_id}" \
 		2>&1); then
 		return 0
 	fi
 
-	if api_err=$(gh api --method DELETE \
+	if err=$(gh api --method DELETE \
 		"/users/${GITHUB_ORG}/packages/container/${PACKAGE_NAME}/versions/${version_id}" \
 		2>&1); then
 		return 0
 	fi
 
-	log_error "Failed to delete version ${version_id}: ${api_err}"
+	log_error "Failed to delete version ${version_id}: ${err}"
 	return 1
 }
 
@@ -141,6 +141,8 @@ fi
 
 # =============================================================================
 # Filter to untagged versions eligible for deletion
+# Uses updated_at for age comparison to avoid deleting recently refreshed
+# versions whose created_at predates the cutoff.
 # =============================================================================
 cutoff_date=$(date -u -v-"${MIN_AGE_DAYS}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
 	date -u -d "${MIN_AGE_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
@@ -148,13 +150,19 @@ cutoff_date=$(date -u -v-"${MIN_AGE_DAYS}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
 
 log_info "Cutoff date: $cutoff_date (older than $MIN_AGE_DAYS days)"
 
-eligible_versions=$(echo "$all_versions" | jq --arg cutoff "$cutoff_date" --argjson refs "$(printf '%s\n' "${referenced_digests[@]}" | jq -R . | jq -s .)" '
-	def version_time: .created_at // .updated_at // "";
+if ((${#referenced_digests[@]} > 0)); then
+	refs_json=$(printf '%s\n' "${referenced_digests[@]}" | jq -R . | jq -s .)
+else
+	refs_json='[]'
+fi
+
+eligible_versions=$(echo "$all_versions" | jq --arg cutoff "$cutoff_date" --argjson refs "$refs_json" '
+	def version_time: .updated_at // .created_at // "";
 	[ .[] |
 	  select((.metadata.container.tags | length) == 0) |
 	  select(version_time < $cutoff) |
 	  select(.name as $n | ($refs | index($n) | not))
-	] | sort_by(.created_at // .updated_at) | reverse
+	] | sort_by(.updated_at // .created_at) | reverse
 ')
 
 eligible_count=$(echo "$eligible_versions" | jq 'length')
@@ -169,11 +177,14 @@ if [[ "$eligible_count" -le "$KEEP_LATEST" ]]; then
 else
 	to_delete=$(echo "$eligible_versions" | jq --argjson skip "$KEEP_LATEST" '.[$skip:]')
 	delete_count=$(echo "$to_delete" | jq 'length')
-	log_info "Will delete $delete_count untagged version(s) (keeping $KEEP_LATEST most recent untagged)"
+	actual_kept=$((eligible_count - delete_count))
+	log_info "Will delete $delete_count untagged version(s) (keeping $actual_kept most recent untagged)"
 fi
 
 # =============================================================================
 # Build-cache ephemeral tag pruning
+# Uses updated_at for age comparison to avoid deleting recently refreshed
+# cache entries whose created_at predates the cutoff.
 # =============================================================================
 buildcache_delete_count=0
 buildcache_to_delete='[]'
@@ -184,7 +195,7 @@ if [[ "$PRUNE_BUILDCACHE" == "true" ]]; then
 		die "Could not compute buildcache cutoff date")
 
 	buildcache_candidates=$(echo "$all_versions" | jq --arg cutoff "$buildcache_cutoff" '
-		def version_time: .created_at // .updated_at // "";
+		def version_time: .updated_at // .created_at // "";
 		[ .[] |
 		  select((.metadata.container.tags | length) > 0) |
 		  select(version_time < $cutoff)
@@ -198,7 +209,7 @@ if [[ "$PRUNE_BUILDCACHE" == "true" ]]; then
 			log_info "Buildcache eligible: version $version_id ($version_name, tags=$(jq -r 'join(",")' <<<"$tags_json"), updated $updated_at)"
 		fi
 	done < <(
-		echo "$buildcache_candidates" | jq -r '.[] | [.id, (.metadata.container.tags | @json), .name, (.created_at // .updated_at)] | @tsv'
+		echo "$buildcache_candidates" | jq -r '.[] | [.id, (.metadata.container.tags | @json), .name, (.updated_at // .created_at)] | @tsv'
 	)
 
 	if ((${#buildcache_ids[@]} > 0)); then
@@ -242,7 +253,7 @@ while IFS=$'\t' read -r version_id version_name updated_at; do
 	else
 		failed=$((failed + 1))
 	fi
-done < <(echo "$to_delete" | jq -r '.[] | [.id, .name, (.created_at // .updated_at)] | @tsv')
+done < <(echo "$to_delete" | jq -r '.[] | [.id, .name, (.updated_at // .created_at)] | @tsv')
 
 while IFS= read -r version_id; do
 	[[ -z "$version_id" ]] && continue
@@ -269,6 +280,8 @@ else
 	log_success "Cleanup complete: $deleted deleted, $failed failed"
 fi
 
+actual_kept=$((eligible_count < KEEP_LATEST ? eligible_count : KEEP_LATEST))
+
 add_github_summary "## GHCR Cleanup"
 add_github_summary ""
 add_github_summary "| Property | Value |"
@@ -277,7 +290,7 @@ add_github_summary "| Package | \`${GITHUB_ORG}/${PACKAGE_NAME}\` |"
 add_github_summary "| Total versions | $total_count |"
 add_github_summary "| Eligible untagged | $eligible_count |"
 add_github_summary "| Eligible build-cache | $buildcache_delete_count |"
-add_github_summary "| Kept (most recent untagged) | $KEEP_LATEST |"
+add_github_summary "| Kept (most recent untagged) | $actual_kept |"
 add_github_summary "| Referenced digests protected | ${#referenced_digests[@]} |"
 
 if [[ "$DRY_RUN" == "true" ]]; then

--- a/scripts/ci/actions/ghcr-cleanup.sh
+++ b/scripts/ci/actions/ghcr-cleanup.sh
@@ -46,7 +46,6 @@ source "$SCRIPT_DIR/../lib/ghcr/registry.sh"
 source "$SCRIPT_DIR/../lib/ghcr/tags.sh"
 
 ghcr_fetch_versions() {
-	local api_err=""
 	all_versions=$(gh api --paginate \
 		"/orgs/${GITHUB_ORG}/packages/container/${PACKAGE_NAME}/versions" \
 		2>/dev/null | jq -s 'add // []') || {
@@ -80,24 +79,6 @@ ghcr_delete_version() {
 	return 1
 }
 
-ghcr_version_timestamp() {
-	jq -r '.created_at // .updated_at // ""'
-}
-
-ghcr_is_older_than_days() {
-	local timestamp="$1"
-	local min_days="$2"
-	local cutoff_date
-
-	[[ -z "$timestamp" ]] && return 1
-
-	cutoff_date=$(date -u -v-"${min_days}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
-		date -u -d "${min_days} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
-		die "Could not compute cutoff date")
-
-	[[ "$timestamp" < "$cutoff_date" ]]
-}
-
 # =============================================================================
 # Fetch all package versions
 # =============================================================================
@@ -113,7 +94,6 @@ log_info "Found $total_count total version(s)"
 # =============================================================================
 referenced_digests=()
 referenced_complete=true
-protected_refs=0
 
 if [[ "$PROTECT_REFERENCED" == "true" && "$total_count" -gt 0 ]]; then
 	registry_token=""

--- a/scripts/ci/actions/ghcr-cleanup.sh
+++ b/scripts/ci/actions/ghcr-cleanup.sh
@@ -194,11 +194,12 @@ if [[ "$PRUNE_BUILDCACHE" == "true" ]]; then
 		date -u -d "${BUILD_CACHE_PR_AGE_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
 		die "Could not compute buildcache cutoff date")
 
-	buildcache_candidates=$(echo "$all_versions" | jq --arg cutoff "$buildcache_cutoff" '
+	buildcache_candidates=$(echo "$all_versions" | jq --arg cutoff "$buildcache_cutoff" --argjson refs "$refs_json" '
 		def version_time: .updated_at // .created_at // "";
 		[ .[] |
 		  select((.metadata.container.tags | length) > 0) |
-		  select(version_time < $cutoff)
+		  select(version_time < $cutoff) |
+		  select(.name as $n | ($refs | index($n) | not))
 		]
 	')
 

--- a/scripts/ci/actions/ghcr-cleanup.sh
+++ b/scripts/ci/actions/ghcr-cleanup.sh
@@ -45,12 +45,15 @@ source "$SCRIPT_DIR/../lib/ghcr/registry.sh"
 # shellcheck source=../lib/ghcr/tags.sh
 source "$SCRIPT_DIR/../lib/ghcr/tags.sh"
 
+# GitHub Packages REST API encodes nested path slashes; registry v2 paths do not.
+PACKAGE_NAME_API="${PACKAGE_NAME//\//%2F}"
+
 ghcr_fetch_versions() {
 	all_versions=$(gh api --paginate \
-		"/orgs/${GITHUB_ORG}/packages/container/${PACKAGE_NAME}/versions" \
+		"/orgs/${GITHUB_ORG}/packages/container/${PACKAGE_NAME_API}/versions" \
 		2>/dev/null | jq -s 'add // []') || {
 		all_versions=$(gh api --paginate \
-			"/users/${GITHUB_ORG}/packages/container/${PACKAGE_NAME}/versions" \
+			"/users/${GITHUB_ORG}/packages/container/${PACKAGE_NAME_API}/versions" \
 			2>/dev/null | jq -s 'add // []') || die "Failed to fetch package versions"
 	}
 }
@@ -64,13 +67,13 @@ ghcr_delete_version() {
 
 	local err=""
 	if err=$(gh api --method DELETE \
-		"/orgs/${GITHUB_ORG}/packages/container/${PACKAGE_NAME}/versions/${version_id}" \
+		"/orgs/${GITHUB_ORG}/packages/container/${PACKAGE_NAME_API}/versions/${version_id}" \
 		2>&1); then
 		return 0
 	fi
 
 	if err=$(gh api --method DELETE \
-		"/users/${GITHUB_ORG}/packages/container/${PACKAGE_NAME}/versions/${version_id}" \
+		"/users/${GITHUB_ORG}/packages/container/${PACKAGE_NAME_API}/versions/${version_id}" \
 		2>&1); then
 		return 0
 	fi

--- a/scripts/ci/lib/ghcr.sh
+++ b/scripts/ci/lib/ghcr.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Barrel file for GHCR library modules
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE:-$0}")/ghcr.sh"
+
+[[ -n "${_LGTM_CI_GHCR_LOADED:-}" ]] && return 0
+readonly _LGTM_CI_GHCR_LOADED=1
+
+_GHCR_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/ghcr" && pwd)"
+
+# shellcheck source=ghcr/registry.sh
+source "$_GHCR_LIB_DIR/registry.sh"
+# shellcheck source=ghcr/tags.sh
+source "$_GHCR_LIB_DIR/tags.sh"

--- a/scripts/ci/lib/ghcr/registry.sh
+++ b/scripts/ci/lib/ghcr/registry.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: GHCR registry helpers for referenced-digest protection during prune
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE:-$0}")/registry.sh"
+#   ghcr_exchange_registry_token owner package github_token
+#   ghcr_collect_referenced_digests owner package versions_json registry_token
+
+[[ -n "${_LGTM_CI_GHCR_REGISTRY_LOADED:-}" ]] && return 0
+readonly _LGTM_CI_GHCR_REGISTRY_LOADED=1
+
+_GHCR_MANIFEST_ACCEPT=$(
+	cat <<'EOF'
+application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json
+EOF
+)
+readonly _GHCR_MANIFEST_ACCEPT
+
+readonly _GHCR_REFERRERS_ACCEPT="application/vnd.oci.image.index.v1+json"
+
+# Exchange GITHUB_TOKEN for a ghcr.io registry pull bearer token.
+# Args:
+#   $1 - package owner (org/user)
+#   $2 - package name
+#   $3 - GitHub token with read:packages
+# Prints bearer token on stdout; returns 1 when exchange fails.
+ghcr_exchange_registry_token() {
+	local owner="${1:?owner required}"
+	local package_name="${2:?package required}"
+	local github_token="${3:?github token required}"
+	local auth url token
+
+	auth=$(printf 'x:%s' "$github_token" | base64 | tr -d '\n')
+	url="https://ghcr.io/token?service=ghcr.io&scope=repository:${owner}/${package_name}:pull"
+
+	if ! token=$(
+		curl -fsS "$url" \
+			-H "Authorization: Basic ${auth}" 2>/dev/null |
+			jq -r '.token // .access_token // empty'
+	); then
+		return 1
+	fi
+
+	if [[ -z "$token" ]]; then
+		return 1
+	fi
+
+	printf '%s' "$token"
+}
+
+# Fetch a manifest from ghcr.io by digest.
+# Returns manifest JSON on stdout; prints "404" when genuinely absent;
+# prints "ERROR" and returns 1 on transient failures.
+ghcr_fetch_manifest() {
+	local owner="${1:?owner required}"
+	local package_name="${2:?package required}"
+	local digest="${3:?digest required}"
+	local registry_token="${4:?registry token required}"
+	local url http_code body
+
+	url="https://ghcr.io/v2/${owner}/${package_name}/manifests/${digest}"
+	body=$(
+		curl -sS -w '\n%{http_code}' "$url" \
+			-H "Authorization: Bearer ${registry_token}" \
+			-H "Accept: ${_GHCR_MANIFEST_ACCEPT}" 2>/dev/null
+	) || {
+		printf 'ERROR\n'
+		return 1
+	}
+
+	http_code="${body##*$'\n'}"
+	body="${body%$'\n'*}"
+
+	case "$http_code" in
+	404)
+		printf '404\n'
+		return 0
+		;;
+	2?? | 3??)
+		if ! jq -e 'type == "object"' <<<"$body" >/dev/null 2>&1; then
+			printf 'ERROR\n'
+			return 1
+		fi
+		printf '%s' "$body"
+		return 0
+		;;
+	*)
+		printf 'ERROR\n'
+		return 1
+		;;
+	esac
+}
+
+# Fetch OCI Referrers descriptors for a digest.
+# Prints JSON array on stdout; empty array on genuine 404; returns 1 on transient errors.
+ghcr_fetch_referrers() {
+	local owner="${1:?owner required}"
+	local package_name="${2:?package required}"
+	local digest="${3:?digest required}"
+	local registry_token="${4:?registry token required}"
+	local url http_code body
+
+	url="https://ghcr.io/v2/${owner}/${package_name}/referrers/${digest}"
+	body=$(
+		curl -sS -w '\n%{http_code}' "$url" \
+			-H "Authorization: Bearer ${registry_token}" \
+			-H "Accept: ${_GHCR_REFERRERS_ACCEPT}" 2>/dev/null
+	) || {
+		printf 'ERROR\n'
+		return 1
+	}
+
+	http_code="${body##*$'\n'}"
+	body="${body%$'\n'*}"
+
+	case "$http_code" in
+	404)
+		printf '[]'
+		return 0
+		;;
+	2?? | 3??)
+		if ! jq -e 'type == "object"' <<<"$body" >/dev/null 2>&1; then
+			printf 'ERROR\n'
+			return 1
+		fi
+		jq -c '.manifests // [] | map(select(type == "object"))' <<<"$body"
+		return 0
+		;;
+	*)
+		printf 'ERROR\n'
+		return 1
+		;;
+	esac
+}
+
+# Collect digests referenced by tagged manifest indexes and referrers.
+# Args:
+#   $1 - owner
+#   $2 - package name
+#   $3 - versions JSON array (GitHub API shape)
+#   $4 - registry bearer token
+# Prints newline-delimited digests on stdout.
+# Sets GHCR_REFERENCED_COMPLETE=true|false in caller scope via named return vars:
+#   referenced_complete_var referenced_digests_var
+ghcr_collect_referenced_digests() {
+	local owner="${1:?owner required}"
+	local package_name="${2:?package required}"
+	local versions_json="${3:?versions json required}"
+	local registry_token="${4:?registry token required}"
+	local complete_var="${5:?complete var required}"
+	local digests_var="${6:?digests var required}"
+	local -a digests=()
+	local complete=true
+	local digest manifest referrers_json
+
+	while IFS= read -r digest; do
+		[[ -z "$digest" ]] && continue
+
+		manifest=$(ghcr_fetch_manifest \
+			"$owner" \
+			"$package_name" \
+			"$digest" \
+			"$registry_token") || {
+			complete=false
+			continue
+		}
+
+		if [[ "$manifest" == "ERROR" ]]; then
+			complete=false
+			continue
+		fi
+
+		if [[ "$manifest" != "404" ]]; then
+			while IFS= read -r child; do
+				[[ -n "$child" ]] && digests+=("$child")
+			done < <(
+				jq -r '.manifests[]? | select(type == "object") | .digest // empty' \
+					<<<"$manifest"
+			)
+			while IFS= read -r subject; do
+				[[ -n "$subject" ]] && digests+=("$subject")
+			done < <(
+				jq -r '.subject | select(type == "object") | .digest // empty' \
+					<<<"$manifest"
+			)
+		fi
+
+		referrers_json=$(ghcr_fetch_referrers \
+			"$owner" \
+			"$package_name" \
+			"$digest" \
+			"$registry_token") || {
+			complete=false
+			continue
+		}
+
+		if [[ "$referrers_json" == "ERROR" ]]; then
+			complete=false
+			continue
+		fi
+
+		while IFS= read -r ref_digest; do
+			[[ -n "$ref_digest" ]] && digests+=("$ref_digest")
+		done < <(jq -r '.[]? | .digest // empty' <<<"$referrers_json")
+	done < <(
+		jq -r '
+			.[] |
+			select((.metadata.container.tags | length) > 0) |
+			select(.name | startswith("sha256:")) |
+			.name
+		' <<<"$versions_json"
+	)
+
+	printf -v "$complete_var" '%s' "$complete"
+	if ((${#digests[@]} > 0)); then
+		printf -v "$digests_var" '%s' "$(printf '%s\n' "${digests[@]}" | sort -u)"
+	else
+		printf -v "$digests_var" ''
+	fi
+}
+
+export -f ghcr_exchange_registry_token ghcr_fetch_manifest ghcr_fetch_referrers
+export -f ghcr_collect_referenced_digests

--- a/scripts/ci/lib/ghcr/registry.sh
+++ b/scripts/ci/lib/ghcr/registry.sh
@@ -2,6 +2,11 @@
 # SPDX-License-Identifier: MIT
 # Purpose: GHCR registry helpers for referenced-digest protection during prune
 #
+# These functions use raw curl against the Docker registry v2 API (ghcr.io)
+# because `gh api` only speaks the GitHub REST API. Token exchange, manifest
+# fetches, and OCI Referrers lookups require registry-native endpoints that
+# the GitHub CLI cannot reach.
+#
 # Usage:
 #   source "$(dirname "${BASH_SOURCE:-$0}")/registry.sh"
 #   ghcr_exchange_registry_token owner package github_token
@@ -135,14 +140,15 @@ ghcr_fetch_referrers() {
 }
 
 # Collect digests referenced by tagged manifest indexes and referrers.
+# Includes the root tagged digest itself, its manifest children, subject
+# digests, and OCI Referrers descriptors.
 # Args:
 #   $1 - owner
 #   $2 - package name
 #   $3 - versions JSON array (GitHub API shape)
 #   $4 - registry bearer token
-# Prints newline-delimited digests on stdout.
-# Sets GHCR_REFERENCED_COMPLETE=true|false in caller scope via named return vars:
-#   referenced_complete_var referenced_digests_var
+#   $5 - name of caller variable to set complete status (true/false)
+#   $6 - name of caller variable to set newline-delimited digests
 ghcr_collect_referenced_digests() {
 	local owner="${1:?owner required}"
 	local package_name="${2:?package required}"
@@ -156,6 +162,9 @@ ghcr_collect_referenced_digests() {
 
 	while IFS= read -r digest; do
 		[[ -z "$digest" ]] && continue
+
+		# P1: protect the root tagged digest itself
+		digests+=("$digest")
 
 		manifest=$(ghcr_fetch_manifest \
 			"$owner" \

--- a/scripts/ci/lib/ghcr/registry.sh
+++ b/scripts/ci/lib/ghcr/registry.sh
@@ -35,7 +35,7 @@ ghcr_exchange_registry_token() {
 	url="https://ghcr.io/token?service=ghcr.io&scope=repository:${owner}/${package_name}:pull"
 
 	if ! token=$(
-		curl -fsS "$url" \
+		curl -fsS --max-time 30 "$url" \
 			-H "Authorization: Basic ${auth}" 2>/dev/null |
 			jq -r '.token // .access_token // empty'
 	); then
@@ -61,7 +61,7 @@ ghcr_fetch_manifest() {
 
 	url="https://ghcr.io/v2/${owner}/${package_name}/manifests/${digest}"
 	body=$(
-		curl -sS -w '\n%{http_code}' "$url" \
+		curl -sS --max-time 30 -w '\n%{http_code}' "$url" \
 			-H "Authorization: Bearer ${registry_token}" \
 			-H "Accept: ${_GHCR_MANIFEST_ACCEPT}" 2>/dev/null
 	) || {
@@ -103,7 +103,7 @@ ghcr_fetch_referrers() {
 
 	url="https://ghcr.io/v2/${owner}/${package_name}/referrers/${digest}"
 	body=$(
-		curl -sS -w '\n%{http_code}' "$url" \
+		curl -sS --max-time 30 -w '\n%{http_code}' "$url" \
 			-H "Authorization: Bearer ${registry_token}" \
 			-H "Accept: ${_GHCR_REFERRERS_ACCEPT}" 2>/dev/null
 	) || {

--- a/scripts/ci/lib/ghcr/tags.sh
+++ b/scripts/ci/lib/ghcr/tags.sh
@@ -9,7 +9,7 @@
 [[ -n "${_LGTM_CI_GHCR_TAGS_LOADED:-}" ]] && return 0
 readonly _LGTM_CI_GHCR_TAGS_LOADED=1
 
-readonly _GHCR_EPHEMERAL_TAG_PATTERN='^(pr-[0-9]+|mq-[0-9]+|dispatch-[0-9]+)$'
+readonly _GHCR_EPHEMERAL_TAG_PATTERN='^(pr-[a-zA-Z0-9_.-]+|mq-[a-zA-Z0-9_.-]+|dispatch-[a-zA-Z0-9_.-]+)$'
 
 # Return 0 when every tag on the version matches the ephemeral pattern.
 # Args:

--- a/scripts/ci/lib/ghcr/tags.sh
+++ b/scripts/ci/lib/ghcr/tags.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Ephemeral GHCR build-cache tag detection for prune eligibility
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE:-$0}")/tags.sh"
+#   ghcr_is_ephemeral_only_tagged '["pr-42"]'
+
+[[ -n "${_LGTM_CI_GHCR_TAGS_LOADED:-}" ]] && return 0
+readonly _LGTM_CI_GHCR_TAGS_LOADED=1
+
+readonly _GHCR_EPHEMERAL_TAG_PATTERN='^(pr-[0-9]+|mq-[0-9]+|dispatch-[0-9]+)$'
+
+# Return 0 when every tag on the version matches the ephemeral pattern.
+# Args:
+#   $1 - JSON array of tag strings
+ghcr_is_ephemeral_only_tagged() {
+	local tags_json="${1:-[]}"
+	local tag_count ephemeral_count
+
+	tag_count=$(jq -r 'length' <<<"$tags_json")
+	[[ "$tag_count" -eq 0 ]] && return 1
+
+	ephemeral_count=$(
+		jq -r --arg pattern "$_GHCR_EPHEMERAL_TAG_PATTERN" '
+			[.[] | select(test($pattern))] | length
+		' <<<"$tags_json"
+	)
+
+	[[ "$ephemeral_count" -eq "$tag_count" ]]
+}
+
+export -f ghcr_is_ephemeral_only_tagged

--- a/scripts/ci/security/check-vuln-suppressions.sh
+++ b/scripts/ci/security/check-vuln-suppressions.sh
@@ -8,9 +8,10 @@
 #   check-vuln-suppressions.sh
 #
 # Environment:
-#   GH_TOKEN     - GitHub token for PR creation (required)
-#   CONFIG_PATH  - Suppression TOML path (default: .osv-scanner.toml)
-#   WORKFLOW_FILE - Caller workflow filename for PR footer link (optional)
+#   GH_TOKEN           - GitHub token for PR creation (required)
+#   CONFIG_PATH        - Suppression TOML path (default: .osv-scanner.toml)
+#   WORKFLOW_FILE      - Caller workflow filename for PR footer link (optional)
+#   CLEANUP_PR_LABELS  - Comma-separated PR labels (default: security,dependencies,automation)
 
 set -euo pipefail
 
@@ -22,7 +23,8 @@ Detect stale or expired vulnerability suppressions in .osv-scanner.toml.
 
 Runs osv-scanner recursively without suppressions to scan all
 supported lockfiles and see which suppressed vulnerabilities are still
-present. Opens a PR removing entries that are stale (vuln resolved).
+present. Opens a PR removing entries that are stale (vuln resolved) or
+expired (past ignoreUntil).
 
 Requires GH_TOKEN for PR management.
 EOF
@@ -41,6 +43,7 @@ source "$LIB_DIR/github/output.sh"
 cd "$REPO_ROOT"
 
 OSV_TOML="${CONFIG_PATH:-.osv-scanner.toml}"
+CLEANUP_PR_LABELS="${CLEANUP_PR_LABELS:-security,dependencies,automation}"
 
 if [[ ! -f "$OSV_TOML" ]]; then
 	log_success "No $OSV_TOML found. Nothing to check."
@@ -88,7 +91,7 @@ for k in ('stale', 'expired', 'active'):
         print(f'{k.upper()}:{i}')
 ")
 
-REMOVE_IDS=("${STALE_IDS[@]+"${STALE_IDS[@]}"}")
+REMOVE_IDS=("${STALE_IDS[@]+"${STALE_IDS[@]}"}" "${EXPIRED_IDS[@]+"${EXPIRED_IDS[@]}"}")
 
 for id in "${ACTIVE_IDS[@]+"${ACTIVE_IDS[@]}"}"; do
 	log_success "Active: $id"
@@ -100,7 +103,7 @@ for id in "${EXPIRED_IDS[@]+"${EXPIRED_IDS[@]}"}"; do
 	log_warning "Expired: $id"
 done
 
-if [[ ${#REMOVE_IDS[@]} -eq 0 && ${#EXPIRED_IDS[@]} -eq 0 ]]; then
+if [[ ${#REMOVE_IDS[@]} -eq 0 ]]; then
 	log_success "All suppressions are active. Nothing to do."
 	exit 0
 fi
@@ -116,78 +119,64 @@ if [[ "$PR_LIST_EXIT" -ne 0 ]]; then
 	log_error "gh pr list failed: $PR_LIST_OUTPUT"
 	exit 1
 fi
-OPEN_CLEANUP_PR=""
 if [[ -n "$PR_LIST_OUTPUT" ]]; then
-	log_info "Cleanup PR #${PR_LIST_OUTPUT} already open. Skipping PR creation."
-	OPEN_CLEANUP_PR="$PR_LIST_OUTPUT"
+	log_info "Cleanup PR #${PR_LIST_OUTPUT} already open. Skipping."
+	exit 0
 fi
 
-if [[ -z "$OPEN_CLEANUP_PR" ]]; then
-	if [[ ${#REMOVE_IDS[@]} -eq 0 ]]; then
-		log_info "No stale suppressions to remove."
-	else
-		export REMOVE_IDS_JSON
-		REMOVE_IDS_JSON=$(printf '%s\n' "${REMOVE_IDS[@]}" | python3 -c "
+export REMOVE_IDS_JSON
+REMOVE_IDS_JSON=$(printf '%s\n' "${REMOVE_IDS[@]}" | python3 -c "
 import json, sys
 print(json.dumps([line.strip() for line in sys.stdin if line.strip()]))
 ")
 
-		python3 "$SCRIPTS_DIR/remove_stale_suppressions.py" "$OSV_TOML"
+python3 "$SCRIPTS_DIR/remove_stale_suppressions.py" "$OSV_TOML"
 
-		if [[ -f "$OSV_TOML" ]]; then
-			if ! grep -qEv '^[[:space:]]*(#.*)?$' "$OSV_TOML"; then
-				log_info "No substantive content left in $OSV_TOML, removing file"
-				rm -f "$OSV_TOML"
-			fi
-		fi
+if [[ -f "$OSV_TOML" ]]; then
+	if ! grep -qEv '^[[:space:]]*(#.*)?$' "$OSV_TOML"; then
+		log_info "No substantive content left in $OSV_TOML, removing file"
+		rm -f "$OSV_TOML"
+	fi
+fi
 
-		if ! git diff --quiet; then
-			REMOVED_LIST=""
-			for id in "${REMOVE_IDS[@]+"${REMOVE_IDS[@]}"}"; do
-				REMOVED_LIST="${REMOVED_LIST}- \`${id}\`
+if ! git diff --quiet; then
+	REMOVED_LIST=""
+	for id in "${REMOVE_IDS[@]}"; do
+		REMOVED_LIST="${REMOVED_LIST}- \`${id}\`
 "
-			done
+	done
 
-			EXPIRED_LIST=""
-			for id in "${EXPIRED_IDS[@]+"${EXPIRED_IDS[@]}"}"; do
-				EXPIRED_LIST="${EXPIRED_LIST}- \`${id}\`
-"
-			done
-
-			BRANCH="chore/remove-stale-vulns-$(date +%Y%m%d%H%M%S)"
-			configure_git_ci_user
-			git checkout -b "$BRANCH"
-			git add -A -- "$OSV_TOML"
-			git commit -m "$(
-				cat <<EOF
+	BRANCH="chore/remove-stale-vulns-$(date +%Y%m%d%H%M%S)"
+	configure_git_ci_user
+	git checkout -b "$BRANCH"
+	git add -A -- "$OSV_TOML"
+	git commit -m "$(
+		cat <<EOF
 chore(security): remove stale vulnerability suppressions
 
 The following suppressions are no longer needed:
 ${REMOVED_LIST}
 Detected by the weekly vuln-suppression-check workflow.
 EOF
-			)"
+	)"
 
-			git push -u origin "$BRANCH"
+	git push -u origin "$BRANCH"
 
-			WF_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions"
-			if [[ -n "${WORKFLOW_FILE:-}" ]]; then
-				WF_URL="${WF_URL}/workflows/${WORKFLOW_FILE}"
-			fi
+	WF_URL="${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions"
+	if [[ -n "${WORKFLOW_FILE:-}" ]]; then
+		WF_URL="${WF_URL}/workflows/${WORKFLOW_FILE}"
+	fi
 
-			gh pr create \
-				--title "chore(security): remove stale vulnerability suppressions" \
-				--body "$(
-					cat <<EOF
+	gh pr create \
+		--title "chore(security): remove stale vulnerability suppressions" \
+		--label "$CLEANUP_PR_LABELS" \
+		--body "$(
+			cat <<EOF
 ## Summary
-- Remove stale vulnerability suppressions (vuln resolved upstream)
-${REMOVED_LIST:+
-### Removed (stale)
-${REMOVED_LIST}}${EXPIRED_LIST:+
-### ⚠️ Expired (needs manual review)
-The following suppressions have passed their ignoreUntil date but
-the vulnerability may still be present. Renew or fix:
-${EXPIRED_LIST}}
+- Remove stale/expired vulnerability suppressions that are no longer needed
+
+### Removed
+${REMOVED_LIST}
 ## Test plan
 - [ ] CI security audit passes without these suppressions
 - [ ] osv-scanner scan passes without these suppressions
@@ -195,19 +184,9 @@ ${EXPIRED_LIST}}
 ---
 *Auto-created by [vuln-suppression-check](${WF_URL}).*
 EOF
-				)"
+		)"
 
-			log_success "Cleanup PR created on branch $BRANCH"
-		else
-			log_info "No file changes needed."
-		fi
-	fi
-fi
-
-if [[ ${#EXPIRED_IDS[@]} -gt 0 ]]; then
-	log_error "Expired suppressions need manual review — renew or fix:"
-	for id in "${EXPIRED_IDS[@]}"; do
-		log_error "  $id"
-	done
-	exit 1
+	log_success "Cleanup PR created on branch $BRANCH"
+else
+	log_info "No file changes needed."
 fi

--- a/scripts/ci/security/check-vuln-suppressions.sh
+++ b/scripts/ci/security/check-vuln-suppressions.sh
@@ -200,9 +200,17 @@ ${EXPIRED_LIST}"
 ---
 *Auto-created by [vuln-suppression-check](${WF_URL}).*"
 
+	gh_pr_label_args=()
+	IFS=',' read -ra _cleanup_labels <<<"${CLEANUP_PR_LABELS}"
+	for label in "${_cleanup_labels[@]}"; do
+		label="${label#"${label%%[![:space:]]*}"}"
+		label="${label%"${label##*[![:space:]]}"}"
+		[[ -n "$label" ]] && gh_pr_label_args+=(--label "$label")
+	done
+
 	gh pr create \
 		--title "chore(security): remove stale vulnerability suppressions" \
-		--label "$CLEANUP_PR_LABELS" \
+		"${gh_pr_label_args[@]}" \
 		--body "$PR_BODY"
 
 	log_success "Cleanup PR created on branch $BRANCH"

--- a/scripts/ci/security/check-vuln-suppressions.sh
+++ b/scripts/ci/security/check-vuln-suppressions.sh
@@ -11,7 +11,7 @@
 #   GH_TOKEN           - GitHub token for PR creation (required)
 #   CONFIG_PATH        - Suppression TOML path (default: .osv-scanner.toml)
 #   WORKFLOW_FILE      - Caller workflow filename for PR footer link (optional)
-#   CLEANUP_PR_LABELS  - Comma-separated PR labels (default: security,dependencies,automation)
+#   CLEANUP_PR_LABELS  - Comma-separated PR labels (default when unset: security,dependencies,automation; empty opts out)
 
 set -euo pipefail
 
@@ -43,7 +43,8 @@ source "$LIB_DIR/github/output.sh"
 cd "$REPO_ROOT"
 
 OSV_TOML="${CONFIG_PATH:-.osv-scanner.toml}"
-CLEANUP_PR_LABELS="${CLEANUP_PR_LABELS:-security,dependencies,automation}"
+# Default labels only when unset; explicit "" opts out of labeling.
+CLEANUP_PR_LABELS="${CLEANUP_PR_LABELS-security,dependencies,automation}"
 
 if [[ ! -f "$OSV_TOML" ]]; then
 	log_success "No $OSV_TOML found. Nothing to check."
@@ -201,17 +202,25 @@ ${EXPIRED_LIST}"
 *Auto-created by [vuln-suppression-check](${WF_URL}).*"
 
 	gh_pr_label_args=()
-	IFS=',' read -ra _cleanup_labels <<<"${CLEANUP_PR_LABELS}"
-	for label in "${_cleanup_labels[@]}"; do
-		label="${label#"${label%%[![:space:]]*}"}"
-		label="${label%"${label##*[![:space:]]}"}"
-		[[ -n "$label" ]] && gh_pr_label_args+=(--label "$label")
-	done
+	if [[ -n "${CLEANUP_PR_LABELS}" ]]; then
+		IFS=',' read -ra _cleanup_labels <<<"${CLEANUP_PR_LABELS}"
+		for label in "${_cleanup_labels[@]}"; do
+			label="${label#"${label%%[![:space:]]*}"}"
+			label="${label%"${label##*[![:space:]]}"}"
+			[[ -n "$label" ]] && gh_pr_label_args+=(--label "$label")
+		done
+	fi
 
-	gh pr create \
-		--title "chore(security): remove stale vulnerability suppressions" \
-		"${gh_pr_label_args[@]}" \
-		--body "$PR_BODY"
+	if ((${#gh_pr_label_args[@]} > 0)); then
+		gh pr create \
+			--title "chore(security): remove stale vulnerability suppressions" \
+			"${gh_pr_label_args[@]}" \
+			--body "$PR_BODY"
+	else
+		gh pr create \
+			--title "chore(security): remove stale vulnerability suppressions" \
+			--body "$PR_BODY"
+	fi
 
 	log_success "Cleanup PR created on branch $BRANCH"
 

--- a/scripts/ci/security/check-vuln-suppressions.sh
+++ b/scripts/ci/security/check-vuln-suppressions.sh
@@ -108,6 +108,8 @@ if [[ ${#REMOVE_IDS[@]} -eq 0 ]]; then
 	exit 0
 fi
 
+# Check for an existing cleanup PR. If one exists and the current run found
+# new expired suppressions, fail instead of silently masking them.
 PR_LIST_OUTPUT=""
 PR_LIST_EXIT=0
 PR_LIST_OUTPUT=$(
@@ -120,6 +122,10 @@ if [[ "$PR_LIST_EXIT" -ne 0 ]]; then
 	exit 1
 fi
 if [[ -n "$PR_LIST_OUTPUT" ]]; then
+	if [[ ${#EXPIRED_IDS[@]} -gt 0 ]]; then
+		log_error "Cleanup PR #${PR_LIST_OUTPUT} already open, but new expired suppressions found. Manual review required."
+		exit 1
+	fi
 	log_info "Cleanup PR #${PR_LIST_OUTPUT} already open. Skipping."
 	exit 0
 fi
@@ -140,11 +146,17 @@ if [[ -f "$OSV_TOML" ]]; then
 fi
 
 if ! git diff --quiet; then
-	REMOVED_LIST=""
-	for id in "${REMOVE_IDS[@]}"; do
-		REMOVED_LIST="${REMOVED_LIST}- \`${id}\`
+	STALE_LIST=""
+	for id in "${STALE_IDS[@]+"${STALE_IDS[@]}"}"; do
+		STALE_LIST="${STALE_LIST}- \`${id}\` (stale — vulnerability resolved)
 "
 	done
+	EXPIRED_LIST=""
+	for id in "${EXPIRED_IDS[@]+"${EXPIRED_IDS[@]}"}"; do
+		EXPIRED_LIST="${EXPIRED_LIST}- \`${id}\` (expired — past ignoreUntil date)
+"
+	done
+	REMOVED_LIST="${STALE_LIST}${EXPIRED_LIST}"
 
 	BRANCH="chore/remove-stale-vulns-$(date +%Y%m%d%H%M%S)"
 	configure_git_ci_user
@@ -167,26 +179,41 @@ EOF
 		WF_URL="${WF_URL}/workflows/${WORKFLOW_FILE}"
 	fi
 
-	gh pr create \
-		--title "chore(security): remove stale vulnerability suppressions" \
-		--label "$CLEANUP_PR_LABELS" \
-		--body "$(
-			cat <<EOF
-## Summary
+	PR_BODY="## Summary
 - Remove stale/expired vulnerability suppressions that are no longer needed
-
-### Removed
-${REMOVED_LIST}
+"
+	if [[ -n "$STALE_LIST" ]]; then
+		PR_BODY="${PR_BODY}
+### Removed (stale)
+${STALE_LIST}"
+	fi
+	if [[ -n "$EXPIRED_LIST" ]]; then
+		PR_BODY="${PR_BODY}
+### Removed (expired)
+${EXPIRED_LIST}"
+	fi
+	PR_BODY="${PR_BODY}
 ## Test plan
 - [ ] CI security audit passes without these suppressions
 - [ ] osv-scanner scan passes without these suppressions
 
 ---
-*Auto-created by [vuln-suppression-check](${WF_URL}).*
-EOF
-		)"
+*Auto-created by [vuln-suppression-check](${WF_URL}).*"
+
+	gh pr create \
+		--title "chore(security): remove stale vulnerability suppressions" \
+		--label "$CLEANUP_PR_LABELS" \
+		--body "$PR_BODY"
 
 	log_success "Cleanup PR created on branch $BRANCH"
+
+	# Expired suppressions may indicate still-active vulnerabilities
+	# past their ignoreUntil date. Fail the workflow so the team
+	# reviews the PR before the next scan.
+	if [[ ${#EXPIRED_IDS[@]} -gt 0 ]]; then
+		log_error "Expired suppression(s) removed; review the cleanup PR before merging"
+		exit 1
+	fi
 else
 	log_info "No file changes needed."
 fi

--- a/tests/bats/integration/test_composite_action_refs.bats
+++ b/tests/bats/integration/test_composite_action_refs.bats
@@ -93,12 +93,14 @@ YAML
 
 @test "composite actions: resolve SCRIPTS_DIR from GITHUB_ACTION_PATH" {
 	local rc=0
+	local total=0
 	while IFS= read -r -d '' action; do
-		if grep -q 'SCRIPTS_DIR=\${GITHUB_ACTION_PATH' "$action"; then
+		total=$((total + 1))
+		if grep -q 'SCRIPTS_DIR=${GITHUB_ACTION_PATH' "$action"; then
 			echo "broken SCRIPTS_DIR pattern in $action" >&2
 			rc=1
 		fi
-		if grep -q 'GITHUB_ACTION_PATH//\\\\//' "$action"; then
+		if grep -q 'GITHUB_ACTION_PATH//\\/' "$action"; then
 			echo "slash-stripping SCRIPTS_DIR bug in $action" >&2
 			rc=1
 		fi
@@ -109,7 +111,9 @@ YAML
 	local checked=0
 	rc=0
 	while IFS= read -r -d '' action; do
-		grep -q 'GITHUB_ACTION_PATH}/../../../scripts' "$action" || continue
+		if ! grep -q 'SCRIPTS_DIR=.*GITHUB_ACTION_PATH' "$action"; then
+			continue
+		fi
 		checked=$((checked + 1))
 		if ! awk '
 			/SCRIPTS_DIR="\$\(cd "\$\{GITHUB_ACTION_PATH\}\/\.\.\/\.\.\/\.\.\/scripts" && pwd\)"/ { found = 1 }

--- a/tests/bats/integration/test_composite_action_refs.bats
+++ b/tests/bats/integration/test_composite_action_refs.bats
@@ -106,10 +106,19 @@ YAML
 
 	[[ "$rc" -eq 0 ]]
 
-	run awk '
-		BEGIN { found = 0 }
-		/SCRIPTS_DIR="\$\(cd "\$\{GITHUB_ACTION_PATH\}\/\.\.\/\.\.\/\.\.\/scripts" && pwd\)"/ { found++ }
-		END { exit found < 1 }
-	' "${PROJECT_ROOT}/.github/actions/secure-checkout/action.yml"
-	assert_success
+	local checked=0
+	rc=0
+	while IFS= read -r -d '' action; do
+		grep -q 'GITHUB_ACTION_PATH}/../../../scripts' "$action" || continue
+		checked=$((checked + 1))
+		if ! awk '
+			/SCRIPTS_DIR="\$\(cd "\$\{GITHUB_ACTION_PATH\}\/\.\.\/\.\.\/\.\.\/scripts" && pwd\)"/ { found = 1 }
+			END { exit !found }
+		' "$action"; then
+			echo "missing SCRIPTS_DIR cd/pwd pattern in $action" >&2
+			rc=1
+		fi
+	done < <(find "${PROJECT_ROOT}/.github/actions" -path '*/action.yml' -type f -print0)
+
+	[[ "$checked" -ge 1 && "$rc" -eq 0 ]]
 }

--- a/tests/bats/integration/test_composite_action_refs.bats
+++ b/tests/bats/integration/test_composite_action_refs.bats
@@ -90,3 +90,26 @@ YAML
 	' "$action"
 	assert_success
 }
+
+@test "composite actions: resolve SCRIPTS_DIR from GITHUB_ACTION_PATH" {
+	local rc=0
+	while IFS= read -r -d '' action; do
+		if grep -q 'SCRIPTS_DIR=\${GITHUB_ACTION_PATH' "$action"; then
+			echo "broken SCRIPTS_DIR pattern in $action" >&2
+			rc=1
+		fi
+		if grep -q 'GITHUB_ACTION_PATH//\\\\//' "$action"; then
+			echo "slash-stripping SCRIPTS_DIR bug in $action" >&2
+			rc=1
+		fi
+	done < <(find "${PROJECT_ROOT}/.github/actions" -path '*/action.yml' -type f -print0)
+
+	[[ "$rc" -eq 0 ]]
+
+	run awk '
+		BEGIN { found = 0 }
+		/SCRIPTS_DIR="\$\(cd "\$\{GITHUB_ACTION_PATH\}\/\.\.\/\.\.\/\.\.\/scripts" && pwd\)"/ { found++ }
+		END { exit found < 1 }
+	' "${PROJECT_ROOT}/.github/actions/secure-checkout/action.yml"
+	assert_success
+}

--- a/tests/bats/integration/test_composite_action_refs.bats
+++ b/tests/bats/integration/test_composite_action_refs.bats
@@ -100,7 +100,7 @@ YAML
 			echo "broken SCRIPTS_DIR pattern in $action" >&2
 			rc=1
 		fi
-		if grep -q 'GITHUB_ACTION_PATH//\\/' "$action"; then
+		if grep -q 'SCRIPTS_DIR=.*GITHUB_ACTION_PATH//' "$action"; then
 			echo "slash-stripping SCRIPTS_DIR bug in $action" >&2
 			rc=1
 		fi

--- a/tests/bats/integration/test_ghcr_cleanup.bats
+++ b/tests/bats/integration/test_ghcr_cleanup.bats
@@ -23,6 +23,9 @@ setup() {
 	export MIN_AGE_DAYS="7"
 	export KEEP_LATEST="2"
 	export DRY_RUN="false"
+	export PROTECT_REFERENCED="false"
+	export PRUNE_BUILDCACHE="false"
+	export GH_TOKEN="test-token"
 }
 
 teardown() {
@@ -190,4 +193,90 @@ EOF
 	assert_success
 	# Only 1 untagged, which is within keep-latest=2
 	assert_output --partial "nothing to delete"
+}
+
+# =============================================================================
+# keep-latest default and build-cache pruning
+# =============================================================================
+
+@test "ghcr-cleanup: keep-latest 0 deletes all eligible untagged versions" {
+	mock_gh_versions '[
+		{"id": 1, "name": "sha256:aaa", "updated_at": "2020-01-01T00:00:00Z", "metadata": {"container": {"tags": []}}},
+		{"id": 2, "name": "sha256:bbb", "updated_at": "2020-01-02T00:00:00Z", "metadata": {"container": {"tags": []}}}
+	]'
+
+	export KEEP_LATEST="0"
+
+	run bash -c 'bash "$SCRIPT" 2>&1'
+	assert_success
+	assert_output --partial "Deleted untagged version"
+}
+
+@test "ghcr-cleanup: deletes aged ephemeral build-cache tags" {
+	mock_gh_versions '[
+		{"id": 10, "name": "sha256:pr", "updated_at": "2020-01-01T00:00:00Z", "metadata": {"container": {"tags": ["pr-890"]}}},
+		{"id": 11, "name": "sha256:cache", "updated_at": "2020-01-01T00:00:00Z", "metadata": {"container": {"tags": ["cache"]}}}
+	]'
+
+	export PRUNE_BUILDCACHE="true"
+	export KEEP_LATEST="0"
+
+	run bash -c 'bash "$SCRIPT" 2>&1'
+	assert_success
+	assert_output --partial "Deleted build-cache version 10"
+	refute_output --partial "Deleted build-cache version 11"
+}
+
+@test "ghcr-cleanup: preserves mixed ephemeral and permanent tags" {
+	mock_gh_versions '[
+		{"id": 20, "name": "sha256:mixed", "updated_at": "2020-01-01T00:00:00Z", "metadata": {"container": {"tags": ["cache", "pr-3"]}}}
+	]'
+
+	export PRUNE_BUILDCACHE="true"
+
+	run bash -c 'bash "$SCRIPT" 2>&1'
+	assert_success
+	assert_output --partial "nothing to delete"
+}
+
+@test "ghcr-cleanup: skips prune when registry auth fails with protect-referenced" {
+	mock_gh_versions '[
+		{"id": 1, "name": "sha256:orphan", "updated_at": "2020-01-01T00:00:00Z", "metadata": {"container": {"tags": []}}}
+	]'
+
+	export PROTECT_REFERENCED="true"
+	export KEEP_LATEST="0"
+
+	mock_command_multi "curl" '
+		*ghcr.io/token*) exit 22;;
+		*) exit 1;;
+	'
+
+	run bash -c 'bash "$SCRIPT" 2>&1'
+	assert_success
+	assert_output --partial "registry auth failed"
+	refute_output --partial "Deleted"
+}
+
+@test "ghcr-cleanup: protects referenced digests from untagged deletion" {
+	mock_gh_versions '[
+		{"id": 1, "name": "sha256:tagged-index", "updated_at": "2020-01-01T00:00:00Z", "metadata": {"container": {"tags": ["v1.0.0"]}}},
+		{"id": 2, "name": "sha256:slsa-child", "updated_at": "2020-01-01T00:00:00Z", "metadata": {"container": {"tags": []}}},
+		{"id": 3, "name": "sha256:orphan", "updated_at": "2020-01-01T00:00:00Z", "metadata": {"container": {"tags": []}}}
+	]'
+
+	export PROTECT_REFERENCED="true"
+	export KEEP_LATEST="0"
+
+	mock_command_multi "curl" '
+		*ghcr.io/token*) printf "%s\n" "{\"token\":\"registry-bearer\"}";;
+		*manifests/sha256:tagged-index*) printf "%s\n200\n" "{\"manifests\":[{\"digest\":\"sha256:slsa-child\"}]}";;
+		*referrers/sha256:tagged-index*) printf "%s\n404\n" "{}";;
+		*) exit 1;;
+	'
+
+	run bash -c 'bash "$SCRIPT" 2>&1'
+	assert_success
+	assert_output --partial "Deleted untagged version 3"
+	refute_output --partial "Deleted untagged version 2"
 }

--- a/tests/bats/integration/test_ghcr_cleanup.bats
+++ b/tests/bats/integration/test_ghcr_cleanup.bats
@@ -258,6 +258,21 @@ EOF
 	refute_output --partial "Deleted"
 }
 
+@test "ghcr-cleanup: URL-encodes nested package names in Packages API paths" {
+	mock_command_record "gh" '[]' 0
+	export PACKAGE_NAME="nested/sub-package"
+	export PROTECT_REFERENCED="false"
+
+	run bash -c 'bash "$SCRIPT" 2>&1'
+	assert_success
+	assert_output --partial "nothing to delete"
+
+	local calls
+	calls=$(cat "$BATS_TEST_TMPDIR/mock_calls_gh")
+	[[ "$calls" == *"nested%2Fsub-package"* ]]
+	[[ "$calls" != *"packages/container/nested/sub-package"* ]]
+}
+
 @test "ghcr-cleanup: protects referenced digests from untagged deletion" {
 	mock_gh_versions '[
 		{"id": 1, "name": "sha256:tagged-index", "updated_at": "2020-01-01T00:00:00Z", "metadata": {"container": {"tags": ["v1.0.0"]}}},

--- a/tests/bats/integration/test_ghcr_cleanup.bats
+++ b/tests/bats/integration/test_ghcr_cleanup.bats
@@ -303,6 +303,7 @@ EOF
 	]'
 
 	export KEEP_LATEST="0"
+	export PROTECT_REFERENCED="false"
 
 	run bash -c 'bash "$SCRIPT" 2>&1'
 	assert_success
@@ -318,6 +319,7 @@ EOF
 
 	export PRUNE_BUILDCACHE="true"
 	export KEEP_LATEST="0"
+	export PROTECT_REFERENCED="false"
 
 	run bash -c 'bash "$SCRIPT" 2>&1'
 	assert_success

--- a/tests/bats/integration/test_ghcr_cleanup.bats
+++ b/tests/bats/integration/test_ghcr_cleanup.bats
@@ -295,3 +295,32 @@ EOF
 	assert_output --partial "Deleted untagged version 3"
 	refute_output --partial "Deleted untagged version 2"
 }
+
+@test "ghcr-cleanup: skips untagged versions with unknown age" {
+	mock_gh_versions '[
+		{"id": 1, "name": "sha256:dated", "updated_at": "2020-01-01T00:00:00Z", "metadata": {"container": {"tags": []}}},
+		{"id": 2, "name": "sha256:undated", "metadata": {"container": {"tags": []}}}
+	]'
+
+	export KEEP_LATEST="0"
+
+	run bash -c 'bash "$SCRIPT" 2>&1'
+	assert_success
+	assert_output --partial "Deleted untagged version 1"
+	refute_output --partial "Deleted untagged version 2"
+}
+
+@test "ghcr-cleanup: skips ephemeral cache versions with unknown age" {
+	mock_gh_versions '[
+		{"id": 10, "name": "sha256:dated-cache", "updated_at": "2020-01-01T00:00:00Z", "metadata": {"container": {"tags": ["pr-42"]}}},
+		{"id": 11, "name": "sha256:undated-cache", "metadata": {"container": {"tags": ["pr-99"]}}}
+	]'
+
+	export PRUNE_BUILDCACHE="true"
+	export KEEP_LATEST="0"
+
+	run bash -c 'bash "$SCRIPT" 2>&1'
+	assert_success
+	assert_output --partial "Deleted build-cache version 10"
+	refute_output --partial "Deleted build-cache version 11"
+}

--- a/tests/bats/integration/test_reusable_ghcr_cleanup.bats
+++ b/tests/bats/integration/test_reusable_ghcr_cleanup.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-ghcr-cleanup workflow inputs and job shape
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-ghcr-cleanup.yml"
+
+@test "reusable-ghcr-cleanup: keep-latest defaults to 0" {
+	run awk '/^      keep-latest:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial "default: 0"
+}
+
+@test "reusable-ghcr-cleanup: build-cache-pr-age-days defaults to 14" {
+	run awk '/^      build-cache-pr-age-days:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial "default: 14"
+}
+
+@test "reusable-ghcr-cleanup: protect-referenced defaults to true" {
+	run awk '/^      protect-referenced:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial "default: true"
+}
+
+@test "reusable-ghcr-cleanup: passes build-cache and protection env vars" {
+	run awk '
+		/- name: Clean untagged GHCR images/ { step = 1 }
+		step && /BUILD_CACHE_PR_AGE_DAYS:/ { buildcache = 1 }
+		step && /PROTECT_REFERENCED:/ { protect = 1 }
+		step && /PRUNE_BUILDCACHE:/ { prune = 1 }
+		END { exit !(buildcache && protect && prune) }
+	' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_vuln_suppression_check.bats
+++ b/tests/bats/integration/test_reusable_vuln_suppression_check.bats
@@ -85,3 +85,19 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-vuln-suppression-check.yml"
 	' "$WORKFLOW"
 	assert_success
 }
+
+@test "reusable-vuln-suppression-check: cleanup-pr-labels defaults to security labels" {
+	run awk '/^      cleanup-pr-labels:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: "security,dependencies,automation"'
+}
+
+@test "reusable-vuln-suppression-check: passes cleanup-pr-labels to check script" {
+	run awk '
+		/- name: Check suppression staleness/ { step = 1 }
+		step && /CLEANUP_PR_LABELS:/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_vuln_suppressions.bats
+++ b/tests/bats/integration/test_vuln_suppressions.bats
@@ -96,11 +96,25 @@ EOF
 
 mock_gh_for_cleanup_pr() {
 	local pr_url="${1:-https://github.com/test-org/test-repo/pull/1}"
-	mock_command_multi "gh" "
-		*pr\ list*) :;;
-		*pr\ create*) echo '$pr_url';;
-		*) exit 1;;
-	"
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+	local calls_file="${BATS_TEST_TMPDIR}/mock_calls_gh"
+	: >"$calls_file"
+
+	cat >"${mock_bin}/gh" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> '${calls_file}'
+case "\$*" in
+	*pr\ list*) :;;
+	*pr\ create*) echo '${pr_url}';;
+	*) exit 1;;
+esac
+EOF
+	chmod +x "${mock_bin}/gh"
+
+	if [[ ":$PATH:" != *":${mock_bin}:"* ]]; then
+		export PATH="${mock_bin}:$PATH"
+	fi
 }
 
 @test "vuln-suppressions: removes stale suppressions via cleanup PR" {
@@ -125,6 +139,34 @@ EOF
 	assert_output --partial "Cleanup PR created"
 
 	[[ ! -f "$MOCK_GIT_REPO/.osv-scanner.toml" ]] || ! grep -q 'GHSA-stale-2222' "$MOCK_GIT_REPO/.osv-scanner.toml"
+}
+
+@test "vuln-suppressions: passes each cleanup label separately to gh pr create" {
+	setup_suppression_repo
+	cat >"$MOCK_GIT_REPO/.osv-scanner.toml" <<'EOF'
+[[IgnoredVulns]]
+id = "GHSA-stale-2222"
+ignoreUntil = 2099-12-31
+reason = "resolved upstream"
+EOF
+	(
+		cd "$MOCK_GIT_REPO" || exit 1
+		git add .osv-scanner.toml
+		git commit -q --amend --no-edit
+	)
+
+	mock_osv_probe '{"results":[{"packages":[{"vulnerabilities":[]}]}]}'
+	mock_gh_for_cleanup_pr "https://github.com/test-org/test-repo/pull/55"
+
+	run_check_script
+	assert_success
+
+	local calls
+	calls=$(cat "$BATS_TEST_TMPDIR/mock_calls_gh")
+	[[ "$calls" == *"--label security"* ]]
+	[[ "$calls" == *"--label dependencies"* ]]
+	[[ "$calls" == *"--label automation"* ]]
+	[[ "$calls" != *"--label security,dependencies,automation"* ]]
 }
 
 @test "vuln-suppressions: removes expired suppressions via cleanup PR and exits 1" {

--- a/tests/bats/integration/test_vuln_suppressions.bats
+++ b/tests/bats/integration/test_vuln_suppressions.bats
@@ -179,8 +179,8 @@ EOF
 	assert_output --partial "Cleanup PR created"
 
 	[[ ! -f "$MOCK_GIT_REPO/.osv-scanner.toml" ]] || {
-		! grep -q 'GHSA-stale-2222' "$MOCK_GIT_REPO/.osv-scanner.toml"
-		! grep -q 'GHSA-expired-3333' "$MOCK_GIT_REPO/.osv-scanner.toml"
+		! grep -q 'GHSA-stale-2222' "$MOCK_GIT_REPO/.osv-scanner.toml" &&
+			! grep -q 'GHSA-expired-3333' "$MOCK_GIT_REPO/.osv-scanner.toml"
 	}
 }
 

--- a/tests/bats/integration/test_vuln_suppressions.bats
+++ b/tests/bats/integration/test_vuln_suppressions.bats
@@ -127,7 +127,7 @@ EOF
 	[[ ! -f "$MOCK_GIT_REPO/.osv-scanner.toml" ]] || ! grep -q 'GHSA-stale-2222' "$MOCK_GIT_REPO/.osv-scanner.toml"
 }
 
-@test "vuln-suppressions: removes expired suppressions via cleanup PR" {
+@test "vuln-suppressions: removes expired suppressions via cleanup PR and exits 1" {
 	setup_suppression_repo
 	cat >"$MOCK_GIT_REPO/.osv-scanner.toml" <<'EOF'
 [[IgnoredVulns]]
@@ -145,14 +145,14 @@ EOF
 	mock_gh_for_cleanup_pr "https://github.com/test-org/test-repo/pull/43"
 
 	run_check_script
-	assert_success
+	assert_failure
 	assert_output --partial "Cleanup PR created"
-	refute_output --partial "need manual review"
+	assert_output --partial "Expired suppression(s) removed"
 
 	[[ ! -f "$MOCK_GIT_REPO/.osv-scanner.toml" ]] || ! grep -q 'GHSA-expired-3333' "$MOCK_GIT_REPO/.osv-scanner.toml"
 }
 
-@test "vuln-suppressions: removes stale and expired in one cleanup PR" {
+@test "vuln-suppressions: removes stale and expired in one cleanup PR and exits 1" {
 	setup_suppression_repo
 	cat >"$MOCK_GIT_REPO/.osv-scanner.toml" <<'EOF'
 [[IgnoredVulns]]
@@ -175,8 +175,9 @@ EOF
 	mock_gh_for_cleanup_pr "https://github.com/test-org/test-repo/pull/44"
 
 	run_check_script
-	assert_success
+	assert_failure
 	assert_output --partial "Cleanup PR created"
+	assert_output --partial "Expired suppression(s) removed"
 
 	[[ ! -f "$MOCK_GIT_REPO/.osv-scanner.toml" ]] || {
 		! grep -q 'GHSA-stale-2222' "$MOCK_GIT_REPO/.osv-scanner.toml" &&
@@ -184,7 +185,7 @@ EOF
 	}
 }
 
-@test "vuln-suppressions: skips when cleanup PR already open" {
+@test "vuln-suppressions: skips when cleanup PR already open for stale-only" {
 	setup_suppression_repo
 	cat >"$MOCK_GIT_REPO/.osv-scanner.toml" <<'EOF'
 [[IgnoredVulns]]
@@ -207,4 +208,29 @@ EOF
 	run_check_script
 	assert_success
 	assert_output --partial "Cleanup PR #99 already open"
+}
+
+@test "vuln-suppressions: fails when cleanup PR open but new expired found" {
+	setup_suppression_repo
+	cat >"$MOCK_GIT_REPO/.osv-scanner.toml" <<'EOF'
+[[IgnoredVulns]]
+id = "GHSA-expired-4444"
+ignoreUntil = 2020-01-01
+reason = "past due"
+EOF
+	(
+		cd "$MOCK_GIT_REPO" || exit 1
+		git add .osv-scanner.toml
+		git commit -q --amend --no-edit
+	)
+
+	mock_osv_probe '{"results":[{"packages":[{"vulnerabilities":[{"id":"GHSA-expired-4444"}]}]}]}'
+	mock_command_multi "gh" '
+		*pr\ list*) echo -n "99";;
+		*) exit 1;;
+	'
+
+	run_check_script
+	assert_failure
+	assert_output --partial "new expired suppressions found"
 }

--- a/tests/bats/integration/test_vuln_suppressions.bats
+++ b/tests/bats/integration/test_vuln_suppressions.bats
@@ -55,7 +55,7 @@ run_check_script() {
 		cd '$MOCK_GIT_REPO'
 		export GITHUB_WORKSPACE='$MOCK_GIT_REPO'
 		export GH_TOKEN='$GH_TOKEN'
-		export CLEANUP_PR_LABELS='${CLEANUP_PR_LABELS:-security,dependencies,automation}'
+		export CLEANUP_PR_LABELS='${CLEANUP_PR_LABELS-security,dependencies,automation}'
 		export PATH='$PATH'
 		'$SCRIPT' 2>&1
 	"
@@ -167,6 +167,38 @@ EOF
 	[[ "$calls" == *"--label dependencies"* ]]
 	[[ "$calls" == *"--label automation"* ]]
 	[[ "$calls" != *"--label security,dependencies,automation"* ]]
+}
+
+@test "vuln-suppressions: creates unlabeled cleanup PR when labels are empty" {
+	setup_suppression_repo
+	cat >"$MOCK_GIT_REPO/.osv-scanner.toml" <<'EOF'
+[[IgnoredVulns]]
+id = "GHSA-stale-2222"
+ignoreUntil = 2099-12-31
+reason = "resolved upstream"
+EOF
+	(
+		cd "$MOCK_GIT_REPO" || exit 1
+		git add .osv-scanner.toml
+		git commit -q --amend --no-edit
+	)
+
+	mock_osv_probe '{"results":[{"packages":[{"vulnerabilities":[]}]}]}'
+	mock_gh_for_cleanup_pr "https://github.com/test-org/test-repo/pull/56"
+
+	run bash -c "
+		cd '$MOCK_GIT_REPO'
+		export GITHUB_WORKSPACE='$MOCK_GIT_REPO'
+		export GH_TOKEN='$GH_TOKEN'
+		export CLEANUP_PR_LABELS=''
+		export PATH='$PATH'
+		'$SCRIPT' 2>&1
+	"
+	assert_success
+
+	local calls
+	calls=$(cat "$BATS_TEST_TMPDIR/mock_calls_gh")
+	[[ "$calls" != *"--label"* ]]
 }
 
 @test "vuln-suppressions: removes expired suppressions via cleanup PR and exits 1" {

--- a/tests/bats/integration/test_vuln_suppressions.bats
+++ b/tests/bats/integration/test_vuln_suppressions.bats
@@ -1,0 +1,210 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Integration tests for check-vuln-suppressions.sh
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+load "../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/security/check-vuln-suppressions.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+	setup_github_env
+	export LIB_DIR
+	export BATS_TEST_TMPDIR
+	export PROJECT_ROOT
+	export SCRIPT
+	export GH_TOKEN="fake-token"
+	export GITHUB_REPOSITORY="test-org/test-repo"
+	export GITHUB_SERVER_URL="https://github.com"
+}
+
+teardown() {
+	restore_path
+	teardown_github_env
+	teardown_temp_dir
+}
+
+setup_suppression_repo() {
+	setup_mock_git_repo
+	(
+		cd "$MOCK_GIT_REPO" || exit 1
+		printf '' >.osv-scanner.toml
+		git add .osv-scanner.toml
+		git commit -q -m "chore: add suppressions"
+		local bare_dir="${BATS_TEST_TMPDIR}/bare.git"
+		git init -q --bare "$bare_dir"
+		git -C "$bare_dir" config receive.denyCurrentBranch ignore
+		git remote add origin "$bare_dir"
+		git push -q origin HEAD:main 2>/dev/null
+	)
+}
+
+mock_osv_probe() {
+	local probe_json="$1"
+	mock_command_multi "osv-scanner" "
+		*scan*) printf '%s' '$probe_json';;
+		*) exit 1;;
+	"
+}
+
+run_check_script() {
+	run bash -c "
+		cd '$MOCK_GIT_REPO'
+		export GITHUB_WORKSPACE='$MOCK_GIT_REPO'
+		export GH_TOKEN='$GH_TOKEN'
+		export CLEANUP_PR_LABELS='${CLEANUP_PR_LABELS:-security,dependencies,automation}'
+		export PATH='$PATH'
+		'$SCRIPT' 2>&1
+	"
+}
+
+@test "vuln-suppressions: exits cleanly when config file is missing" {
+	setup_mock_git_repo
+	run bash -c "
+		cd '$MOCK_GIT_REPO'
+		export GITHUB_WORKSPACE='$MOCK_GIT_REPO'
+		export GH_TOKEN='$GH_TOKEN'
+		'$SCRIPT' 2>&1
+	"
+	assert_success
+	assert_output --partial "Nothing to check"
+}
+
+@test "vuln-suppressions: exits cleanly when all suppressions are active" {
+	setup_suppression_repo
+	cat >"$MOCK_GIT_REPO/.osv-scanner.toml" <<'EOF'
+[[IgnoredVulns]]
+id = "GHSA-active-1111"
+ignoreUntil = 2099-12-31
+reason = "still present"
+EOF
+	(
+		cd "$MOCK_GIT_REPO" || exit 1
+		git add .osv-scanner.toml
+		git commit -q --amend --no-edit
+	)
+
+	mock_osv_probe '{"results":[{"packages":[{"vulnerabilities":[{"id":"GHSA-active-1111"}]}]}]}'
+
+	run_check_script
+	assert_success
+	assert_output --partial "All suppressions are active"
+}
+
+mock_gh_for_cleanup_pr() {
+	local pr_url="${1:-https://github.com/test-org/test-repo/pull/1}"
+	mock_command_multi "gh" "
+		*pr\ list*) :;;
+		*pr\ create*) echo '$pr_url';;
+		*) exit 1;;
+	"
+}
+
+@test "vuln-suppressions: removes stale suppressions via cleanup PR" {
+	setup_suppression_repo
+	cat >"$MOCK_GIT_REPO/.osv-scanner.toml" <<'EOF'
+[[IgnoredVulns]]
+id = "GHSA-stale-2222"
+ignoreUntil = 2099-12-31
+reason = "resolved upstream"
+EOF
+	(
+		cd "$MOCK_GIT_REPO" || exit 1
+		git add .osv-scanner.toml
+		git commit -q --amend --no-edit
+	)
+
+	mock_osv_probe '{"results":[{"packages":[{"vulnerabilities":[]}]}]}'
+	mock_gh_for_cleanup_pr "https://github.com/test-org/test-repo/pull/42"
+
+	run_check_script
+	assert_success
+	assert_output --partial "Cleanup PR created"
+
+	[[ ! -f "$MOCK_GIT_REPO/.osv-scanner.toml" ]] || ! grep -q 'GHSA-stale-2222' "$MOCK_GIT_REPO/.osv-scanner.toml"
+}
+
+@test "vuln-suppressions: removes expired suppressions via cleanup PR" {
+	setup_suppression_repo
+	cat >"$MOCK_GIT_REPO/.osv-scanner.toml" <<'EOF'
+[[IgnoredVulns]]
+id = "GHSA-expired-3333"
+ignoreUntil = 2020-01-01
+reason = "past due"
+EOF
+	(
+		cd "$MOCK_GIT_REPO" || exit 1
+		git add .osv-scanner.toml
+		git commit -q --amend --no-edit
+	)
+
+	mock_osv_probe '{"results":[{"packages":[{"vulnerabilities":[{"id":"GHSA-expired-3333"}]}]}]}'
+	mock_gh_for_cleanup_pr "https://github.com/test-org/test-repo/pull/43"
+
+	run_check_script
+	assert_success
+	assert_output --partial "Cleanup PR created"
+	refute_output --partial "need manual review"
+
+	[[ ! -f "$MOCK_GIT_REPO/.osv-scanner.toml" ]] || ! grep -q 'GHSA-expired-3333' "$MOCK_GIT_REPO/.osv-scanner.toml"
+}
+
+@test "vuln-suppressions: removes stale and expired in one cleanup PR" {
+	setup_suppression_repo
+	cat >"$MOCK_GIT_REPO/.osv-scanner.toml" <<'EOF'
+[[IgnoredVulns]]
+id = "GHSA-stale-2222"
+ignoreUntil = 2099-12-31
+reason = "resolved upstream"
+
+[[IgnoredVulns]]
+id = "GHSA-expired-3333"
+ignoreUntil = 2020-01-01
+reason = "past due"
+EOF
+	(
+		cd "$MOCK_GIT_REPO" || exit 1
+		git add .osv-scanner.toml
+		git commit -q --amend --no-edit
+	)
+
+	mock_osv_probe '{"results":[{"packages":[{"vulnerabilities":[]}]}]}'
+	mock_gh_for_cleanup_pr "https://github.com/test-org/test-repo/pull/44"
+
+	run_check_script
+	assert_success
+	assert_output --partial "Cleanup PR created"
+
+	[[ ! -f "$MOCK_GIT_REPO/.osv-scanner.toml" ]] || {
+		! grep -q 'GHSA-stale-2222' "$MOCK_GIT_REPO/.osv-scanner.toml"
+		! grep -q 'GHSA-expired-3333' "$MOCK_GIT_REPO/.osv-scanner.toml"
+	}
+}
+
+@test "vuln-suppressions: skips when cleanup PR already open" {
+	setup_suppression_repo
+	cat >"$MOCK_GIT_REPO/.osv-scanner.toml" <<'EOF'
+[[IgnoredVulns]]
+id = "GHSA-stale-2222"
+ignoreUntil = 2099-12-31
+reason = "resolved upstream"
+EOF
+	(
+		cd "$MOCK_GIT_REPO" || exit 1
+		git add .osv-scanner.toml
+		git commit -q --amend --no-edit
+	)
+
+	mock_osv_probe '{"results":[{"packages":[{"vulnerabilities":[]}]}]}'
+	mock_command_multi "gh" '
+		*pr\ list*) echo -n "99";;
+		*) exit 1;;
+	'
+
+	run_check_script
+	assert_success
+	assert_output --partial "Cleanup PR #99 already open"
+}

--- a/tests/bats/unit/lib/ghcr/test_registry.bats
+++ b/tests/bats/unit/lib/ghcr/test_registry.bats
@@ -1,0 +1,309 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/lib/ghcr/registry.sh
+
+load "../../../../helpers/common"
+load "../../../../helpers/mocks"
+
+setup() {
+	setup_temp_dir
+	save_path
+	export LIB_DIR
+	export BATS_TEST_TMPDIR
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+# =============================================================================
+# ghcr_exchange_registry_token
+# =============================================================================
+
+@test "ghcr_exchange_registry_token: exchanges token field from registry" {
+	mock_command_multi "curl" '
+		*ghcr.io/token*) printf "%s" "{\"token\":\"registry-bearer\"}";;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		source "$LIB_DIR/ghcr/registry.sh"
+		ghcr_exchange_registry_token "test-org" "pkg" "github-token"
+	'
+	assert_success
+	assert_output "registry-bearer"
+}
+
+@test "ghcr_exchange_registry_token: accepts access_token field" {
+	mock_command_multi "curl" '
+		*ghcr.io/token*) printf "%s" "{\"access_token\":\"alt-bearer\"}";;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		source "$LIB_DIR/ghcr/registry.sh"
+		ghcr_exchange_registry_token "test-org" "pkg" "github-token"
+	'
+	assert_success
+	assert_output "alt-bearer"
+}
+
+@test "ghcr_exchange_registry_token: fails when curl fails" {
+	mock_command_multi "curl" '
+		*ghcr.io/token*) exit 22;;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		source "$LIB_DIR/ghcr/registry.sh"
+		ghcr_exchange_registry_token "test-org" "pkg" "github-token"
+	'
+	assert_failure
+}
+
+@test "ghcr_exchange_registry_token: fails when response has no token" {
+	mock_command_multi "curl" '
+		*ghcr.io/token*) printf "%s" "{}";;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		source "$LIB_DIR/ghcr/registry.sh"
+		ghcr_exchange_registry_token "test-org" "pkg" "github-token"
+	'
+	assert_failure
+}
+
+# =============================================================================
+# ghcr_fetch_manifest
+# =============================================================================
+
+@test "ghcr_fetch_manifest: returns 404 marker for missing manifest" {
+	mock_command_multi "curl" '
+		*manifests/sha256:missing*) printf "%s\n404\n" "{}";;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		source "$LIB_DIR/ghcr/registry.sh"
+		ghcr_fetch_manifest "test-org" "pkg" "sha256:missing" "bearer"
+	'
+	assert_success
+	assert_output "404"
+}
+
+@test "ghcr_fetch_manifest: returns manifest JSON on success" {
+	mock_command_multi "curl" '
+		*manifests/sha256:index*) printf "%s\n200\n" "{\"manifests\":[{\"digest\":\"sha256:child\"}]}";;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		source "$LIB_DIR/ghcr/registry.sh"
+		ghcr_fetch_manifest "test-org" "pkg" "sha256:index" "bearer"
+	'
+	assert_success
+	assert_output --partial "sha256:child"
+}
+
+@test "ghcr_fetch_manifest: returns ERROR for server failure" {
+	mock_command_multi "curl" '
+		*manifests/sha256:broken*) printf "%s\n500\n" "internal error";;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		source "$LIB_DIR/ghcr/registry.sh"
+		ghcr_fetch_manifest "test-org" "pkg" "sha256:broken" "bearer"
+	'
+	assert_failure
+	assert_output "ERROR"
+}
+
+@test "ghcr_fetch_manifest: returns ERROR when curl fails" {
+	mock_command_multi "curl" '
+		*manifests/*) exit 1;;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		source "$LIB_DIR/ghcr/registry.sh"
+		ghcr_fetch_manifest "test-org" "pkg" "sha256:down" "bearer"
+	'
+	assert_failure
+	assert_output "ERROR"
+}
+
+@test "ghcr_fetch_manifest: returns ERROR for non-object JSON body" {
+	mock_command_multi "curl" '
+		*manifests/sha256:badjson*) printf "%s\n200\n" "[]";;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		source "$LIB_DIR/ghcr/registry.sh"
+		ghcr_fetch_manifest "test-org" "pkg" "sha256:badjson" "bearer"
+	'
+	assert_failure
+	assert_output "ERROR"
+}
+
+# =============================================================================
+# ghcr_fetch_referrers
+# =============================================================================
+
+@test "ghcr_fetch_referrers: returns empty array on 404" {
+	mock_command_multi "curl" '
+		*referrers/sha256:missing*) printf "%s\n404\n" "{}";;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		source "$LIB_DIR/ghcr/registry.sh"
+		ghcr_fetch_referrers "test-org" "pkg" "sha256:missing" "bearer"
+	'
+	assert_success
+	assert_output "[]"
+}
+
+@test "ghcr_fetch_referrers: returns manifest descriptors on success" {
+	mock_command_multi "curl" '
+		*referrers/sha256:root*) printf "%s\n200\n" "{\"manifests\":[{\"digest\":\"sha256:attest\"}]}";;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		source "$LIB_DIR/ghcr/registry.sh"
+		ghcr_fetch_referrers "test-org" "pkg" "sha256:root" "bearer"
+	'
+	assert_success
+	assert_output --partial "sha256:attest"
+}
+
+@test "ghcr_fetch_referrers: returns ERROR for server failure" {
+	mock_command_multi "curl" '
+		*referrers/sha256:broken*) printf "%s\n503\n" "unavailable";;
+		*) exit 1;;
+	'
+
+	run bash -c '
+		source "$LIB_DIR/ghcr/registry.sh"
+		ghcr_fetch_referrers "test-org" "pkg" "sha256:broken" "bearer"
+	'
+	assert_failure
+	assert_output "ERROR"
+}
+
+# =============================================================================
+# ghcr_collect_referenced_digests
+# =============================================================================
+
+@test "ghcr_collect_referenced_digests: collects root, child, subject, and referrer digests" {
+	mock_command_multi "curl" '
+		*manifests/sha256:root*) printf "%s\n200\n" "{\"manifests\":[{\"digest\":\"sha256:child\"}],\"subject\":{\"digest\":\"sha256:subject\"}}";;
+		*referrers/sha256:root*) printf "%s\n200\n" "{\"manifests\":[{\"digest\":\"sha256:referrer\"}]}";;
+		*) exit 1;;
+	'
+
+	local versions='[
+		{"name":"sha256:root","metadata":{"container":{"tags":["v1.0.0"]}}},
+		{"name":"sha256:untagged","metadata":{"container":{"tags":[]}}}
+	]'
+
+	run bash -c "
+		source \"\$LIB_DIR/ghcr/registry.sh\"
+		ghcr_collect_referenced_digests \
+			'test-org' \
+			'pkg' \
+			'$versions' \
+			'bearer' \
+			referenced_complete \
+			referenced_digests
+		printf 'complete=%s\n' \"\$referenced_complete\"
+		printf '%s\n' \"\$referenced_digests\"
+	"
+	assert_success
+	assert_output --partial "complete=true"
+	assert_output --partial "sha256:root"
+	assert_output --partial "sha256:child"
+	assert_output --partial "sha256:subject"
+	assert_output --partial "sha256:referrer"
+	refute_output --partial "sha256:untagged"
+}
+
+@test "ghcr_collect_referenced_digests: marks collection incomplete on manifest error" {
+	mock_command_multi "curl" '
+		*manifests/sha256:root*) printf "%s\n500\n" "error";;
+		*referrers/sha256:root*) printf "%s\n200\n" "{\"manifests\":[]}";;
+		*) exit 1;;
+	'
+
+	local versions='[{"name":"sha256:root","metadata":{"container":{"tags":["v1.0.0"]}}}]'
+
+	run bash -c "
+		source \"\$LIB_DIR/ghcr/registry.sh\"
+		ghcr_collect_referenced_digests \
+			'test-org' \
+			'pkg' \
+			'$versions' \
+			'bearer' \
+			referenced_complete \
+			referenced_digests
+		printf 'complete=%s\n' \"\$referenced_complete\"
+	"
+	assert_success
+	assert_output --partial "complete=false"
+}
+
+@test "ghcr_collect_referenced_digests: marks collection incomplete on referrers error" {
+	mock_command_multi "curl" '
+		*manifests/sha256:root*) printf "%s\n404\n" "{}";;
+		*referrers/sha256:root*) printf "%s\n500\n" "error";;
+		*) exit 1;;
+	'
+
+	local versions='[{"name":"sha256:root","metadata":{"container":{"tags":["v1.0.0"]}}}]'
+
+	run bash -c "
+		source \"\$LIB_DIR/ghcr/registry.sh\"
+		ghcr_collect_referenced_digests \
+			'test-org' \
+			'pkg' \
+			'$versions' \
+			'bearer' \
+			referenced_complete \
+			referenced_digests
+		printf 'complete=%s\n' \"\$referenced_complete\"
+	"
+	assert_success
+	assert_output --partial "complete=false"
+}
+
+@test "ghcr_collect_referenced_digests: returns empty digests for untagged-only versions" {
+	run bash -c '
+		source "$LIB_DIR/ghcr/registry.sh"
+		ghcr_collect_referenced_digests \
+			"test-org" \
+			"pkg" \
+			"[{\"name\":\"sha256:orphan\",\"metadata\":{\"container\":{\"tags\":[]}}}]" \
+			"bearer" \
+			referenced_complete \
+			referenced_digests
+		printf "complete=%s\n" "$referenced_complete"
+		printf "digests=%s\n" "$referenced_digests"
+	'
+	assert_success
+	assert_output --partial "complete=true"
+	assert_output --partial "digests="
+}
+
+@test "ghcr/registry.sh: second source is a no-op when already loaded" {
+	run bash -c '
+		source "$LIB_DIR/ghcr/registry.sh"
+		source "$LIB_DIR/ghcr/registry.sh"
+		declare -F ghcr_exchange_registry_token >/dev/null && echo loaded
+	'
+	assert_success
+	assert_output "loaded"
+}

--- a/tests/bats/unit/lib/ghcr/test_tags.bats
+++ b/tests/bats/unit/lib/ghcr/test_tags.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/lib/ghcr/tags.sh
+
+load "../../../../helpers/common"
+
+setup() {
+	setup_temp_dir
+	export LIB_DIR
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+# =============================================================================
+# ghcr_is_ephemeral_only_tagged
+# =============================================================================
+
+@test "ghcr_is_ephemeral_only_tagged: accepts numeric ephemeral tags" {
+	run bash -c '
+		source "$LIB_DIR/ghcr/tags.sh"
+		ghcr_is_ephemeral_only_tagged "[\"pr-42\",\"mq-7\",\"dispatch-99\"]"
+	'
+	assert_success
+}
+
+@test "ghcr_is_ephemeral_only_tagged: accepts non-numeric ephemeral suffixes" {
+	run bash -c '
+		source "$LIB_DIR/ghcr/tags.sh"
+		ghcr_is_ephemeral_only_tagged "[\"pr-feature\",\"dispatch-nightly\"]"
+	'
+	assert_success
+}
+
+@test "ghcr_is_ephemeral_only_tagged: rejects mixed ephemeral and permanent tags" {
+	run bash -c '
+		source "$LIB_DIR/ghcr/tags.sh"
+		ghcr_is_ephemeral_only_tagged "[\"cache\",\"pr-3\"]"
+	'
+	assert_failure
+}
+
+@test "ghcr_is_ephemeral_only_tagged: rejects permanent-only tags" {
+	run bash -c '
+		source "$LIB_DIR/ghcr/tags.sh"
+		ghcr_is_ephemeral_only_tagged "[\"latest\",\"v1.0.0\"]"
+	'
+	assert_failure
+}
+
+@test "ghcr_is_ephemeral_only_tagged: rejects empty tag list" {
+	run bash -c '
+		source "$LIB_DIR/ghcr/tags.sh"
+		ghcr_is_ephemeral_only_tagged "[]"
+	'
+	assert_failure
+}
+
+@test "ghcr_is_ephemeral_only_tagged: rejects missing argument as empty list" {
+	run bash -c '
+		source "$LIB_DIR/ghcr/tags.sh"
+		ghcr_is_ephemeral_only_tagged
+	'
+	assert_failure
+}
+
+@test "ghcr/tags.sh: second source is a no-op when already loaded" {
+	run bash -c '
+		source "$LIB_DIR/ghcr/tags.sh"
+		source "$LIB_DIR/ghcr/tags.sh"
+		ghcr_is_ephemeral_only_tagged "[\"pr-1\"]"
+	'
+	assert_success
+}

--- a/tests/bats/unit/lib/test_ghcr.bats
+++ b/tests/bats/unit/lib/test_ghcr.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/lib/ghcr.sh aggregator
+
+load "../../../helpers/common"
+
+setup() {
+	setup_temp_dir
+	export LIB_DIR
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "ghcr.sh: loads registry helpers" {
+	run bash -c 'source "$LIB_DIR/ghcr.sh" && declare -F ghcr_collect_referenced_digests >/dev/null && echo loaded'
+	assert_success
+	assert_output "loaded"
+}
+
+@test "ghcr.sh: loads tag helpers" {
+	run bash -c 'source "$LIB_DIR/ghcr.sh" && declare -F ghcr_is_ephemeral_only_tagged >/dev/null && echo loaded'
+	assert_success
+	assert_output "loaded"
+}
+
+@test "ghcr.sh: second source is a no-op when already loaded" {
+	run bash -c '
+		source "$LIB_DIR/ghcr.sh"
+		source "$LIB_DIR/ghcr.sh"
+		ghcr_is_ephemeral_only_tagged "[\"pr-1\"]"
+	'
+	assert_success
+}


### PR DESCRIPTION
## Summary

Close lgtm-ci adoption gaps blocking py-lintro thin reusable callers for GHCR
cleanup, vuln suppression checks, and secure-checkout composites.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Changes Made

- Fix `SCRIPTS_DIR` resolution across 33 composite actions using
  `GITHUB_ACTION_PATH` (replaces broken slash-stripping pattern)
- Extend `ghcr-cleanup.sh` with referenced-digest protection, ephemeral
  build-cache tag pruning, and `keep-latest` default `0`
- Align `check-vuln-suppressions.sh` with py-lintro: remove stale + expired
  suppressions, add cleanup PR labels, expose `cleanup-pr-labels` input
- Add BATS coverage for SCRIPTS_DIR guard, GHCR parity, and vuln suppression paths
- Update reusable workflow docs, workflow contract, and changelog

## Closes

- Closes #363

## Testing

- [x] `make test-bats` (2231 tests)
- [x] `uv run lintro chk` (zero issues)
- [x] Targeted integration tests for GHCR cleanup, vuln suppression, composite refs

## Quality Checks

- [x] Shell scripts pass `shellcheck` (via lintro)
- [x] YAML files pass `yamllint` (via lintro)
- [x] Python code passes `ruff` and `black` (via lintro)

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

`reusable-ghcr-cleanup.yml` `keep-latest` default changes from `5` to `0`.
Callers relying on the old default must pass `keep-latest: 5` explicitly.

## Related Issues

Relates to lgtm-hq/py-lintro#979, lgtm-hq/py-lintro#980, lgtm-hq/py-lintro#984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional referenced-digest protection and configurable build-cache pruning to GHCR cleanup.
  * Extended the vulnerability suppression reusable workflow with a `cleanup-pr-labels` input.
* **Changed**
  * Updated GHCR cleanup behavior: new defaults, improved eligibility selection, and tag pruning logic.
  * Vulnerability suppression cleanup now handles both stale and expired entries and fails when expired items are removed.
* **Bug Fixes**
  * Fixed composite-action `SCRIPTS_DIR` resolution for more consistent runtime environment setup.
* **Documentation**
  * Updated workflow and contract docs, plus added GHCR cleanup documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR closes adoption gaps blocking py-lintro reusable workflow migration by: fixing `SCRIPTS_DIR` resolution in 33 composite actions (replacing a broken slash-strip pattern with `cd && pwd`), extending `ghcr-cleanup.sh` with referenced-digest protection and ephemeral build-cache tag pruning, aligning `check-vuln-suppressions.sh` to handle expired suppressions alongside stale ones, and adding significant BATS coverage.

- **SCRIPTS_DIR fix**: All 33 composite actions now use `cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd` for reliable canonical path resolution.
- **GHCR cleanup expansion**: New `PROTECT_REFERENCED` flag collects child/referrer digests before pruning; new `PRUNE_BUILDCACHE` path removes aged `pr-*`/`mq-*`/`dispatch-*` ephemeral tags; `KEEP_LATEST` default changes from 5 → 0 (breaking change, documented).
- **Vuln suppression**: Expired suppressions are now folded into `REMOVE_IDS`, the `cleanup-pr-labels` input is exposed, and label splitting is fixed to pass multiple `--label` flags correctly.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge with attention: registry auth failure silently disables all cleanup, and expired suppressions with no diff exit 0 — both open items from prior review threads.

The referenced-digest protection, build-cache pruning, label-splitting fixes, timestamp preference, URL encoding, and empty-timestamp guard all address regressions from earlier rounds. Two open operational concerns (registry auth failure disabling all cleanup; expired-suppression no-diff exits 0) are carried from prior review threads.

scripts/ci/actions/ghcr-cleanup.sh (registry auth failure disables all cleanup including build-cache pruning), scripts/ci/security/check-vuln-suppressions.sh (expired suppressions with no remover diff exits 0)

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/ci/actions/ghcr-cleanup.sh | Major expansion adding referenced-digest protection, build-cache pruning, and URL-encoded package names; timestamp logic now prefers updated_at; several edge cases addressed from previous review rounds. |
| scripts/ci/security/check-vuln-suppressions.sh | Expired suppressions now fold into REMOVE_IDS and trigger a cleanup PR + exit 1; label splitting fixed; minor: hardcoded "stale" in PR title/commit message even for expired-only removals. |
| scripts/ci/lib/ghcr/registry.sh | New library: token exchange, manifest/referrer fetches, and referenced-digest collection; root tagged digest now protected; child-manifest referrers not recursively walked (noted in prior review). |
| scripts/ci/lib/ghcr/tags.sh | New library: ephemeral tag detection via regex; pattern now covers alphanumeric/underscore/dot/hyphen suffixes. |
| .github/workflows/reusable-ghcr-cleanup.yml | Added protect-referenced, prune-buildcache, and build-cache-pr-age-days inputs; keep-latest default changed from 5→0; egress preset may need updating for new registry calls. |
| .github/workflows/reusable-vuln-suppression-check.yml | Added cleanup-pr-labels input with correct default; label string passed to script which handles splitting correctly. |
| tests/bats/integration/test_vuln_suppressions.bats | New comprehensive BATS test file covering stale/expired/active classification paths and PR creation logic. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ghcr-cleanup.sh starts] --> B[Fetch all package versions via REST API]
    B --> C{PROTECT_REFERENCED=true\nand total_count > 0?}
    C -->|Yes| D[Exchange GHCR registry token]
    D -->|auth fails| E[Log warning + exit 0 ⚠️\nAll cleanup skipped]
    D -->|auth ok| F[ghcr_collect_referenced_digests\nroot + children + subjects + referrers]
    F -->|collection incomplete| G[Log warning + exit 0 ⚠️\nAll cleanup skipped]
    F -->|complete| H[Build refs_json protection set]
    C -->|No| H
    H --> I[Filter untagged versions\nupdated_at // created_at < cutoff\nand not in refs_json]
    I --> J[Apply keep-latest threshold\nskip first KEEP_LATEST entries]
    J --> K{PRUNE_BUILDCACHE=true?}
    K -->|Yes| L[Filter tagged versions\nby build-cache cutoff\nephemeral pattern check]
    K -->|No| M{delete_count=0\nand buildcache=0?}
    L --> M
    M -->|Yes| N[Exit 0 - nothing to clean]
    M -->|No| O[Delete untagged versions loop]
    O --> P[Delete build-cache versions loop]
    P --> Q[Emit GitHub summary]
    Q --> R{failed > 0?}
    R -->|Yes| S[Exit 1]
    R -->|No| T[Exit 0]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[ghcr-cleanup.sh starts] --> B[Fetch all package versions via REST API]
    B --> C{PROTECT_REFERENCED=true\nand total_count > 0?}
    C -->|Yes| D[Exchange GHCR registry token]
    D -->|auth fails| E[Log warning + exit 0 ⚠️\nAll cleanup skipped]
    D -->|auth ok| F[ghcr_collect_referenced_digests\nroot + children + subjects + referrers]
    F -->|collection incomplete| G[Log warning + exit 0 ⚠️\nAll cleanup skipped]
    F -->|complete| H[Build refs_json protection set]
    C -->|No| H
    H --> I[Filter untagged versions\nupdated_at // created_at < cutoff\nand not in refs_json]
    I --> J[Apply keep-latest threshold\nskip first KEEP_LATEST entries]
    J --> K{PRUNE_BUILDCACHE=true?}
    K -->|Yes| L[Filter tagged versions\nby build-cache cutoff\nephemeral pattern check]
    K -->|No| M{delete_count=0\nand buildcache=0?}
    L --> M
    M -->|Yes| N[Exit 0 - nothing to clean]
    M -->|No| O[Delete untagged versions loop]
    O --> P[Delete build-cache versions loop]
    P --> Q[Emit GitHub summary]
    Q --> R{failed > 0?}
    R -->|Yes| S[Exit 1]
    R -->|No| T[Exit 0]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (8)</h3></summary>

1. `.github/workflows/reusable-ghcr-cleanup.yml`, line 69-76 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/10a5151b0eca7661ea85ed5a91765df3178939fa/.github/workflows/reusable-ghcr-cleanup.yml#L69-L76)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Allow registry egress**

   The workflow enables referenced-digest protection by default, and that path calls `https://ghcr.io/token` plus GHCR `/v2/...` registry endpoints. The default `github-tooling` preset does not include `ghcr.io` or the container registry hosts, while `egress-policy` defaults to `block`. With default inputs, harden-runner can block the new registry calls and the cleanup exits as skipped instead of pruning anything.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2069-76%0A%0AComment%3A%0A**Allow%20registry%20egress**%0A%0AThe%20workflow%20enables%20referenced-digest%20protection%20by%20default%2C%20and%20that%20path%20calls%20%60https%3A%2F%2Fghcr.io%2Ftoken%60%20plus%20GHCR%20%60%2Fv2%2F...%60%20registry%20endpoints.%20The%20default%20%60github-tooling%60%20preset%20does%20not%20include%20%60ghcr.io%60%20or%20the%20container%20registry%20hosts%2C%20while%20%60egress-policy%60%20defaults%20to%20%60block%60.%20With%20default%20inputs%2C%20harden-runner%20can%20block%20the%20new%20registry%20calls%20and%20the%20cleanup%20exits%20as%20skipped%20instead%20of%20pruning%20anything.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2069-76%0A%0AComment%3A%0A**Allow%20registry%20egress**%0A%0AThe%20workflow%20enables%20referenced-digest%20protection%20by%20default%2C%20and%20that%20path%20calls%20%60https%3A%2F%2Fghcr.io%2Ftoken%60%20plus%20GHCR%20%60%2Fv2%2F...%60%20registry%20endpoints.%20The%20default%20%60github-tooling%60%20preset%20does%20not%20include%20%60ghcr.io%60%20or%20the%20container%20registry%20hosts%2C%20while%20%60egress-policy%60%20defaults%20to%20%60block%60.%20With%20default%20inputs%2C%20harden-runner%20can%20block%20the%20new%20registry%20calls%20and%20the%20cleanup%20exits%20as%20skipped%20instead%20of%20pruning%20anything.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F363-close-adoption-gaps-blocking-py-lintro%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F363-close-adoption-gaps-blocking-py-lintro%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2069-76%0A%0AComment%3A%0A**Allow%20registry%20egress**%0A%0AThe%20workflow%20enables%20referenced-digest%20protection%20by%20default%2C%20and%20that%20path%20calls%20%60https%3A%2F%2Fghcr.io%2Ftoken%60%20plus%20GHCR%20%60%2Fv2%2F...%60%20registry%20endpoints.%20The%20default%20%60github-tooling%60%20preset%20does%20not%20include%20%60ghcr.io%60%20or%20the%20container%20registry%20hosts%2C%20while%20%60egress-policy%60%20defaults%20to%20%60block%60.%20With%20default%20inputs%2C%20harden-runner%20can%20block%20the%20new%20registry%20calls%20and%20the%20cleanup%20exits%20as%20skipped%20instead%20of%20pruning%20anything.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

2. `.github/workflows/reusable-ghcr-cleanup.yml`, line 69-76 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/aeffe4ff7806b262425b9281616901afd242ee4b/.github/workflows/reusable-ghcr-cleanup.yml#L69-L76)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Allow GHCR egress**

   The cleanup job now calls `ghcr.io` directly to exchange a registry token and fetch manifests/referrers, but the default `github-tooling` preset does not include `ghcr.io:443` or the container registry hosts. With the default `egress-policy: block` and `protect-referenced: true`, those new registry calls can be blocked before cleanup runs, causing the cleanup step to report registry auth failure and exit successfully without pruning anything.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2069-76%0A%0AComment%3A%0A**Allow%20GHCR%20egress**%0A%0AThe%20cleanup%20job%20now%20calls%20%60ghcr.io%60%20directly%20to%20exchange%20a%20registry%20token%20and%20fetch%20manifests%2Freferrers%2C%20but%20the%20default%20%60github-tooling%60%20preset%20does%20not%20include%20%60ghcr.io%3A443%60%20or%20the%20container%20registry%20hosts.%20With%20the%20default%20%60egress-policy%3A%20block%60%20and%20%60protect-referenced%3A%20true%60%2C%20those%20new%20registry%20calls%20can%20be%20blocked%20before%20cleanup%20runs%2C%20causing%20the%20cleanup%20step%20to%20report%20registry%20auth%20failure%20and%20exit%20successfully%20without%20pruning%20anything.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2069-76%0A%0AComment%3A%0A**Allow%20GHCR%20egress**%0A%0AThe%20cleanup%20job%20now%20calls%20%60ghcr.io%60%20directly%20to%20exchange%20a%20registry%20token%20and%20fetch%20manifests%2Freferrers%2C%20but%20the%20default%20%60github-tooling%60%20preset%20does%20not%20include%20%60ghcr.io%3A443%60%20or%20the%20container%20registry%20hosts.%20With%20the%20default%20%60egress-policy%3A%20block%60%20and%20%60protect-referenced%3A%20true%60%2C%20those%20new%20registry%20calls%20can%20be%20blocked%20before%20cleanup%20runs%2C%20causing%20the%20cleanup%20step%20to%20report%20registry%20auth%20failure%20and%20exit%20successfully%20without%20pruning%20anything.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F363-close-adoption-gaps-blocking-py-lintro%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F363-close-adoption-gaps-blocking-py-lintro%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2069-76%0A%0AComment%3A%0A**Allow%20GHCR%20egress**%0A%0AThe%20cleanup%20job%20now%20calls%20%60ghcr.io%60%20directly%20to%20exchange%20a%20registry%20token%20and%20fetch%20manifests%2Freferrers%2C%20but%20the%20default%20%60github-tooling%60%20preset%20does%20not%20include%20%60ghcr.io%3A443%60%20or%20the%20container%20registry%20hosts.%20With%20the%20default%20%60egress-policy%3A%20block%60%20and%20%60protect-referenced%3A%20true%60%2C%20those%20new%20registry%20calls%20can%20be%20blocked%20before%20cleanup%20runs%2C%20causing%20the%20cleanup%20step%20to%20report%20registry%20auth%20failure%20and%20exit%20successfully%20without%20pruning%20anything.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Ephemeral build-cache tags are not pruned when referenced-digest protection is enabled**

   - **Bug**
     - With successful registry collection and default `PRUNE_BUILDCACHE=true`, versions tagged only with aged ephemeral build-cache tags (`pr-890`, `mq-abc`, `dispatch-nightly`) should be deleted while `cache` and mixed `cache`+`pr-3` are preserved. The head run instead reported `Eligible build-cache | 0 |` and made no delete calls for version ids 10, 11, or 12. This contradicts the reusable workflow/script contract that aged `pr-*`/`mq-*`/`dispatch-*` build-cache tags are pruned by default.
   - **Cause**
     - In `scripts/ci/actions/ghcr-cleanup.sh`, the build-cache candidate filter excludes any digest present in `refs_json` (`select(.name as $n | ($refs | index($n) | not))`). `ghcr_collect_referenced_digests` adds every tagged digest root to the protection set, so all tagged build-cache versions are considered referenced and removed from build-cache pruning before `ghcr_is_ephemeral_only_tagged` can select them.
   - **Fix**
     - Do not apply referenced-digest root protection to ephemeral build-cache pruning, or compute a separate protection set for build-cache that protects child/referrer digests without excluding the ephemeral tagged root digest itself. Then run the ephemeral-only tag predicate against aged tagged versions and delete those whose only tags match `pr-*`, `mq-*`, or `dispatch-*`.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

4. `.github/workflows/reusable-ghcr-cleanup.yml`, line 76 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/1a2941136889ecb02558aecb03e0cdda4e5febb2/.github/workflows/reusable-ghcr-cleanup.yml#L76)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Allow registry egress**

   The workflow now defaults `PROTECT_REFERENCED` to true, and `ghcr-cleanup.sh` calls the GHCR registry token endpoint before pruning. With the current default `egress-policy: block` and `egress-preset: github-tooling`, the resolved allowlist does not include `ghcr.io`, so the token exchange is blocked. For a default caller with any package versions, the script takes the registry-auth-failed path and exits 0 as skipped before deleting untagged versions or build-cache tags. Use a preset that includes the GHCR registry endpoints, such as the docker preset, or add those endpoints to this workflow's default allowlist.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2076%0A%0AComment%3A%0A**Allow%20registry%20egress**%0A%0AThe%20workflow%20now%20defaults%20%60PROTECT_REFERENCED%60%20to%20true%2C%20and%20%60ghcr-cleanup.sh%60%20calls%20the%20GHCR%20registry%20token%20endpoint%20before%20pruning.%20With%20the%20current%20default%20%60egress-policy%3A%20block%60%20and%20%60egress-preset%3A%20github-tooling%60%2C%20the%20resolved%20allowlist%20does%20not%20include%20%60ghcr.io%60%2C%20so%20the%20token%20exchange%20is%20blocked.%20For%20a%20default%20caller%20with%20any%20package%20versions%2C%20the%20script%20takes%20the%20registry-auth-failed%20path%20and%20exits%200%20as%20skipped%20before%20deleting%20untagged%20versions%20or%20build-cache%20tags.%20Use%20a%20preset%20that%20includes%20the%20GHCR%20registry%20endpoints%2C%20such%20as%20the%20docker%20preset%2C%20or%20add%20those%20endpoints%20to%20this%20workflow's%20default%20allowlist.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2076%0A%0AComment%3A%0A**Allow%20registry%20egress**%0A%0AThe%20workflow%20now%20defaults%20%60PROTECT_REFERENCED%60%20to%20true%2C%20and%20%60ghcr-cleanup.sh%60%20calls%20the%20GHCR%20registry%20token%20endpoint%20before%20pruning.%20With%20the%20current%20default%20%60egress-policy%3A%20block%60%20and%20%60egress-preset%3A%20github-tooling%60%2C%20the%20resolved%20allowlist%20does%20not%20include%20%60ghcr.io%60%2C%20so%20the%20token%20exchange%20is%20blocked.%20For%20a%20default%20caller%20with%20any%20package%20versions%2C%20the%20script%20takes%20the%20registry-auth-failed%20path%20and%20exits%200%20as%20skipped%20before%20deleting%20untagged%20versions%20or%20build-cache%20tags.%20Use%20a%20preset%20that%20includes%20the%20GHCR%20registry%20endpoints%2C%20such%20as%20the%20docker%20preset%2C%20or%20add%20those%20endpoints%20to%20this%20workflow's%20default%20allowlist.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F363-close-adoption-gaps-blocking-py-lintro%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F363-close-adoption-gaps-blocking-py-lintro%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2076%0A%0AComment%3A%0A**Allow%20registry%20egress**%0A%0AThe%20workflow%20now%20defaults%20%60PROTECT_REFERENCED%60%20to%20true%2C%20and%20%60ghcr-cleanup.sh%60%20calls%20the%20GHCR%20registry%20token%20endpoint%20before%20pruning.%20With%20the%20current%20default%20%60egress-policy%3A%20block%60%20and%20%60egress-preset%3A%20github-tooling%60%2C%20the%20resolved%20allowlist%20does%20not%20include%20%60ghcr.io%60%2C%20so%20the%20token%20exchange%20is%20blocked.%20For%20a%20default%20caller%20with%20any%20package%20versions%2C%20the%20script%20takes%20the%20registry-auth-failed%20path%20and%20exits%200%20as%20skipped%20before%20deleting%20untagged%20versions%20or%20build-cache%20tags.%20Use%20a%20preset%20that%20includes%20the%20GHCR%20registry%20endpoints%2C%20such%20as%20the%20docker%20preset%2C%20or%20add%20those%20endpoints%20to%20this%20workflow's%20default%20allowlist.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

5. `.github/workflows/reusable-ghcr-cleanup.yml`, line 76 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/e6b16094028b41b555faf124d8a5e9f30d5185ca/.github/workflows/reusable-ghcr-cleanup.yml#L76)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Allow GHCR egress**

   The workflow now enables referenced-digest protection by default, and that path calls the GHCR registry API directly. The default `github-tooling` egress preset does not allow `ghcr.io:443`, so a default run with `egress-policy: block` can block the registry token request. `ghcr-cleanup.sh` then exits successfully with `registry auth failed` before pruning any untagged versions or build-cache tags.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2076%0A%0AComment%3A%0A**Allow%20GHCR%20egress**%0A%0AThe%20workflow%20now%20enables%20referenced-digest%20protection%20by%20default%2C%20and%20that%20path%20calls%20the%20GHCR%20registry%20API%20directly.%20The%20default%20%60github-tooling%60%20egress%20preset%20does%20not%20allow%20%60ghcr.io%3A443%60%2C%20so%20a%20default%20run%20with%20%60egress-policy%3A%20block%60%20can%20block%20the%20registry%20token%20request.%20%60ghcr-cleanup.sh%60%20then%20exits%20successfully%20with%20%60registry%20auth%20failed%60%20before%20pruning%20any%20untagged%20versions%20or%20build-cache%20tags.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2076%0A%0AComment%3A%0A**Allow%20GHCR%20egress**%0A%0AThe%20workflow%20now%20enables%20referenced-digest%20protection%20by%20default%2C%20and%20that%20path%20calls%20the%20GHCR%20registry%20API%20directly.%20The%20default%20%60github-tooling%60%20egress%20preset%20does%20not%20allow%20%60ghcr.io%3A443%60%2C%20so%20a%20default%20run%20with%20%60egress-policy%3A%20block%60%20can%20block%20the%20registry%20token%20request.%20%60ghcr-cleanup.sh%60%20then%20exits%20successfully%20with%20%60registry%20auth%20failed%60%20before%20pruning%20any%20untagged%20versions%20or%20build-cache%20tags.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F363-close-adoption-gaps-blocking-py-lintro%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F363-close-adoption-gaps-blocking-py-lintro%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2076%0A%0AComment%3A%0A**Allow%20GHCR%20egress**%0A%0AThe%20workflow%20now%20enables%20referenced-digest%20protection%20by%20default%2C%20and%20that%20path%20calls%20the%20GHCR%20registry%20API%20directly.%20The%20default%20%60github-tooling%60%20egress%20preset%20does%20not%20allow%20%60ghcr.io%3A443%60%2C%20so%20a%20default%20run%20with%20%60egress-policy%3A%20block%60%20can%20block%20the%20registry%20token%20request.%20%60ghcr-cleanup.sh%60%20then%20exits%20successfully%20with%20%60registry%20auth%20failed%60%20before%20pruning%20any%20untagged%20versions%20or%20build-cache%20tags.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

6. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Default reference protection prevents ephemeral build-cache pruning**

   - **Bug**
     - With default `PROTECT_REFERENCED=true` and successful registry collection, every tagged version digest is added to `referenced_digests` before build-cache candidates are filtered. The build-cache pruning query then excludes any candidate whose `.name` appears in refs, so aged versions tagged only `pr-*`, `mq-*`, or `dispatch-*` are retained instead of being pruned. The executed head artifact shows four tagged versions, all collected for protection, zero build-cache deletions, and `nothing to delete`.
   - **Cause**
     - `ghcr_collect_referenced_digests` intentionally adds each tagged root digest to the protected set, and `buildcache_candidates` filters tagged versions with `select(.name as $n | ($refs | index($n) | not))` before `ghcr_is_ephemeral_only_tagged` can select ephemeral-only tags. This makes default successful reference collection shadow the new build-cache prune behavior.
   - **Fix**
     - Do not apply root tagged digest protection to ephemeral-only build-cache candidates, or compute build-cache pruning before/root-exempt from the referenced-digest filter while still protecting child/referrer digests and mixed/non-ephemeral tags. Add an integration test covering default `PROTECT_REFERENCED=true` plus successful registry collection for pr-/mq-/dispatch-only tags.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

7. `.github/workflows/reusable-ghcr-cleanup.yml`, line 69-76 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/20cb6cd72b4b69d0074793d9602174be0d31a1e3/.github/workflows/reusable-ghcr-cleanup.yml#L69-L76)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Allow GHCR egress**

   The workflow now defaults `protect-referenced` to true, and the cleanup script calls the GHCR registry API with `curl` to exchange a registry token and fetch manifests before pruning. However, this workflow still defaults to `egress-preset: github-tooling`, which allows GitHub API and checkout hosts but not the GHCR registry hosts such as `ghcr.io:443` or `pkg-containers.githubusercontent.com:443`. With the default `egress-policy: block`, those registry calls can be blocked; `ghcr-cleanup.sh` then takes the registry-auth-failed path, logs that cleanup was skipped, and exits 0, leaving untagged versions and build-cache tags unpruned. Please include the GHCR registry hosts in the default allowlist or default this workflow to a preset that permits the new registry calls.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2069-76%0A%0AComment%3A%0A**Allow%20GHCR%20egress**%0A%0AThe%20workflow%20now%20defaults%20%60protect-referenced%60%20to%20true%2C%20and%20the%20cleanup%20script%20calls%20the%20GHCR%20registry%20API%20with%20%60curl%60%20to%20exchange%20a%20registry%20token%20and%20fetch%20manifests%20before%20pruning.%20However%2C%20this%20workflow%20still%20defaults%20to%20%60egress-preset%3A%20github-tooling%60%2C%20which%20allows%20GitHub%20API%20and%20checkout%20hosts%20but%20not%20the%20GHCR%20registry%20hosts%20such%20as%20%60ghcr.io%3A443%60%20or%20%60pkg-containers.githubusercontent.com%3A443%60.%20With%20the%20default%20%60egress-policy%3A%20block%60%2C%20those%20registry%20calls%20can%20be%20blocked%3B%20%60ghcr-cleanup.sh%60%20then%20takes%20the%20registry-auth-failed%20path%2C%20logs%20that%20cleanup%20was%20skipped%2C%20and%20exits%200%2C%20leaving%20untagged%20versions%20and%20build-cache%20tags%20unpruned.%20Please%20include%20the%20GHCR%20registry%20hosts%20in%20the%20default%20allowlist%20or%20default%20this%20workflow%20to%20a%20preset%20that%20permits%20the%20new%20registry%20calls.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2069-76%0A%0AComment%3A%0A**Allow%20GHCR%20egress**%0A%0AThe%20workflow%20now%20defaults%20%60protect-referenced%60%20to%20true%2C%20and%20the%20cleanup%20script%20calls%20the%20GHCR%20registry%20API%20with%20%60curl%60%20to%20exchange%20a%20registry%20token%20and%20fetch%20manifests%20before%20pruning.%20However%2C%20this%20workflow%20still%20defaults%20to%20%60egress-preset%3A%20github-tooling%60%2C%20which%20allows%20GitHub%20API%20and%20checkout%20hosts%20but%20not%20the%20GHCR%20registry%20hosts%20such%20as%20%60ghcr.io%3A443%60%20or%20%60pkg-containers.githubusercontent.com%3A443%60.%20With%20the%20default%20%60egress-policy%3A%20block%60%2C%20those%20registry%20calls%20can%20be%20blocked%3B%20%60ghcr-cleanup.sh%60%20then%20takes%20the%20registry-auth-failed%20path%2C%20logs%20that%20cleanup%20was%20skipped%2C%20and%20exits%200%2C%20leaving%20untagged%20versions%20and%20build-cache%20tags%20unpruned.%20Please%20include%20the%20GHCR%20registry%20hosts%20in%20the%20default%20allowlist%20or%20default%20this%20workflow%20to%20a%20preset%20that%20permits%20the%20new%20registry%20calls.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F363-close-adoption-gaps-blocking-py-lintro%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F363-close-adoption-gaps-blocking-py-lintro%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2069-76%0A%0AComment%3A%0A**Allow%20GHCR%20egress**%0A%0AThe%20workflow%20now%20defaults%20%60protect-referenced%60%20to%20true%2C%20and%20the%20cleanup%20script%20calls%20the%20GHCR%20registry%20API%20with%20%60curl%60%20to%20exchange%20a%20registry%20token%20and%20fetch%20manifests%20before%20pruning.%20However%2C%20this%20workflow%20still%20defaults%20to%20%60egress-preset%3A%20github-tooling%60%2C%20which%20allows%20GitHub%20API%20and%20checkout%20hosts%20but%20not%20the%20GHCR%20registry%20hosts%20such%20as%20%60ghcr.io%3A443%60%20or%20%60pkg-containers.githubusercontent.com%3A443%60.%20With%20the%20default%20%60egress-policy%3A%20block%60%2C%20those%20registry%20calls%20can%20be%20blocked%3B%20%60ghcr-cleanup.sh%60%20then%20takes%20the%20registry-auth-failed%20path%2C%20logs%20that%20cleanup%20was%20skipped%2C%20and%20exits%200%2C%20leaving%20untagged%20versions%20and%20build-cache%20tags%20unpruned.%20Please%20include%20the%20GHCR%20registry%20hosts%20in%20the%20default%20allowlist%20or%20default%20this%20workflow%20to%20a%20preset%20that%20permits%20the%20new%20registry%20calls.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>

8. `.github/workflows/reusable-ghcr-cleanup.yml`, line 76 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/c21edb52d335f6006038465a86126cadbb0bf308/.github/workflows/reusable-ghcr-cleanup.yml#L76)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Allow GHCR egress**

   The workflow now defaults `protect-referenced` to true, and `ghcr-cleanup.sh` calls `https://ghcr.io/token` and GHCR registry v2 endpoints before pruning. The default `github-tooling` egress preset does not allow `ghcr.io:443`, so block-mode harden-runner can block the token exchange. In that default path the script exits as skipped before deleting untagged versions or build-cache tags, so scheduled cleanup callers can stop cleaning GHCR unless they override the egress inputs.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2076%0A%0AComment%3A%0A**Allow%20GHCR%20egress**%0A%0AThe%20workflow%20now%20defaults%20%60protect-referenced%60%20to%20true%2C%20and%20%60ghcr-cleanup.sh%60%20calls%20%60https%3A%2F%2Fghcr.io%2Ftoken%60%20and%20GHCR%20registry%20v2%20endpoints%20before%20pruning.%20The%20default%20%60github-tooling%60%20egress%20preset%20does%20not%20allow%20%60ghcr.io%3A443%60%2C%20so%20block-mode%20harden-runner%20can%20block%20the%20token%20exchange.%20In%20that%20default%20path%20the%20script%20exits%20as%20skipped%20before%20deleting%20untagged%20versions%20or%20build-cache%20tags%2C%20so%20scheduled%20cleanup%20callers%20can%20stop%20cleaning%20GHCR%20unless%20they%20override%20the%20egress%20inputs.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2076%0A%0AComment%3A%0A**Allow%20GHCR%20egress**%0A%0AThe%20workflow%20now%20defaults%20%60protect-referenced%60%20to%20true%2C%20and%20%60ghcr-cleanup.sh%60%20calls%20%60https%3A%2F%2Fghcr.io%2Ftoken%60%20and%20GHCR%20registry%20v2%20endpoints%20before%20pruning.%20The%20default%20%60github-tooling%60%20egress%20preset%20does%20not%20allow%20%60ghcr.io%3A443%60%2C%20so%20block-mode%20harden-runner%20can%20block%20the%20token%20exchange.%20In%20that%20default%20path%20the%20script%20exits%20as%20skipped%20before%20deleting%20untagged%20versions%20or%20build-cache%20tags%2C%20so%20scheduled%20cleanup%20callers%20can%20stop%20cleaning%20GHCR%20unless%20they%20override%20the%20egress%20inputs.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F363-close-adoption-gaps-blocking-py-lintro%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F363-close-adoption-gaps-blocking-py-lintro%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-ghcr-cleanup.yml%0ALine%3A%2076%0A%0AComment%3A%0A**Allow%20GHCR%20egress**%0A%0AThe%20workflow%20now%20defaults%20%60protect-referenced%60%20to%20true%2C%20and%20%60ghcr-cleanup.sh%60%20calls%20%60https%3A%2F%2Fghcr.io%2Ftoken%60%20and%20GHCR%20registry%20v2%20endpoints%20before%20pruning.%20The%20default%20%60github-tooling%60%20egress%20preset%20does%20not%20allow%20%60ghcr.io%3A443%60%2C%20so%20block-mode%20harden-runner%20can%20block%20the%20token%20exchange.%20In%20that%20default%20path%20the%20script%20exits%20as%20skipped%20before%20deleting%20untagged%20versions%20or%20build-cache%20tags%2C%20so%20scheduled%20cleanup%20callers%20can%20stop%20cleaning%20GHCR%20unless%20they%20override%20the%20egress%20inputs.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fci%2Fsecurity%2Fcheck-vuln-suppressions.sh%3A166-174%0AHardcoded%20%22stale%22%20in%20PR%20title%20and%20commit%20message%20when%20removing%20expired-only%20suppressions.%20When%20%60STALE_IDS%60%20is%20empty%20and%20only%20%60EXPIRED_IDS%60%20drove%20the%20cleanup%2C%20both%20the%20git%20commit%20and%20the%20auto-created%20PR%20will%20say%20%22remove%20stale%20vulnerability%20suppressions%22%20%E2%80%94%20which%20misrepresents%20the%20change%20and%20could%20mislead%20reviewers%20of%20the%20cleanup%20PR%20into%20thinking%20no%20live%20vulnerability%20existed%20at%20expiry%20time.%0A%0A%60%60%60suggestion%0A%09_commit_subject%3D%22chore%28security%29%3A%20remove%20stale%20vulnerability%20suppressions%22%0A%09if%20%5B%5B%20%24%7B%23STALE_IDS%5B%40%5D%7D%20-eq%200%20%26%26%20%24%7B%23EXPIRED_IDS%5B%40%5D%7D%20-gt%200%20%5D%5D%3B%20then%0A%09%09_commit_subject%3D%22chore%28security%29%3A%20remove%20expired%20vulnerability%20suppressions%22%0A%09elif%20%5B%5B%20%24%7B%23STALE_IDS%5B%40%5D%7D%20-gt%200%20%26%26%20%24%7B%23EXPIRED_IDS%5B%40%5D%7D%20-gt%200%20%5D%5D%3B%20then%0A%09%09_commit_subject%3D%22chore%28security%29%3A%20remove%20stale%20and%20expired%20vulnerability%20suppressions%22%0A%09fi%0A%09git%20commit%20-m%20%22%24%28%0A%09%09cat%20%3C%3CEOF%0A%24%7B_commit_subject%7D%0A%0AThe%20following%20suppressions%20are%20no%20longer%20needed%3A%0A%24%7BREMOVED_LIST%7D%0ADetected%20by%20the%20weekly%20vuln-suppression-check%20workflow.%0AEOF%0A%09%29%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Fci%2Fsecurity%2Fcheck-vuln-suppressions.sh%3A214-223%0APR%20title%20mirrors%20the%20same%20hardcoded%20%22stale%22%20text.%20Should%20be%20aligned%20with%20the%20commit%20subject%20fix%20so%20the%20cleanup%20PR%20title%20accurately%20reflects%20which%20suppression%20type%20triggered%20the%20run.%0A%0A%60%60%60suggestion%0A%09if%20%28%28%24%7B%23gh_pr_label_args%5B%40%5D%7D%20%3E%200%29%29%3B%20then%0A%09%09gh%20pr%20create%20%5C%0A%09%09%09--title%20%22%24%7B_commit_subject%7D%22%20%5C%0A%09%09%09%22%24%7Bgh_pr_label_args%5B%40%5D%7D%22%20%5C%0A%09%09%09--body%20%22%24PR_BODY%22%0A%09else%0A%09%09gh%20pr%20create%20%5C%0A%09%09%09--title%20%22%24%7B_commit_subject%7D%22%20%5C%0A%09%09%09--body%20%22%24PR_BODY%22%0A%09fi%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Ascripts%2Fci%2Factions%2Fghcr-cleanup.sh%3A61-68%0A%60ghcr_delete_version%60%20has%20its%20own%20%60DRY_RUN%60%20early-return%2C%20but%20both%20callers%20already%20%60continue%60%20before%20the%20function%20is%20ever%20reached%20when%20%60DRY_RUN%3Dtrue%60.%20The%20inner%20check%20is%20dead%20code.%20If%20a%20future%20caller%20invokes%20%60ghcr_delete_version%60%20directly%20without%20the%20outer%20guard%2C%20it%20silently%20returns%200%20without%20logging%20anything.%0A%0A%60%60%60suggestion%0Aghcr_delete_version%28%29%20%7B%0A%09local%20version_id%3D%22%241%22%0A%09local%20err%3D%22%22%0A%60%60%60%0A%0A&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fci%2Fsecurity%2Fcheck-vuln-suppressions.sh%3A166-174%0AHardcoded%20%22stale%22%20in%20PR%20title%20and%20commit%20message%20when%20removing%20expired-only%20suppressions.%20When%20%60STALE_IDS%60%20is%20empty%20and%20only%20%60EXPIRED_IDS%60%20drove%20the%20cleanup%2C%20both%20the%20git%20commit%20and%20the%20auto-created%20PR%20will%20say%20%22remove%20stale%20vulnerability%20suppressions%22%20%E2%80%94%20which%20misrepresents%20the%20change%20and%20could%20mislead%20reviewers%20of%20the%20cleanup%20PR%20into%20thinking%20no%20live%20vulnerability%20existed%20at%20expiry%20time.%0A%0A%60%60%60suggestion%0A%09_commit_subject%3D%22chore%28security%29%3A%20remove%20stale%20vulnerability%20suppressions%22%0A%09if%20%5B%5B%20%24%7B%23STALE_IDS%5B%40%5D%7D%20-eq%200%20%26%26%20%24%7B%23EXPIRED_IDS%5B%40%5D%7D%20-gt%200%20%5D%5D%3B%20then%0A%09%09_commit_subject%3D%22chore%28security%29%3A%20remove%20expired%20vulnerability%20suppressions%22%0A%09elif%20%5B%5B%20%24%7B%23STALE_IDS%5B%40%5D%7D%20-gt%200%20%26%26%20%24%7B%23EXPIRED_IDS%5B%40%5D%7D%20-gt%200%20%5D%5D%3B%20then%0A%09%09_commit_subject%3D%22chore%28security%29%3A%20remove%20stale%20and%20expired%20vulnerability%20suppressions%22%0A%09fi%0A%09git%20commit%20-m%20%22%24%28%0A%09%09cat%20%3C%3CEOF%0A%24%7B_commit_subject%7D%0A%0AThe%20following%20suppressions%20are%20no%20longer%20needed%3A%0A%24%7BREMOVED_LIST%7D%0ADetected%20by%20the%20weekly%20vuln-suppression-check%20workflow.%0AEOF%0A%09%29%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Fci%2Fsecurity%2Fcheck-vuln-suppressions.sh%3A214-223%0APR%20title%20mirrors%20the%20same%20hardcoded%20%22stale%22%20text.%20Should%20be%20aligned%20with%20the%20commit%20subject%20fix%20so%20the%20cleanup%20PR%20title%20accurately%20reflects%20which%20suppression%20type%20triggered%20the%20run.%0A%0A%60%60%60suggestion%0A%09if%20%28%28%24%7B%23gh_pr_label_args%5B%40%5D%7D%20%3E%200%29%29%3B%20then%0A%09%09gh%20pr%20create%20%5C%0A%09%09%09--title%20%22%24%7B_commit_subject%7D%22%20%5C%0A%09%09%09%22%24%7Bgh_pr_label_args%5B%40%5D%7D%22%20%5C%0A%09%09%09--body%20%22%24PR_BODY%22%0A%09else%0A%09%09gh%20pr%20create%20%5C%0A%09%09%09--title%20%22%24%7B_commit_subject%7D%22%20%5C%0A%09%09%09--body%20%22%24PR_BODY%22%0A%09fi%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Ascripts%2Fci%2Factions%2Fghcr-cleanup.sh%3A61-68%0A%60ghcr_delete_version%60%20has%20its%20own%20%60DRY_RUN%60%20early-return%2C%20but%20both%20callers%20already%20%60continue%60%20before%20the%20function%20is%20ever%20reached%20when%20%60DRY_RUN%3Dtrue%60.%20The%20inner%20check%20is%20dead%20code.%20If%20a%20future%20caller%20invokes%20%60ghcr_delete_version%60%20directly%20without%20the%20outer%20guard%2C%20it%20silently%20returns%200%20without%20logging%20anything.%0A%0A%60%60%60suggestion%0Aghcr_delete_version%28%29%20%7B%0A%09local%20version_id%3D%22%241%22%0A%09local%20err%3D%22%22%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F363-close-adoption-gaps-blocking-py-lintro%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F363-close-adoption-gaps-blocking-py-lintro%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fci%2Fsecurity%2Fcheck-vuln-suppressions.sh%3A166-174%0AHardcoded%20%22stale%22%20in%20PR%20title%20and%20commit%20message%20when%20removing%20expired-only%20suppressions.%20When%20%60STALE_IDS%60%20is%20empty%20and%20only%20%60EXPIRED_IDS%60%20drove%20the%20cleanup%2C%20both%20the%20git%20commit%20and%20the%20auto-created%20PR%20will%20say%20%22remove%20stale%20vulnerability%20suppressions%22%20%E2%80%94%20which%20misrepresents%20the%20change%20and%20could%20mislead%20reviewers%20of%20the%20cleanup%20PR%20into%20thinking%20no%20live%20vulnerability%20existed%20at%20expiry%20time.%0A%0A%60%60%60suggestion%0A%09_commit_subject%3D%22chore%28security%29%3A%20remove%20stale%20vulnerability%20suppressions%22%0A%09if%20%5B%5B%20%24%7B%23STALE_IDS%5B%40%5D%7D%20-eq%200%20%26%26%20%24%7B%23EXPIRED_IDS%5B%40%5D%7D%20-gt%200%20%5D%5D%3B%20then%0A%09%09_commit_subject%3D%22chore%28security%29%3A%20remove%20expired%20vulnerability%20suppressions%22%0A%09elif%20%5B%5B%20%24%7B%23STALE_IDS%5B%40%5D%7D%20-gt%200%20%26%26%20%24%7B%23EXPIRED_IDS%5B%40%5D%7D%20-gt%200%20%5D%5D%3B%20then%0A%09%09_commit_subject%3D%22chore%28security%29%3A%20remove%20stale%20and%20expired%20vulnerability%20suppressions%22%0A%09fi%0A%09git%20commit%20-m%20%22%24%28%0A%09%09cat%20%3C%3CEOF%0A%24%7B_commit_subject%7D%0A%0AThe%20following%20suppressions%20are%20no%20longer%20needed%3A%0A%24%7BREMOVED_LIST%7D%0ADetected%20by%20the%20weekly%20vuln-suppression-check%20workflow.%0AEOF%0A%09%29%22%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Ascripts%2Fci%2Fsecurity%2Fcheck-vuln-suppressions.sh%3A214-223%0APR%20title%20mirrors%20the%20same%20hardcoded%20%22stale%22%20text.%20Should%20be%20aligned%20with%20the%20commit%20subject%20fix%20so%20the%20cleanup%20PR%20title%20accurately%20reflects%20which%20suppression%20type%20triggered%20the%20run.%0A%0A%60%60%60suggestion%0A%09if%20%28%28%24%7B%23gh_pr_label_args%5B%40%5D%7D%20%3E%200%29%29%3B%20then%0A%09%09gh%20pr%20create%20%5C%0A%09%09%09--title%20%22%24%7B_commit_subject%7D%22%20%5C%0A%09%09%09%22%24%7Bgh_pr_label_args%5B%40%5D%7D%22%20%5C%0A%09%09%09--body%20%22%24PR_BODY%22%0A%09else%0A%09%09gh%20pr%20create%20%5C%0A%09%09%09--title%20%22%24%7B_commit_subject%7D%22%20%5C%0A%09%09%09--body%20%22%24PR_BODY%22%0A%09fi%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Ascripts%2Fci%2Factions%2Fghcr-cleanup.sh%3A61-68%0A%60ghcr_delete_version%60%20has%20its%20own%20%60DRY_RUN%60%20early-return%2C%20but%20both%20callers%20already%20%60continue%60%20before%20the%20function%20is%20ever%20reached%20when%20%60DRY_RUN%3Dtrue%60.%20The%20inner%20check%20is%20dead%20code.%20If%20a%20future%20caller%20invokes%20%60ghcr_delete_version%60%20directly%20without%20the%20outer%20guard%2C%20it%20silently%20returns%200%20without%20logging%20anything.%0A%0A%60%60%60suggestion%0Aghcr_delete_version%28%29%20%7B%0A%09local%20version_id%3D%22%241%22%0A%09local%20err%3D%22%22%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (8): Last reviewed commit: ["chore(ci): trigger CI run"](https://github.com/lgtm-hq/lgtm-ci/commit/c26c9bbcf94582ccffa7ab06fb04f153a53c6487) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38783076)</sub>

<!-- /greptile_comment -->