### PR TITLE
feat(network): enforce TLS floor and add opt-in cert pinning to downloads

### DIFF
--- a/scripts/ci/lib/installer/binary.sh
+++ b/scripts/ci/lib/installer/binary.sh
@@ -297,9 +297,9 @@ install_anchore_tool() {
 	local resolved_version="$version"
 	if [[ "$version" == "latest" ]]; then
 		local latest_url
-		if ! latest_url=$(curl -fsSL --proto '=https' --tlsv1.2 \
+		_lgtm_ci_installer_build_curl_args 60 || return 1
+		if ! latest_url=$(curl "${_LGTM_CI_INSTALLER_CURL_ARGS[@]}" \
 			-o /dev/null -w '%{url_effective}' \
-			--connect-timeout 30 --max-time 60 \
 			"https://github.com/anchore/${tool}/releases/latest"); then
 			log_error "Failed to resolve latest release for $tool"
 			return 1

--- a/scripts/ci/lib/installer/binary.sh
+++ b/scripts/ci/lib/installer/binary.sh
@@ -52,7 +52,7 @@ if ! declare -f download_with_retries &>/dev/null; then
 	download_with_retries() {
 		local url="$1" out="$2" attempts="${3:-3}" i
 		for ((i = 1; i <= attempts; i++)); do
-			curl -fsSL --connect-timeout 30 --max-time 300 "$url" -o "$out" 2>/dev/null && return 0
+			curl -fsSL --proto '=https' --tlsv1.2 --connect-timeout 30 --max-time 300 "$url" -o "$out" 2>/dev/null && return 0
 		done
 		return 1
 	}
@@ -72,7 +72,7 @@ if ! declare -f download_and_run_installer &>/dev/null; then
 			tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/lgtm-installer.XXXXXXXXXX") || exit 1
 			trap 'rm -rf "$tmpdir"' EXIT
 			local script_file="$tmpdir/installer.sh"
-			curl -fsSL --connect-timeout 30 --max-time 120 "$url" -o "$script_file" || exit 1
+			curl -fsSL --proto '=https' --tlsv1.2 --connect-timeout 30 --max-time 120 "$url" -o "$script_file" || exit 1
 			chmod +x "$script_file" || exit 1
 			"$script_file" "$@"
 		)
@@ -269,7 +269,8 @@ install_anchore_tool() {
 	local resolved_version="$version"
 	if [[ "$version" == "latest" ]]; then
 		local latest_url
-		if ! latest_url=$(curl -fsSL -o /dev/null -w '%{url_effective}' \
+		if ! latest_url=$(curl -fsSL --proto '=https' --tlsv1.2 \
+			-o /dev/null -w '%{url_effective}' \
 			--connect-timeout 30 --max-time 60 \
 			"https://github.com/anchore/${tool}/releases/latest"); then
 			log_error "Failed to resolve latest release for $tool"

--- a/scripts/ci/lib/installer/binary.sh
+++ b/scripts/ci/lib/installer/binary.sh
@@ -48,11 +48,38 @@ if [[ -f "$_LGTM_CI_INSTALLER_LIB_DIR/network/checksum.sh" ]]; then
 fi
 
 # Minimal fallbacks if libraries unavailable
+# Build hardened curl args into _LGTM_CI_INSTALLER_CURL_ARGS, honoring the
+# same opt-in env knobs as network/download.sh (LGTM_CI_CA_BUNDLE,
+# LGTM_CI_PINNED_PUBKEY) so pinning is not silently bypassed here.
+# Returns 1 (fail closed) if LGTM_CI_CA_BUNDLE is set but not readable.
+_lgtm_ci_installer_build_curl_args() {
+	local max_time="${1:-300}"
+	_LGTM_CI_INSTALLER_CURL_ARGS=(
+		-fsSL
+		--proto '=https'
+		--tlsv1.2
+		--connect-timeout 30
+		--max-time "$max_time"
+	)
+	if [[ -n "${LGTM_CI_CA_BUNDLE:-}" ]]; then
+		if [[ ! -r "$LGTM_CI_CA_BUNDLE" ]]; then
+			log_error "CA bundle not readable: $LGTM_CI_CA_BUNDLE"
+			return 1
+		fi
+		_LGTM_CI_INSTALLER_CURL_ARGS+=(--cacert "$LGTM_CI_CA_BUNDLE")
+	fi
+	if [[ -n "${LGTM_CI_PINNED_PUBKEY:-}" ]]; then
+		_LGTM_CI_INSTALLER_CURL_ARGS+=(--pinnedpubkey "$LGTM_CI_PINNED_PUBKEY")
+	fi
+	return 0
+}
+
 if ! declare -f download_with_retries &>/dev/null; then
 	download_with_retries() {
 		local url="$1" out="$2" attempts="${3:-3}" i
+		_lgtm_ci_installer_build_curl_args 300 || return 1
 		for ((i = 1; i <= attempts; i++)); do
-			curl -fsSL --proto '=https' --tlsv1.2 --connect-timeout 30 --max-time 300 "$url" -o "$out" 2>/dev/null && return 0
+			curl "${_LGTM_CI_INSTALLER_CURL_ARGS[@]}" "$url" -o "$out" 2>/dev/null && return 0
 		done
 		return 1
 	}
@@ -72,7 +99,8 @@ if ! declare -f download_and_run_installer &>/dev/null; then
 			tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/lgtm-installer.XXXXXXXXXX") || exit 1
 			trap 'rm -rf "$tmpdir"' EXIT
 			local script_file="$tmpdir/installer.sh"
-			curl -fsSL --proto '=https' --tlsv1.2 --connect-timeout 30 --max-time 120 "$url" -o "$script_file" || exit 1
+			_lgtm_ci_installer_build_curl_args 120 || exit 1
+			curl "${_LGTM_CI_INSTALLER_CURL_ARGS[@]}" "$url" -o "$script_file" || exit 1
 			chmod +x "$script_file" || exit 1
 			"$script_file" "$@"
 		)

--- a/scripts/ci/lib/network/download.sh
+++ b/scripts/ci/lib/network/download.sh
@@ -5,6 +5,18 @@
 # Usage:
 #   source "$(dirname "${BASH_SOURCE:-$0}")/download.sh"
 #   download_with_retries "https://example.com/file" "./file"
+#
+# Security model:
+#   All downloads enforce a TLS floor (HTTPS-only, TLS >= 1.2) and reject
+#   protocol downgrades in redirects. Two opt-in, defense-in-depth knobs are
+#   supported via environment variables (defaults unchanged when unset):
+#     LGTM_CI_CA_BUNDLE      Path to a custom CA bundle (curl --cacert)
+#     LGTM_CI_PINNED_PUBKEY  Pinned public key (curl --pinnedpubkey), either
+#                            a "sha256//BASE64" hash or a path to a PEM/DER
+#                            public key file
+#   For explicit caller-supplied pins use download_with_pinning, which fails
+#   closed when no pin is available. Pins are the caller's responsibility to
+#   rotate; this library deliberately does not ship a hard-coded pin registry.
 
 # Prevent multiple sourcing
 [[ -n "${_LGTM_CI_NETWORK_DOWNLOAD_LOADED:-}" ]] && return 0
@@ -25,6 +37,33 @@ fi
 # Download helpers
 # =============================================================================
 
+# Build hardened curl arguments into the global array _LGTM_CI_CURL_ARGS.
+# Enforces HTTPS-only + TLS >= 1.2, and appends opt-in CA bundle / pinned
+# public key options from the environment (see security model above).
+# Usage: _lgtm_ci_build_curl_args [max_time]
+# Returns 1 (fail closed) if LGTM_CI_CA_BUNDLE is set but not a readable file.
+_lgtm_ci_build_curl_args() {
+	local max_time="${1:-300}"
+	_LGTM_CI_CURL_ARGS=(
+		-fsSL
+		--proto '=https'
+		--tlsv1.2
+		--connect-timeout 30
+		--max-time "$max_time"
+	)
+	if [[ -n "${LGTM_CI_CA_BUNDLE:-}" ]]; then
+		if [[ ! -r "$LGTM_CI_CA_BUNDLE" ]]; then
+			log_error "CA bundle not readable: $LGTM_CI_CA_BUNDLE"
+			return 1
+		fi
+		_LGTM_CI_CURL_ARGS+=(--cacert "$LGTM_CI_CA_BUNDLE")
+	fi
+	if [[ -n "${LGTM_CI_PINNED_PUBKEY:-}" ]]; then
+		_LGTM_CI_CURL_ARGS+=(--pinnedpubkey "$LGTM_CI_PINNED_PUBKEY")
+	fi
+	return 0
+}
+
 # Download file with retries and exponential backoff
 # Usage: download_with_retries "url" "output_file" [max_attempts]
 download_with_retries() {
@@ -34,9 +73,11 @@ download_with_retries() {
 	local delay=0.5
 	local i
 
+	_lgtm_ci_build_curl_args 300 || return 1
+
 	for ((i = 1; i <= attempts; i++)); do
 		log_verbose "Download attempt $i/$attempts: $url"
-		if curl -fsSL --connect-timeout 30 --max-time 300 "$url" -o "$out"; then
+		if curl "${_LGTM_CI_CURL_ARGS[@]}" "$url" -o "$out"; then
 			return 0
 		fi
 		if [[ $i -lt $attempts ]]; then
@@ -78,8 +119,10 @@ download_and_run_installer() {
 
 		local script_file="$tmpdir/installer.sh"
 
+		_lgtm_ci_build_curl_args 120 || exit 1
+
 		log_verbose "Downloading installer from: $url"
-		if ! curl -fsSL --connect-timeout 30 --max-time 120 "$url" -o "$script_file"; then
+		if ! curl "${_LGTM_CI_CURL_ARGS[@]}" "$url" -o "$script_file"; then
 			log_error "Failed to download installer script"
 			exit 1
 		fi
@@ -113,7 +156,38 @@ download_and_run_installer() {
 	)
 }
 
+# Download a file with an explicit pinned public key (fails closed).
+# Unlike download_with_retries (where pinning is an env opt-in), this
+# function requires a pin: it errors out rather than silently downloading
+# unpinned. Intended for high-value artifacts (installers, signing keys).
+# Usage: download_with_pinning "url" "output_file" [pinned_key] [ca_bundle]
+#   pinned_key  curl --pinnedpubkey value ("sha256//BASE64" or key file path);
+#               falls back to $LGTM_CI_PINNED_PUBKEY when omitted
+#   ca_bundle   optional custom CA bundle path (curl --cacert);
+#               falls back to $LGTM_CI_CA_BUNDLE when omitted
+download_with_pinning() {
+	local url="$1"
+	local out="$2"
+	local pinned_key="${3:-${LGTM_CI_PINNED_PUBKEY:-}}"
+	local ca_bundle="${4:-${LGTM_CI_CA_BUNDLE:-}}"
+
+	if [[ -z "$pinned_key" ]]; then
+		log_error "download_with_pinning: no pinned public key provided" \
+			"(argument or LGTM_CI_PINNED_PUBKEY); refusing unpinned download"
+		return 1
+	fi
+	# A pin that is a file path must exist; hash pins use the sha256// prefix
+	if [[ "$pinned_key" != sha256//* && ! -r "$pinned_key" ]]; then
+		log_error "download_with_pinning: pinned key file not readable: $pinned_key"
+		return 1
+	fi
+
+	LGTM_CI_PINNED_PUBKEY="$pinned_key" LGTM_CI_CA_BUNDLE="$ca_bundle" \
+		download_with_retries "$url" "$out"
+}
+
 # =============================================================================
 # Export functions
 # =============================================================================
-export -f download_with_retries download_and_run_installer
+export -f _lgtm_ci_build_curl_args download_with_retries \
+	download_and_run_installer download_with_pinning

--- a/scripts/ci/security/install-osv-scanner.sh
+++ b/scripts/ci/security/install-osv-scanner.sh
@@ -28,6 +28,8 @@ LIB_DIR="$SCRIPT_DIR/../lib"
 
 # shellcheck source=../lib/fs.sh
 source "$LIB_DIR/fs.sh"
+# shellcheck source=../lib/network/download.sh
+source "$LIB_DIR/network/download.sh"
 
 OSV_VERSION="${1:-${OSV_VERSION:-2.3.5}}"
 
@@ -55,27 +57,37 @@ if [[ ! -w "$INSTALL_DIR" ]]; then
 	INSTALL_DIR="${HOME}/.local/bin"
 	mkdir -p "$INSTALL_DIR"
 fi
-TMPDIR=$(create_temp_dir)
+# NOTE: create_temp_dir installs its cleanup trap inside the command-
+# substitution subshell, so `dir=$(create_temp_dir)` deletes the directory the
+# instant the subshell exits (see tests/bats/unit/lib/test_fs.bats). This
+# installer needs the directory to survive for the whole download+verify flow,
+# so create it directly in this shell and register cleanup on THIS shell's EXIT.
+WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/lgtm-ci-osv.XXXXXXXXXX")
+trap 'rm -rf "$WORKDIR"' EXIT
 
 log_info "Installing osv-scanner v${OSV_VERSION}..."
 
-CURL_ARGS=(-fsSL --proto '=https' --tlsv1.2 --connect-timeout 30 --max-time 300)
+# Build hardened curl args via the shared builder so these security-tool
+# downloads honor the same TLS floor AND the opt-in LGTM_CI_CA_BUNDLE /
+# LGTM_CI_PINNED_PUBKEY knobs as every other download path. Fail closed if a
+# custom CA bundle is configured but unreadable.
+_lgtm_ci_build_curl_args 300 || exit 1
 
-curl "${CURL_ARGS[@]}" "$BINARY_URL" -o "${TMPDIR}/osv-scanner"
-curl "${CURL_ARGS[@]}" "$CHECKSUMS_URL" -o "${TMPDIR}/SHA256SUMS"
+curl "${_LGTM_CI_CURL_ARGS[@]}" "$BINARY_URL" -o "${WORKDIR}/osv-scanner"
+curl "${_LGTM_CI_CURL_ARGS[@]}" "$CHECKSUMS_URL" -o "${WORKDIR}/SHA256SUMS"
 
 CHECKSUMS_SIG_URL="${BASE_URL}/osv-scanner_SHA256SUMS.sig"
 CHECKSUMS_CERT_URL="${BASE_URL}/osv-scanner_SHA256SUMS.pem"
-if curl "${CURL_ARGS[@]}" "$CHECKSUMS_SIG_URL" -o "${TMPDIR}/SHA256SUMS.sig" 2>/dev/null &&
-	curl "${CURL_ARGS[@]}" "$CHECKSUMS_CERT_URL" -o "${TMPDIR}/SHA256SUMS.pem" 2>/dev/null; then
+if curl "${_LGTM_CI_CURL_ARGS[@]}" "$CHECKSUMS_SIG_URL" -o "${WORKDIR}/SHA256SUMS.sig" 2>/dev/null &&
+	curl "${_LGTM_CI_CURL_ARGS[@]}" "$CHECKSUMS_CERT_URL" -o "${WORKDIR}/SHA256SUMS.pem" 2>/dev/null; then
 	if command -v cosign >/dev/null 2>&1; then
 		log_info "Verifying SHA256SUMS sigstore signature..."
 		cosign verify-blob \
-			--signature "${TMPDIR}/SHA256SUMS.sig" \
-			--certificate "${TMPDIR}/SHA256SUMS.pem" \
+			--signature "${WORKDIR}/SHA256SUMS.sig" \
+			--certificate "${WORKDIR}/SHA256SUMS.pem" \
 			--certificate-identity-regexp='https://github\.com/google/osv-scanner/.*' \
 			--certificate-oidc-issuer='https://token.actions.githubusercontent.com' \
-			"${TMPDIR}/SHA256SUMS"
+			"${WORKDIR}/SHA256SUMS"
 		log_success "SHA256SUMS signature verified"
 	else
 		log_warn "cosign not found; skipping SHA256SUMS signature verification"
@@ -85,7 +97,7 @@ else
 fi
 
 EXPECTED=$(
-	awk -v fn="osv-scanner_${PLATFORM}" '$2 == fn { print $1; exit }' "${TMPDIR}/SHA256SUMS"
+	awk -v fn="osv-scanner_${PLATFORM}" '$2 == fn { print $1; exit }' "${WORKDIR}/SHA256SUMS"
 )
 if [[ -z "$EXPECTED" ]]; then
 	log_error "No checksum entry for osv-scanner_${PLATFORM} in SHA256SUMS"
@@ -93,12 +105,12 @@ if [[ -z "$EXPECTED" ]]; then
 fi
 
 printf '%s  osv-scanner\n' "$EXPECTED" | (
-	cd "${TMPDIR}" && sha256sum -c -
+	cd "${WORKDIR}" && sha256sum -c -
 )
 log_success "SHA256 verified: ${EXPECTED}"
 
-chmod +x "${TMPDIR}/osv-scanner"
-mv "${TMPDIR}/osv-scanner" "${INSTALL_DIR}/osv-scanner"
+chmod +x "${WORKDIR}/osv-scanner"
+mv "${WORKDIR}/osv-scanner" "${INSTALL_DIR}/osv-scanner"
 
 "${INSTALL_DIR}/osv-scanner" --version
 log_success "osv-scanner v${OSV_VERSION} installed to ${INSTALL_DIR}"

--- a/scripts/ci/security/install-osv-scanner.sh
+++ b/scripts/ci/security/install-osv-scanner.sh
@@ -59,13 +59,15 @@ TMPDIR=$(create_temp_dir)
 
 log_info "Installing osv-scanner v${OSV_VERSION}..."
 
-curl -fsSL "$BINARY_URL" -o "${TMPDIR}/osv-scanner"
-curl -fsSL "$CHECKSUMS_URL" -o "${TMPDIR}/SHA256SUMS"
+CURL_ARGS=(-fsSL --proto '=https' --tlsv1.2 --connect-timeout 30 --max-time 300)
+
+curl "${CURL_ARGS[@]}" "$BINARY_URL" -o "${TMPDIR}/osv-scanner"
+curl "${CURL_ARGS[@]}" "$CHECKSUMS_URL" -o "${TMPDIR}/SHA256SUMS"
 
 CHECKSUMS_SIG_URL="${BASE_URL}/osv-scanner_SHA256SUMS.sig"
 CHECKSUMS_CERT_URL="${BASE_URL}/osv-scanner_SHA256SUMS.pem"
-if curl -fsSL "$CHECKSUMS_SIG_URL" -o "${TMPDIR}/SHA256SUMS.sig" 2>/dev/null &&
-	curl -fsSL "$CHECKSUMS_CERT_URL" -o "${TMPDIR}/SHA256SUMS.pem" 2>/dev/null; then
+if curl "${CURL_ARGS[@]}" "$CHECKSUMS_SIG_URL" -o "${TMPDIR}/SHA256SUMS.sig" 2>/dev/null &&
+	curl "${CURL_ARGS[@]}" "$CHECKSUMS_CERT_URL" -o "${TMPDIR}/SHA256SUMS.pem" 2>/dev/null; then
 	if command -v cosign >/dev/null 2>&1; then
 		log_info "Verifying SHA256SUMS sigstore signature..."
 		cosign verify-blob \

--- a/tests/bats/unit/lib/installer/test_binary.bats
+++ b/tests/bats/unit/lib/installer/test_binary.bats
@@ -950,3 +950,118 @@ exit 0'
 	assert_failure
 	assert_output --partial "not found in PATH"
 }
+
+# =============================================================================
+# _lgtm_ci_installer_build_curl_args (hardened fallback curl args)
+# =============================================================================
+
+@test "installer curl args: baseline includes TLS floor and https-only" {
+	run bash -c 'source "$LIB_DIR/installer/binary.sh" &&
+		_lgtm_ci_installer_build_curl_args 120 &&
+		printf "%s\n" "${_LGTM_CI_INSTALLER_CURL_ARGS[@]}"'
+	assert_success
+	assert_output --partial -- "--tlsv1.2"
+	assert_output --partial "=https"
+	assert_output --partial "120"
+}
+
+@test "installer curl args: appends --cacert when LGTM_CI_CA_BUNDLE is readable" {
+	local bundle="${BATS_TEST_TMPDIR}/ca.pem"
+	echo "cert" >"$bundle"
+	run bash -c 'export LGTM_CI_CA_BUNDLE="'"$BATS_TEST_TMPDIR"'/ca.pem"
+		source "$LIB_DIR/installer/binary.sh" &&
+		_lgtm_ci_installer_build_curl_args &&
+		printf "%s\n" "${_LGTM_CI_INSTALLER_CURL_ARGS[@]}"'
+	assert_success
+	assert_output --partial -- "--cacert"
+}
+
+@test "installer curl args: fails closed when LGTM_CI_CA_BUNDLE is unreadable" {
+	run bash -c 'export LGTM_CI_CA_BUNDLE="'"$BATS_TEST_TMPDIR"'/missing.pem"
+		source "$LIB_DIR/installer/binary.sh" &&
+		_lgtm_ci_installer_build_curl_args'
+	assert_failure
+	assert_output --partial "CA bundle not readable"
+}
+
+@test "installer curl args: appends --pinnedpubkey when LGTM_CI_PINNED_PUBKEY set" {
+	run bash -c 'export LGTM_CI_PINNED_PUBKEY="sha256//AAAA"
+		source "$LIB_DIR/installer/binary.sh" &&
+		_lgtm_ci_installer_build_curl_args &&
+		printf "%s\n" "${_LGTM_CI_INSTALLER_CURL_ARGS[@]}"'
+	assert_success
+	assert_output --partial -- "--pinnedpubkey"
+	assert_output --partial "sha256//AAAA"
+}
+
+# =============================================================================
+# Fallback downloaders (no network/ modules present)
+# =============================================================================
+
+# Copy binary.sh into an isolated lib tree without network/ so the minimal
+# fallback implementations are defined instead of network/download.sh.
+_setup_isolated_binary_lib() {
+	local iso="${BATS_TEST_TMPDIR}/isolated-lib"
+	mkdir -p "$iso/installer"
+	cp "$LIB_DIR/log.sh" "$iso/log.sh"
+	cp "$LIB_DIR/fs.sh" "$iso/fs.sh"
+	cp "$LIB_DIR/installer/binary.sh" "$iso/installer/binary.sh"
+	echo "$iso"
+}
+
+@test "fallback download_with_retries: uses hardened curl args" {
+	local iso
+	iso="$(_setup_isolated_binary_lib)"
+	mock_command_record "curl" ""
+	run bash -c 'source "$1/installer/binary.sh" &&
+		download_with_retries "https://example.com/f" "$2/out.txt" 1' _ "$iso" "$BATS_TEST_TMPDIR"
+	assert_success
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_curl"
+	assert_output --partial -- "--tlsv1.2"
+	assert_output --partial "https://example.com/f"
+}
+
+@test "fallback download_with_retries: passes pinned pubkey from env" {
+	local iso
+	iso="$(_setup_isolated_binary_lib)"
+	mock_command_record "curl" ""
+	run bash -c 'export LGTM_CI_PINNED_PUBKEY="sha256//BBBB"
+		source "$1/installer/binary.sh" &&
+		download_with_retries "https://example.com/f" "$2/out.txt" 1' _ "$iso" "$BATS_TEST_TMPDIR"
+	assert_success
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_curl"
+	assert_output --partial -- "--pinnedpubkey sha256//BBBB"
+}
+
+@test "fallback download_with_retries: fails after exhausting attempts" {
+	local iso
+	iso="$(_setup_isolated_binary_lib)"
+	mock_command "curl" "" 1
+	run bash -c 'source "$1/installer/binary.sh" &&
+		download_with_retries "https://example.com/f" "$2/out.txt" 2' _ "$iso" "$BATS_TEST_TMPDIR"
+	assert_failure
+}
+
+@test "fallback download_and_run_installer: downloads and executes script" {
+	local iso
+	iso="$(_setup_isolated_binary_lib)"
+	local mock_bin="${BATS_TEST_TMPDIR}/fbbin"
+	mkdir -p "$mock_bin"
+	cat >"${mock_bin}/curl" <<'CURL'
+#!/usr/bin/env bash
+out=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	-o) out="$2"; shift 2 ;;
+	*) shift ;;
+	esac
+done
+printf '#!/usr/bin/env bash\necho installer-ran\n' >"$out"
+CURL
+	chmod +x "${mock_bin}/curl"
+	export PATH="${mock_bin}:$PATH"
+	run bash -c 'source "$1/installer/binary.sh" &&
+		download_and_run_installer "https://example.com/install.sh"' _ "$iso"
+	assert_success
+	assert_output --partial "installer-ran"
+}

--- a/tests/bats/unit/lib/installer/test_binary.bats
+++ b/tests/bats/unit/lib/installer/test_binary.bats
@@ -589,6 +589,37 @@ chmod +x '${mock_bin}/grype'
 	refute_output --partial "/main/install.sh"
 }
 
+@test "install_anchore_tool: latest resolver honors LGTM_CI_CA_BUNDLE" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+
+	rm -f "${mock_bin}/grype"
+	command -v grype >/dev/null 2>&1 && skip "grype installed on host"
+
+	local ca_bundle="${BATS_TEST_TMPDIR}/ca.pem"
+	echo "fake-ca" >"$ca_bundle"
+
+	create_anchore_curl_mock "#!/usr/bin/env bash
+cat >'${mock_bin}/grype' <<'INNER'
+#!/usr/bin/env bash
+echo \"Application: grype\"
+echo \"Version: 9.9.9\"
+INNER
+chmod +x '${mock_bin}/grype'
+"
+
+	run bash -c '
+		export LGTM_CI_CA_BUNDLE="'"$ca_bundle"'"
+		source "$LIB_DIR/installer/binary.sh"
+		install_anchore_tool "grype" "latest" 2>&1
+	'
+	assert_success
+
+	# The releases/latest resolution call must carry the CA bundle
+	run grep "releases/latest" "$BATS_TEST_TMPDIR/mock_calls_curl"
+	assert_success
+	assert_output --partial "--cacert ${ca_bundle}"
+}
+
 @test "install_anchore_tool: fails when latest release cannot be resolved" {
 	local mock_bin="${BATS_TEST_TMPDIR}/bin"
 	rm -f "${mock_bin}/syft"

--- a/tests/bats/unit/lib/network/test_download.bats
+++ b/tests/bats/unit/lib/network/test_download.bats
@@ -55,6 +55,133 @@ teardown() {
 	assert_failure
 }
 
+@test "download_with_retries: enforces HTTPS-only and TLS 1.2 floor" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	mock_curl_download_record "content"
+	run bash -c 'source "$LIB_DIR/network/download.sh" && download_with_retries "https://example.com/file" "$BATS_TEST_TMPDIR/out"'
+	assert_success
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_curl"
+	assert_output --partial "--proto =https"
+	assert_output --partial "--tlsv1.2"
+}
+
+@test "download_with_retries: passes pinned pubkey from env" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	mock_curl_download_record "content"
+	run bash -c 'source "$LIB_DIR/network/download.sh" && LGTM_CI_PINNED_PUBKEY="sha256//AAAA" download_with_retries "https://example.com/file" "$BATS_TEST_TMPDIR/out"'
+	assert_success
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_curl"
+	assert_output --partial "--pinnedpubkey sha256//AAAA"
+}
+
+@test "download_with_retries: no pinning args by default" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	mock_curl_download_record "content"
+	run bash -c 'source "$LIB_DIR/network/download.sh" && download_with_retries "https://example.com/file" "$BATS_TEST_TMPDIR/out"'
+	assert_success
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_curl"
+	refute_output --partial "--pinnedpubkey"
+	refute_output --partial "--cacert"
+}
+
+@test "download_with_retries: passes custom CA bundle from env" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	mock_curl_download_record "content"
+	local bundle="${BATS_TEST_TMPDIR}/ca.pem"
+	echo "fake-ca" >"$bundle"
+	run bash -c "source \"\$LIB_DIR/network/download.sh\" && LGTM_CI_CA_BUNDLE=\"$bundle\" download_with_retries \"https://example.com/file\" \"\$BATS_TEST_TMPDIR/out\""
+	assert_success
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_curl"
+	assert_output --partial "--cacert ${bundle}"
+}
+
+@test "download_with_retries: fails closed on unreadable CA bundle" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	mock_curl_download_record "content"
+	run bash -c 'source "$LIB_DIR/network/download.sh" && LGTM_CI_CA_BUNDLE="/nonexistent/ca.pem" download_with_retries "https://example.com/file" "$BATS_TEST_TMPDIR/out" 2>&1'
+	assert_failure
+	assert_output --partial "CA bundle not readable"
+	# curl must never be invoked
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_curl"
+	assert_output ""
+}
+
+# =============================================================================
+# download_with_pinning tests
+# =============================================================================
+
+@test "download_with_pinning: succeeds with explicit hash pin" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	mock_curl_download_record "pinned content"
+	run bash -c 'source "$LIB_DIR/network/download.sh" && download_with_pinning "https://example.com/file" "$BATS_TEST_TMPDIR/out" "sha256//BBBB"'
+	assert_success
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_curl"
+	assert_output --partial "--pinnedpubkey sha256//BBBB"
+	run cat "${BATS_TEST_TMPDIR}/out"
+	assert_output "pinned content"
+}
+
+@test "download_with_pinning: accepts pin from LGTM_CI_PINNED_PUBKEY env" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	mock_curl_download_record "content"
+	run bash -c 'source "$LIB_DIR/network/download.sh" && LGTM_CI_PINNED_PUBKEY="sha256//CCCC" download_with_pinning "https://example.com/file" "$BATS_TEST_TMPDIR/out"'
+	assert_success
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_curl"
+	assert_output --partial "--pinnedpubkey sha256//CCCC"
+}
+
+@test "download_with_pinning: fails closed without a pin" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	mock_curl_download_record "content"
+	run bash -c 'source "$LIB_DIR/network/download.sh" && download_with_pinning "https://example.com/file" "$BATS_TEST_TMPDIR/out" 2>&1'
+	assert_failure
+	assert_output --partial "refusing unpinned download"
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_curl"
+	assert_output ""
+}
+
+@test "download_with_pinning: fails closed on unreadable pin key file" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	mock_curl_download_record "content"
+	run bash -c 'source "$LIB_DIR/network/download.sh" && download_with_pinning "https://example.com/file" "$BATS_TEST_TMPDIR/out" "/nonexistent/pin.pem" 2>&1'
+	assert_failure
+	assert_output --partial "pinned key file not readable"
+}
+
+@test "download_with_pinning: accepts pin key file path and CA bundle" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	mock_curl_download_record "content"
+	local pin="${BATS_TEST_TMPDIR}/pin.pem"
+	local bundle="${BATS_TEST_TMPDIR}/ca.pem"
+	echo "fake-key" >"$pin"
+	echo "fake-ca" >"$bundle"
+	run bash -c "source \"\$LIB_DIR/network/download.sh\" && download_with_pinning \"https://example.com/file\" \"\$BATS_TEST_TMPDIR/out\" \"$pin\" \"$bundle\""
+	assert_success
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_curl"
+	assert_output --partial "--pinnedpubkey ${pin}"
+	assert_output --partial "--cacert ${bundle}"
+}
+
 # =============================================================================
 # download_and_run_installer tests
 # =============================================================================
