### PR TITLE
feat(security): enable verify-tags in own action-pinning validation

### DIFF
--- a/.github/actions/validate-action-pinning/action.yml
+++ b/.github/actions/validate-action-pinning/action.yml
@@ -57,8 +57,10 @@ runs:
       id: validate
       shell: bash
       env:
-        # gh api needs a token for verify-tags / audit-transitive resolution
-        GH_TOKEN: ${{ github.token }}
+        # gh api needs a token for verify-tags / audit-transitive resolution.
+        # Callers may provide their own GH_TOKEN (e.g. a PAT that can resolve
+        # private or cross-org actions); fall back to the workflow token.
+        GH_TOKEN: ${{ env.GH_TOKEN || github.token }}
         INPUT_ENFORCE: ${{ inputs.enforce }}
         INPUT_ALLOW_TAG_EXCEPTIONS: ${{ inputs['allow-tag-exceptions'] }}
         INPUT_ALLOW_ORG_VERSIONS: ${{ inputs['allow-org-versions'] }}

--- a/.github/actions/validate-action-pinning/action.yml
+++ b/.github/actions/validate-action-pinning/action.yml
@@ -35,6 +35,13 @@ inputs:
       Warn when pinned composite actions reference nested actions by mutable tag
     required: false
     default: "false"
+  gh-token:
+    description: >-
+      GitHub token used by gh for verify-tags / audit-transitive API
+      resolution (e.g. a PAT able to resolve private or cross-org actions).
+      Falls back to a caller-set GH_TOKEN env var, then the workflow token.
+    required: false
+    default: ""
 
 outputs:
   offenders:
@@ -58,9 +65,9 @@ runs:
       shell: bash
       env:
         # gh api needs a token for verify-tags / audit-transitive resolution.
-        # Callers may provide their own GH_TOKEN (e.g. a PAT that can resolve
-        # private or cross-org actions); fall back to the workflow token.
-        GH_TOKEN: ${{ env.GH_TOKEN || github.token }}
+        # Precedence: explicit gh-token input, caller-set GH_TOKEN env var,
+        # then the workflow token.
+        GH_TOKEN: ${{ inputs['gh-token'] || env.GH_TOKEN || github.token }}
         INPUT_ENFORCE: ${{ inputs.enforce }}
         INPUT_ALLOW_TAG_EXCEPTIONS: ${{ inputs['allow-tag-exceptions'] }}
         INPUT_ALLOW_ORG_VERSIONS: ${{ inputs['allow-org-versions'] }}

--- a/.github/actions/validate-action-pinning/action.yml
+++ b/.github/actions/validate-action-pinning/action.yml
@@ -57,6 +57,8 @@ runs:
       id: validate
       shell: bash
       env:
+        # gh api needs a token for verify-tags / audit-transitive resolution
+        GH_TOKEN: ${{ github.token }}
         INPUT_ENFORCE: ${{ inputs.enforce }}
         INPUT_ALLOW_TAG_EXCEPTIONS: ${{ inputs['allow-tag-exceptions'] }}
         INPUT_ALLOW_ORG_VERSIONS: ${{ inputs['allow-org-versions'] }}

--- a/scripts/ci/actions/validate-action-pinning.sh
+++ b/scripts/ci/actions/validate-action-pinning.sh
@@ -9,6 +9,9 @@
 #   INPUT_SCAN_PATHS           - Space-separated paths to scan for workflow files
 #   INPUT_VERIFY_TAGS          - Verify Renovate version comments match pinned SHAs
 #   INPUT_AUDIT_TRANSITIVE     - Warn on mutable tag refs in nested composite actions
+#   GH_TOKEN                   - GitHub token consumed by gh for API resolution
+#                                (required when INPUT_VERIFY_TAGS or
+#                                INPUT_AUDIT_TRANSITIVE is true)
 
 set -euo pipefail
 

