### PR TITLE
fix(security): fail scan-vulnerabilities on missing or unparseable grype results

### DIFF
--- a/.github/actions/scan-vulnerabilities/action.yml
+++ b/.github/actions/scan-vulnerabilities/action.yml
@@ -85,38 +85,10 @@ runs:
       id: counts
       if: inputs.output-format == 'json'
       shell: bash
-      run: |
-        RESULTS="${{ steps.scan.outputs.json }}"
-        count_severity() {
-          jq -r "[.matches[]? | select(.vulnerability.severity == \"$1\")] | length" \
-            "$RESULTS" 2>/dev/null || echo 0
-        }
-        if [[ -f "$RESULTS" ]] && command -v jq >/dev/null 2>&1; then
-          CRITICAL=$(count_severity Critical)
-          HIGH=$(count_severity High)
-          MEDIUM=$(count_severity Medium)
-          LOW=$(count_severity Low)
-          TOTAL=$((CRITICAL + HIGH + MEDIUM + LOW))
-          {
-            echo "critical-count=$CRITICAL"
-            echo "high-count=$HIGH"
-            echo "medium-count=$MEDIUM"
-            echo "low-count=$LOW"
-            if [[ $TOTAL -gt 0 ]]; then
-              echo "vulnerabilities-found=true"
-            else
-              echo "vulnerabilities-found=false"
-            fi
-          } >> "$GITHUB_OUTPUT"
-        else
-          {
-            echo "critical-count=0"
-            echo "high-count=0"
-            echo "medium-count=0"
-            echo "low-count=0"
-            echo "vulnerabilities-found=false"
-          } >> "$GITHUB_OUTPUT"
-        fi
+      env:
+        STEP: counts
+        RESULTS_FILE: ${{ steps.scan.outputs.json }}
+      run: $SCRIPTS_DIR/ci/actions/scan-vulnerabilities.sh
 
     - name: Generate SARIF report
       id: sarif

--- a/scripts/ci/actions/scan-vulnerabilities.sh
+++ b/scripts/ci/actions/scan-vulnerabilities.sh
@@ -3,10 +3,11 @@
 # Purpose: Scan for vulnerabilities using Grype
 #
 # Required environment variables:
-#   STEP - Which step to run: install, scan, parse, sarif, summary
+#   STEP - Which step to run: install, scan, parse, counts, sarif, summary
 #   TARGET - Target to scan (SBOM file, image, directory)
 #   TARGET_TYPE - Type of target (sbom, image, dir)
 #   FAIL_ON - Severity threshold to fail on (critical, high, medium, low, none)
+#   RESULTS_FILE - Path to grype JSON results (counts, parse, summary steps)
 
 set -euo pipefail
 
@@ -122,6 +123,45 @@ parse)
 	# Output vulnerability details
 	log_info "Vulnerability Details:"
 	jq -r '.matches[]? | "\(.vulnerability.severity): \(.vulnerability.id) in \(.artifact.name)@\(.artifact.version)"' "$RESULTS_FILE" | sort | head -50
+	;;
+
+counts)
+	: "${RESULTS_FILE:?RESULTS_FILE is required}"
+
+	if [[ ! -f "$RESULTS_FILE" || ! -r "$RESULTS_FILE" ]]; then
+		log_error "Results file not found or unreadable: $RESULTS_FILE"
+		exit 1
+	fi
+
+	if ! command -v jq >/dev/null 2>&1; then
+		log_error "jq is required to parse vulnerability counts"
+		exit 1
+	fi
+
+	if ! counts_line=$(jq -r '[
+			([.matches[]? | select(.vulnerability.severity == "Critical")] | length),
+			([.matches[]? | select(.vulnerability.severity == "High")] | length),
+			([.matches[]? | select(.vulnerability.severity == "Medium")] | length),
+			([.matches[]? | select(.vulnerability.severity == "Low")] | length)
+		] | join(" ")' "$RESULTS_FILE"); then
+		log_error "Failed to parse grype results with jq: $RESULTS_FILE"
+		exit 1
+	fi
+	read -r critical_count high_count medium_count low_count <<<"$counts_line"
+
+	vulnerabilities_found="false"
+	total=$((critical_count + high_count + medium_count + low_count))
+	if [[ $total -gt 0 ]]; then
+		vulnerabilities_found="true"
+	fi
+
+	set_github_output "vulnerabilities-found" "$vulnerabilities_found"
+	set_github_output "critical-count" "$critical_count"
+	set_github_output "high-count" "$high_count"
+	set_github_output "medium-count" "$medium_count"
+	set_github_output "low-count" "$low_count"
+
+	log_info "Critical: $critical_count, High: $high_count, Medium: $medium_count, Low: $low_count"
 	;;
 
 sarif)

