### PR TITLE
fix(deps): cover all lintro digest pins in renovate custom manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,9 @@
       "customType": "regex",
       "description": "Track pinned py-lintro Docker image digests",
       "managerFilePatterns": [
-        "/^\\.github/workflows/reusable-quality\\.yml$/",
+        "/^\\.github/workflows/reusable-quality-lint\\.yml$/",
+        "/^\\.github/workflows/reusable-security-audit\\.yml$/",
+        "/^scripts/ci/quality/resolve-lintro-image\\.sh$/",
         "/^\\.github/actions/run-quality/action\\.yml$/",
         "/^README\\.md$/",
         "/^\\.github/actions/README\\.md$/"

--- a/tests/bats/integration/test_lintro_digest_pins.bats
+++ b/tests/bats/integration/test_lintro_digest_pins.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Guard that all py-lintro digest pins across the repo stay in sync
+
+load "../../helpers/common"
+
+@test "lintro digest pins: all py-lintro@sha256 pins in .github/ and scripts/ are identical" {
+	run bash -c '
+		grep -rhoE "py-lintro@sha256:[a-f0-9]{64}" \
+			"'"${PROJECT_ROOT}"'/.github" \
+			"'"${PROJECT_ROOT}"'/scripts" \
+			| sort -u
+	'
+	assert_success
+	local count
+	count="$(printf '%s\n' "$output" | grep -c 'py-lintro@sha256:')"
+	if [[ "$count" -ne 1 ]]; then
+		echo "Expected exactly one unique py-lintro digest pin, found ${count}:" >&2
+		echo "$output" >&2
+		return 1
+	fi
+}

--- a/tests/bats/integration/test_lintro_digest_pins.bats
+++ b/tests/bats/integration/test_lintro_digest_pins.bats
@@ -4,11 +4,12 @@
 
 load "../../helpers/common"
 
-@test "lintro digest pins: all py-lintro@sha256 pins in .github/ and scripts/ are identical" {
+@test "lintro digest pins: all py-lintro@sha256 pins in .github/, scripts/, and README.md are identical" {
 	run bash -c '
 		grep -rhoE "py-lintro@sha256:[a-f0-9]{64}" \
 			"'"${PROJECT_ROOT}"'/.github" \
 			"'"${PROJECT_ROOT}"'/scripts" \
+			"'"${PROJECT_ROOT}"'/README.md" \
 			| sort -u
 	'
 	assert_success


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

The py-lintro custom regex manager in `renovate.json` still listed the long-gone
`.github/workflows/reusable-quality.yml`, so Renovate digest bumps missed the
files that actually carry pins. This replaces the dead pattern with patterns for
`reusable-quality-lint.yml`, `reusable-security-audit.yml`, and
`scripts/ci/quality/resolve-lintro-image.sh`, and adds a BATS guard asserting
every `py-lintro@sha256:` pin across `.github/` and `scripts/` is identical.

## Type of Change

- [x] Bug fix
- [x] CI/CD improvement

## Changes Made

- Replace dead `reusable-quality.yml` pattern in
  `customManagers[0].managerFilePatterns` with `reusable-quality-lint.yml`,
  `reusable-security-audit.yml`, and `resolve-lintro-image.sh`; keep the
  existing run-quality action and README patterns
- Add `tests/bats/integration/test_lintro_digest_pins.bats` asserting all
  py-lintro digest pins in the repo resolve to exactly one unique digest

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #367

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes py-lintro digest coverage for Renovate and adds a guard for pin drift.

- Updates Renovate regex manager file patterns for current workflow and script files.
- Keeps the existing action README and root README patterns.
- Adds a BATS test requiring one unique py-lintro digest across `.github/`, `scripts/`, and `README.md`.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| renovate.json | Updates the py-lintro custom manager patterns to include the current lint, security-audit, resolver, action, and README pin locations. |
| tests/bats/integration/test_lintro_digest_pins.bats | Adds an integration test that checks the tracked py-lintro digest pins stay identical across the scanned repository paths. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/367-renovat..."](https://github.com/lgtm-hq/lgtm-ci/commit/424acc170a83dbd7a4153b9e6926758e38bfcb4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41898187)</sub>

<!-- /greptile_comment -->