### PR TITLE
chore(org): document ruleset check paths and add sync tooling (no committed JSON)

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1475,6 +1475,12 @@ Org ruleset gate: asserts an upstream reusable job succeeded (and optional
 outputs) under a caller-controlled `job-name`. Replaces consumer-local shim
 `runs-on` jobs. See `docs/workflow-contract.md` (Org ruleset check names).
 
+The gate reports its check as `{caller_job_id} / {job-name}` (below:
+`lintro-code-quality / 🛠️ Lintro Code Quality`), and org rulesets must
+require that exact prefixed context. The registry of org rulesets and the
+required context names per consumer repo lives in `docs/org-rulesets.md`,
+alongside the export/sync tooling under `scripts/ci/org/`.
+
 ```yaml
 lintro-code-quality:
   needs: dogfooding-lint

--- a/docs/org-rulesets.md
+++ b/docs/org-rulesets.md
@@ -1,0 +1,62 @@
+# Org rulesets
+
+Registry of lgtm-hq organization rulesets and the **required status check
+contexts** they enforce. This document is the source of truth for check
+**names**; GitHub is the source of truth for full ruleset payloads. Do not
+commit exported ruleset JSON to this repository.
+
+## Check-name contract
+
+Org rulesets must require the **exact** check names workflows report:
+
+- **`uses:` gates (workflow_call reusables):** GitHub reports the check as
+  **`{caller_job_id} / {inner_job_name}`**. For `reusable-required-check.yml`
+  that is the caller job id plus the `job-name` input (for example
+  `test-suite-coverage / 🧪 Test Suite & Coverage`). The inner `job-name`
+  alone is **not** sufficient for a ruleset.
+- **Inline `runs-on` jobs:** the ruleset matches the job `name:` only (for
+  example `🔐 Security Audit`).
+
+See [workflow-contract.md](workflow-contract.md) (Org ruleset check names)
+for the caller-side YAML pattern.
+
+## Registry
+
+<!-- markdownlint-disable MD013 -->
+
+| Ruleset | GitHub id | Repos | Required contexts |
+| ------- | --------- | ----- | ----------------- |
+| `checks-py-lintro` | `16132640` | `py-lintro` | `test-suite-coverage / 🧪 Test Suite & Coverage`, `lintro-code-quality / 🛠️ Lintro Code Quality`, `🔐 Security Audit` |
+| `checks-rustume` | `16132643` | `Rustume` | `quality / 🛠️ Lintro Code Quality & Analysis`, `rust-build / 🔨 Build Check`, `rust-coverage / 🦀 Rust Coverage`, `web-coverage / 🌐 Web Coverage`, `🔐 Security Audit` |
+
+<!-- markdownlint-enable MD013 -->
+
+Both rows follow the prefixed-path pattern: every `uses:` gate context is
+`{caller_job_id} / {job-name}`, and only inline jobs (`🔐 Security Audit`)
+appear unprefixed. Consumer repos must keep caller job ids stable — renaming
+a caller job id changes the reported check path and breaks the ruleset gate
+(checks stay **Expected** while Actions shows green under the new name).
+
+When migrating additional rulesets (for example `checks-turbo-themes`),
+update this table in the same PR that updates the live ruleset.
+
+## Tooling
+
+Operator scripts live under `scripts/ci/org/`. They require org-admin `gh`
+auth and honor `LGTM_ORG` (default `lgtm-hq`). Workflow: export → edit
+locally → dry-run sync → apply.
+
+```bash
+# Fetch a live ruleset (read-only; stdout by default, -o for a local file)
+scripts/ci/org/export-ruleset.sh checks-py-lintro 16132640 -o /tmp/ruleset.json
+
+# Edit /tmp/ruleset.json, then preview the sanitized PUT payload (no API call)
+scripts/ci/org/sync-ruleset.sh /tmp/ruleset.json
+
+# Apply the change to the live org ruleset
+scripts/ci/org/sync-ruleset.sh --apply /tmp/ruleset.json
+```
+
+`sync-ruleset.sh` strips read-only fields (`id`, `node_id`, `source`,
+`created_at`, `_links`, …) before the PUT and is a dry run unless `--apply`
+is passed. Exported JSON is a local working file only — never check it in.

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -124,9 +124,13 @@ jobs:
 
 ### Org ruleset gate (`reusable-required-check.yml`)
 
-Thin aggregate-status gate for branch-protection check names that differ from
-the work reusable’s `job-name`. See [workflow-contract.md](workflow-contract.md)
-(Org ruleset check names).
+Thin aggregate-status gate for org rulesets. Like every `uses:` job, it
+reports its check as `{caller_job_id} / {job-name}` — the ruleset must
+require that prefixed path (below:
+`test-suite-coverage / 🧪 Test Suite & Coverage`), never the unprefixed
+`job-name`. Only inline `runs-on` jobs match on `name:` alone. See
+[workflow-contract.md](workflow-contract.md) (Org ruleset check names) and
+the ruleset registry in [org-rulesets.md](org-rulesets.md).
 
 ```yaml
 test-suite-coverage:

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -343,18 +343,26 @@ Custom package scripts use `reusable-test-node-custom.yml` with required
 ## Org ruleset check names
 
 Reusable workflows report checks as **`caller_job_id / inner_job_name`**. Org