--- a/tests/bats/integration/test_version_drift_workflows.bats
+++ b/tests/bats/integration/test_version_drift_workflows.bats
@@ -25,7 +25,7 @@ load "../../helpers/common"
 @test "validate-action-pinning action: wires GH_TOKEN for verify-tags API resolution" {
 	local action="${PROJECT_ROOT}/.github/actions/validate-action-pinning/action.yml"
 
-	run grep -F 'GH_TOKEN: ${{ env.GH_TOKEN || github.token }}' "$action"
+	run grep -F "GH_TOKEN: \${{ inputs['gh-token'] || env.GH_TOKEN || github.token }}" "$action"
 	assert_success
 }
 

--- a/tests/bats/integration/test_version_drift_workflows.bats
+++ b/tests/bats/integration/test_version_drift_workflows.bats
@@ -15,6 +15,20 @@ load "../../helpers/common"
 	assert_success
 }
 
+@test "reusable-validate-action-pinning: forwards verify-tags input to action" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-validate-action-pinning.yml"
+
+	run grep -F 'verify-tags: ${{ inputs.verify-tags }}' "$workflow"
+	assert_success
+}
+
+@test "validate-action-pinning action: wires GH_TOKEN for verify-tags API resolution" {
+	local action="${PROJECT_ROOT}/.github/actions/validate-action-pinning/action.yml"
+
+	run grep -F 'GH_TOKEN: ${{ github.token }}' "$action"
+	assert_success
+}
+
 @test "dependency-review workflow: calls reusable dependency review" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/dependency-review.yml"
 

--- a/tests/bats/integration/test_version_drift_workflows.bats
+++ b/tests/bats/integration/test_version_drift_workflows.bats
@@ -25,7 +25,7 @@ load "../../helpers/common"
 @test "validate-action-pinning action: wires GH_TOKEN for verify-tags API resolution" {
 	local action="${PROJECT_ROOT}/.github/actions/validate-action-pinning/action.yml"
 
-	run grep -F 'GH_TOKEN: ${{ github.token }}' "$action"
+	run grep -F 'GH_TOKEN: ${{ env.GH_TOKEN || github.token }}' "$action"
 	assert_success
 }
 


### PR DESCRIPTION
## Summary

The repo's own caller workflow already sets `verify-tags: true` and `audit-transitive: true`, but the underlying script resolves Renovate version comments with `gh api` and no token ever reached the composite action step — so tag verification silently degraded to "could not resolve via GitHub API" warnings in CI. This PR wires `GH_TOKEN: ${{ github.token }}` into the validate step of the composite action so verification actually runs, documents the requirement in the script header, and adds contract tests for the wiring.

