### PR TITLE
docs(examples): add consumer starter workflows

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,30 @@
 Sample caller layouts for lgtm-hq repositories. Copy and adapt into your
 `.github/workflows/` directory.
 
+## Index
+
+<!-- markdownlint-disable MD013 -- index table; row text exceeds default line length -->
+
+| Example                                                                        | When to use                                                                    |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [ci-python.yml](ci-python.yml)                                                 | Python repo CI: lint + pytest coverage with PR summaries                       |
+| [ci-node-vitest.yml](ci-node-vitest.yml)                                       | Node.js repo CI with Vitest tests                                              |
+| [ci-node-custom.yml](ci-node-custom.yml)                                       | Node.js CI with a custom test command (Bun, monorepo subdir)                   |
+| [ci-rust.yml](ci-rust.yml)                                                     | Rust workspace CI: build check + coverage; explicit `allowed-endpoints`        |
+| [ci-docker.yml](ci-docker.yml)                                                 | Docker image: multi-arch PR validation, push to GHCR on main                   |
+| [ci-quality-only.yml](ci-quality-only.yml)                                     | Lint-only pipelines (tag/release or no PR comments)                            |
+| [release-version-pr.yml](release-version-pr.yml)                               | Open `chore(release)` version-bump PRs from conventional commits               |
+| [release-auto-tag.yml](release-auto-tag.yml)                                   | Tag + GitHub Release when the version PR merges                                |
+| [release-version-pr-changelog-only.yml](release-version-pr-changelog-only.yml) | Version PRs for repos with no package version files                            |
+| [publish-python-release.yml](publish-python-release.yml)                       | Publish to PyPI on tag (trusted publishing + attestation)                      |
+
+<!-- markdownlint-enable MD013 -->
+
+All starters pin reusable workflow `uses:` refs and `tooling-ref` to the same
+lgtm-ci release commit SHA with a `# vX.Y.Z` comment (see
+[docs/workflow-contract.md](../docs/workflow-contract.md), "Action pinning
+policy"). Update both together when bumping releases.
+
 ## Reusable workflows (recommended)
 
 Examples such as `publish-python-release.yml` and

--- a/examples/ci-docker.yml
+++ b/examples/ci-docker.yml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+# Starter Docker build/publish workflow: full multi-arch validation on PRs
+# (no push), push to GHCR on main. Copy into your repository as
+# .github/workflows/docker.yml. Permissions cover all jobs in
+# reusable-docker.yml — GitHub validates every job in a called reusable at
+# parse time (docs/workflow-contract.md "Permissions by mode").
+---
+name: Docker
+
+"on":
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-docker.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      security-events: write
+    with:
+      tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
+      file: Dockerfile
+      push: ${{ github.event_name != 'pull_request' }}
+      # Split per-platform validation on PRs without QEMU overhead
+      validate-on-pr: ${{ github.event_name == 'pull_request' }}
+      # Native arm64 runner instead of QEMU (contract: "Runner pinning")
+      runner-map: '{"linux/arm64":"ubuntu-24.04-arm"}'
+      scan: true
+      scan-exit-code: "1"
+      smoke-test: --version
+      egress-policy: block
+      egress-preset: docker

--- a/examples/ci-node-custom.yml
+++ b/examples/ci-node-custom.yml
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: MIT
+# Starter CI for a Node.js repository with a custom test command (Bun shown).
+# Copy into your repository as .github/workflows/ci.yml.
+# Uses reusable-test-node-custom.yml (required test-command); for plain
+# Vitest see examples/ci-node-vitest.yml. Permissions per
+# docs/workflow-contract.md "Permissions by mode".
+---
+name: CI
+
+"on":
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    permissions:
+      contents: read
+      packages: read
+    with:
+      tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
+      job-name: "Lintro Quality Checks"
+      egress-policy: block
+      egress-preset: quality
+
+  publish-quality-summary:
+    needs: quality
+    # Fork PRs cannot post comments (contract: "Fork PR summaries and reports")
+    if: >-
+      !cancelled()
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.fork == false
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      exit-code: ${{ needs.quality.outputs.exit-code }}
+      tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
+
+  web-coverage:
+    # Custom command runs in working-directory after dependency install
+    # (contract: "Low-noise Rust and Node checks").
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node-custom.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
+      job-name: "Web Coverage"
+      working-directory: apps/web
+      package-manager: bun
+      test-command: bun run test:coverage
+      coverage: true
+      publish-test-summary: true
+      runner-image: ubuntu-24.04
+      egress-policy: block
+      egress-preset: quality

--- a/examples/ci-node-custom.yml
+++ b/examples/ci-node-custom.yml
@@ -64,6 +64,10 @@ jobs:
       test-command: bun run test:coverage
       coverage: true
       publish-test-summary: true
+      # The PR summary reads counts from this file; it must match where your
+      # test command writes its JSON summary (Vitest: coverage.reporter
+      # "json-summary"), otherwise the summary reports zeros.
+      coverage-summary-file: coverage/coverage-summary.json
       runner-image: ubuntu-24.04
       egress-policy: block
       egress-preset: quality

--- a/examples/ci-node-vitest.yml
+++ b/examples/ci-node-vitest.yml
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: MIT
+# Starter CI for a Node.js repository whose tests run via Vitest.
+# Copy into your repository as .github/workflows/ci.yml.
+# Uses reusable-test-node.yml (Vitest); for arbitrary package scripts see
+# examples/ci-node-custom.yml. Permissions per docs/workflow-contract.md
+# "Permissions by mode".
+---
+name: CI
+
+"on":
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    permissions:
+      contents: read
+      packages: read
+    with:
+      tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
+      job-name: "Lintro Quality Checks"
+      egress-policy: block
+      egress-preset: quality
+
+  publish-quality-summary:
+    needs: quality
+    # Fork PRs cannot post comments (contract: "Fork PR summaries and reports")
+    if: >-
+      !cancelled()
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.fork == false
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      exit-code: ${{ needs.quality.outputs.exit-code }}
+      tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
+
+  test:
+    # Coverage mode: single node-version + coverage: true (contract:
+    # "Compat vs coverage contract"). For a compat matrix instead, pass
+    # node-versions: "20,22" with coverage/publish disabled.
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-node.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
+      job-name: "Node.js Tests"
+      node-version: "22"
+      package-manager: npm
+      coverage: true
+      publish-test-summary: true
+      runner-image: ubuntu-24.04
+      egress-policy: block
+      egress-preset: quality

--- a/examples/ci-python.yml
+++ b/examples/ci-python.yml
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MIT
+# Starter CI for a Python (uv/pytest) repository using lgtm-ci reusables.
+# Copy into your repository as .github/workflows/ci.yml.
+# Permissions per docs/workflow-contract.md "Permissions by mode".
+# Quality summary is a split caller job with a fork-PR guard; the test
+# reusable routes its PR comment through an internal publish-test-summary
+# job (contract: "Permissions split").
+---
+name: CI
+
+"on":
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    permissions:
+      contents: read
+      packages: read
+    with:
+      tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
+      job-name: "Lintro Quality Checks"
+      egress-policy: block
+      egress-preset: quality
+
+  publish-quality-summary:
+    needs: quality
+    # Fork PRs cannot post comments (contract: "Fork PR summaries and reports")
+    if: >-
+      !cancelled()
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.fork == false
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      exit-code: ${{ needs.quality.outputs.exit-code }}
+      tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
+
+  test:
+    # Coverage mode: single python-version + coverage: true (contract:
+    # "Compat vs coverage contract"). For a compat matrix instead, pass
+    # python-versions: "3.11,3.12,3.13" with coverage/publish disabled.
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-test-python.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
+      job-name: "Python Tests"
+      python-version: "3.12"
+      coverage: true
+      upload-coverage: true
+      publish-test-summary: true
+      runner-image: ubuntu-24.04
+      egress-policy: block
+      egress-preset: pypi

--- a/examples/ci-quality-only.yml
+++ b/examples/ci-quality-only.yml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+# Lint-only CI: Lintro quality checks with no PR comment jobs.
+# Copy into your repository as .github/workflows/quality.yml.
+# Suitable for tag/release pipelines or repos that disable PR summaries —
+# call the lint reusable only and omit the publish reusable entirely
+# (docs/workflow-contract.md "Permissions by mode"). No pull-requests: write
+# is needed anywhere.
+---
+name: Quality
+
+"on":
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: quality-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    permissions:
+      contents: read
+      packages: read
+    with:
+      tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
+      job-name: "Lintro Quality Checks"
+      egress-policy: block
+      egress-preset: quality

--- a/examples/ci-rust.yml
+++ b/examples/ci-rust.yml
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: MIT
+# Starter CI for a Rust workspace using lgtm-ci reusables.
+# Copy into your repository as .github/workflows/ci.yml.
+# This example demonstrates explicit allowed-endpoints allowlists instead of
+# egress presets (contract: "Egress block examples"); the other starters use
+# egress-preset. Permissions per docs/workflow-contract.md
+# "Permissions by mode".
+---
+name: CI
+
+"on":
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-quality-lint.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    permissions:
+      contents: read
+      packages: read
+    with:
+      tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
+      job-name: "Lintro Quality Checks"
+      egress-policy: block
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        ghcr.io:443
+        api.osv.dev:443
+        semgrep.dev:443
+        metrics.semgrep.dev:443
+
+  publish-quality-summary:
+    needs: quality
+    # Fork PRs cannot post comments (contract: "Fork PR summaries and reports")
+    if: >-
+      !cancelled()
+      && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.fork == false
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-quality-summary.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      exit-code: ${{ needs.quality.outputs.exit-code }}
+      tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
+
+  rust-build:
+    # Build-only check, separate from tests (contract:
+    # "Low-noise Rust and Node checks").
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-build.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    permissions:
+      contents: read
+    with:
+      tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
+      job-name: "Build Check"
+      egress-policy: block
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        static.rust-lang.org:443
+        crates.io:443
+        static.crates.io:443
+        index.crates.io:443
+
+  rust-coverage:
+    # Coverage mode: single rust-toolchain + coverage: true (contract:
+    # "Compat vs coverage contract"). PR summary posts via the reusable's
+    # internal publish-test-summary job.
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-rust-test.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
+      job-name: "Rust Coverage"
+      rust-toolchain: stable
+      coverage: true
+      publish-test-summary: true
+      runner-image: ubuntu-24.04
+      egress-policy: block
+      allowed-endpoints: >
+        github.com:443
+        api.github.com:443
+        codeload.github.com:443
+        static.rust-lang.org:443
+        sh.rustup.rs:443
+        crates.io:443
+        static.crates.io:443
+        index.crates.io:443

--- a/examples/ci-rust.yml
+++ b/examples/ci-rust.yml
@@ -31,10 +31,16 @@ jobs:
       tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
       job-name: "Lintro Quality Checks"
       egress-policy: block
+      # GHCR image pulls resolve layers via pkg-containers.githubusercontent.com;
+      # codeload/objects cover tooling checkout and action release downloads.
       allowed-endpoints: >
         github.com:443
         api.github.com:443
+        codeload.github.com:443
+        objects.githubusercontent.com:443
         ghcr.io:443
+        pkg-containers.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
         api.osv.dev:443
         semgrep.dev:443
         metrics.semgrep.dev:443
@@ -66,10 +72,15 @@ jobs:
       tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
       job-name: "Build Check"
       egress-policy: block
+      # raw/objects/github-releases hosts cover the cargo-binstall bootstrap
+      # (installer script + release binary downloads) run by setup-rust.
       allowed-endpoints: >
         github.com:443
         api.github.com:443
         codeload.github.com:443
+        raw.githubusercontent.com:443
+        objects.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
         static.rust-lang.org:443
         crates.io:443
         static.crates.io:443
@@ -92,10 +103,18 @@ jobs:
       publish-test-summary: true
       runner-image: ubuntu-24.04
       egress-policy: block
+      # raw/objects/github-releases hosts cover the cargo-binstall bootstrap
+      # (installer script + release binary downloads) used to install
+      # cargo-nextest and cargo-llvm-cov; pipelines host covers the coverage
+      # artifact upload for the PR summary.
       allowed-endpoints: >
         github.com:443
         api.github.com:443
         codeload.github.com:443
+        raw.githubusercontent.com:443
+        objects.githubusercontent.com:443
+        github-releases.githubusercontent.com:443
+        pipelines.actions.githubusercontent.com:443
         static.rust-lang.org:443
         sh.rustup.rs:443
         crates.io:443

--- a/examples/release-auto-tag.yml
+++ b/examples/release-auto-tag.yml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: MIT
+# Starter auto-tag workflow: tags the release commit created by the version
+# PR (chore(release): ...) and creates a GitHub Release.
+# Copy into your repository as .github/workflows/release-auto-tag.yml.
+# Requires a GitHub App (RELEASE_APP_ID / RELEASE_APP_PRIVATE_KEY secrets).
+# Permissions per docs/workflow-contract.md "Permissions by mode":
+# actions: read + issues: write cover the report-release-failure job.
+# Rust monorepos tagging from Cargo.toml: see the "Cargo auto-tag contract"
+# section (version-source: cargo).
+---
+name: "Release: Auto Tag"
+
+"on":
+  push:
+    branches: [main]
+    paths:
+      - "CHANGELOG.md"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version to tag (e.g., 1.2.3)"
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: release-auto-tag-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  auto-tag:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-auto-tag.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    permissions:
+      contents: write
+      actions: read
+      issues: write
+    with:
+      tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
+      version: ${{ github.event_name == 'workflow_dispatch' && inputs.version || '' }}
+      tag-prefix: v
+      create-release: true
+      egress-policy: block
+      egress-preset: github-tooling
+    secrets:
+      RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+      RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/examples/release-version-pr.yml
+++ b/examples/release-version-pr.yml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MIT
+# Starter version-PR workflow: opens a chore(release) PR that bumps version
+# files and CHANGELOG from conventional commits since the last tag.
+# Copy into your repository as .github/workflows/release-version-pr.yml.
+# Pair with examples/release-auto-tag.yml, which tags once the PR merges.
+# Requires a GitHub App (RELEASE_APP_ID / RELEASE_APP_PRIVATE_KEY secrets).
+# Permissions per docs/workflow-contract.md "Permissions by mode":
+# actions: read + issues: write cover the report-release-failure job.
+# CHANGELOG-only repos: see examples/release-version-pr-changelog-only.yml.
+---
+name: "Release: Create Version PR"
+
+"on":
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: release-version-pr-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  version-pr:
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@4aaefe64763b7841b6d92d94dc47185083d34c9a # v0.46.0
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+      issues: write
+    with:
+      tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
+      # Ecosystems whose version files get bumped: node, rust, python,
+      # ruby, swift, dart, kotlin (comma-separated). Empty = CHANGELOG only.
+      ecosystems: python
+      max-bump: minor
+      egress-policy: block
+      egress-preset: github-tooling
+    secrets:
+      RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+      RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Adds eight copy-paste starter caller workflows to `examples/` so consumer
repositories can adopt lgtm-ci reusables without deriving permissions, egress
allowlists, and pin style from the contract docs. Every example pins reusable
`uses:` refs and `tooling-ref` to the v0.46.0 release commit SHA
(`4aaefe64763b7841b6d92d94dc47185083d34c9a`) with `# v0.46.0` comments, uses
permissions from the docs/workflow-contract.md "Permissions by mode" table,
and shows split `publish-quality-summary` jobs with the fork-PR guard from
`ci.yml`. `ci-rust.yml` demonstrates explicit `allowed-endpoints`; the other
starters use `egress-preset`. `examples/README.md` gains an index table
(example → when to use).

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Changes Made

- Add `examples/ci-python.yml` — Python CI (quality + publish summary + pytest coverage)
- Add `examples/ci-node-vitest.yml` — Node.js CI with Vitest
- Add `examples/ci-node-custom.yml` — Node.js CI with a custom test command (Bun, monorepo subdir)
- Add `examples/ci-rust.yml` — Rust CI (build check + coverage) with explicit `allowed-endpoints`
- Add `examples/ci-docker.yml` — multi-arch Docker PR validation + GHCR push on main
- Add `examples/ci-quality-only.yml` — lint-only pipeline (no PR comment jobs)
- Add `examples/release-auto-tag.yml` — tag + GitHub Release after version PR merges
- Add `examples/release-version-pr.yml` — conventional-commit version-bump PRs (ecosystems demo)
- Update `examples/README.md` with an index table and pinning note

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

`actionlint` passes on all eight examples; `uv run lintro chk` reports zero
issues; full BATS suite passes (2264/2264).

## Breaking Changes

None

## Closes

- Closes #382

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds starter workflows that consumers can copy into their repositories. The main changes are:

- New CI examples for Python, Node, Rust, Docker, and quality-only checks.
- New release workflow examples for version PRs and auto-tagging.
- An examples README index with pinning guidance.
</details>

<h3>Confidence Score: 4/5</h3>

This is close, but the Rust starter should be fixed before merging.

- The updated Rust coverage allowlist includes the bootstrap hosts.
- The Rust build allowlist still omits `sh.rustup.rs`.
- Fresh runners can fail before the build check starts when egress blocking is enabled.

examples/ci-rust.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| examples/ci-rust.yml | Adds a Rust starter with explicit egress allowlists, but the build job still lacks the rustup bootstrap host. |
| examples/ci-node-custom.yml | Adds a custom Node starter and documents the coverage summary file contract for published test summaries. |
| examples/README.md | Adds an index table and pinning guidance for the starter workflows. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aexamples%2Fci-rust.yml%3A83-85%0A**Rustup%20Host%20Missing**%0A%0AThe%20build%20job%20runs%20with%20%60egress-policy%3A%20block%60%2C%20and%20this%20explicit%20%60allowed-endpoints%60%20list%20replaces%20the%20preset.%20On%20a%20fresh%20runner%2C%20the%20Rust%20setup%20path%20can%20fetch%20rustup%20from%20%60sh.rustup.rs%60%20before%20the%20build%20check%20runs.%20Because%20this%20host%20is%20not%20listed%20here%2C%20the%20build%20job%20can%20fail%20during%20toolchain%20setup%20even%20though%20the%20coverage%20job%20includes%20the%20same%20host.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20github-releases.githubusercontent.com%3A443%0A%20%20%20%20%20%20%20%20sh.rustup.rs%3A443%0A%20%20%20%20%20%20%20%20static.rust-lang.org%3A443%0A%20%20%20%20%20%20%20%20crates.io%3A443%0A%60%60%60%0A%0A&pr=391&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aexamples%2Fci-rust.yml%3A83-85%0A**Rustup%20Host%20Missing**%0A%0AThe%20build%20job%20runs%20with%20%60egress-policy%3A%20block%60%2C%20and%20this%20explicit%20%60allowed-endpoints%60%20list%20replaces%20the%20preset.%20On%20a%20fresh%20runner%2C%20the%20Rust%20setup%20path%20can%20fetch%20rustup%20from%20%60sh.rustup.rs%60%20before%20the%20build%20check%20runs.%20Because%20this%20host%20is%20not%20listed%20here%2C%20the%20build%20job%20can%20fail%20during%20toolchain%20setup%20even%20though%20the%20coverage%20job%20includes%20the%20same%20host.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20github-releases.githubusercontent.com%3A443%0A%20%20%20%20%20%20%20%20sh.rustup.rs%3A443%0A%20%20%20%20%20%20%20%20static.rust-lang.org%3A443%0A%20%20%20%20%20%20%20%20crates.io%3A443%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=391&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22docs%2F382-starter-examples%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2F382-starter-examples%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aexamples%2Fci-rust.yml%3A83-85%0A**Rustup%20Host%20Missing**%0A%0AThe%20build%20job%20runs%20with%20%60egress-policy%3A%20block%60%2C%20and%20this%20explicit%20%60allowed-endpoints%60%20list%20replaces%20the%20preset.%20On%20a%20fresh%20runner%2C%20the%20Rust%20setup%20path%20can%20fetch%20rustup%20from%20%60sh.rustup.rs%60%20before%20the%20build%20check%20runs.%20Because%20this%20host%20is%20not%20listed%20here%2C%20the%20build%20job%20can%20fail%20during%20toolchain%20setup%20even%20though%20the%20coverage%20job%20includes%20the%20same%20host.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20github-releases.githubusercontent.com%3A443%0A%20%20%20%20%20%20%20%20sh.rustup.rs%3A443%0A%20%20%20%20%20%20%20%20static.rust-lang.org%3A443%0A%20%20%20%20%20%20%20%20crates.io%3A443%0A%60%60%60%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=391&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into docs/382-starte..."](https://github.com/lgtm-hq/lgtm-ci/commit/79c9f70f3f72d38caf75be154f731f3098dbf157) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41898252)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->