### PR TITLE
fix(release): peel annotated tag when updating floating tag

### DIFF
--- a/scripts/ci/release/update-floating-tag.sh
+++ b/scripts/ci/release/update-floating-tag.sh
@@ -44,7 +44,7 @@ if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
 fi
 
 # Force-update the floating tag locally
-git tag -fa "$FLOATING_TAG" "$TAG" -m "Release ${FLOATING_TAG} (latest: ${TAG})"
+git tag -fa "$FLOATING_TAG" "${TAG}^{}" -m "Release ${FLOATING_TAG} (latest: ${TAG})"
 log_success "Updated local tag: $FLOATING_TAG -> $TAG"
 
 # Push if requested

--- a/tests/bats/unit/release/test_update_floating_tag.bats
+++ b/tests/bats/unit/release/test_update_floating_tag.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/release/update-floating-tag.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+load "../../../helpers/github_env"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+	setup_mock_git_repo
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+# Create an annotated release tag in the mock repo
+# Usage: create_release_tag "v1.2.3"
+create_release_tag() {
+	local tag="$1"
+	git -C "$MOCK_GIT_REPO" tag -a "$tag" -m "Release $tag"
+}
+
+run_update_floating_tag() {
+	local tag="$1"
+	(
+		cd "$MOCK_GIT_REPO" || exit 1
+		env TAG="$tag" PUSH=false \
+			bash "${PROJECT_ROOT}/scripts/ci/release/update-floating-tag.sh"
+	)
+}
+
+@test "update-floating-tag: creates floating tag for release" {
+	create_release_tag "v1.2.3"
+
+	run run_update_floating_tag "v1.2.3"
+
+	assert_success
+	assert_output --partial "floating-tag=v1"
+	assert_output --partial "source-tag=v1.2.3"
+	git -C "$MOCK_GIT_REPO" rev-parse --verify refs/tags/v1
+}
+
+@test "update-floating-tag: floating tag is annotated" {
+	create_release_tag "v1.2.3"
+
+	run run_update_floating_tag "v1.2.3"
+	assert_success
+
+	run git -C "$MOCK_GIT_REPO" cat-file -t refs/tags/v1
+	assert_success
+	assert_output "tag"
+}
+
+@test "update-floating-tag: floating tag points at commit, not nested tag" {
+	create_release_tag "v1.2.3"
+
+	run run_update_floating_tag "v1.2.3"
+	assert_success
+
+	# The immediate target of the annotated floating tag must be a commit,
+	# not the release tag object (regression test for nested tags, #373)
+	run bash -c "git -C '$MOCK_GIT_REPO' cat-file tag refs/tags/v1 | grep '^type '"
+	assert_success
+	assert_output "type commit"
+
+	local target_type
+	target_type=$(git -C "$MOCK_GIT_REPO" cat-file -t "$(git -C "$MOCK_GIT_REPO" rev-parse 'v1^{}')")
+	assert_equal "commit" "$target_type"
+}
+
+@test "update-floating-tag: floating tag dereferences to release commit" {
+	create_release_tag "v1.2.3"
+
+	run run_update_floating_tag "v1.2.3"
+	assert_success
+
+	local floating_commit release_commit
+	floating_commit=$(git -C "$MOCK_GIT_REPO" rev-parse 'v1^{}')
+	release_commit=$(git -C "$MOCK_GIT_REPO" rev-parse 'v1.2.3^{}')
+	assert_equal "$release_commit" "$floating_commit"
+}
+
+@test "update-floating-tag: force-updates existing floating tag to new release" {
+	create_release_tag "v1.2.3"
+	run run_update_floating_tag "v1.2.3"
+	assert_success
+
+	# New commit and new release tag
+	(
+		cd "$MOCK_GIT_REPO" || exit 1
+		echo "update" >>README.md
+		git add README.md
+		git commit -q -m "feat: another change"
+	)
+	create_release_tag "v1.3.0"
+
+	run run_update_floating_tag "v1.3.0"
+	assert_success
+
+	local floating_commit release_commit
+	floating_commit=$(git -C "$MOCK_GIT_REPO" rev-parse 'v1^{}')
+	release_commit=$(git -C "$MOCK_GIT_REPO" rev-parse 'v1.3.0^{}')
+	assert_equal "$release_commit" "$floating_commit"
+
+	run bash -c "git -C '$MOCK_GIT_REPO' cat-file tag refs/tags/v1 | grep '^type '"
+	assert_success
+	assert_output "type commit"
+}
+
+@test "update-floating-tag: fails on invalid semver tag" {
+	run run_update_floating_tag "not-a-version"
+
+	assert_failure
+	assert_output --partial "Invalid semver tag"
+}
+
+@test "update-floating-tag: writes GitHub Actions outputs" {
+	create_release_tag "v2.0.0"
+
+	run run_update_floating_tag "v2.0.0"
+
+	assert_success
+	assert_file_contains "$GITHUB_OUTPUT" "floating-tag=v2"
+	assert_file_contains "$GITHUB_OUTPUT" "source-tag=v2.0.0"
+}


### PR DESCRIPTION
## Summary

`update-floating-tag.sh` created the floating major tag (e.g. `v1`) as an annotated tag pointing at the annotated release tag object, producing a nested tag (tag -> tag -> commit). This peels the release tag with `${TAG}^{}` so the floating tag's immediate target is the release commit.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Changes Made

- `scripts/ci/release/update-floating-tag.sh`: tag `${TAG}^{}` (peeled commit) instead of `$TAG`
- `tests/bats/unit/release/test_update_floating_tag.bats`: new unit tests using a temp git repo with an annotated release tag; assert the floating tag exists, is annotated, its immediate target object type is `commit` (not `tag`), it dereferences to the release commit, force-updates on subsequent releases, fails on invalid semver, and writes GitHub Actions outputs

## Testing

- New bats tests fail against the unfixed script (nested-tag assertions) and pass with the fix
- `bats --recursive tests/bats` passes

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #373

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes floating release tags so they point directly at release commits. The main changes are:

- Peels the source release tag before creating the floating major tag.
- Keeps the floating tag annotated while avoiding nested tag objects.
- Adds Bats tests for annotated tags, dereferencing, force updates, invalid tags, and GitHub Actions outputs.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/release/update-floating-tag.sh | Updates floating tag creation to target the peeled release commit instead of the release tag object. |
| tests/bats/unit/release/test_update_floating_tag.bats | Adds release tag tests for annotated floating tags, commit targets, force updates, invalid input, and workflow outputs. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/373-floatin..."](https://github.com/lgtm-hq/lgtm-ci/commit/cb67db9432ac1c25d1f3f79e04895934da2ac325) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41897709)</sub>

<!-- /greptile_comment -->