### PR TITLE
docs(security): document self-gating limitation and repo hygiene

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Reporting Security Issues
+
+Please do **not** open public GitHub issues for security vulnerabilities.
+Report them privately via
+[GitHub private vulnerability reporting](https://github.com/lgtm-hq/lgtm-ci/security/advisories/new)
+or email [security@lgtm-hq.com](mailto:security@lgtm-hq.com).
+
+## Threat Model: Self-Gating CI Checks
+
+This repository's own quality gates (`validate-action-pinning.yml`, quality,
+shell tests) run on `pull_request` events and execute code **from the PR
+branch**. That means the gates are self-gating: a pull request can modify a
+validator script and the workflow that runs it in the same change, so the
+checks validate the attacker's version of the validator rather than the
+trusted one on `main`.
+
+This is an accepted residual risk, mitigated by controls outside the
+workflows themselves:
+
+- **CODEOWNERS** — changes to workflows and CI scripts require review by
+  designated owners.
+- **Organization rulesets and branch protection** — merges to `main` require
+  an approving review; direct pushes are blocked.
+- **Required human review** — reviewers are the trust boundary. A malicious
+  change to a validator plus its workflow passes CI by construction; only
+  review catches it.
+
+### Consumer impact
+
+Consumer repositories pull `scripts/ci/` and composite actions at a pinned
+`tooling-ref`. A malicious change merged to this repository does **not**
+reach consumers immediately — it ships at each consumer's next repin. This
+limits blast radius but does not remove it: once a consumer repins past a
+malicious merge, that consumer runs the compromised tooling. Review
+requirements on this repository are therefore a security control for every
+downstream consumer, not just for lgtm-ci itself.

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -103,6 +103,15 @@ Contract enforcement: `scripts/ci/quality/validate-runner-contract.sh` (covered
 by BATS). See [reusable-workflows.md](reusable-workflows.md#runner-pinning) for
 caller examples including `runner-map`.
 
+#### Egress policy exceptions
+
+`reusable-publish-rust-release.yml` intentionally omits the `egress-policy`
+input. Every job hardcodes `egress-policy: block` and validates the runner
+policy at tier `strict`, so callers cannot downgrade release publishing to
+`audit`. Callers can still extend the allowlist through `allowed-endpoints`
+and `allowed-endpoints-mode`. Contract checks should not flag the missing
+input.
+
 See [reusable-workflows.md](reusable-workflows.md) (CodeQL build-mode) for
 interpreted-language scanning guidance.
 

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -108,9 +108,11 @@ caller examples including `runner-map`.
 `reusable-publish-rust-release.yml` intentionally omits the `egress-policy`
 input. Every job hardcodes `egress-policy: block` and validates the runner
 policy at tier `strict`, so callers cannot downgrade release publishing to
-`audit`. Callers can still extend the allowlist through `allowed-endpoints`
-and `allowed-endpoints-mode`. Contract checks should not flag the missing
-input.
+`audit`. Callers can still extend the allowlist for the binary build job
+through `allowed-endpoints` and `allowed-endpoints-mode`; the tag
+verification and GitHub release jobs keep their fixed presets
+(`github-minimal` and `github-tooling`) and do not accept caller endpoints.
+Contract checks should not flag the missing input.
 
 See [reusable-workflows.md](reusable-workflows.md) (CodeQL build-mode) for
 interpreted-language scanning guidance.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Documents two hardening/hygiene items from the full-repo assessment (#375):

- **SECURITY.md**: adds the file with a "Threat Model: Self-Gating CI Checks" section.
  In-repo gates run on `pull_request` from the PR branch, so a PR can modify a validator
  and its workflow together — CI validates the attacker's version. Documents the
  mitigations (CODEOWNERS, org rulesets, required review) and the consumer impact:
  consumers pull `scripts/ci/` at a pinned `tooling-ref`, so a merged malicious change
  ships at each consumer's next repin.
- **docs/workflow-contract.md**: adds an "Egress policy exceptions" note documenting that
  `reusable-publish-rust-release.yml` intentionally omits the `egress-policy` input
  (every job hardcodes `egress-policy: block`, runner policy tier `strict`), alongside
  the existing runner-pinning exceptions.

Notes on the other #375 items:

- **.gitignore**: no change needed — `*.tap` (covers `bats-output.tap`), `report.xml`,
  and `*.egg-info/` are already present; verified with `git check-ignore`.
- **PR #150 overlap**: #150 adds a fuller SECURITY.md (reporting/contact). The
  threat-model section was proposed there as a comment
  (<https://github.com/lgtm-hq/lgtm-ci/pull/150#issuecomment-4885731891>). This PR's
  SECURITY.md is intentionally minimal; whichever merges second takes #150's
  reporting/contact sections and keeps the threat-model section.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #375
- Relates to #150

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR documents security and workflow-contract expectations for the repository.

- Adds `SECURITY.md` with private reporting guidance.
- Documents the self-gating CI threat model and downstream consumer impact.
- Clarifies the Rust release workflow egress exception and endpoint scope.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| SECURITY.md | Adds private reporting guidance and documents the self-gating CI threat model. |
| docs/workflow-contract.md | Clarifies that custom release egress endpoints apply only to the binary build job. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(security): scope allowed-endpoints ..."](https://github.com/lgtm-hq/lgtm-ci/commit/4ad9526c30e4587df5a1a371cff714bf14445f49) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41897838)</sub>

<!-- /greptile_comment -->