--- a/tests/bats/unit/actions/test_scan_vulnerabilities.bats
+++ b/tests/bats/unit/actions/test_scan_vulnerabilities.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/scan-vulnerabilities.sh counts step
+
+load "../../../helpers/common"
+load "../../../helpers/github_env"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+_run_counts() {
+	local results_file="$1"
+	run env \
+		STEP=counts \
+		RESULTS_FILE="$results_file" \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/scan-vulnerabilities.sh"
+}
+
+_write_results_fixture() {
+	local file="$1"
+	cat >"$file" <<'EOF'
+{
+  "matches": [
+    {"vulnerability": {"severity": "Critical", "id": "CVE-1"}, "artifact": {"name": "a", "version": "1.0"}},
+    {"vulnerability": {"severity": "High", "id": "CVE-2"}, "artifact": {"name": "b", "version": "1.0"}},
+    {"vulnerability": {"severity": "High", "id": "CVE-3"}, "artifact": {"name": "c", "version": "1.0"}},
+    {"vulnerability": {"severity": "Medium", "id": "CVE-4"}, "artifact": {"name": "d", "version": "1.0"}},
+    {"vulnerability": {"severity": "Low", "id": "CVE-5"}, "artifact": {"name": "e", "version": "1.0"}},
+    {"vulnerability": {"severity": "Low", "id": "CVE-6"}, "artifact": {"name": "f", "version": "1.0"}},
+    {"vulnerability": {"severity": "Low", "id": "CVE-7"}, "artifact": {"name": "g", "version": "1.0"}},
+    {"vulnerability": {"severity": "Negligible", "id": "CVE-8"}, "artifact": {"name": "h", "version": "1.0"}}
+  ]
+}
+EOF
+}
+
+@test "scan-vulnerabilities counts: fails when RESULTS_FILE is not set" {
+	run env STEP=counts \
+		bash "${PROJECT_ROOT}/scripts/ci/actions/scan-vulnerabilities.sh"
+
+	assert_failure
+	assert_output --partial "RESULTS_FILE is required"
+}
+
+@test "scan-vulnerabilities counts: fails when results file is missing" {
+	_run_counts "${BATS_TEST_TMPDIR}/does-not-exist.json"
+
+	assert_failure
+	assert_output --partial "Results file not found or unreadable"
+	run grep -qE -- '^critical-count=' "$GITHUB_OUTPUT"
+	assert_failure
+}
+
+@test "scan-vulnerabilities counts: fails on malformed JSON" {
+	printf 'not-json{{{\n' >"${BATS_TEST_TMPDIR}/results.json"
+
+	_run_counts "${BATS_TEST_TMPDIR}/results.json"
+
+	assert_failure
+	assert_output --partial "Failed to parse grype results with jq"
+	run grep -qE -- '^critical-count=' "$GITHUB_OUTPUT"
+	assert_failure
+}
+
+@test "scan-vulnerabilities counts: emits correct counts for known severities" {
+	_write_results_fixture "${BATS_TEST_TMPDIR}/results.json"
+
+	_run_counts "${BATS_TEST_TMPDIR}/results.json"
+
+	assert_success
+	assert_file_contains "$GITHUB_OUTPUT" '^vulnerabilities-found=true$'
+	assert_file_contains "$GITHUB_OUTPUT" '^critical-count=1$'
+	assert_file_contains "$GITHUB_OUTPUT" '^high-count=2$'
+	assert_file_contains "$GITHUB_OUTPUT" '^medium-count=1$'
+	assert_file_contains "$GITHUB_OUTPUT" '^low-count=3$'
+}
+
+@test "scan-vulnerabilities counts: emits zeros when no matches present" {
+	printf '{"matches": []}\n' >"${BATS_TEST_TMPDIR}/results.json"
+
+	_run_counts "${BATS_TEST_TMPDIR}/results.json"
+
+	assert_success
+	assert_file_contains "$GITHUB_OUTPUT" '^vulnerabilities-found=false$'
+	assert_file_contains "$GITHUB_OUTPUT" '^critical-count=0$'
+	assert_file_contains "$GITHUB_OUTPUT" '^high-count=0$'
+	assert_file_contains "$GITHUB_OUTPUT" '^medium-count=0$'
+	assert_file_contains "$GITHUB_OUTPUT" '^low-count=0$'
+}


### PR DESCRIPTION
## Summary

The scan-vulnerabilities composite action parsed grype vulnerability counts with an inline run block that failed open: a missing results file, missing jq, or a jq parse error silently produced zero counts and `vulnerabilities-found=false`. This PR moves the parsing into a dedicated `counts` STEP in `scripts/ci/actions/scan-vulnerabilities.sh` that fails the step with a logged error instead of emitting silent zeros.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Changes Made

- Add a `counts` STEP case to `scripts/ci/actions/scan-vulnerabilities.sh` that reads `RESULTS_FILE`, counts Critical/High/Medium/Low matches with a single jq pass, and emits outputs via `set_github_output`
- Fail (log_error + exit 1) when `RESULTS_FILE` is missing/unreadable, jq is unavailable, or jq fails to parse the results
- Replace the inline "Parse vulnerability counts" run block in `.github/actions/scan-vulnerabilities/action.yml` with a script call matching sibling steps (`STEP: counts`, `RESULTS_FILE` from `steps.scan.outputs.json`)
- Add `tests/bats/unit/actions/test_scan_vulnerabilities.bats` covering missing file, malformed JSON, known-severity fixture counts, and empty-matches zeros

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. `reusable-sbom.yml` fail-on-severity defaults are unchanged (deferred per issue discussion).

## Closes

- Closes #366

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes the vulnerability scan count step fail when Grype results cannot be parsed. The main changes are:

- Moves count parsing from the composite action YAML into `scan-vulnerabilities.sh`.
- Adds explicit errors for missing results, unreadable results, missing `jq`, and malformed JSON.
- Emits severity count outputs from the shared script path.
- Adds Bats tests for failure cases and valid count output.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/scan-vulnerabilities/action.yml | Calls the shared scan-vulnerabilities script for JSON count parsing. |
| scripts/ci/actions/scan-vulnerabilities.sh | Adds the counts step with validation, jq parsing, output emission, and error handling. |
| tests/bats/unit/actions/test_scan_vulnerabilities.bats | Adds tests for count parsing success and failure cases. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/366-scan-vu..."](https://github.com/lgtm-hq/lgtm-ci/commit/8a95b2c8d0dda96b23fdf804670ddc38f07dcccf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41898153)</sub>

<!-- /greptile_comment -->