### PR TITLE
chore(log): remove legacy un-namespaced color constant aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **log**: legacy un-namespaced color constant aliases (`RED`, `GREEN`, `YELLOW`,
+  `BLUE`, `NC`) from `scripts/ci/lib/log.sh` (#383). Consumers sourcing `log.sh`
+  must migrate to the namespaced `LGTM_CI_*` names (e.g. `LGTM_CI_RED`,
+  `LGTM_CI_NC`).
+
 ### Fixed
 
 ### Security

--- a/scripts/ci/lib/log.sh
+++ b/scripts/ci/lib/log.sh
@@ -19,19 +19,6 @@ readonly LGTM_CI_YELLOW='\033[1;33m'
 readonly LGTM_CI_BLUE='\033[0;34m'
 readonly LGTM_CI_NC='\033[0m' # No Color
 
-# Export for compatibility with scripts expecting these names
-# SC2034: These appear unused but are exported for scripts that source this file
-# shellcheck disable=SC2034
-readonly RED="${LGTM_CI_RED}"
-# shellcheck disable=SC2034
-readonly GREEN="${LGTM_CI_GREEN}"
-# shellcheck disable=SC2034
-readonly YELLOW="${LGTM_CI_YELLOW}"
-# shellcheck disable=SC2034
-readonly BLUE="${LGTM_CI_BLUE}"
-# shellcheck disable=SC2034
-readonly NC="${LGTM_CI_NC}"
-
 # =============================================================================
 # Logging functions
 # =============================================================================

--- a/tests/bats/unit/lib/test_log.bats
+++ b/tests/bats/unit/lib/test_log.bats
@@ -26,10 +26,10 @@ teardown() {
 	assert_output --partial "test"
 }
 
-@test "log.sh: exports legacy color aliases" {
+@test "log.sh: does not define legacy un-namespaced color aliases" {
 	run bash -c '
 		source "$LIB_DIR/log.sh"
-		declare -p RED GREEN YELLOW BLUE NC >/dev/null 2>&1
+		! declare -p RED GREEN YELLOW BLUE NC >/dev/null 2>&1
 	'
 	assert_success
 }


### PR DESCRIPTION
## Summary

Removes the legacy un-namespaced color constant aliases (`RED`, `GREEN`, `YELLOW`, `BLUE`, `NC`) from `scripts/ci/lib/log.sh`, along with their `shellcheck disable=SC2034` lines and the compatibility comment. The namespaced `LGTM_CI_*` constants are unchanged and remain the only color constants exported by the library.

Verified zero bare usages of the legacy names across `scripts/` and `tests/` before removal (the `$RED_THRESHOLD` / `$YELLOW_THRESHOLD` variables in `generate-coverage-badge.sh` are unrelated locals).

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Changes Made

- Remove `RED`/`GREEN`/`YELLOW`/`BLUE`/`NC` alias block from `scripts/ci/lib/log.sh`
- Update `tests/bats/unit/lib/test_log.bats` to assert the legacy names are no longer defined
- Add CHANGELOG entry under `[Unreleased]` → `Removed` with a consumer migration note

## Checklist

- [x] I have tested these changes locally (`bats --recursive tests/bats`, `uv run lintro chk`)
- [x] I have updated documentation if needed (CHANGELOG migration note)
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

Consumers sourcing `log.sh` and referencing the bare `RED`, `GREEN`, `YELLOW`, `BLUE`, or `NC` names must migrate to the namespaced equivalents (`LGTM_CI_RED`, `LGTM_CI_GREEN`, `LGTM_CI_YELLOW`, `LGTM_CI_BLUE`, `LGTM_CI_NC`).

## Closes

- Closes #383

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes the old color aliases from the CI logging library. The main changes are:

- Removed bare `RED`, `GREEN`, `YELLOW`, `BLUE`, and `NC` aliases from `scripts/ci/lib/log.sh`.
- Kept the namespaced `LGTM_CI_*` color constants unchanged.
- Updated the Bats test to assert the legacy aliases are absent.
- Added a changelog note with migration guidance.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/lib/log.sh | Removes the legacy un-namespaced color aliases while preserving the namespaced logging constants and functions. |
| tests/bats/unit/lib/test_log.bats | Updates the log library test to match the intended removal of the legacy aliases. |
| CHANGELOG.md | Documents the alias removal and points consumers to the namespaced color constants. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into chore/383-remov..."](https://github.com/lgtm-hq/lgtm-ci/commit/8e992f0bee16ec0dcb6f58fbeeaca9700b72ae62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41898226)</sub>

<!-- /greptile_comment -->