### PR TITLE
fix(supply-chain): pin anchore and cargo-binstall installer downloads

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,14 @@
       "depNameTemplate": "ghcr.io/lgtm-hq/py-lintro",
       "currentValueTemplate": "latest",
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Track pinned tool versions in shell scripts via renovate comments",
+      "managerFilePatterns": ["/^scripts/.*\\.sh$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s*\\n\\s*[A-Za-z_]+=\"?v?(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\"?"
+      ]
     }
   ],
   "packageRules": [

--- a/scripts/ci/actions/setup-rust.sh
+++ b/scripts/ci/actions/setup-rust.sh
@@ -30,8 +30,55 @@ cargo-env)
 
 binstall)
 	if ! command -v cargo-binstall &>/dev/null; then
-		echo "Installing cargo-binstall..."
-		curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+		# Pinned release binary download (no pipe-to-bash of main-branch
+		# script). cargo-binstall publishes minisign signatures (.sig)
+		# but no sha256 checksum files, so pinning the version + TLS is
+		# the integrity control here.
+		# renovate: datasource=github-releases depName=cargo-bins/cargo-binstall
+		CARGO_BINSTALL_VERSION="1.20.1"
+		echo "Installing cargo-binstall v${CARGO_BINSTALL_VERSION}..."
+
+		os=$(uname -s)
+		arch=$(uname -m)
+		case "$os" in
+		Linux)
+			case "$arch" in
+			x86_64) target="x86_64-unknown-linux-musl" ;;
+			aarch64 | arm64) target="aarch64-unknown-linux-musl" ;;
+			*)
+				echo "Unsupported architecture: $arch"
+				exit 1
+				;;
+			esac
+			ext="tgz"
+			;;
+		Darwin)
+			target="universal-apple-darwin"
+			ext="zip"
+			;;
+		*)
+			echo "Unsupported OS: $os"
+			exit 1
+			;;
+		esac
+
+		url="https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-${target}.${ext}"
+		tmpdir=$(mktemp -d)
+		trap 'rm -rf "$tmpdir"' EXIT
+
+		echo "Downloading pinned release: $url"
+		curl -L --proto '=https' --tlsv1.2 -sSf -o "$tmpdir/cargo-binstall.$ext" "$url"
+
+		if [[ "$ext" == "tgz" ]]; then
+			tar -xzf "$tmpdir/cargo-binstall.$ext" -C "$tmpdir"
+		else
+			unzip -q "$tmpdir/cargo-binstall.$ext" -d "$tmpdir"
+		fi
+
+		install_dir="${CARGO_HOME:-$HOME/.cargo}/bin"
+		mkdir -p "$install_dir"
+		install -m 0755 "$tmpdir/cargo-binstall" "$install_dir/cargo-binstall"
+		echo "cargo-binstall v${CARGO_BINSTALL_VERSION} installed to $install_dir"
 	else
 		echo "cargo-binstall already installed"
 	fi

--- a/scripts/ci/lib/installer/binary.sh
+++ b/scripts/ci/lib/installer/binary.sh
@@ -58,6 +58,27 @@ if ! declare -f download_with_retries &>/dev/null; then
 	}
 fi
 