-rulesets may require a **legacy display name** that does not match the inner
-`job-name` on the work job (for example ruleset `🧪 Test Suite & Coverage` vs
-`test / Python Compatibility`).
+rulesets **must require that exact prefixed path** for every `uses:` gate —
+the inner `job-name` alone is never sufficient. Inline `runs-on` jobs are the
+only unprefixed contexts: the ruleset matches their `name:` directly (for
+example `🔐 Security Audit`). A ruleset that requires an unprefixed name for a
+`uses:` gate leaves the PR stuck on **Expected** while Actions shows the green
+prefixed check.
 
-**Preferred (no shim):** Update the org ruleset to require the actual check path
-after repinning, and set `job-name` (and caller job `id` when helpful) to match.
+The registry of org rulesets, their GitHub ids, and the exact required
+contexts lives in [org-rulesets.md](org-rulesets.md), together with the
+export/sync tooling under `scripts/ci/org/`. When a check name must change,
+update the org ruleset to the new `{caller_job_id} / {job-name}` path in the
+same change.
 
-**Legacy gate:** When the ruleset cannot change yet, add a thin caller job that
-calls `reusable-required-check.yml` instead of hand-rolled `runs-on` shims. Pass
-`upstream-result` and optional `passed-output` / `status-output` from the work
-job. Use `always()` on the caller job so the gate still runs when the upstream
-job fails.
+**Aggregate gate:** When a single ruleset context should summarize one or more
+work jobs, add a thin caller job that calls `reusable-required-check.yml`
+instead of hand-rolled `runs-on` shims. The gate itself is a `uses:` job, so
+the ruleset must require its prefixed path too (below:
+`test-suite-coverage / 🧪 Test Suite & Coverage`). Pass `upstream-result` and
+optional `passed-output` / `status-output` from the work job. Use `always()`
+on the caller job so the gate still runs when the upstream job fails.
 
 ```yaml
 test:

--- a/scripts/ci/org/export-ruleset.sh
+++ b/scripts/ci/org/export-ruleset.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Export a live org ruleset via the GitHub API (read-only)
+#
+# Usage:
+#   export-ruleset.sh <name> <id> [-o <file>]
+#
+# Arguments:
+#   name - Expected ruleset name (safety check against the fetched payload)
+#   id   - Numeric GitHub ruleset id (see docs/org-rulesets.md)
+#
+# Options:
+#   -o <file> - Write JSON to <file> instead of stdout (for local edits only)
+#
+# Environment variables:
+#   LGTM_ORG - GitHub organization (default: lgtm-hq)
+#
+# Requires org-admin `gh` auth. Prints the ruleset JSON to stdout by
+# default. Never commit exported JSON to the repository — GitHub is the
+# source of truth for full ruleset payloads (see docs/org-rulesets.md).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/log.sh
+source "$SCRIPT_DIR/../lib/log.sh"
+
+usage() {
+	echo "Usage: $(basename "$0") <name> <id> [-o <file>]" >&2
+}
+
+if [[ $# -lt 2 ]]; then
+	usage
+	exit 2
+fi
+
+RULESET_NAME="$1"
+RULESET_ID="$2"
+shift 2
+
+OUTPUT_FILE=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	-o)
+		if [[ $# -lt 2 ]]; then
+			log_error "-o requires a file argument"
+			exit 2
+		fi
+		OUTPUT_FILE="$2"
+		shift 2
+		;;
+	*)
+		log_error "Unknown argument: $1"
+		usage
+		exit 2
+		;;
+	esac
+done
+
+if [[ ! "$RULESET_ID" =~ ^[0-9]+$ ]]; then
+	log_error "Ruleset id must be numeric, got: ${RULESET_ID}"
+	exit 2
+fi
+
+for tool in gh jq; do
+	if ! command -v "$tool" >/dev/null 2>&1; then
+		log_error "Required tool not found: ${tool}"
+		exit 1
+	fi
+done
+
+LGTM_ORG="${LGTM_ORG:-lgtm-hq}"
+readonly ENDPOINT="orgs/${LGTM_ORG}/rulesets/${RULESET_ID}"
+
+log_info "Fetching ruleset ${RULESET_ID} from ${LGTM_ORG} (read-only)"
+
+if ! payload="$(gh api "$ENDPOINT")"; then
+	log_error "Failed to fetch ${ENDPOINT} (check gh auth and ruleset id)"
+	exit 1
+fi
+
+fetched_name="$(jq -r '.name // empty' <<<"$payload")"
+if [[ "$fetched_name" != "$RULESET_NAME" ]]; then
+	log_error "Ruleset name mismatch: expected '${RULESET_NAME}', got '${fetched_name}'"
+	exit 1
+fi
+
+if [[ -n "$OUTPUT_FILE" ]]; then
+	jq '.' <<<"$payload" >"$OUTPUT_FILE"
+	log_success "Wrote ruleset '${RULESET_NAME}' to ${OUTPUT_FILE} (do not commit)"
+else
+	jq '.' <<<"$payload"
+fi

--- a/scripts/ci/org/sync-ruleset.sh
+++ b/scripts/ci/org/sync-ruleset.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Sync an operator-edited org ruleset payload back to GitHub
+#
+# Usage:
+#   sync-ruleset.sh [--apply] [--id <ruleset-id>] <path-to-local-json | ->
+#
+# Arguments:
+#   path-to-local-json - Local JSON file with the ruleset payload, or `-`
+#                        to read from stdin (operator workflow:
+#                        export-ruleset.sh → edit → sync-ruleset.sh)
+#
+# Options:
+#   --apply          - Actually PUT the payload to GitHub. Without this
+#                      flag the script is a dry run: it validates the
+#                      payload, strips read-only fields, and prints the
+#                      sanitized payload without contacting GitHub.
+#   --id <id>        - Numeric ruleset id; defaults to `.id` (or
+#                      `.ruleset_id`) from the payload
+#
+# Environment variables:
+#   LGTM_ORG - GitHub organization (default: lgtm-hq)
+#
+# Requires org-admin `gh` auth for --apply. Payloads are operator-supplied
+# local files; never commit ruleset JSON to the repository — GitHub is the
+# source of truth (see docs/org-rulesets.md).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/log.sh
+source "$SCRIPT_DIR/../lib/log.sh"
+
+# JSON fields returned by GET that the PUT endpoint does not accept.
+readonly READONLY_FIELDS_FILTER='del(
+	.id, .ruleset_id, .node_id, .source, .source_type,
+	.created_at, .updated_at, ._links, .current_user_can_bypass
+)'
+
+usage() {
+	echo "Usage: $(basename "$0") [--apply] [--id <ruleset-id>] <path-to-local-json | ->" >&2
+}
+
+APPLY="false"
+RULESET_ID=""
+INPUT_PATH=""
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--apply)
+		APPLY="true"
+		shift
+		;;
+	--id)
+		if [[ $# -lt 2 ]]; then
+			log_error "--id requires an argument"
+			exit 2
+		fi
+		RULESET_ID="$2"
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		if [[ -n "$INPUT_PATH" ]]; then
+			log_error "Unexpected argument: $1"
+			usage
+			exit 2
+		fi
+		INPUT_PATH="$1"
+		shift
+		;;
+	esac
+done
+
+if [[ -z "$INPUT_PATH" ]]; then
+	usage
+	exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+	log_error "Required tool not found: jq"
+	exit 1
+fi
+
+if [[ "$INPUT_PATH" == "-" ]]; then
+	payload="$(cat)"
+else
+	if [[ ! -f "$INPUT_PATH" ]]; then
+		log_error "Payload file not found: ${INPUT_PATH}"
+		exit 1
+	fi
+	payload="$(cat "$INPUT_PATH")"
+fi
+
+if ! jq -e 'type == "object"' <<<"$payload" >/dev/null 2>&1; then
+	log_error "Payload is not a valid JSON object"
+	exit 1
+fi
+
+if [[ -z "$RULESET_ID" ]]; then
+	RULESET_ID="$(jq -r '.id // .ruleset_id // empty' <<<"$payload")"
+fi
+
+if [[ ! "$RULESET_ID" =~ ^[0-9]+$ ]]; then
+	log_error "Could not resolve a numeric ruleset id (pass --id or include .id in the payload)"
+	exit 2
+fi
+
+sanitized="$(jq "$READONLY_FIELDS_FILTER" <<<"$payload")"
+
+LGTM_ORG="${LGTM_ORG:-lgtm-hq}"
+readonly ENDPOINT="orgs/${LGTM_ORG}/rulesets/${RULESET_ID}"
+
+if [[ "$APPLY" != "true" ]]; then
+	log_info "Dry run: would PUT the following payload to ${ENDPOINT}"
+	log_info "Re-run with --apply to update the live ruleset"
+	printf '%s\n' "$sanitized"
+	exit 0
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+	log_error "Required tool not found: gh"
+	exit 1
+fi
+
+log_info "Applying ruleset payload to ${ENDPOINT}"
+if ! gh api --method PUT "$ENDPOINT" --input - <<<"$sanitized" >/dev/null; then
+	log_error "Failed to update ${ENDPOINT}"
+	exit 1
+fi
+
+log_success "Updated ruleset ${RULESET_ID} in ${LGTM_ORG}"

--- a/scripts/ci/org/sync-ruleset.sh
+++ b/scripts/ci/org/sync-ruleset.sh
@@ -126,6 +126,22 @@ if ! command -v gh >/dev/null 2>&1; then
 	exit 1
 fi
 
+# Identity check: refuse to overwrite a ruleset whose live name does not
+# match the payload (guards against a wrong --id or stale LGTM_ORG).
+payload_name="$(jq -r '.name // empty' <<<"$sanitized")"
+if [[ -z "$payload_name" ]]; then
+	log_error "Payload has no .name; cannot verify ruleset identity"
+	exit 1
+fi
+if ! live_name="$(gh api "$ENDPOINT" --jq '.name')"; then
+	log_error "Failed to fetch live ruleset ${ENDPOINT} for identity check"
+	exit 1
+fi
+if [[ "$live_name" != "$payload_name" ]]; then
+	log_error "Ruleset identity mismatch: live ruleset ${RULESET_ID} is named '${live_name}' but payload is '${payload_name}' (check --id and LGTM_ORG)"
+	exit 1
+fi
+
 log_info "Applying ruleset payload to ${ENDPOINT}"
 if ! gh api --method PUT "$ENDPOINT" --input - <<<"$sanitized" >/dev/null; then
 	log_error "Failed to update ${ENDPOINT}"

--- a/tests/bats/unit/org/test_export_ruleset.bats
+++ b/tests/bats/unit/org/test_export_ruleset.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/org/export-ruleset.sh (mocked gh, no live API)
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+
+FIXTURE_RELATIVE="json/org_ruleset_checks_py_lintro.json"
+
+setup() {
+	setup_temp_dir
+	save_path
+	export SCRIPT="${PROJECT_ROOT}/scripts/ci/org/export-ruleset.sh"
+	export FIXTURE="${FIXTURES_DIR}/${FIXTURE_RELATIVE}"
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+mock_gh_with_fixture() {
+	mock_command_record "gh" "$(cat "$FIXTURE")"
+}
+
+@test "export-ruleset: prints ruleset JSON to stdout" {
+	mock_gh_with_fixture
+	run bash "$SCRIPT" checks-py-lintro 16132640
+	assert_success
+	assert_output --partial '"name": "checks-py-lintro"'
+	assert_output --partial "test-suite-coverage / 🧪 Test Suite & Coverage"
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_output --partial "api orgs/lgtm-hq/rulesets/16132640"
+}
+
+@test "export-ruleset: -o writes JSON to a file" {
+	mock_gh_with_fixture
+	local out="${BATS_TEST_TMPDIR}/ruleset.json"
+	run bash "$SCRIPT" checks-py-lintro 16132640 -o "$out"
+	assert_success
+	assert_output --partial "do not commit"
+	run jq -r '.name' "$out"
+	assert_output "checks-py-lintro"
+}
+
+@test "export-ruleset: fails when fetched name does not match" {
+	mock_gh_with_fixture
+	run bash "$SCRIPT" checks-rustume 16132640
+	assert_failure
+	assert_output --partial "Ruleset name mismatch"
+}
+
+@test "export-ruleset: fails on non-numeric ruleset id" {
+	run bash "$SCRIPT" checks-py-lintro not-a-number
+	assert_failure
+	assert_output --partial "must be numeric"
+}
+
+@test "export-ruleset: fails when gh api errors" {
+	mock_command "gh" "" 1
+	run bash "$SCRIPT" checks-py-lintro 16132640
+	assert_failure
+	assert_output --partial "Failed to fetch"
+}
+
+@test "export-ruleset: fails with usage when arguments are missing" {
+	run bash "$SCRIPT" checks-py-lintro
+	assert_failure
+	assert_output --partial "Usage:"
+}

--- a/tests/bats/unit/org/test_sync_ruleset.bats
+++ b/tests/bats/unit/org/test_sync_ruleset.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/org/sync-ruleset.sh (dry-run and payload sanitization)
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+
+FIXTURE_RELATIVE="json/org_ruleset_checks_py_lintro.json"
+
+setup() {
+	setup_temp_dir
+	save_path
+	export SCRIPT="${PROJECT_ROOT}/scripts/ci/org/sync-ruleset.sh"
+	export FIXTURE="${FIXTURES_DIR}/${FIXTURE_RELATIVE}"
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+@test "sync-ruleset: dry run succeeds and reports target endpoint" {
+	run bash "$SCRIPT" "$FIXTURE"
+	assert_success
+	assert_output --partial "Dry run"
+	assert_output --partial "orgs/lgtm-hq/rulesets/16132640"
+	assert_output --partial "--apply"
+}
+
+@test "sync-ruleset: dry run strips read-only fields from the payload" {
+	run bash "$SCRIPT" "$FIXTURE"
+	assert_success
+	refute_output --partial '"node_id"'
+	refute_output --partial '"created_at"'
+	refute_output --partial '"updated_at"'
+	refute_output --partial '"_links"'
+	refute_output --partial '"source_type"'
+	refute_output --partial '"id": 16132640'
+}
+
+@test "sync-ruleset: dry run preserves required status check contexts" {
+	run bash "$SCRIPT" "$FIXTURE"
+	assert_success
+	assert_output --partial "test-suite-coverage / 🧪 Test Suite & Coverage"
+	assert_output --partial "lintro-code-quality / 🛠️ Lintro Code Quality"
+	assert_output --partial "🔐 Security Audit"
+}
+
+@test "sync-ruleset: dry run does not invoke gh" {
+	mock_command_record "gh"
+	run bash "$SCRIPT" "$FIXTURE"
+	assert_success
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_output ""
+}
+
+@test "sync-ruleset: reads payload from stdin with -" {
+	run bash -c "cat '$FIXTURE' | bash '$SCRIPT' -"
+	assert_success
+	assert_output --partial "orgs/lgtm-hq/rulesets/16132640"
+}
+
+@test "sync-ruleset: --id overrides the payload ruleset id" {
+	run bash "$SCRIPT" --id 99999 "$FIXTURE"
+	assert_success
+	assert_output --partial "orgs/lgtm-hq/rulesets/99999"
+}
+
+@test "sync-ruleset: LGTM_ORG overrides the target organization" {
+	LGTM_ORG="other-org" run bash "$SCRIPT" "$FIXTURE"
+	assert_success
+	assert_output --partial "orgs/other-org/rulesets/16132640"
+}
+
+@test "sync-ruleset: resolves id from ruleset_id when id is absent" {
+	local payload="${BATS_TEST_TMPDIR}/payload.json"
+	jq 'del(.id) | .ruleset_id = 12345' "$FIXTURE" >"$payload"
+	run bash "$SCRIPT" "$payload"
+	assert_success
+	assert_output --partial "orgs/lgtm-hq/rulesets/12345"
+}
+
+@test "sync-ruleset: --apply PUTs the sanitized payload via gh" {
+	mock_command_record "gh"
+	run bash "$SCRIPT" --apply "$FIXTURE"
+	assert_success
+	assert_output --partial "Updated ruleset 16132640"
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_output --partial "api --method PUT orgs/lgtm-hq/rulesets/16132640 --input -"
+}
+
+@test "sync-ruleset: --apply fails when gh returns an error" {
+	mock_command "gh" "" 1
+	run bash "$SCRIPT" --apply "$FIXTURE"
+	assert_failure
+	assert_output --partial "Failed to update orgs/lgtm-hq/rulesets/16132640"
+}
+
+@test "sync-ruleset: fails on missing payload file" {
+	run bash "$SCRIPT" "${BATS_TEST_TMPDIR}/does-not-exist.json"
+	assert_failure
+	assert_output --partial "Payload file not found"
+}
+
+@test "sync-ruleset: fails on invalid JSON payload" {
+	local payload="${BATS_TEST_TMPDIR}/bad.json"
+	echo "not json" >"$payload"
+	run bash "$SCRIPT" "$payload"
+	assert_failure
+	assert_output --partial "not a valid JSON object"
+}
+
+@test "sync-ruleset: fails when no ruleset id can be resolved" {
+	local payload="${BATS_TEST_TMPDIR}/no-id.json"
+	jq 'del(.id)' "$FIXTURE" >"$payload"
+	run bash "$SCRIPT" "$payload"
+	assert_failure
+	assert_output --partial "Could not resolve a numeric ruleset id"
+}
+
+@test "sync-ruleset: fails with usage when no path argument given" {
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "Usage:"
+}

--- a/tests/bats/unit/org/test_sync_ruleset.bats
+++ b/tests/bats/unit/org/test_sync_ruleset.bats
@@ -81,7 +81,13 @@ teardown() {
 }
 
 @test "sync-ruleset: --apply PUTs the sanitized payload via gh" {
-	mock_command_record "gh"
+	mock_command_multi "gh" '
+	"api orgs/lgtm-hq/rulesets/16132640 --jq .name")
+		echo "checks-py-lintro"
+		;;
+	*)
+		echo "$@" >>"'"${BATS_TEST_TMPDIR}"'/mock_calls_gh"
+		;;'
 	run bash "$SCRIPT" --apply "$FIXTURE"
 	assert_success
 	assert_output --partial "Updated ruleset 16132640"
@@ -89,8 +95,29 @@ teardown() {
 	assert_output --partial "api --method PUT orgs/lgtm-hq/rulesets/16132640 --input -"
 }
 
-@test "sync-ruleset: --apply fails when gh returns an error" {
+@test "sync-ruleset: --apply fails when the identity check GET fails" {
 	mock_command "gh" "" 1
+	run bash "$SCRIPT" --apply "$FIXTURE"
+	assert_failure
+	assert_output --partial "Failed to fetch live ruleset orgs/lgtm-hq/rulesets/16132640"
+}
+
+@test "sync-ruleset: --apply refuses when live ruleset name mismatches payload" {
+	mock_command "gh" "checks-rustume"
+	run bash "$SCRIPT" --apply "$FIXTURE"
+	assert_failure
+	assert_output --partial "Ruleset identity mismatch"
+	assert_output --partial "checks-rustume"
+}
+
+@test "sync-ruleset: --apply fails when the PUT returns an error" {
+	mock_command_multi "gh" '
+	"api orgs/lgtm-hq/rulesets/16132640 --jq .name")
+		echo "checks-py-lintro"
+		;;
+	*)
+		exit 1
+		;;'
 	run bash "$SCRIPT" --apply "$FIXTURE"
 	assert_failure
 	assert_output --partial "Failed to update orgs/lgtm-hq/rulesets/16132640"

--- a/tests/fixtures/json/org_ruleset_checks_py_lintro.json
+++ b/tests/fixtures/json/org_ruleset_checks_py_lintro.json
@@ -1,0 +1,51 @@
+{
+  "id": 16132640,
+  "name": "checks-py-lintro",
+  "target": "branch",
+  "source_type": "Organization",
+  "source": "lgtm-hq",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": ["~DEFAULT_BRANCH"]
+    },
+    "repository_name": {
+      "exclude": [],
+      "include": ["py-lintro"],
+      "protected": false
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "test-suite-coverage / 🧪 Test Suite & Coverage" },
+          { "context": "🔐 Security Audit" },
+          { "context": "lintro-code-quality / 🛠️ Lintro Code Quality" }
+        ]
+      }
+    }
+  ],
+  "node_id": "RRS_TESTFIXTURE0000000000",
+  "created_at": "2026-05-08T11:55:38.677+02:00",
+  "updated_at": "2026-06-20T17:13:02.093+02:00",
+  "bypass_actors": [
+    {
+      "actor_id": null,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "pull_request"
+    }
+  ],
+  "_links": {
+    "self": {
+      "href": "https://api.github.com/orgs/lgtm-hq/rulesets/16132640"
+    },
+    "html": {
+      "href": "http://github.com/organizations/lgtm-hq/settings/rules/16132640"
+    }
+  }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Makes the org ruleset check-name contract durable in lgtm-ci without committing
per-repo ruleset JSON. Adds `docs/org-rulesets.md` as a markdown registry of org
rulesets (name, GitHub id, target repos, required contexts), tightens
`docs/workflow-contract.md` / `docs/reusable-workflows.md` so rulesets must
require the prefixed `{caller_job_id} / {job-name}` path for `uses:` gates
(inline `runs-on` jobs match `name:` only), and adds operator tooling under
`scripts/ci/org/` for the export → edit → sync workflow against live org
rulesets. GitHub stays the source of truth for full payloads; this repo is the
source of truth for check names.

- `docs/org-rulesets.md` (new): check-name contract, registry seeded with
  `checks-py-lintro` (16132640) and `checks-rustume` (16132643), tooling usage
- `docs/workflow-contract.md`: rulesets MUST require
  `{caller_job_id} / {job-name}` for workflow_call gates; removed legacy
  framing that implied unprefixed inner job names suffice
- `docs/reusable-workflows.md`: org ruleset gate section now spells out the
  prefixed path and links the registry
- `.github/actions/README.md`: paragraph pointing to `docs/org-rulesets.md`
  for ruleset context names
- `scripts/ci/org/export-ruleset.sh` (new): read-only `gh api` fetch of a live
  ruleset; stdout by default, `-o` for a local working file; validates the
  fetched name matches
- `scripts/ci/org/sync-ruleset.sh` (new): dry-run by default (validates JSON,
  strips read-only fields, prints the sanitized PUT payload without touching
  GitHub); mutation only behind explicit `--apply`; payload from operator file
  or stdin; `LGTM_ORG` env (default `lgtm-hq`)
- BATS: `tests/bats/unit/org/` (20 tests) with mocked `gh` and a fixture under
  `tests/fixtures/json/` — no live org API calls in CI
- No `org/rulesets/*.json` committed; no change to
  `reusable-required-check.yml` behavior

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #301
- Relates to #168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tools to export and sync organization ruleset settings, including dry-run support and safe payload validation.
* **Documentation**
  * Clarified how required GitHub Actions check names are matched, including exact prefixed contexts for reusable workflows.
  * Added a new reference for organization ruleset check-name requirements and operator workflow guidance.
* **Tests**
  * Added unit coverage for exporting and syncing ruleset behavior, including error handling and payload sanitization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR documents the org ruleset check-name contract and adds operator tooling for ruleset exports and syncs.

- Adds a registry for org rulesets and required status check contexts.
- Clarifies prefixed check names for reusable workflow gates.
- Adds scripts to export live rulesets and dry-run or apply sanitized updates.
- Adds BATS coverage with mocked GitHub CLI calls and a ruleset fixture.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/org/sync-ruleset.sh | Adds ruleset sync behavior with dry-run output, payload sanitization, and a live-name check before applying updates. |
| scripts/ci/org/export-ruleset.sh | Adds a read-only ruleset export script that validates the fetched ruleset name before output. |
| tests/bats/unit/org/test_sync_ruleset.bats | Adds unit coverage for sync dry runs, sanitization, apply behavior, identity mismatch handling, and error paths. |
| tests/bats/unit/org/test_export_ruleset.bats | Adds unit coverage for export output, file writing, name mismatch handling, invalid IDs, and API failures. |
| docs/org-rulesets.md | Adds the org ruleset registry, required context names, and the documented export-edit-sync workflow. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into chore/301-rules..."](https://github.com/lgtm-hq/lgtm-ci/commit/fca8d1d0cd529329d09522b6fd6686531c57dbe1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41926544)</sub>

<!-- /greptile_comment -->