The `verify-tags` defaults in the action and reusable workflow are deliberately **not** flipped to `true` here — that would be breaking for offline/token-less consumers and is left as a follow-up (noted on #369).

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Changes Made

- `.github/actions/validate-action-pinning/action.yml`: export `GH_TOKEN: ${{ github.token }}` on the validate step so `gh api` tag/manifest resolution works for `verify-tags` and `audit-transitive`
- `scripts/ci/actions/validate-action-pinning.sh`: document the `GH_TOKEN` requirement in the env var header
- `tests/bats/integration/test_version_drift_workflows.bats`: contract tests asserting the reusable forwards `verify-tags` to the action and the action wires `GH_TOKEN`

## Checklist

- [x] I have tested these changes locally (`bats --recursive tests/bats`: 2266 tests, 0 failures; `uv run lintro chk`: all tools PASS)
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. Defaults unchanged; `github.token` is available in all GitHub-hosted runs.

## Closes

- Refs #369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved workflow support by passing a GitHub token into action pinning checks when needed.
  * Added coverage to confirm version-drift workflow inputs and token forwarding behave as expected.

* **Documentation**
  * Updated environment variable guidance to include the new token requirement for certain checks.

* **Tests**
  * Added integration tests for workflow wiring and token handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves action-pinning validation token handling. The main changes are:

- Added a `gh-token` input to the composite validation action.
- Passed `GH_TOKEN` into the validation step for tag and transitive-action API lookups.
- Documented the token requirement in the validation script header.
- Added Bats coverage for verify-tags forwarding and token wiring.
</details>

<h3>Confidence Score: 4/5</h3>

This is close, but the reusable workflow token path should be fixed before merging.

- The composite action can now accept a stronger token directly.
- The reusable workflow does not expose or forward that token input.
- Private or cross-org action checks can still degrade to warnings when only `github.token` reaches `gh api`.

.github/actions/validate-action-pinning/action.yml and .github/workflows/reusable-validate-action-pinning.yml

<details open><summary><h3>Security Review</h3></summary>

The token wiring still leaves reusable workflow callers without a direct way to pass the stronger token needed for private or cross-org action verification.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/validate-action-pinning/action.yml | Adds the token input and step env wiring, but the new input is not available through the reusable workflow path. |
| scripts/ci/actions/validate-action-pinning.sh | Documents the `GH_TOKEN` requirement for API-backed tag and transitive-action checks. |
| tests/bats/integration/test_version_drift_workflows.bats | Adds contract checks for verify-tags forwarding and composite action token wiring. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Factions%2Fvalidate-action-pinning%2Faction.yml%3A38-44%0A**Reusable%20Token%20Missing**%0A%0AThis%20adds%20%60gh-token%60%20to%20the%20composite%20action%2C%20but%20the%20reusable%20workflow%20path%20that%20forwards%20%60verify-tags%60%20and%20%60audit-transitive%60%20still%20has%20no%20matching%20token%20input%20or%20secret%20passthrough.%20A%20caller%20using%20the%20reusable%20workflow%20cannot%20pass%20the%20stronger%20PAT%2FApp%20token%20through%20this%20new%20input%2C%20so%20private%20or%20cross-org%20action%20lookups%20can%20still%20fall%20back%20to%20%60github.token%60.%20When%20that%20token%20cannot%20resolve%20the%20action%2C%20the%20script%20records%20a%20warning%20and%20the%20verification%2Faudit%20continues%20without%20checking%20the%20tag%20or%20nested%20action.%0A%0A&pr=385&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Factions%2Fvalidate-action-pinning%2Faction.yml%3A38-44%0A**Reusable%20Token%20Missing**%0A%0AThis%20adds%20%60gh-token%60%20to%20the%20composite%20action%2C%20but%20the%20reusable%20workflow%20path%20that%20forwards%20%60verify-tags%60%20and%20%60audit-transitive%60%20still%20has%20no%20matching%20token%20input%20or%20secret%20passthrough.%20A%20caller%20using%20the%20reusable%20workflow%20cannot%20pass%20the%20stronger%20PAT%2FApp%20token%20through%20this%20new%20input%2C%20so%20private%20or%20cross-org%20action%20lookups%20can%20still%20fall%20back%20to%20%60github.token%60.%20When%20that%20token%20cannot%20resolve%20the%20action%2C%20the%20script%20records%20a%20warning%20and%20the%20verification%2Faudit%20continues%20without%20checking%20the%20tag%20or%20nested%20action.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=385&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F369-verify-tags-default%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F369-verify-tags-default%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Factions%2Fvalidate-action-pinning%2Faction.yml%3A38-44%0A**Reusable%20Token%20Missing**%0A%0AThis%20adds%20%60gh-token%60%20to%20the%20composite%20action%2C%20but%20the%20reusable%20workflow%20path%20that%20forwards%20%60verify-tags%60%20and%20%60audit-transitive%60%20still%20has%20no%20matching%20token%20input%20or%20secret%20passthrough.%20A%20caller%20using%20the%20reusable%20workflow%20cannot%20pass%20the%20stronger%20PAT%2FApp%20token%20through%20this%20new%20input%2C%20so%20private%20or%20cross-org%20action%20lookups%20can%20still%20fall%20back%20to%20%60github.token%60.%20When%20that%20token%20cannot%20resolve%20the%20action%2C%20the%20script%20records%20a%20warning%20and%20the%20verification%2Faudit%20continues%20without%20checking%20the%20tag%20or%20nested%20action.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=385&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/369-verify..."](https://github.com/lgtm-hq/lgtm-ci/commit/a90668461cf2e2c1ecea721f769e3e5cea34b5e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41897572)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->