+if ! declare -f download_and_run_installer &>/dev/null; then
+	download_and_run_installer() {
+		local url="$1"
+		shift
+		# Skip optional checksum arg (64 hex chars) for signature parity
+		# with network/download.sh; the fallback cannot verify it
+		if [[ $# -gt 0 && "$1" =~ ^[a-fA-F0-9]{64}$ ]]; then
+			shift
+		fi
+		(
+			local tmpdir
+			tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/lgtm-installer.XXXXXXXXXX") || exit 1
+			trap 'rm -rf "$tmpdir"' EXIT
+			local script_file="$tmpdir/installer.sh"
+			curl -fsSL --connect-timeout 30 --max-time 120 "$url" -o "$script_file" || exit 1
+			chmod +x "$script_file" || exit 1
+			"$script_file" "$@"
+		)
+	}
+fi
+
 if ! declare -f verify_checksum &>/dev/null; then
 	verify_checksum() {
 		local file="$1" expected="$2" actual
@@ -243,10 +264,32 @@ install_anchore_tool() {
 
 	log_info "Installing $tool ${version}..."
 
-	# Use official installer script with version parameter
-	local installer_url="https://raw.githubusercontent.com/anchore/${tool}/main/install.sh"
+	# Resolve 'latest' to a concrete release tag so the installer script can
+	# be pinned to that tag instead of executing main-branch code
+	local resolved_version="$version"
+	if [[ "$version" == "latest" ]]; then
+		local latest_url
+		if ! latest_url=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+			--connect-timeout 30 --max-time 60 \
+			"https://github.com/anchore/${tool}/releases/latest"); then
+			log_error "Failed to resolve latest release for $tool"
+			return 1
+		fi
+		resolved_version="${latest_url##*/}"
+		if [[ ! "$resolved_version" =~ ^v[0-9] ]]; then
+			log_error "Could not determine latest version for $tool (got: ${resolved_version:-empty})"
+			return 1
+		fi
+	fi
+	local tag="v${resolved_version#v}"
 
-	if ! curl -sSfL "$installer_url" | sh -s -- -b "$bin_dir" "$version"; then
+	# Tag-pinned installer script (never main-branch). Anchore does not
+	# publish checksums for install.sh itself, so the script is downloaded
+	# to a temp file and executed (no curl|sh); the installer verifies the
+	# release binary checksums internally.
+	local installer_url="https://raw.githubusercontent.com/anchore/${tool}/${tag}/install.sh"
+
+	if ! download_and_run_installer "$installer_url" -b "$bin_dir" "$tag"; then
 		log_error "Failed to install $tool"
 		return 1
 	fi

--- a/tests/bats/unit/actions/test_setup_rust.bats
+++ b/tests/bats/unit/actions/test_setup_rust.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/setup-rust.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+
+setup() {
+	export SCRIPT="$PROJECT_ROOT/scripts/ci/actions/setup-rust.sh"
+	setup_temp_dir
+	save_path
+	export CARGO_HOME="${BATS_TEST_TMPDIR}/cargo"
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+# Create a curl mock that records calls and serves a tgz archive containing
+# a fake cargo-binstall binary
+create_binstall_curl_mock() {
+	local mock_bin="${BATS_TEST_TMPDIR}/mock_bin"
+	mkdir -p "$mock_bin"
+
+	local calls_file="${BATS_TEST_TMPDIR}/mock_calls_curl"
+	: >"$calls_file"
+
+	# Build a real tgz with a cargo-binstall executable
+	local archive_dir="${BATS_TEST_TMPDIR}/archive_content"
+	mkdir -p "$archive_dir"
+	printf '#!/usr/bin/env bash\necho "cargo-binstall mock"\n' >"$archive_dir/cargo-binstall"
+	chmod +x "$archive_dir/cargo-binstall"
+	local archive_file="${BATS_TEST_TMPDIR}/cargo-binstall.tgz"
+	tar -czf "$archive_file" -C "$archive_dir" cargo-binstall
+
+	cat >"${mock_bin}/curl" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >>'${calls_file}'
+output_file=""
+while [[ \$# -gt 0 ]]; do
+    case "\$1" in
+        -o) output_file="\$2"; shift 2;;
+        *) shift;;
+    esac
+done
+if [[ -n "\$output_file" ]]; then
+    cp '${archive_file}' "\$output_file"
+fi
+exit 0
+EOF
+	chmod +x "${mock_bin}/curl"
+	export MOCK_BIN="$mock_bin"
+}
+
+@test "setup-rust: binstall step downloads pinned release binary" {
+	create_binstall_curl_mock
+
+	# Mock uname for a deterministic target triple
+	cat >"${MOCK_BIN}/uname" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+    -m) echo "x86_64";;
+    *) echo "Linux";;
+esac
+EOF
+	chmod +x "${MOCK_BIN}/uname"
+
+	# Restricted PATH: mocks first, no ~/.cargo/bin (so cargo-binstall is
+	# "not installed")
+	run bash -c "
+		export PATH='${MOCK_BIN}:/usr/bin:/bin'
+		export STEP=binstall
+		export CARGO_HOME='$CARGO_HOME'
+		bash '$SCRIPT' 2>&1
+	"
+	assert_success
+	assert_output --partial "Installing cargo-binstall"
+	assert_output --partial "installed to"
+
+	# Binary installed to CARGO_HOME/bin
+	[[ -x "$CARGO_HOME/bin/cargo-binstall" ]]
+
+	# Requested URL is the release pinned to the version literal in the script
+	local pinned_version
+	pinned_version=$(grep -oE 'CARGO_BINSTALL_VERSION="[0-9.]+"' "$SCRIPT" | grep -oE '[0-9.]+')
+	[[ -n "$pinned_version" ]]
+
+	run cat "$BATS_TEST_TMPDIR/mock_calls_curl"
+	assert_output --partial "releases/download/v${pinned_version}/cargo-binstall-x86_64-unknown-linux-musl.tgz"
+	refute_output --partial "/main/"
+	refute_output --partial "install-from-binstall-release.sh"
+}
+
+@test "setup-rust: binstall step skips install when cargo-binstall present" {
+	create_binstall_curl_mock
+
+	# Provide a cargo-binstall on PATH
+	cat >"${MOCK_BIN}/cargo-binstall" <<'EOF'
+#!/usr/bin/env bash
+echo "cargo-binstall 1.0.0"
+EOF
+	chmod +x "${MOCK_BIN}/cargo-binstall"
+
+	run bash -c "
+		export PATH='${MOCK_BIN}:/usr/bin:/bin'
+		export STEP=binstall
+		bash '$SCRIPT' 2>&1
+	"
+	assert_success
+	assert_output --partial "already installed"
+
+	# curl must not have been invoked
+	run cat "$BATS_TEST_TMPDIR/mock_calls_curl"
+	assert_output ""
+}
+
+@test "setup-rust: binstall step fails on unsupported OS" {
+	create_binstall_curl_mock
+
+	cat >"${MOCK_BIN}/uname" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+    -m) echo "x86_64";;
+    *) echo "SunOS";;
+esac
+EOF
+	chmod +x "${MOCK_BIN}/uname"
+
+	run bash -c "
+		export PATH='${MOCK_BIN}:/usr/bin:/bin'
+		export STEP=binstall
+		bash '$SCRIPT' 2>&1
+	"
+	assert_failure
+	assert_output --partial "Unsupported OS"
+}
+
+@test "setup-rust: pinned version carries a renovate comment" {
+	run bash -c "grep -B1 'CARGO_BINSTALL_VERSION=' '$SCRIPT' | head -2"
+	assert_success
+	assert_output --partial "renovate: datasource=github-releases depName=cargo-bins/cargo-binstall"
+}
+
+@test "setup-rust: does not pipe remote content to a shell" {
+	run grep -nE '^[^#]*curl[^|#]*\|[[:space:]]*(ba)?sh' "$SCRIPT"
+	assert_failure
+}
+
+@test "setup-rust: rejects unknown step" {
+	run bash -c "STEP=bogus bash '$SCRIPT' 2>&1"
+	assert_failure
+	assert_output --partial "Unknown step"
+}