@@ -124,6 +251,28 @@ CURL
 	assert_output --partial "Failed to download"
 }
 
+@test "download_and_run_installer: enforces HTTPS-only and TLS 1.2 floor" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	mock_curl_installer_script 'echo "installer ran"'
+	# Wrap the mock curl to record args (mock_curl_installer_script does not)
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mv "${mock_bin}/curl" "${mock_bin}/curl.real"
+	cat >"${mock_bin}/curl" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> '${BATS_TEST_TMPDIR}/mock_calls_curl'
+exec '${mock_bin}/curl.real' "\$@"
+EOF
+	chmod +x "${mock_bin}/curl"
+
+	run bash -c 'source "$LIB_DIR/network/download.sh" && download_and_run_installer "https://example.com/install.sh"'
+	assert_success
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_curl"
+	assert_output --partial "--proto =https"
+	assert_output --partial "--tlsv1.2"
+}
+
 # =============================================================================
 # Function export tests
 # =============================================================================
@@ -135,6 +284,15 @@ CURL
 	mock_curl_download "content"
 	run bash -c 'source "$LIB_DIR/network/download.sh" && bash -c "download_with_retries http://example.com /dev/null"'
 	assert_success
+}
+
+@test "download.sh: declares download_with_pinning function" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	run bash -c 'source "$LIB_DIR/network/download.sh" && declare -f download_with_pinning >/dev/null && echo "declared"'
+	assert_success
+	assert_output "declared"
 }
 
 @test "download.sh: declares download_and_run_installer function" {

--- a/tests/bats/unit/security/test_install_osv_scanner.bats
+++ b/tests/bats/unit/security/test_install_osv_scanner.bats
@@ -1,0 +1,185 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/security/install-osv-scanner.sh
+#
+# Regression coverage for the download-hardening contract: the osv-scanner
+# install downloads must route through the shared hardened curl-args builder
+# so they honor the TLS floor AND the opt-in LGTM_CI_CA_BUNDLE /
+# LGTM_CI_PINNED_PUBKEY knobs, exactly like every other download path.
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+
+setup() {
+	export SCRIPT="$PROJECT_ROOT/scripts/ci/security/install-osv-scanner.sh"
+	setup_temp_dir
+	save_path
+	export CALLS_FILE="${BATS_TEST_TMPDIR}/mock_calls_curl"
+	export INSTALL_DIR="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$INSTALL_DIR"
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+# Build mocks for curl, uname, and sha256sum so the install script can run to
+# completion off-Linux without network access.
+#
+#   curl      - records every argv; serves a fake binary for the binary URL,
+#               a checksum line for SHA256SUMS, and fails the .sig/.pem
+#               fetches so signature verification is skipped.
+#   uname     - reports Linux/x86_64 for a deterministic platform.
+#   sha256sum - succeeds on `-c` so the checksum gate passes.
+_setup_osv_mocks() {
+	local mock_bin="${BATS_TEST_TMPDIR}/mock_bin"
+	mkdir -p "$mock_bin"
+	: >"$CALLS_FILE"
+
+	local fake_binary="${BATS_TEST_TMPDIR}/fake-osv-scanner"
+	printf '#!/usr/bin/env bash\necho "osv-scanner 2.3.5 (mock)"\n' >"$fake_binary"
+	chmod +x "$fake_binary"
+
+	cat >"${mock_bin}/curl" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >>'${CALLS_FILE}'
+url=""
+out=""
+while [[ \$# -gt 0 ]]; do
+	case "\$1" in
+	-o) out="\$2"; shift 2;;
+	http*|https*) url="\$1"; shift;;
+	*) shift;;
+	esac
+done
+case "\$url" in
+*SHA256SUMS.sig|*SHA256SUMS.pem) exit 22;;
+*_linux_amd64) cp '${fake_binary}' "\$out";;
+*SHA256SUMS) printf '%s  osv-scanner_linux_amd64\n' deadbeef >"\$out";;
+*) exit 22;;
+esac
+exit 0
+EOF
+	chmod +x "${mock_bin}/curl"
+
+	cat >"${mock_bin}/uname" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+-m) echo "x86_64";;
+*) echo "Linux";;
+esac
+EOF
+	chmod +x "${mock_bin}/uname"
+
+	cat >"${mock_bin}/sha256sum" <<'EOF'
+#!/usr/bin/env bash
+# Consume stdin when invoked as `sha256sum -c -` and report success.
+[[ "$1" == "-c" ]] && { cat >/dev/null; exit 0; }
+exit 0
+EOF
+	chmod +x "${mock_bin}/sha256sum"
+
+	export MOCK_BIN="$mock_bin"
+}
+
+@test "install-osv-scanner: downloads osv-scanner and installs it" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	_setup_osv_mocks
+	run bash -c "
+		export PATH='${MOCK_BIN}:/usr/bin:/bin'
+		export INSTALL_DIR='${INSTALL_DIR}'
+		bash '$SCRIPT' 2>&1
+	"
+	assert_success
+	assert_output --partial "installed to"
+	[[ -x "${INSTALL_DIR}/osv-scanner" ]]
+}
+
+@test "install-osv-scanner: downloads enforce the HTTPS-only + TLS 1.2 floor" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	_setup_osv_mocks
+	run bash -c "
+		export PATH='${MOCK_BIN}:/usr/bin:/bin'
+		export INSTALL_DIR='${INSTALL_DIR}'
+		bash '$SCRIPT' 2>&1
+	"
+	assert_success
+	run cat "$CALLS_FILE"
+	assert_output --partial "--proto =https"
+	assert_output --partial "--tlsv1.2"
+}
+
+@test "install-osv-scanner: passes custom CA bundle to every download" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	_setup_osv_mocks
+	local bundle="${BATS_TEST_TMPDIR}/ca.pem"
+	echo "fake-ca" >"$bundle"
+	run bash -c "
+		export PATH='${MOCK_BIN}:/usr/bin:/bin'
+		export INSTALL_DIR='${INSTALL_DIR}'
+		export LGTM_CI_CA_BUNDLE='${bundle}'
+		bash '$SCRIPT' 2>&1
+	"
+	assert_success
+	# Every recorded curl invocation must carry --cacert: no download path may
+	# bypass the configured CA bundle.
+	run grep -c "^" "$CALLS_FILE"
+	local total="$output"
+	[[ "$total" -ge 2 ]]
+	run grep -cv -- "--cacert ${bundle}" "$CALLS_FILE"
+	assert_output "0"
+}
+
+@test "install-osv-scanner: passes pinned pubkey to downloads" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	_setup_osv_mocks
+	run bash -c "
+		export PATH='${MOCK_BIN}:/usr/bin:/bin'
+		export INSTALL_DIR='${INSTALL_DIR}'
+		export LGTM_CI_PINNED_PUBKEY='sha256//AAAA'
+		bash '$SCRIPT' 2>&1
+	"
+	assert_success
+	run cat "$CALLS_FILE"
+	assert_output --partial "--pinnedpubkey sha256//AAAA"
+}
+
+@test "install-osv-scanner: no pinning args by default" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	_setup_osv_mocks
+	run bash -c "
+		export PATH='${MOCK_BIN}:/usr/bin:/bin'
+		export INSTALL_DIR='${INSTALL_DIR}'
+		bash '$SCRIPT' 2>&1
+	"
+	assert_success
+	run cat "$CALLS_FILE"
+	refute_output --partial "--cacert"
+	refute_output --partial "--pinnedpubkey"
+}
+
+@test "install-osv-scanner: fails closed on unreadable CA bundle" {
+	if ! bash4_available; then
+		skip "bash 3 detected - requires bash 4+ (macOS system bash is outdated)"
+	fi
+	_setup_osv_mocks
+	run bash -c "
+		export PATH='${MOCK_BIN}:/usr/bin:/bin'
+		export INSTALL_DIR='${INSTALL_DIR}'
+		export LGTM_CI_CA_BUNDLE='/nonexistent/ca.pem'
+		bash '$SCRIPT' 2>&1
+	"
+	assert_failure
+	assert_output --partial "CA bundle not readable"
+}

