### PR TITLE
docs(release): document consumer upgrade path for KAC-aligned changelog generator

### DIFF
--- a/docs/python-release-publish.md
+++ b/docs/python-release-publish.md
@@ -296,4 +296,6 @@ in the product repository release workflow.
 
 - [workflow-contract.md](workflow-contract.md)
 - [reusable-workflows.md](reusable-workflows.md)
+- [release-changelog.md](release-changelog.md) — migrating consumer changelogs
+  to the Keep a Changelog generator (v0.43.1+)
 - [homebrew-tap](https://github.com/lgtm-hq/homebrew-tap) — formula config and dispatch handler

--- a/docs/release-changelog.md
+++ b/docs/release-changelog.md
@@ -1,0 +1,75 @@
+# Release changelog migration (Keep a Changelog)
+
+The release changelog generator was aligned with
+[Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) in
+**v0.43.1** (#344). Consumers pinned to an older
+`reusable-release-version-pr.yml` still receive the legacy section headings
+(`### Features`, `### Bug Fixes`, ...), which forces manual heading edits and
+lint fixes on every release PR. This guide covers upgrading a consumer
+repository to the KAC-aligned generator.
+
+## Minimum pin
+
+Bump `reusable-release-version-pr.yml` to **v0.43.1 or later** (pin the SHA of
+that tag or newer). Ideally bump all lgtm-ci refs in the repository to the same
+release so the version-PR and publish workflows do not run split versions —
+for example, publishing on a current release while the release PR workflow is
+still pinned to an older one generates legacy headings on new release PRs.
+
+```yaml
+jobs:
+  version-pr:
+    # v0.43.1+ — KAC-aligned changelog generator
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-release-version-pr.yml@<sha>
+```
+
+## Heading mapping
+
+| Commit type                       | Pre-v0.43.1 heading    | v0.43.1+ heading |
+| --------------------------------- | ---------------------- | ---------------- |
+| `feat`                            | `### Features`         | `### Added`      |
+| `fix`                             | `### Bug Fixes`        | `### Fixed`      |
+| breaking (`!` / `BREAKING CHANGE`)| `### Breaking Changes` | `### Changed`    |
+| `docs`                            | `### Documentation`    | `### Changed`    |
+| other (`chore`, `refactor`, ...)  | `### Other Changes`    | `### Changed`    |
+
+Generated version sections use only `Added`, `Changed`, and `Fixed`. The
+reset `[Unreleased]` template additionally includes the empty `Deprecated`,
+`Removed`, and `Security` sections for hand-written entries.
+
+## Historical entries
+
+Do **not** rewrite existing `Features` / `Bug Fixes` sections in a consumer
+`CHANGELOG.md`. Only version sections generated after the pin bump follow the
+KAC headings; mixed history is expected and fine.
+
+## Markdownlint (MD024)
+
+Changelog files repeat the same section headings in every version block, which
+trips MD024 (`no-duplicate-heading`). Org convention is a top-of-file HTML
+comment in `CHANGELOG.md`:
+
+```markdown
+<!-- markdownlint-disable MD024 -- duplicate headings are standard in changelogs -->
+```
+
+Alternatively, configure `"MD024": { "siblings_only": true }` in the
+repository's markdownlint config.
+
+## Verification checklist
+
+On the next release PR after bumping the pin:
+
+- [ ] Generated section headings are `### Added` / `### Changed` / `### Fixed`
+      (no `### Features` / `### Bug Fixes` / `### Other Changes`)
+- [ ] Hand-written `[Unreleased]` entries were merged into the matching KAC
+      sections of the new version block
+- [ ] `[Unreleased]` was reset with the empty KAC section skeleton
+- [ ] Markdown lint passes without manual heading edits
+
+## References
+
+- Generator implementation: `scripts/ci/lib/release/changelog.sh`
+- Unreleased-section merge: `scripts/ci/lib/release/changelog_merge.sh`
+- Workflow entry point: `reusable-release-version-pr.yml` (see
+  [reusable-workflows.md](reusable-workflows.md))

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -349,6 +349,11 @@ layout so the artifact root is browsable HTML.
 
 ## Release
 
+`reusable-release-version-pr.yml` generates Keep a Changelog section headings
+(`Added` / `Changed` / `Fixed`) as of v0.43.1. If your pin predates that, see
+[release-changelog.md](release-changelog.md) for the consumer migration guide
+(minimum pin, heading mapping, MD024 lint note).
+
 When release automation fails on the default branch, the follow-up
 `report-release-failure` job runs two steps in order: it first writes release
 trigger context to the job step summary, then creates or updates a deduplicated


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Adds `docs/release-changelog.md`, a consumer migration guide for the Keep a
Changelog-aligned generator shipped in #344: minimum pin, legacy-to-KAC
heading mapping table, historical-entry policy (no rewrites), the MD024
markdownlint disable convention, and a verification checklist for the next
release PR. Cross-linked from the Release section of `docs/reusable-workflows.md`
and the Related docs list in `docs/python-release-publish.md`.

Note: the issue states the generator change shipped in v0.45.0, but #344
(db268ab) first shipped in **v0.43.1** (`git tag --contains` and the CHANGELOG
entry agree), so the guide documents v0.43.1 as the minimum pin. The CHANGELOG
already lists #344 under 0.43.1, so no CHANGELOG edit was made.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #357

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds documentation for migrating release changelogs to the Keep a Changelog generator.

- New consumer migration guide in `docs/release-changelog.md`.
- Cross-link from the reusable workflow release docs.
- Cross-link from the Python release publish related-docs list.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/release-changelog.md | Adds the changelog migration guide with pinning, heading mapping, lint guidance, and release verification steps. |
| docs/reusable-workflows.md | Adds a release-section link to the changelog migration guide. |
| docs/python-release-publish.md | Adds the changelog migration guide to the related documentation list. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(release): add consumer migration gu..."](https://github.com/lgtm-hq/lgtm-ci/commit/5571e2e5054c43cb01760daebfe9c55402c76366) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41924581)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for the updated release changelog format, including how existing changelog entries map to the new headings.
  * Documented the minimum supported release version for the changelog workflow and where to find migration steps.
  * Expanded the reusable workflows notes to explain the new changelog heading structure and related setup requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->