--- a/tests/bats/unit/lib/installer/test_binary.bats
+++ b/tests/bats/unit/lib/installer/test_binary.bats
@@ -103,6 +103,52 @@ EOF
 	export PATH="${mock_bin}:$PATH"
 }
 
+# Mock curl for install_anchore_tool flows:
+# - records all invocations to $BATS_TEST_TMPDIR/mock_calls_curl
+# - answers releases/latest resolution (-w '%{url_effective}') with .../tag/v9.9.9
+# - writes the given installer script body to the -o output file otherwise
+# Usage: create_anchore_curl_mock "installer script body"
+create_anchore_curl_mock() {
+	local installer_body="$1"
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+
+	local calls_file="${BATS_TEST_TMPDIR}/mock_calls_curl"
+	: >"$calls_file"
+
+	local installer_file="${mock_bin}/.fake_installer"
+	printf '%s\n' "$installer_body" >"$installer_file"
+
+	cat >"${mock_bin}/curl" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >>'${calls_file}'
+output_file=""
+url=""
+while [[ \$# -gt 0 ]]; do
+    case "\$1" in
+        -o) output_file="\$2"; shift 2;;
+        -w) shift 2;;
+        http*) url="\$1"; shift;;
+        *) shift;;
+    esac
+done
+if [[ "\$url" == *"/releases/latest"* ]]; then
+    # Simulate the redirect target reported via -w '%{url_effective}'
+    printf '%s' "\${url%/latest}/tag/v9.9.9"
+    exit 0
+fi
+if [[ -n "\$output_file" ]]; then
+    cat '${installer_file}' >"\$output_file"
+fi
+exit 0
+EOF
+	chmod +x "${mock_bin}/curl"
+
+	if [[ ":$PATH:" != *":${mock_bin}:"* ]]; then
+		export PATH="${mock_bin}:$PATH"
+	fi
+}
+
 # =============================================================================
 # installer_download_binary tests - basic functionality
 # =============================================================================
