### PR TITLE
refactor(lib): make aggregators fail explicitly on missing modules

### DIFF
--- a/.github/actions/harden-runner/lib/egress.sh
+++ b/.github/actions/harden-runner/lib/egress.sh
@@ -17,7 +17,7 @@ _LGTM_CI_EGRESS_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/egress" && pwd)" || {
 	return 1
 }
 # shellcheck source=egress/presets.sh
-source "$_LGTM_CI_EGRESS_DIR/presets.sh"
+source "$_LGTM_CI_EGRESS_DIR/presets.sh" || return 1
 readonly _LGTM_CI_EGRESS_LOADED=1
 
 # Normalize multiline host:port list (trim lines, drop blanks).

--- a/scripts/ci/lib/actions.sh
+++ b/scripts/ci/lib/actions.sh
@@ -9,34 +9,48 @@
 # This aggregator sources common libraries needed by action scripts:
 #   - log.sh (logging utilities)
 #   - github.sh (GitHub Actions helpers)
-#   - sbom.sh (SBOM utilities, if available)
-#   - installer.sh (tool installation, if available)
+#   - sbom.sh (SBOM utilities)
+#   - installer.sh (tool installation)
+#
+# Loading contract: all libraries are required; sourcing fails loudly
+# (returns 1 with an error naming the missing library) when one is absent.
 
 # Prevent multiple sourcing
 [[ -n "${_LGTM_CI_ACTIONS_LOADED:-}" ]] && return 0
-readonly _LGTM_CI_ACTIONS_LOADED=1
 
 # Determine library directory relative to this file
-_LGTM_CI_ACTIONS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+_LGTM_CI_ACTIONS_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)" || {
+	echo "actions.sh: cannot resolve library directory" >&2
+	return 1
+}
 
-# Source core libraries (required)
+# Source all libraries (all required)
+[[ -f "$_LGTM_CI_ACTIONS_LIB_DIR/log.sh" ]] || {
+	echo "actions.sh: missing required library log.sh in $_LGTM_CI_ACTIONS_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=log.sh
-if [[ -f "$_LGTM_CI_ACTIONS_LIB_DIR/log.sh" ]]; then
-	source "$_LGTM_CI_ACTIONS_LIB_DIR/log.sh"
-else
-	echo "[ERROR] Required library not found: log.sh" >&2
-	exit 1
-fi
-# shellcheck source=github.sh
-if [[ -f "$_LGTM_CI_ACTIONS_LIB_DIR/github.sh" ]]; then
-	source "$_LGTM_CI_ACTIONS_LIB_DIR/github.sh"
-else
-	log_error "Required library not found: github.sh"
-	exit 1
-fi
+source "$_LGTM_CI_ACTIONS_LIB_DIR/log.sh" || return 1
 
-# Source optional libraries (load if available)
+[[ -f "$_LGTM_CI_ACTIONS_LIB_DIR/github.sh" ]] || {
+	log_error "actions.sh: missing required library github.sh in $_LGTM_CI_ACTIONS_LIB_DIR"
+	return 1
+}
+# shellcheck source=github.sh
+source "$_LGTM_CI_ACTIONS_LIB_DIR/github.sh" || return 1
+
+[[ -f "$_LGTM_CI_ACTIONS_LIB_DIR/sbom.sh" ]] || {
+	log_error "actions.sh: missing required library sbom.sh in $_LGTM_CI_ACTIONS_LIB_DIR"
+	return 1
+}
 # shellcheck source=sbom.sh
-[[ -f "$_LGTM_CI_ACTIONS_LIB_DIR/sbom.sh" ]] && source "$_LGTM_CI_ACTIONS_LIB_DIR/sbom.sh"
+source "$_LGTM_CI_ACTIONS_LIB_DIR/sbom.sh" || return 1
+
+[[ -f "$_LGTM_CI_ACTIONS_LIB_DIR/installer.sh" ]] || {
+	log_error "actions.sh: missing required library installer.sh in $_LGTM_CI_ACTIONS_LIB_DIR"
+	return 1
+}
 # shellcheck source=installer.sh
-[[ -f "$_LGTM_CI_ACTIONS_LIB_DIR/installer.sh" ]] && source "$_LGTM_CI_ACTIONS_LIB_DIR/installer.sh"
+source "$_LGTM_CI_ACTIONS_LIB_DIR/installer.sh" || return 1
+
+readonly _LGTM_CI_ACTIONS_LOADED=1

--- a/scripts/ci/lib/docker.sh
+++ b/scripts/ci/lib/docker.sh
@@ -4,20 +4,39 @@
 #
 # Sources all Docker-related libraries for convenient single-file import.
 # Usage: source "scripts/ci/lib/docker.sh"
+#
+# Loading contract: all docker/* modules are required; sourcing fails loudly
+# (returns 1 with an error naming the missing module) when one is absent.
 
 # Guard against multiple sourcing
 [[ -n "${_LGTM_CI_DOCKER_LOADED:-}" ]] && return 0
-readonly _LGTM_CI_DOCKER_LOADED=1
 
 # Get the directory of this script
-DOCKER_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+DOCKER_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)" || {
+	echo "docker.sh: cannot resolve library directory" >&2
+	return 1
+}
 