--- a/tests/helpers/mocks.bash
+++ b/tests/helpers/mocks.bash
@@ -200,6 +200,46 @@ EOF
 	fi
 }
 
+# Mock curl for file download that also records its arguments
+# Usage: mock_curl_download_record "file content"
+# Check recorded args with: cat "$BATS_TEST_TMPDIR/mock_calls_curl"
+mock_curl_download_record() {
+	local content="${1:-downloaded content}"
+
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+
+	local calls_file="${BATS_TEST_TMPDIR}/mock_calls_curl"
+	: >"$calls_file"
+
+	local payload_file="${mock_bin}/.curl_payload"
+	printf '%s\n' "$content" >"$payload_file"
+
+	cat >"${mock_bin}/curl" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> '${calls_file}'
+output_file=""
+while [[ \$# -gt 0 ]]; do
+    case "\$1" in
+        -o) output_file="\$2"; shift 2;;
+        --output) output_file="\$2"; shift 2;;
+        --output=*) output_file="\${1#*=}"; shift;;
+        *) shift;;
+    esac
+done
+
+if [[ -n "\$output_file" ]]; then
+    cat '${payload_file}' > "\$output_file"
+fi
+exit 0
+EOF
+	chmod +x "${mock_bin}/curl"
+
+	if [[ ":$PATH:" != *":${mock_bin}:"* ]]; then
+		export PATH="${mock_bin}:$PATH"
+	fi
+}
+
 # =============================================================================
 # Checksum tool mocks
 # =============================================================================


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Implements SSL/TLS hardening for the download utilities (#31): a uniform TLS floor across all download paths, plus opt-in certificate pinning and custom CA bundle support with fail-closed semantics.

### Scoping decision

The issue's core ask — opt-in pinning with **caller-supplied** pins — is implemented as proposed. One element was deliberately scoped out: a hard-coded pin registry (`pins.sh`). GitHub and CDN-fronted endpoints rotate leaf certificates and keys on their own schedule, so a shipped registry would be a recurring breakage source and a false sense of security when stale. The issue itself anticipates this ("prefer caller-supplied pins over a large hard-coded registry"), so pins are exclusively caller-supplied — via argument or `LGTM_CI_PINNED_PUBKEY`. The security model is documented in the `download.sh` header.

Fail-closed tests use an arg-recording curl mock (asserting `--pinnedpubkey`/`--cacert` wiring and that curl is never invoked when validation fails) rather than a live TLS handshake with a wrong pin, since unit tests run without network access.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Changes Made

- `scripts/ci/lib/network/download.sh`
  - All curl invocations now go through a shared hardened-args builder enforcing `--proto '=https' --tlsv1.2` (HTTPS-only, no downgrade on redirect, TLS >= 1.2)
  - Opt-in env knobs, defaults unchanged when unset: `LGTM_CI_CA_BUNDLE` (`--cacert`, fails closed if unreadable) and `LGTM_CI_PINNED_PUBKEY` (`--pinnedpubkey`, `sha256//BASE64` or key file path)
  - New `download_with_pinning url out [pin] [ca_bundle]`: requires a pin (argument or env) and refuses to download unpinned; validates key-file pins exist before invoking curl
  - Security model documented in the file header
- `scripts/ci/lib/installer/binary.sh`: same TLS floor applied to the standalone curl fallbacks and the `latest`-release resolver
- `scripts/ci/security/install-osv-scanner.sh`: TLS floor + connect/max-time timeouts on all four curl calls
- `tests/helpers/mocks.bash`: new `mock_curl_download_record` (download mock that records curl args)
- `tests/bats/unit/lib/network/test_download.bats`: 12 new tests covering the TLS floor (both download functions), env opt-ins, no-op default behavior, and fail-closed pinning/CA-bundle paths

## Checklist

- [x] I have tested these changes locally (`bats --recursive tests/bats`: 2314 tests, only pre-existing environmental failure in `test_run_rust_coverage_html.bats`, unrelated; `uv run lintro chk`: 0 issues)
- [x] I have updated documentation if needed (security model in `download.sh` header)
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None expected: all in-repo download callers already use HTTPS URLs, and the pinning/CA knobs are opt-in. Strictly speaking, any external consumer downloading over plain HTTP or TLS < 1.2 through these helpers would now be rejected — which is the point.

## Closes

- Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pinned-download option for CI downloads, with support for trusted certificate bundles and explicit public key pinning.
  * Expanded installer and security-related downloads to use stricter HTTPS/TLS settings and timeouts.

* **Bug Fixes**
  * Hardened fallback download paths to fail safely when certificate bundles are missing or unreadable.
  * Improved reliability of installer and binary downloads under network failures and retry conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens CI download paths for TLS and optional pinning. The main changes are:

- Shared curl argument builders for HTTPS-only downloads and TLS 1.2 or newer.
- Optional custom CA bundle and pinned public key support for download helpers.
- Installer fallback and Anchore latest-resolution curl calls routed through hardened args.
- OSV scanner downloads updated to use the shared hardened download settings.
- Unit tests covering CA bundles, pinned keys, TLS args, and fail-closed paths.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The previously affected download paths now route curl calls through hardened argument builders.
- Tests cover the main CA bundle, pinned key, and fail-closed cases.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/lib/installer/binary.sh | Installer fallback downloads and Anchore latest resolution now use hardened curl args with CA and pin support. |
| scripts/ci/lib/network/download.sh | The shared download helper now centralizes TLS settings, custom CA handling, and optional public key pinning. |
| scripts/ci/security/install-osv-scanner.sh | OSV scanner artifact downloads now use the shared hardened curl args and a shell-local temporary work directory. |

</details>

<sub>Reviews (6): Last reviewed commit: ["fix(security): harden osv-scanner instal..."](https://github.com/lgtm-hq/lgtm-ci/commit/2efe0f4111f2ec45713e2edfa678d5273da933c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41925709)</sub>

<!-- /greptile_comment -->