@@ -450,47 +496,27 @@ EOF
 	assert_output --partial "already installed"
 }
 
-@test "install_anchore_tool: reinstalls when version mismatch" {
-	# Mock existing syft with different version
+@test "install_anchore_tool: reinstalls when version mismatch using pinned installer" {
 	local mock_bin="${BATS_TEST_TMPDIR}/bin"
-	mkdir -p "$mock_bin"
+	local flag_file="${BATS_TEST_TMPDIR}/installed_flag"
 
-	# First call returns wrong version, subsequent calls after "install" return correct
-	local call_count_file="${mock_bin}/.syft_calls"
-	echo "0" >"$call_count_file"
-
+	# syft reports the old version until the fake installer runs
 	cat >"${mock_bin}/syft" <<EOF
 #!/usr/bin/env bash
-count=\$(cat "$call_count_file")
-if [[ \$count -eq 0 ]]; then
-    echo "Application: syft"
-    echo "Version: 0.80.0"
-else
+if [[ -f "$flag_file" ]]; then
     echo "Application: syft"
     echo "Version: 0.90.0"
+else
+    echo "Application: syft"
+    echo "Version: 0.80.0"
 fi
 exit 0
 EOF
 	chmod +x "${mock_bin}/syft"
 
-	# Mock curl for installer script
-	cat >"${mock_bin}/curl" <<EOF
-#!/usr/bin/env bash
-# Return a mock installer script that just updates the syft mock
-echo '#!/bin/bash'
-echo "echo \"1\" > \"$call_count_file\""
-EOF
-	chmod +x "${mock_bin}/curl"
-
-	# Mock sh to "run" the installer
-	cat >"${mock_bin}/sh" <<EOF
-#!/usr/bin/env bash
-echo "1" > "$call_count_file"
-exit 0
-EOF
-	chmod +x "${mock_bin}/sh"
-
-	export PATH="${mock_bin}:$PATH"
+	create_anchore_curl_mock "#!/usr/bin/env bash
+touch '$flag_file'
+"
 
 	run bash -c '
 		source "$LIB_DIR/installer/binary.sh"
@@ -500,41 +526,88 @@ EOF
 	# Should attempt reinstall due to version mismatch
 	assert_output --partial "version mismatch"
 
-	# Verify the mock installer ran (sh wrote "1" to call_count_file)
-	[[ -f "${BATS_TEST_TMPDIR}/bin/.syft_calls" ]]
-	[[ "$(cat "${BATS_TEST_TMPDIR}/bin/.syft_calls")" == "1" ]]
+	# Verify the downloaded (not piped) installer actually ran
+	[[ -f "$flag_file" ]]
+
+	# Verify the installer was fetched from the tag-pinned URL
+	run cat "$BATS_TEST_TMPDIR/mock_calls_curl"
+	assert_output --partial "raw.githubusercontent.com/anchore/syft/v0.90.0/install.sh"
+	refute_output --partial "/main/install.sh"
 }
 
-@test "install_anchore_tool: uses correct installer URL for syft" {
-	# Track curl calls to verify URL
-	mock_command_record "curl" '#!/bin/bash\necho installed' 0
+@test "install_anchore_tool: requests tag-pinned installer URL for explicit version" {
 	local mock_bin="${BATS_TEST_TMPDIR}/bin"
-
-	# Mock sh to simulate installer creating the syft binary
-	cat >"${mock_bin}/sh" <<MOCK
-#!/usr/bin/env bash
-cat >"${mock_bin}/syft" <<'INNER'
-#!/usr/bin/env bash
-echo "Application: syft"
-echo "Version: latest"
-INNER
-chmod +x "${mock_bin}/syft"
-MOCK
-	chmod +x "${mock_bin}/sh"
 
 	# Remove any existing syft mock so it's "not installed"
 	rm -f "${mock_bin}/syft"
 
+	create_anchore_curl_mock "#!/usr/bin/env bash
+cat >'${mock_bin}/syft' <<'INNER'
+#!/usr/bin/env bash
+echo \"Application: syft\"
+echo \"Version: 1.2.3\"
+INNER
+chmod +x '${mock_bin}/syft'
+"
+
 	run bash -c '
-		export PATH="${BATS_TEST_TMPDIR}/bin:$PATH"
 		source "$LIB_DIR/installer/binary.sh"
-		install_anchore_tool "syft" "latest" 2>&1
+		install_anchore_tool "syft" "1.2.3" 2>&1
 	'
 	assert_success
 
-	# Verify curl was called with anchore/syft URL
 	run cat "$BATS_TEST_TMPDIR/mock_calls_curl"
-	assert_output --partial "anchore"
+	assert_output --partial "raw.githubusercontent.com/anchore/syft/v1.2.3/install.sh"
+	refute_output --partial "/main/install.sh"
+}
+
+@test "install_anchore_tool: resolves latest to a pinned tag before install" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+
+	# Ensure grype is "not installed"
+	rm -f "${mock_bin}/grype"
+	command -v grype >/dev/null 2>&1 && skip "grype installed on host"
+
+	create_anchore_curl_mock "#!/usr/bin/env bash
+cat >'${mock_bin}/grype' <<'INNER'
+#!/usr/bin/env bash
+echo \"Application: grype\"
+echo \"Version: 9.9.9\"
+INNER
+chmod +x '${mock_bin}/grype'
+"
+
+	run bash -c '
+		source "$LIB_DIR/installer/binary.sh"
+		install_anchore_tool "grype" "latest" 2>&1
+	'
+	assert_success
+
+	run cat "$BATS_TEST_TMPDIR/mock_calls_curl"
+	assert_output --partial "github.com/anchore/grype/releases/latest"
+	assert_output --partial "raw.githubusercontent.com/anchore/grype/v9.9.9/install.sh"
+	refute_output --partial "/main/install.sh"
+}
+
+@test "install_anchore_tool: fails when latest release cannot be resolved" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	rm -f "${mock_bin}/syft"
+	command -v syft >/dev/null 2>&1 && skip "syft installed on host"
+
+	# curl fails for every request
+	mock_command "curl" "" 22
+
+	run bash -c '
+		source "$LIB_DIR/installer/binary.sh"
+		install_anchore_tool "syft" "latest" 2>&1
+	'
+	assert_failure
+	assert_output --partial "Failed to resolve latest release"
+}
+
+@test "binary.sh: does not pipe remote content to a shell" {
+	run grep -nE '^[^#]*curl[^|#]*\|[[:space:]]*(ba)?sh' "$LIB_DIR/installer/binary.sh"
+	assert_failure
 }
 
 @test "install_anchore_tool: defaults to latest version" {

--- a/tests/bats/unit/lib/installer/test_binary.bats
+++ b/tests/bats/unit/lib/installer/test_binary.bats
@@ -710,3 +710,243 @@ chmod +x '${mock_bin}/grype'
 	run bash -c 'source "$LIB_DIR/installer/binary.sh" && declare -F ensure_directory'
 	assert_success
 }