-# Source all docker sub-libraries in dependency order
+# Source all docker sub-libraries in dependency order (all required)
+[[ -f "$DOCKER_LIB_DIR/docker/core.sh" ]] || {
+	echo "docker.sh: missing required module docker/core.sh in $DOCKER_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=./docker/core.sh
-source "$DOCKER_LIB_DIR/docker/core.sh"
+source "$DOCKER_LIB_DIR/docker/core.sh" || return 1
 
+[[ -f "$DOCKER_LIB_DIR/docker/registry.sh" ]] || {
+	echo "docker.sh: missing required module docker/registry.sh in $DOCKER_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=./docker/registry.sh
-source "$DOCKER_LIB_DIR/docker/registry.sh"
+source "$DOCKER_LIB_DIR/docker/registry.sh" || return 1
 
+[[ -f "$DOCKER_LIB_DIR/docker/tags.sh" ]] || {
+	echo "docker.sh: missing required module docker/tags.sh in $DOCKER_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=./docker/tags.sh
-source "$DOCKER_LIB_DIR/docker/tags.sh"
+source "$DOCKER_LIB_DIR/docker/tags.sh" || return 1
+
+readonly _LGTM_CI_DOCKER_LOADED=1

--- a/scripts/ci/lib/egress.sh
+++ b/scripts/ci/lib/egress.sh
@@ -17,7 +17,7 @@ _LGTM_CI_EGRESS_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/egress" && pwd)" || {
 	return 1
 }
 # shellcheck source=egress/presets.sh
-source "$_LGTM_CI_EGRESS_DIR/presets.sh"
+source "$_LGTM_CI_EGRESS_DIR/presets.sh" || return 1
 readonly _LGTM_CI_EGRESS_LOADED=1
 
 # Normalize multiline host:port list (trim lines, drop blanks).

--- a/scripts/ci/lib/github.sh
+++ b/scripts/ci/lib/github.sh
@@ -5,15 +5,45 @@
 # Usage:
 #   source "$(dirname "${BASH_SOURCE:-$0}")/github.sh"
 #   # Now all github functions are available
+#
+# Loading contract: all github/* modules are required; sourcing fails loudly
+# (returns 1 with an error naming the missing module) when one is absent.
 
 # Prevent multiple sourcing
 [[ -n "${_LGTM_CI_GITHUB_LOADED:-}" ]] && return 0
+
+_LGTM_CI_GITHUB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/github" && pwd)" || {
+	echo "github.sh: cannot resolve github modules directory" >&2
+	return 1
+}
+
+# Source all GitHub modules in dependency order (all required)
+[[ -f "$_LGTM_CI_GITHUB_DIR/env.sh" ]] || {
+	echo "github.sh: missing required module env.sh in $_LGTM_CI_GITHUB_DIR" >&2
+	return 1
+}
+# shellcheck source=github/env.sh
+source "$_LGTM_CI_GITHUB_DIR/env.sh" || return 1
+
+[[ -f "$_LGTM_CI_GITHUB_DIR/output.sh" ]] || {
+	echo "github.sh: missing required module output.sh in $_LGTM_CI_GITHUB_DIR" >&2
+	return 1
+}
+# shellcheck source=github/output.sh
+source "$_LGTM_CI_GITHUB_DIR/output.sh" || return 1
+
+[[ -f "$_LGTM_CI_GITHUB_DIR/summary.sh" ]] || {
+	echo "github.sh: missing required module summary.sh in $_LGTM_CI_GITHUB_DIR" >&2
+	return 1
+}
+# shellcheck source=github/summary.sh
+source "$_LGTM_CI_GITHUB_DIR/summary.sh" || return 1
+
+[[ -f "$_LGTM_CI_GITHUB_DIR/format.sh" ]] || {
+	echo "github.sh: missing required module format.sh in $_LGTM_CI_GITHUB_DIR" >&2
+	return 1
+}
+# shellcheck source=github/format.sh
+source "$_LGTM_CI_GITHUB_DIR/format.sh" || return 1
+
 readonly _LGTM_CI_GITHUB_LOADED=1
-
-_LGTM_CI_GITHUB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/github" && pwd)"
-
-# Source all GitHub modules in dependency order
-[[ -f "$_LGTM_CI_GITHUB_DIR/env.sh" ]] && source "$_LGTM_CI_GITHUB_DIR/env.sh"
-[[ -f "$_LGTM_CI_GITHUB_DIR/output.sh" ]] && source "$_LGTM_CI_GITHUB_DIR/output.sh"
-[[ -f "$_LGTM_CI_GITHUB_DIR/summary.sh" ]] && source "$_LGTM_CI_GITHUB_DIR/summary.sh"
-[[ -f "$_LGTM_CI_GITHUB_DIR/format.sh" ]] && source "$_LGTM_CI_GITHUB_DIR/format.sh"

--- a/scripts/ci/lib/installer.sh
+++ b/scripts/ci/lib/installer.sh
@@ -6,22 +6,52 @@
 #   source "$(dirname "${BASH_SOURCE:-$0}")/installer.sh"
 #   installer_init
 #   installer_parse_args "$@"
+#
+# Loading contract: all installer/* modules are required; sourcing fails loudly
+# (returns 1 with an error naming the missing module) when one is absent.
 
 # Prevent multiple sourcing
 [[ -n "${_LGTM_CI_INSTALLER_LOADED:-}" ]] && return 0
+
+_LGTM_CI_INSTALLER_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/installer" && pwd)" || {
+	echo "installer.sh: cannot resolve installer modules directory" >&2
+	return 1
+}
+
+# Source all installer modules in dependency order (all required)
+[[ -f "$_LGTM_CI_INSTALLER_DIR/core.sh" ]] || {
+	echo "installer.sh: missing required module core.sh in $_LGTM_CI_INSTALLER_DIR" >&2
+	return 1
+}
+# shellcheck source=installer/core.sh
+source "$_LGTM_CI_INSTALLER_DIR/core.sh" || return 1
+
+[[ -f "$_LGTM_CI_INSTALLER_DIR/args.sh" ]] || {
+	echo "installer.sh: missing required module args.sh in $_LGTM_CI_INSTALLER_DIR" >&2
+	return 1
+}
+# shellcheck source=installer/args.sh
+source "$_LGTM_CI_INSTALLER_DIR/args.sh" || return 1
+
+[[ -f "$_LGTM_CI_INSTALLER_DIR/version.sh" ]] || {
+	echo "installer.sh: missing required module version.sh in $_LGTM_CI_INSTALLER_DIR" >&2
+	return 1
+}
+# shellcheck source=installer/version.sh
+source "$_LGTM_CI_INSTALLER_DIR/version.sh" || return 1
+
+[[ -f "$_LGTM_CI_INSTALLER_DIR/binary.sh" ]] || {
+	echo "installer.sh: missing required module binary.sh in $_LGTM_CI_INSTALLER_DIR" >&2
+	return 1
+}
+# shellcheck source=installer/binary.sh
+source "$_LGTM_CI_INSTALLER_DIR/binary.sh" || return 1
+
+[[ -f "$_LGTM_CI_INSTALLER_DIR/fallbacks.sh" ]] || {
+	echo "installer.sh: missing required module fallbacks.sh in $_LGTM_CI_INSTALLER_DIR" >&2
+	return 1
+}
+# shellcheck source=installer/fallbacks.sh
+source "$_LGTM_CI_INSTALLER_DIR/fallbacks.sh" || return 1
+
 readonly _LGTM_CI_INSTALLER_LOADED=1
-
-_LGTM_CI_INSTALLER_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/installer" && pwd)"
-
-# Source all installer modules in dependency order
-# Core module is critical - warn if missing
-if [[ -f "$_LGTM_CI_INSTALLER_DIR/core.sh" ]]; then
-	# shellcheck source=installer/core.sh
-	source "$_LGTM_CI_INSTALLER_DIR/core.sh"
-else
-	echo "[WARN] installer/core.sh not found - installer_init will be unavailable" >&2
-fi
-[[ -f "$_LGTM_CI_INSTALLER_DIR/args.sh" ]] && source "$_LGTM_CI_INSTALLER_DIR/args.sh"
-[[ -f "$_LGTM_CI_INSTALLER_DIR/version.sh" ]] && source "$_LGTM_CI_INSTALLER_DIR/version.sh"
-[[ -f "$_LGTM_CI_INSTALLER_DIR/binary.sh" ]] && source "$_LGTM_CI_INSTALLER_DIR/binary.sh"
-[[ -f "$_LGTM_CI_INSTALLER_DIR/fallbacks.sh" ]] && source "$_LGTM_CI_INSTALLER_DIR/fallbacks.sh"

--- a/scripts/ci/lib/network.sh
+++ b/scripts/ci/lib/network.sh
@@ -5,17 +5,38 @@
 # Usage:
 #   source "$(dirname "${BASH_SOURCE:-$0}")/network.sh"
 #   # Now all network functions are available
+#
+# Loading contract: all network/* modules are required; sourcing fails loudly
+# (returns 1 with an error naming the missing module) when one is absent.
 
 # Prevent multiple sourcing
 [[ -n "${_LGTM_CI_NETWORK_LOADED:-}" ]] && return 0
-readonly _LGTM_CI_NETWORK_LOADED=1
 
-_LGTM_CI_NETWORK_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/network" && pwd)"
+_LGTM_CI_NETWORK_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/network" && pwd)" || {
+	echo "network.sh: cannot resolve network modules directory" >&2
+	return 1
+}
 
-# Source all network modules
+# Source all network modules (all required)
+[[ -f "$_LGTM_CI_NETWORK_DIR/port.sh" ]] || {
+	echo "network.sh: missing required module port.sh in $_LGTM_CI_NETWORK_DIR" >&2
+	return 1
+}
 # shellcheck source=network/port.sh
-[[ -f "$_LGTM_CI_NETWORK_DIR/port.sh" ]] && source "$_LGTM_CI_NETWORK_DIR/port.sh"
+source "$_LGTM_CI_NETWORK_DIR/port.sh" || return 1
+
+[[ -f "$_LGTM_CI_NETWORK_DIR/checksum.sh" ]] || {
+	echo "network.sh: missing required module checksum.sh in $_LGTM_CI_NETWORK_DIR" >&2
+	return 1
+}
 # shellcheck source=network/checksum.sh
-[[ -f "$_LGTM_CI_NETWORK_DIR/checksum.sh" ]] && source "$_LGTM_CI_NETWORK_DIR/checksum.sh"
+source "$_LGTM_CI_NETWORK_DIR/checksum.sh" || return 1
+
+[[ -f "$_LGTM_CI_NETWORK_DIR/download.sh" ]] || {
+	echo "network.sh: missing required module download.sh in $_LGTM_CI_NETWORK_DIR" >&2
+	return 1
+}
 # shellcheck source=network/download.sh
-[[ -f "$_LGTM_CI_NETWORK_DIR/download.sh" ]] && source "$_LGTM_CI_NETWORK_DIR/download.sh"
+source "$_LGTM_CI_NETWORK_DIR/download.sh" || return 1
+
+readonly _LGTM_CI_NETWORK_LOADED=1

--- a/scripts/ci/lib/publish.sh
+++ b/scripts/ci/lib/publish.sh
@@ -6,29 +6,53 @@
 #   source "$(dirname "${BASH_SOURCE:-$0}")/publish.sh"
 #
 # This aggregator sources all publishing-related libraries:
+#   - log.sh (logging, loaded first if not already loaded)
 #   - publish/version.sh (version extraction)
 #   - publish/validate.sh (package validation)
 #   - publish/registry.sh (registry availability)
+#
+# Loading contract: all modules are required; sourcing fails loudly
+# (returns 1 with an error naming the missing module) when one is absent.
 
 # Prevent multiple sourcing
 [[ -n "${_LGTM_CI_PUBLISH_LOADED:-}" ]] && return 0
-readonly _LGTM_CI_PUBLISH_LOADED=1
 
 # Determine library directory relative to this file
-_LGTM_CI_PUBLISH_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+_LGTM_CI_PUBLISH_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)" || {
+	echo "publish.sh: cannot resolve library directory" >&2
+	return 1
+}
 
 # Source log.sh first if not already loaded (needed by publish modules)
 if [[ -z "${_LGTM_CI_LOG_LOADED:-}" ]]; then
+	[[ -f "$_LGTM_CI_PUBLISH_LIB_DIR/log.sh" ]] || {
+		echo "publish.sh: missing required module log.sh in $_LGTM_CI_PUBLISH_LIB_DIR" >&2
+		return 1
+	}
 	# shellcheck source=log.sh
-	[[ -f "$_LGTM_CI_PUBLISH_LIB_DIR/log.sh" ]] && source "$_LGTM_CI_PUBLISH_LIB_DIR/log.sh"
+	source "$_LGTM_CI_PUBLISH_LIB_DIR/log.sh" || return 1
 fi
 
-# Source all publish modules
+# Source all publish modules (all required)
+[[ -f "$_LGTM_CI_PUBLISH_LIB_DIR/publish/version.sh" ]] || {
+	echo "publish.sh: missing required module publish/version.sh in $_LGTM_CI_PUBLISH_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=publish/version.sh
-[[ -f "$_LGTM_CI_PUBLISH_LIB_DIR/publish/version.sh" ]] && source "$_LGTM_CI_PUBLISH_LIB_DIR/publish/version.sh"
+source "$_LGTM_CI_PUBLISH_LIB_DIR/publish/version.sh" || return 1
 
+[[ -f "$_LGTM_CI_PUBLISH_LIB_DIR/publish/validate.sh" ]] || {
+	echo "publish.sh: missing required module publish/validate.sh in $_LGTM_CI_PUBLISH_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=publish/validate.sh
-[[ -f "$_LGTM_CI_PUBLISH_LIB_DIR/publish/validate.sh" ]] && source "$_LGTM_CI_PUBLISH_LIB_DIR/publish/validate.sh"
+source "$_LGTM_CI_PUBLISH_LIB_DIR/publish/validate.sh" || return 1
 
+[[ -f "$_LGTM_CI_PUBLISH_LIB_DIR/publish/registry.sh" ]] || {
+	echo "publish.sh: missing required module publish/registry.sh in $_LGTM_CI_PUBLISH_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=publish/registry.sh
-[[ -f "$_LGTM_CI_PUBLISH_LIB_DIR/publish/registry.sh" ]] && source "$_LGTM_CI_PUBLISH_LIB_DIR/publish/registry.sh"
+source "$_LGTM_CI_PUBLISH_LIB_DIR/publish/registry.sh" || return 1
+
+readonly _LGTM_CI_PUBLISH_LOADED=1

--- a/scripts/ci/lib/release.sh
+++ b/scripts/ci/lib/release.sh
@@ -4,32 +4,63 @@
 #
 # Sources all release-related libraries for convenient single-file import.
 # Usage: source "scripts/ci/lib/release.sh"
+#
+# Loading contract: all release/* modules are required; sourcing fails loudly
+# (returns 1 with an error naming the missing module) when one is absent.
 
 # Guard against multiple sourcing
 [[ -n "${_RELEASE_LOADED:-}" ]] && return 0
-readonly _RELEASE_LOADED=1
 
 # Get the directory of this script
-RELEASE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+RELEASE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)" || {
+	echo "release.sh: cannot resolve library directory" >&2
+	return 1
+}
 
-# Source all release sub-libraries in dependency order
+# Source all release sub-libraries in dependency order (all required)
+[[ -f "$RELEASE_LIB_DIR/release/version.sh" ]] || {
+	echo "release.sh: missing required module release/version.sh in $RELEASE_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=./release/version.sh
-source "$RELEASE_LIB_DIR/release/version.sh"
+source "$RELEASE_LIB_DIR/release/version.sh" || return 1
 
+[[ -f "$RELEASE_LIB_DIR/release/extract.sh" ]] || {
+	echo "release.sh: missing required module release/extract.sh in $RELEASE_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=./release/extract.sh
-source "$RELEASE_LIB_DIR/release/extract.sh"
+source "$RELEASE_LIB_DIR/release/extract.sh" || return 1
 
+[[ -f "$RELEASE_LIB_DIR/release/conventional.sh" ]] || {
+	echo "release.sh: missing required module release/conventional.sh in $RELEASE_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=./release/conventional.sh
-source "$RELEASE_LIB_DIR/release/conventional.sh"
+source "$RELEASE_LIB_DIR/release/conventional.sh" || return 1
 
+[[ -f "$RELEASE_LIB_DIR/release/analyze.sh" ]] || {
+	echo "release.sh: missing required module release/analyze.sh in $RELEASE_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=./release/analyze.sh
-source "$RELEASE_LIB_DIR/release/analyze.sh"
+source "$RELEASE_LIB_DIR/release/analyze.sh" || return 1
 
+[[ -f "$RELEASE_LIB_DIR/release/changelog.sh" ]] || {
+	echo "release.sh: missing required module release/changelog.sh in $RELEASE_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=./release/changelog.sh
-source "$RELEASE_LIB_DIR/release/changelog.sh"
+source "$RELEASE_LIB_DIR/release/changelog.sh" || return 1
 
+[[ -f "$RELEASE_LIB_DIR/release/fileops.sh" ]] || {
+	echo "release.sh: missing required module release/fileops.sh in $RELEASE_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=./release/fileops.sh
-source "$RELEASE_LIB_DIR/release/fileops.sh"
+source "$RELEASE_LIB_DIR/release/fileops.sh" || return 1
+
+readonly _RELEASE_LOADED=1
 
 # ============================================================================
 # High-level release functions

--- a/scripts/ci/lib/sbom.sh
+++ b/scripts/ci/lib/sbom.sh
@@ -5,14 +5,38 @@
 # Usage:
 #   source "$(dirname "${BASH_SOURCE:-$0}")/sbom.sh"
 #   # Now all sbom functions are available
+#
+# Loading contract: all sbom/* modules are required; sourcing fails loudly
+# (returns 1 with an error naming the missing module) when one is absent.
 
 # Prevent multiple sourcing
 [[ -n "${_LGTM_CI_SBOM_LOADED:-}" ]] && return 0
+
+_LGTM_CI_SBOM_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/sbom" && pwd)" || {
+	echo "sbom.sh: cannot resolve sbom modules directory" >&2
+	return 1
+}
+
+# Source all SBOM modules in dependency order (all required)
+[[ -f "$_LGTM_CI_SBOM_DIR/format.sh" ]] || {
+	echo "sbom.sh: missing required module format.sh in $_LGTM_CI_SBOM_DIR" >&2
+	return 1
+}
+# shellcheck source=sbom/format.sh
+source "$_LGTM_CI_SBOM_DIR/format.sh" || return 1
+
+[[ -f "$_LGTM_CI_SBOM_DIR/severity.sh" ]] || {
+	echo "sbom.sh: missing required module severity.sh in $_LGTM_CI_SBOM_DIR" >&2
+	return 1
+}
+# shellcheck source=sbom/severity.sh
+source "$_LGTM_CI_SBOM_DIR/severity.sh" || return 1
+
+[[ -f "$_LGTM_CI_SBOM_DIR/target.sh" ]] || {
+	echo "sbom.sh: missing required module target.sh in $_LGTM_CI_SBOM_DIR" >&2
+	return 1
+}
+# shellcheck source=sbom/target.sh
+source "$_LGTM_CI_SBOM_DIR/target.sh" || return 1
+
 readonly _LGTM_CI_SBOM_LOADED=1
-
-_LGTM_CI_SBOM_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/sbom" && pwd)"
-
-# Source all SBOM modules in dependency order
-[[ -f "$_LGTM_CI_SBOM_DIR/format.sh" ]] && source "$_LGTM_CI_SBOM_DIR/format.sh"
-[[ -f "$_LGTM_CI_SBOM_DIR/severity.sh" ]] && source "$_LGTM_CI_SBOM_DIR/severity.sh"
-[[ -f "$_LGTM_CI_SBOM_DIR/target.sh" ]] && source "$_LGTM_CI_SBOM_DIR/target.sh"

--- a/scripts/ci/lib/testing.sh
+++ b/scripts/ci/lib/testing.sh
@@ -4,23 +4,46 @@
 #
 # Sources all testing-related libraries for convenient single-file import.
 # Usage: source "scripts/ci/lib/testing.sh"
+#
+# Loading contract: all testing/* modules are required; sourcing fails loudly
+# (returns 1 with an error naming the missing module) when one is absent.
 
 # Guard against multiple sourcing
 [[ -n "${_LGTM_CI_TESTING_LOADED:-}" ]] && return 0
-readonly _LGTM_CI_TESTING_LOADED=1
 
 # Get the directory of this script
-TESTING_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+TESTING_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)" || {
+	echo "testing.sh: cannot resolve library directory" >&2
+	return 1
+}
 
-# Source all testing sub-libraries in dependency order
+# Source all testing sub-libraries in dependency order (all required)
+[[ -f "$TESTING_LIB_DIR/testing/detect.sh" ]] || {
+	echo "testing.sh: missing required module testing/detect.sh in $TESTING_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=./testing/detect.sh
-source "$TESTING_LIB_DIR/testing/detect.sh"
+source "$TESTING_LIB_DIR/testing/detect.sh" || return 1
 
+[[ -f "$TESTING_LIB_DIR/testing/parse.sh" ]] || {
+	echo "testing.sh: missing required module testing/parse.sh in $TESTING_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=./testing/parse.sh
-source "$TESTING_LIB_DIR/testing/parse.sh"
+source "$TESTING_LIB_DIR/testing/parse.sh" || return 1
 
+[[ -f "$TESTING_LIB_DIR/testing/coverage.sh" ]] || {
+	echo "testing.sh: missing required module testing/coverage.sh in $TESTING_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=./testing/coverage.sh
-source "$TESTING_LIB_DIR/testing/coverage.sh"
+source "$TESTING_LIB_DIR/testing/coverage.sh" || return 1
 
+[[ -f "$TESTING_LIB_DIR/testing/badge.sh" ]] || {
+	echo "testing.sh: missing required module testing/badge.sh in $TESTING_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=./testing/badge.sh
-source "$TESTING_LIB_DIR/testing/badge.sh"
+source "$TESTING_LIB_DIR/testing/badge.sh" || return 1
+
+readonly _LGTM_CI_TESTING_LOADED=1

--- a/scripts/ci/lib/testing/coverage/merge.sh
+++ b/scripts/ci/lib/testing/coverage/merge.sh
@@ -8,19 +8,34 @@
 
 # Prevent multiple sourcing
 [[ -n "${_LGTM_CI_TESTING_COVERAGE_MERGE_LOADED:-}" ]] && return 0
-readonly _LGTM_CI_TESTING_COVERAGE_MERGE_LOADED=1
 
 # Get directory of this script for sourcing dependencies
-_LGTM_CI_TESTING_COV_MERGE_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/.." && pwd)"
+_LGTM_CI_TESTING_COV_MERGE_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/.." && pwd)" || {
+	echo "merge.sh: cannot resolve coverage modules directory" >&2
+	return 1
+}
 
-# Source detect.sh for format detection
+# Source detect.sh for format detection (required)
+[[ -f "$_LGTM_CI_TESTING_COV_MERGE_DIR/detect.sh" ]] || {
+	echo "merge.sh: missing required module detect.sh in $_LGTM_CI_TESTING_COV_MERGE_DIR" >&2
+	return 1
+}
 # shellcheck source=../detect.sh
-[[ -f "$_LGTM_CI_TESTING_COV_MERGE_DIR/detect.sh" ]] && source "$_LGTM_CI_TESTING_COV_MERGE_DIR/detect.sh"
+source "$_LGTM_CI_TESTING_COV_MERGE_DIR/detect.sh" || return 1
 
-# Source actions.sh for logging (if available)
-_LGTM_CI_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/../.." && pwd)"
+# Source actions.sh for logging (required)
+_LGTM_CI_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/../.." && pwd)" || {
+	echo "merge.sh: cannot resolve lib directory" >&2
+	return 1
+}
+[[ -f "$_LGTM_CI_LIB_DIR/actions.sh" ]] || {
+	echo "merge.sh: missing required library actions.sh in $_LGTM_CI_LIB_DIR" >&2
+	return 1
+}
 # shellcheck source=../../actions.sh
-[[ -f "$_LGTM_CI_LIB_DIR/actions.sh" ]] && source "$_LGTM_CI_LIB_DIR/actions.sh"
+source "$_LGTM_CI_LIB_DIR/actions.sh" || return 1
+
+readonly _LGTM_CI_TESTING_COVERAGE_MERGE_LOADED=1
 
 # Merge multiple LCOV files into one
 # Usage: merge_lcov_files "output.lcov" "file1.lcov" "file2.lcov" ...

--- a/scripts/ci/lib/testing/coverage/merge.sh
+++ b/scripts/ci/lib/testing/coverage/merge.sh
@@ -23,16 +23,19 @@ _LGTM_CI_TESTING_COV_MERGE_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/.." && pwd
 # shellcheck source=../detect.sh
 source "$_LGTM_CI_TESTING_COV_MERGE_DIR/detect.sh" || return 1
 
-# Source actions.sh for logging when the full lib tree is present.
-# It is optional so a minimal coverage-only copy still works, but if the
-# file exists it must load cleanly (fail explicitly on a broken tree).
+# Source log.sh for logging when the lib tree is present. merge.sh only needs
+# log_warn, so it depends on the minimal log module rather than the heavy
+# actions.sh aggregator (which also pulls in the unrelated github/sbom/installer
+# trees). This keeps a coverage-only copy loadable when those trees are absent
+# or broken, while still failing explicitly if log.sh itself is present but
+# broken. If log.sh is missing entirely, fall back to a local log_warn.
 _LGTM_CI_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/../.." && pwd)" || {
 	echo "merge.sh: cannot resolve lib directory" >&2
 	return 1
 }
-if [[ -f "$_LGTM_CI_LIB_DIR/actions.sh" ]]; then
-	# shellcheck source=../../actions.sh
-	source "$_LGTM_CI_LIB_DIR/actions.sh" || return 1
+if [[ -f "$_LGTM_CI_LIB_DIR/log.sh" ]]; then
+	# shellcheck source=../../log.sh
+	source "$_LGTM_CI_LIB_DIR/log.sh" || return 1
 fi
 if ! declare -f log_warn &>/dev/null; then
 	log_warn() { echo "[WARN] $*" >&2; }

--- a/scripts/ci/lib/testing/coverage/merge.sh
+++ b/scripts/ci/lib/testing/coverage/merge.sh
@@ -23,17 +23,20 @@ _LGTM_CI_TESTING_COV_MERGE_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/.." && pwd
 # shellcheck source=../detect.sh
 source "$_LGTM_CI_TESTING_COV_MERGE_DIR/detect.sh" || return 1
 
-# Source actions.sh for logging (required)
+# Source actions.sh for logging when the full lib tree is present.
+# It is optional so a minimal coverage-only copy still works, but if the
+# file exists it must load cleanly (fail explicitly on a broken tree).
 _LGTM_CI_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")/../.." && pwd)" || {
 	echo "merge.sh: cannot resolve lib directory" >&2
 	return 1
 }
-[[ -f "$_LGTM_CI_LIB_DIR/actions.sh" ]] || {
-	echo "merge.sh: missing required library actions.sh in $_LGTM_CI_LIB_DIR" >&2
-	return 1
-}
-# shellcheck source=../../actions.sh
-source "$_LGTM_CI_LIB_DIR/actions.sh" || return 1
+if [[ -f "$_LGTM_CI_LIB_DIR/actions.sh" ]]; then
+	# shellcheck source=../../actions.sh
+	source "$_LGTM_CI_LIB_DIR/actions.sh" || return 1
+fi
+if ! declare -f log_warn &>/dev/null; then
+	log_warn() { echo "[WARN] $*" >&2; }
+fi
 
 readonly _LGTM_CI_TESTING_COVERAGE_MERGE_LOADED=1
 

--- a/tests/bats/unit/lib/test_aggregator_strict_loading.bats
+++ b/tests/bats/unit/lib/test_aggregator_strict_loading.bats
@@ -21,7 +21,7 @@ teardown() {
 # Helper: source an aggregator from the temp lib copy and capture rc/output
 _source_tmp_lib() {
 	local file="$1"
-	bash -c "source '$TMP_LIB_DIR/$file'"
+	bash -c 'source "$1"' _ "$TMP_LIB_DIR/$file"
 }
 
 @test "github.sh: fails loudly when a required module is missing" {
@@ -108,22 +108,26 @@ _source_tmp_lib() {
 	assert_output --partial "missing required module detect.sh"
 }
 
+# Runs from a script file (not bash -c) so BASH_SOURCE is bound: kcov's
+# bash instrumentation references BASH_SOURCE in a DEBUG trap and aborts
+# under set -u inside a bash -c script. Paths are passed via the exported
+# TMP_LIB_DIR, never interpolated into shell syntax.
 @test "aggregators: all load successfully when modules are present" {
-	run bash -c "set -euo pipefail
-		source '$TMP_LIB_DIR/actions.sh'
-		source '$TMP_LIB_DIR/testing.sh'
-		source '$TMP_LIB_DIR/release.sh'
-		source '$TMP_LIB_DIR/docker.sh'
-		source '$TMP_LIB_DIR/publish.sh'
-		source '$TMP_LIB_DIR/network.sh'
-		source '$TMP_LIB_DIR/egress.sh'
-		echo loaded"
+	local smoke="$BATS_TEST_TMPDIR/aggregator_smoke.sh"
+	cat >"$smoke" <<'SMOKE'
+set -euo pipefail
+for lib in actions testing release docker publish network egress; do
+	source "$TMP_LIB_DIR/$lib.sh"
+done
+echo loaded
+SMOKE
+	run bash "$smoke"
 	assert_success
 	assert_output --partial "loaded"
 }
 
 @test "aggregators: sourcing twice is still a no-op" {
-	run bash -c "source '$TMP_LIB_DIR/github.sh' && source '$TMP_LIB_DIR/github.sh' && echo ok"
+	run bash -c 'source "$1" && source "$1" && echo ok' _ "$TMP_LIB_DIR/github.sh"
 	assert_success
 	assert_output --partial "ok"
 }

--- a/tests/bats/unit/lib/test_aggregator_strict_loading.bats
+++ b/tests/bats/unit/lib/test_aggregator_strict_loading.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Verify library aggregators fail explicitly when a required
+#          sub-module is missing (issue #30). Each test copies the lib tree
+#          into a temp dir, removes one module, and asserts sourcing fails
+#          with a clear error naming the missing file.
+
+load "../../../helpers/common"
+
+setup() {
+	setup_temp_dir
+	TMP_LIB_DIR="$BATS_TEST_TMPDIR/lib"
+	cp -R "$PROJECT_ROOT/scripts/ci/lib" "$TMP_LIB_DIR"
+	export TMP_LIB_DIR
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+# Helper: source an aggregator from the temp lib copy and capture rc/output
+_source_tmp_lib() {
+	local file="$1"
+	bash -c "source '$TMP_LIB_DIR/$file'"
+}
+
+@test "github.sh: fails loudly when a required module is missing" {
+	rm "$TMP_LIB_DIR/github/summary.sh"
+	run _source_tmp_lib "github.sh"
+	assert_failure
+	assert_output --partial "missing required module summary.sh"
+}
+
+@test "github.sh: fails loudly when modules directory is missing" {
+	rm -rf "$TMP_LIB_DIR/github"
+	run _source_tmp_lib "github.sh"
+	assert_failure
+	assert_output --partial "cannot resolve github modules directory"
+}
+
+@test "network.sh: fails loudly when a required module is missing" {
+	rm "$TMP_LIB_DIR/network/checksum.sh"
+	run _source_tmp_lib "network.sh"
+	assert_failure
+	assert_output --partial "missing required module checksum.sh"
+}
+
+@test "sbom.sh: fails loudly when a required module is missing" {
+	rm "$TMP_LIB_DIR/sbom/severity.sh"
+	run _source_tmp_lib "sbom.sh"
+	assert_failure
+	assert_output --partial "missing required module severity.sh"
+}
+
+@test "installer.sh: fails loudly when a required module is missing" {
+	rm "$TMP_LIB_DIR/installer/core.sh"
+	run _source_tmp_lib "installer.sh"
+	assert_failure
+	assert_output --partial "missing required module core.sh"
+}
+
+@test "publish.sh: fails loudly when a required module is missing" {
+	rm "$TMP_LIB_DIR/publish/registry.sh"
+	run _source_tmp_lib "publish.sh"
+	assert_failure
+	assert_output --partial "missing required module publish/registry.sh"
+}
+
+@test "docker.sh: fails loudly when a required module is missing" {
+	rm "$TMP_LIB_DIR/docker/tags.sh"
+	run _source_tmp_lib "docker.sh"
+	assert_failure
+	assert_output --partial "missing required module docker/tags.sh"
+}
+
+@test "testing.sh: fails loudly when a required module is missing" {
+	rm "$TMP_LIB_DIR/testing/parse.sh"
+	run _source_tmp_lib "testing.sh"
+	assert_failure
+	assert_output --partial "missing required module testing/parse.sh"
+}
+
+@test "release.sh: fails loudly when a required module is missing" {
+	rm "$TMP_LIB_DIR/release/changelog.sh"
+	run _source_tmp_lib "release.sh"
+	assert_failure
+	assert_output --partial "missing required module release/changelog.sh"
+}
+
+@test "actions.sh: fails loudly when a required library is missing" {
+	rm "$TMP_LIB_DIR/sbom.sh"
+	run _source_tmp_lib "actions.sh"
+	assert_failure
+	assert_output --partial "missing required library sbom.sh"
+}
+
+@test "actions.sh: propagates failure from nested aggregator" {
+	rm "$TMP_LIB_DIR/github/output.sh"
+	run _source_tmp_lib "actions.sh"
+	assert_failure
+	assert_output --partial "missing required module output.sh"
+}
+
+@test "coverage/merge.sh: fails loudly when detect.sh is missing" {
+	rm "$TMP_LIB_DIR/testing/detect.sh"
+	run _source_tmp_lib "testing/coverage/merge.sh"
+	assert_failure
+	assert_output --partial "missing required module detect.sh"
+}
+
+@test "aggregators: all load successfully when modules are present" {
+	run bash -c "set -euo pipefail
+		source '$TMP_LIB_DIR/actions.sh'
+		source '$TMP_LIB_DIR/testing.sh'
+		source '$TMP_LIB_DIR/release.sh'
+		source '$TMP_LIB_DIR/docker.sh'
+		source '$TMP_LIB_DIR/publish.sh'
+		source '$TMP_LIB_DIR/network.sh'
+		source '$TMP_LIB_DIR/egress.sh'
+		echo loaded"
+	assert_success
+	assert_output --partial "loaded"
+}
+
+@test "aggregators: sourcing twice is still a no-op" {
+	run bash -c "source '$TMP_LIB_DIR/github.sh' && source '$TMP_LIB_DIR/github.sh' && echo ok"
+	assert_success
+	assert_output --partial "ok"
+}

--- a/tests/bats/unit/lib/test_aggregator_strict_loading.bats
+++ b/tests/bats/unit/lib/test_aggregator_strict_loading.bats
@@ -131,3 +131,89 @@ SMOKE
 	assert_success
 	assert_output --partial "ok"
 }
+
+# =============================================================================
+# Exhaustive per-module coverage: every required-module error path fires
+# =============================================================================
+
+# Re-create the temp lib copy (used between iterations of the loops below).
+_reset_tmp_lib() {
+	rm -rf "$TMP_LIB_DIR"
+	cp -R "$PROJECT_ROOT/scripts/ci/lib" "$TMP_LIB_DIR"
+}
+
+# Resolve a "missing required module" token from an aggregator to the path
+# (relative to the lib root) that must be removed to trigger it.
+_module_removal_path() {
+	local agg_dir="$1" token="$2"
+	if [[ "$token" == */* ]]; then
+		echo "$token"
+	elif [[ -f "$TMP_LIB_DIR/$agg_dir/$token" ]]; then
+		echo "$agg_dir/$token"
+	else
+		echo "$token"
+	fi
+}
+
+# For the given aggregator, remove each required module in turn and assert
+# sourcing fails with the "missing required module" error.
+_assert_all_modules_required() {
+	local agg="$1"
+	local agg_dir="${agg%.sh}"
+	local token path
+	while IFS= read -r token; do
+		[[ -n "$token" ]] || continue
+		_reset_tmp_lib
+		path="$(_module_removal_path "$agg_dir" "$token")"
+		rm "$TMP_LIB_DIR/$path"
+		run _source_tmp_lib "$agg"
+		assert_failure
+		assert_output --partial "missing required module"
+	done < <(grep -oE 'missing required module [A-Za-z0-9/_.-]+' \
+		"$PROJECT_ROOT/scripts/ci/lib/$agg" | awk '{print $4}' | sort -u)
+}
+
+@test "github.sh: every required module is enforced" {
+	_assert_all_modules_required "github.sh"
+}
+
+@test "network.sh: every required module is enforced" {
+	_assert_all_modules_required "network.sh"
+}
+
+@test "sbom.sh: every required module is enforced" {
+	_assert_all_modules_required "sbom.sh"
+}
+
+@test "installer.sh: every required module is enforced" {
+	_assert_all_modules_required "installer.sh"
+}
+
+@test "publish.sh: every required module is enforced" {
+	_assert_all_modules_required "publish.sh"
+}
+
+@test "docker.sh: every required module is enforced" {
+	_assert_all_modules_required "docker.sh"
+}
+
+@test "testing.sh: every required module is enforced" {
+	_assert_all_modules_required "testing.sh"
+}
+
+@test "release.sh: every required module is enforced" {
+	_assert_all_modules_required "release.sh"
+}
+
+@test "actions.sh: every required library is enforced" {
+	local token
+	while IFS= read -r token; do
+		[[ -n "$token" ]] || continue
+		_reset_tmp_lib
+		rm "$TMP_LIB_DIR/$token"
+		run _source_tmp_lib "actions.sh"
+		assert_failure
+		assert_output --partial "missing required library"
+	done < <(grep -oE 'missing required library [A-Za-z0-9/_.-]+' \
+		"$PROJECT_ROOT/scripts/ci/lib/actions.sh" | awk '{print $4}' | sort -u)
+}

--- a/tests/bats/unit/lib/test_aggregator_strict_loading.bats
+++ b/tests/bats/unit/lib/test_aggregator_strict_loading.bats
@@ -108,6 +108,25 @@ _source_tmp_lib() {
 	assert_output --partial "missing required module detect.sh"
 }
 
+# merge.sh only needs log_warn (from log.sh), so it must NOT be coupled to the
+# unrelated github/sbom/installer trees that the heavy actions.sh aggregator
+# pulls in. A coverage-only copy with those trees absent must still load.
+@test "coverage/merge.sh: loads when unrelated lib trees are absent" {
+	rm -rf "$TMP_LIB_DIR/github" "$TMP_LIB_DIR/sbom" "$TMP_LIB_DIR/installer"
+	run bash -c 'source "$1" && declare -f merge_lcov_files >/dev/null && declare -f merge_istanbul_files >/dev/null && echo loaded' _ "$TMP_LIB_DIR/testing/coverage/merge.sh"
+	assert_success
+	assert_output --partial "loaded"
+}
+
+# Even when log.sh is entirely absent, merge.sh falls back to a local log_warn
+# and still defines its merge helpers.
+@test "coverage/merge.sh: loads with a fallback logger when log.sh is absent" {
+	rm "$TMP_LIB_DIR/log.sh"
+	run bash -c 'source "$1" && declare -f merge_lcov_files >/dev/null && declare -f log_warn >/dev/null && echo loaded' _ "$TMP_LIB_DIR/testing/coverage/merge.sh"
+	assert_success
+	assert_output --partial "loaded"
+}
+
 # Runs from a script file (not bash -c) so BASH_SOURCE is bound: kcov's
 # bash instrumentation references BASH_SOURCE in a DEBUG trap and aborts
 # under set -u inside a bash -c script. Paths are passed via the exported


### PR DESCRIPTION
## Summary

Library aggregators in `scripts/ci/lib/` previously sourced sub-modules behind silent `[[ -f ... ]] && source` guards (or bare `source`), so a missing module left functions silently undefined and surfaced only as cryptic `command not found` errors far from the root cause. Every aggregator now loads strictly: a missing sub-module (or unresolvable module directory) emits a clear error naming the missing file and returns 1, following the pattern already established by `egress.sh`.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Changes Made

- `actions.sh`, `github.sh`, `installer.sh`, `network.sh`, `sbom.sh`, `publish.sh`, `docker.sh`, `testing.sh`, `release.sh`, `testing/coverage/merge.sh`: all sub-modules are now required — missing files fail loudly with `<aggregator>: missing required module <file> in <dir>` and return 1 (sourced-lib convention, no `exit`, no `set -euo pipefail`)
- Module-directory resolution (`cd ... && pwd`) is guarded the same way
- Nested aggregator failures propagate via `source ... || return 1` (previously `actions.sh` continued past a failed `github.sh` load); `egress.sh` gained the same guard
- `_LOADED` guards are now set only after a fully successful load, so a failed load can be retried
- Synced the harden-runner bundled copy of `egress.sh` via `sync-harden-runner-bundle.sh`
- New BATS suite `tests/bats/unit/lib/test_aggregator_strict_loading.bats` (14 tests): temp-dir copies of the lib tree with one module removed assert failure with the explicit message for every aggregator, plus happy-path and re-source no-op checks

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None for repo consumers (all modules ship together). Consumers deploying partial copies of `scripts/ci/lib` now fail at source time with an explicit error instead of continuing with undefined functions — this is the intended contract change.

## Closes

- Closes #30

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes the CI library aggregators fail clearly when required modules are missing. The main changes are:

- Strict loading checks across the library aggregators.
- Loaded guards set only after successful imports.
- Coverage merge logging decoupled from the heavy actions aggregator.
- BATS coverage for missing-module failures and safe temp-path handling.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/lib/testing/coverage/merge.sh | Loads only the minimal logging dependency when present and falls back to a local warning logger when absent. |
| tests/bats/unit/lib/test_aggregator_strict_loading.bats | Adds strict-loading tests and passes temp paths as data instead of embedding them into shell syntax. |
| scripts/ci/lib/actions.sh | Requires all expected libraries and marks the aggregator loaded only after successful sourcing. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(lib): decouple coverage/merge.sh fro..."](https://github.com/lgtm-hq/lgtm-ci/commit/cb35a80dad85adf30cc4a2c2432db60425be903e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41926824)</sub>

<!-- /greptile_comment -->