+
+# =============================================================================
+# installer_download_binary tests - extraction and checksum edge cases
+# =============================================================================
+
+# Mock curl that serves arbitrary content for every -o download
+create_mock_curl_serving() {
+	local first_content="$1"
+	local second_content="${2-}"
+
+	local mock_bin="${BATS_TEST_TMPDIR}/mock_bin"
+	mkdir -p "$mock_bin"
+	local call_count_file="${mock_bin}/.curl_call_count"
+	echo "0" >"$call_count_file"
+	printf '%s' "$first_content" >"${mock_bin}/.first_payload"
+	printf '%s' "$second_content" >"${mock_bin}/.second_payload"
+
+	cat >"${mock_bin}/curl" <<EOF
+#!/usr/bin/env bash
+call_count=\$(cat "$call_count_file")
+output_file=""
+while [[ \$# -gt 0 ]]; do
+    case "\$1" in
+        -o) output_file="\$2"; shift 2;;
+        --output) output_file="\$2"; shift 2;;
+        *) shift;;
+    esac
+done
+if [[ -n "\$output_file" ]]; then
+    if [[ \$call_count -eq 0 ]]; then
+        cat "${mock_bin}/.first_payload" > "\$output_file"
+    else
+        cat "${mock_bin}/.second_payload" > "\$output_file"
+    fi
+    echo \$((\$call_count + 1)) > "$call_count_file"
+fi
+exit 0
+EOF
+	chmod +x "${mock_bin}/curl"
+	export PATH="${mock_bin}:$PATH"
+}
+
+@test "installer_download_binary: fails on tar.xz extraction error" {
+	require_bash4
+	create_mock_curl_serving "not a tar.xz archive"
+
+	run bash -c "
+		export BIN_DIR='$BIN_DIR'
+		source \"\$LIB_DIR/installer/binary.sh\"
+		installer_download_binary 'https://example.com/tool.tar.xz' '' 'tar.xz' 'mytool' 2>&1
+	"
+	assert_failure
+	assert_output --partial "tar.xz extraction failed"
+}
+
+@test "installer_download_binary: fails on zip extraction error" {
+	require_bash4
+	create_mock_curl_serving "not a zip archive"
+
+	run bash -c "
+		export BIN_DIR='$BIN_DIR'
+		source \"\$LIB_DIR/installer/binary.sh\"
+		installer_download_binary 'https://example.com/tool.zip' '' 'zip' 'mytool' 2>&1
+	"
+	assert_failure
+	assert_output --partial "zip extraction failed"
+}
+
+@test "installer_download_binary: fails when checksum file cannot be parsed" {
+	require_bash4
+	create_mock_download_binary "mytool" '#!/bin/bash\necho "tool"'
+	create_mock_curl_serving "archive content" ""
+
+	run bash -c "
+		export BIN_DIR='$BIN_DIR'
+		source \"\$LIB_DIR/installer/binary.sh\"
+		installer_download_binary 'https://example.com/tool.tar.gz' 'https://example.com/checksums.txt' 'tar.gz' 'mytool' 2>&1
+	"
+	assert_failure
+	assert_output --partial "Could not parse checksum"
+}
+
+@test "installer_download_binary: unparseable checksum passes with ALLOW_UNVERIFIED=1" {
+	require_bash4
+	local archive_dir="${BATS_TEST_TMPDIR}/xdir"
+	mkdir -p "$archive_dir"
+	printf '#!/bin/bash\necho tool\n' >"$archive_dir/mytool"
+	chmod +x "$archive_dir/mytool"
+	tar -czf "${BATS_TEST_TMPDIR}/good.tar.gz" -C "$archive_dir" mytool
+	create_mock_curl_serving "placeholder" ""
+	# Binary-safe payload: overwrite first payload with the real archive bytes
+	cp "${BATS_TEST_TMPDIR}/good.tar.gz" "${BATS_TEST_TMPDIR}/mock_bin/.first_payload"
+
+	run bash -c "
+		export BIN_DIR='$BIN_DIR'
+		export ALLOW_UNVERIFIED=1
+		source \"\$LIB_DIR/installer/binary.sh\"
+		installer_download_binary 'https://example.com/tool.tar.gz' 'https://example.com/checksums.txt' 'tar.gz' 'mytool' 2>&1
+	"
+	assert_success
+	assert_output --partial "Could not parse checksum, skipping verification"
+}
+
+@test "installer_download_binary: fails when checksum download fails without ALLOW_UNVERIFIED" {
+	require_bash4
+
+	local mock_bin="${BATS_TEST_TMPDIR}/mock_bin"
+	mkdir -p "$mock_bin"
+	local call_count_file="${mock_bin}/.curl_call_count"
+	echo "0" >"$call_count_file"
+
+	cat >"${mock_bin}/curl" <<EOF
+#!/usr/bin/env bash
+call_count=\$(cat "$call_count_file")
+output_file=""
+while [[ \$# -gt 0 ]]; do
+    case "\$1" in
+        -o) output_file="\$2"; shift 2;;
+        *) shift;;
+    esac
+done
+echo \$((\$call_count + 1)) > "$call_count_file"
+if [[ \$call_count -eq 0 ]]; then
+    [[ -n "\$output_file" ]] && echo "archive content" > "\$output_file"
+    exit 0
+fi
+exit 22
+EOF
+	chmod +x "${mock_bin}/curl"
+	export PATH="${mock_bin}:$PATH"
+
+	run bash -c "
+		export BIN_DIR='$BIN_DIR'
+		source \"\$LIB_DIR/installer/binary.sh\"
+		installer_download_binary 'https://example.com/tool.tar.gz' 'https://example.com/checksums.txt' 'tar.gz' 'mytool' 2>&1
+	"
+	assert_failure
+	assert_output --partial "Could not download checksum"
+}
+
+@test "installer_download_binary: fails when binary missing from archive" {
+	require_bash4
+	create_mock_download_binary "othertool" '#!/bin/bash\necho other'
+
+	run bash -c "
+		export BIN_DIR='$BIN_DIR'
+		source \"\$LIB_DIR/installer/binary.sh\"
+		installer_download_binary 'https://example.com/tool.tar.gz' '' 'tar.gz' 'missingtool' 2>&1
+	"
+	assert_failure
+}
+
+@test "installer_download_binary: falls back to mkdir when mktemp fails" {
+	require_bash4
+	create_mock_download_binary "mytool" '#!/bin/bash\necho "mytool"'
+
+	local mock_bin="${BATS_TEST_TMPDIR}/mock_bin"
+	cat >"${mock_bin}/mktemp" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+	chmod +x "${mock_bin}/mktemp"
+
+	run bash -c "
+		export BIN_DIR='$BIN_DIR'
+		source \"\$LIB_DIR/installer/binary.sh\"
+		installer_download_binary 'https://example.com/mytool.tar.gz' '' 'tar.gz' 'mytool' 2>&1
+	"
+	assert_success
+	assert_output --partial "installed to"
+	[[ -x "$BIN_DIR/mytool" ]]
+}
+
+# =============================================================================
+# install_anchore_tool tests - failure paths
+# =============================================================================
+
+@test "install_anchore_tool: fails when latest resolves to a non-version URL" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	rm -f "${mock_bin}/syft"
+	command -v syft >/dev/null 2>&1 && skip "syft installed on host"
+
+	mkdir -p "$mock_bin"
+	cat >"${mock_bin}/curl" <<'EOF'
+#!/usr/bin/env bash
+url=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        http*) url="$1"; shift;;
+        *) shift;;
+    esac
+done
+if [[ "$url" == *"/releases/latest"* ]]; then
+    printf '%s' "${url%/latest}"
+    exit 0
+fi
+exit 22
+EOF
+	chmod +x "${mock_bin}/curl"
+	[[ ":$PATH:" != *":${mock_bin}:"* ]] && export PATH="${mock_bin}:$PATH"
+
+	run bash -c '
+		source "$LIB_DIR/installer/binary.sh"
+		install_anchore_tool "syft" "latest" 2>&1
+	'
+	assert_failure
+	assert_output --partial "Could not determine latest version"
+}
+
+@test "install_anchore_tool: fails when installer script exits non-zero" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	rm -f "${mock_bin}/syft"
+	command -v syft >/dev/null 2>&1 && skip "syft installed on host"
+
+	create_anchore_curl_mock '#!/usr/bin/env bash
+exit 1'
+
+	run bash -c '
+		source "$LIB_DIR/installer/binary.sh"
+		install_anchore_tool "syft" "v1.2.3" 2>&1
+	'
+	assert_failure
+	assert_output --partial "Failed to install syft"
+}
+
+@test "install_anchore_tool: fails when tool missing after installer succeeds" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	rm -f "${mock_bin}/syft"
+	command -v syft >/dev/null 2>&1 && skip "syft installed on host"
+
+	create_anchore_curl_mock '#!/usr/bin/env bash
+exit 0'
+
+	run bash -c '
+		source "$LIB_DIR/installer/binary.sh"
+		install_anchore_tool "syft" "v1.2.3" 2>&1
+	'
+	assert_failure
+	assert_output --partial "not found in PATH"
+}


### PR DESCRIPTION
## Summary

Removes the last two curl-pipe-to-shell installs of main-branch scripts and replaces them with pinned, download-then-execute installs.

- `install_anchore_tool` (syft/grype) now resolves `latest` to a concrete release tag and fetches the tag-pinned `install.sh` via `download_and_run_installer` (temp file, no `curl | sh`). Anchore does not publish checksums for `install.sh` itself; the installer verifies the release binary checksums internally.
- `setup-rust.sh` `binstall` step now downloads the version-pinned cargo-binstall release archive directly from GitHub releases (no pipe-to-bash of the main-branch `install-from-binstall-release.sh`). Upstream publishes only minisign `.sig` files, no sha256 checksums, so version pinning + TLS is the integrity control.
- The pinned cargo-binstall version carries a Renovate comment, backed by a new regex custom manager in `renovate.json`.

## Type of Change

- [x] Bug fix
- [x] CI/CD improvement

## Changes Made

- `scripts/ci/lib/installer/binary.sh`: tag-pinned installer URL derived from the requested version; `latest` resolved via the GitHub releases redirect; download-then-execute via `download_and_run_installer` (with a standalone fallback implementation)
- `scripts/ci/actions/setup-rust.sh`: direct pinned release binary download for cargo-binstall (Linux musl / macOS universal targets), installed to `$CARGO_HOME/bin`
- `renovate.json`: regex manager tracking `# renovate: datasource=... depName=...` version comments in shell scripts
- BATS: curl mocks assert the tag-pinned URLs are requested (and never `/main/`), plus static assertions that no remote content is piped to a shell; new `tests/bats/unit/actions/test_setup_rust.bats`

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #368

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR pins the remaining installer downloads used by the CI scripts. The main changes are:

- Anchore syft/grype installers now resolve `latest` to a release tag before download.
- Anchore installer scripts are downloaded to a temp file before execution.
- cargo-binstall now installs from a pinned GitHub release archive.
- Renovate now tracks pinned shell-script tool versions.
- BATS coverage now checks pinned URLs and rejects remote pipe-to-shell patterns.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/actions/setup-rust.sh | Replaces the cargo-binstall installer script with a pinned release archive download. |
| scripts/ci/lib/installer/binary.sh | Pins Anchore installer script downloads to release tags and executes them from temp files. |
| renovate.json | Adds Renovate tracking for pinned versions in shell scripts. |
| tests/bats/unit/actions/test_setup_rust.bats | Adds tests for the pinned cargo-binstall install path. |
| tests/bats/unit/lib/installer/test_binary.bats | Adds tests for tag-pinned Anchore installer downloads and related failure paths. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/368-pin-ins..."](https://github.com/lgtm-hq/lgtm-ci/commit/d55c1aa83fb8afbf10db36123241a36df71dc163) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41897290)</sub>

<!-- /greptile_comment -->