### PR TITLE
chore(quality): add script-to-BATS-test ratchet and first test tranche

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **quality**: script-to-BATS-test coverage ratchet (#370):
+  `scripts/ci/quality/validate-script-test-coverage.sh` requires every
+  `scripts/ci` entrypoint (excluding `lib/`) to be referenced by a BATS test,
+  with known-untested scripts tracked in
+  `scripts/ci/quality/script-test-coverage-allowlist.txt` (seeded with 53
+  entries, ratcheted down to 42 in this change). Wired into the BATS
+  integration suite via `tests/bats/integration/test_script_test_coverage.bats`
+- **tests**: first tranche of BATS tests for release/publish entrypoints
+  (#370): `create-tag.sh`, `create-github-release.sh`,
+  `configure-git-remote.sh`, `enable-auto-merge.sh`, `publish-npm.sh`,
+  `publish-gem.sh`, `wait-for-package.sh`, `validate-package.sh`,
+  `egress-audit.sh`, `verify-attestation.sh`, `docker-login.sh`
+
 ### Changed
 
 - **workflows**: **BREAKING** — `reusable-deploy-pages.yml` is now a hardened
@@ -52,8 +65,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `BLUE`, `NC`) from `scripts/ci/lib/log.sh` (#383). Consumers sourcing `log.sh`
   must migrate to the namespaced `LGTM_CI_*` names (e.g. `LGTM_CI_RED`,
   `LGTM_CI_NC`).
+- **python**: `[tool.pytest.ini_options]` and pytest-only dev dependencies
+  (`pytest`, `assertpy`, `pytest-timeout`, `pytest-xdist`) from
+  `pyproject.toml` — the repository has no Python test suite; its Python
+  helpers are exercised through the BATS suite (#370)
 
 ### Fixed
+
+- **actions**: BSD/macOS-incompatible `\s` regex escapes in the
+  name-extraction pipelines of `publish-npm.sh`, `publish-gem.sh`, and
+  `validate-package.sh` replaced with POSIX `[[:space:]]` (#370)
 
 ### Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,6 @@ Issues = "https://github.com/lgtm-hq/lgtm-ci/issues"
 dev = [
   # Keep in sync with LINTRO_IMAGE digest in reusable-quality-lint.yml / run-quality action
   "lintro==0.64.1",
-  "pytest>=8.0.0",
-  "assertpy>=1.1",
   "ruff>=0.14.0",
   "black>=25.0.0",
   "tomli-w>=1.0.0",
@@ -60,13 +58,6 @@ convention = "google"
 line-length = 88
 target-version = ["py311", "py312", "py313"]
 
-[tool.pytest.ini_options]
-testpaths = ["tests"]
-python_files = ["test_*.py"]
-python_classes = ["Test*"]
-python_functions = ["test_*"]
-addopts = "-v --tb=short"
-
 [tool.bandit]
 exclude_dirs = [".venv", "venv", "env", "build", "dist", "tests"]
 skips = [
@@ -76,6 +67,3 @@ skips = [
   "B607", # start_process_with_partial_path - using standard executables
   "B108", # hardcoded_tmp_directory - mocking GitHub env vars
 ]
-
-[dependency-groups]
-dev = ["pytest-timeout>=2.4.0", "pytest-xdist>=3.8.0"]

--- a/scripts/ci/actions/publish-gem.sh
+++ b/scripts/ci/actions/publish-gem.sh
@@ -55,7 +55,7 @@ validate)
 	fi
 
 	# Extract metadata
-	name=$(grep -E '\.(name)\s*=' "$gemspec" | head -1 | sed 's/.*=\s*["\x27]\([^"\x27]*\)["\x27].*/\1/')
+	name=$(grep -E '\.(name)[[:space:]]*=' "$gemspec" | head -1 | sed 's/.*=[[:space:]]*["\x27]\([^"\x27]*\)["\x27].*/\1/')
 	version=$(extract_gem_version "$gemspec") || die "Could not extract version"
 
 	log_success "Gemspec valid: $name@$version"
@@ -80,7 +80,7 @@ build)
 	fi
 
 	# Extract metadata from gemspec
-	name=$(grep -E '\.(name)\s*=' "$gemspec" | head -1 | sed 's/.*=\s*["\x27]\([^"\x27]*\)["\x27].*/\1/')
+	name=$(grep -E '\.(name)[[:space:]]*=' "$gemspec" | head -1 | sed 's/.*=[[:space:]]*["\x27]\([^"\x27]*\)["\x27].*/\1/')
 	version=$(extract_gem_version "$gemspec") || die "Could not extract version"
 
 	log_success "Built: $gem_file"

--- a/scripts/ci/actions/publish-npm.sh
+++ b/scripts/ci/actions/publish-npm.sh
@@ -34,7 +34,7 @@ validate)
 	fi
 
 	# Check for required fields for publishing
-	name=$(grep -E '^\s*"name"\s*:' package.json | sed 's/.*:\s*"\([^"]*\)".*/\1/')
+	name=$(grep -E '^[[:space:]]*"name"[[:space:]]*:' package.json | sed 's/.*:[[:space:]]*"\([^"]*\)".*/\1/')
 	version=$(extract_npm_version ".") || die "Could not extract version"
 
 	log_success "Package valid: $name@$version"
@@ -44,7 +44,7 @@ build)
 	log_info "Building and packing npm package..."
 
 	# Extract metadata
-	name=$(grep -E '^\s*"name"\s*:' package.json | sed 's/.*:\s*"\([^"]*\)".*/\1/')
+	name=$(grep -E '^[[:space:]]*"name"[[:space:]]*:' package.json | sed 's/.*:[[:space:]]*"\([^"]*\)".*/\1/')
 	version=$(extract_npm_version ".") || die "Could not extract version"
 
 	# Detect package manager once based on lockfile

--- a/scripts/ci/actions/validate-package.sh
+++ b/scripts/ci/actions/validate-package.sh
@@ -117,7 +117,7 @@ validate)
 		;;
 	npm)
 		if validate_npm_package "$PACKAGE_PATH"; then
-			name=$(grep -E '^\s*"name"\s*:' "$PACKAGE_PATH/package.json" | sed 's/.*:\s*"\([^"]*\)".*/\1/')
+			name=$(grep -E '^[[:space:]]*"name"[[:space:]]*:' "$PACKAGE_PATH/package.json" | sed 's/.*:[[:space:]]*"\([^"]*\)".*/\1/')
 			version=$(extract_npm_version "$PACKAGE_PATH") || true
 			valid="true"
 		fi
@@ -127,7 +127,7 @@ validate)
 			version=$(extract_gem_version "$PACKAGE_PATH") || true
 			gemspec=$(find "$PACKAGE_PATH" -maxdepth 1 -name "*.gemspec" -print -quit 2>/dev/null || true)
 			if [[ -n "$gemspec" ]]; then
-				name=$(grep -E '\.(name)\s*=' "$gemspec" | head -1 | sed 's/.*=\s*["\x27]\([^"\x27]*\)["\x27].*/\1/' || true)
+				name=$(grep -E '\.(name)[[:space:]]*=' "$gemspec" | head -1 | sed 's/.*=[[:space:]]*["\x27]\([^"\x27]*\)["\x27].*/\1/' || true)
 			fi
 			valid="true"
 		fi

--- a/scripts/ci/quality/script-test-coverage-allowlist.txt
+++ b/scripts/ci/quality/script-test-coverage-allowlist.txt
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: MIT
+# Known-untested scripts/ci entrypoints (paths relative to scripts/ci).
+# Ratchet: do not add entries; remove one whenever its script gains a BATS test.
+actions/check-coverage-threshold.sh
+actions/collect-coverage.sh
+actions/deploy-pages.sh
+actions/docker/cleanup-staging.sh
+actions/docker/health-check-local.sh
+actions/docker/health-lib.sh
+actions/docker/merge-manifests.sh
+actions/docker/metadata.sh
+actions/docker/push.sh
+actions/docker/record-digest.sh
+actions/docker/resolve-local-health-check-image.sh
+actions/docker/resolve-local-scan-image.sh
+actions/docker/set-output-digest.sh
+actions/docker/setup.sh
+actions/docker/sign-image.sh
+actions/generate-coverage-badge.sh
+actions/generate-lintro-comment.sh
+actions/generate-matrix.sh
+actions/generate-sbom.sh
+actions/merge-node-coverage.sh
+actions/merge-playwright-reports.sh
+actions/run-bats-tests.sh
+actions/run-command.sh
+actions/run-lighthouse.sh
+actions/run-playwright.sh
+actions/run-pytest.sh
+actions/run-tests.sh
+actions/run-validate-script.sh
+actions/setup-env.sh
+actions/setup-node.sh
+actions/setup-package-manager.sh
+actions/setup-python.sh
+actions/setup-ruby.sh
+quality/lint-check.sh
+release/build-rust-binary.sh
+release/remove-tooling-checkout.sh
+release/run-version-update-script.sh
+release/write-release-summary.sh
+release/write-version-pr-summary.sh
+security/install-osv-scanner.sh
+testing/rust/build-workspace.sh
+testing/rust/setup-rust-nextest.sh

--- a/scripts/ci/quality/script-test-coverage-allowlist.txt
+++ b/scripts/ci/quality/script-test-coverage-allowlist.txt
@@ -40,6 +40,5 @@ release/remove-tooling-checkout.sh
 release/run-version-update-script.sh
 release/write-release-summary.sh
 release/write-version-pr-summary.sh
-security/install-osv-scanner.sh
 testing/rust/build-workspace.sh
 testing/rust/setup-rust-nextest.sh

--- a/scripts/ci/quality/validate-script-test-coverage.sh
+++ b/scripts/ci/quality/validate-script-test-coverage.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Ratchet check — every scripts/ci entrypoint must be referenced by a BATS test.
+#
+# For each shell entrypoint under scripts/ci (excluding scripts/ci/lib, which
+# holds sourced libraries, not entrypoints), require its basename to appear in
+# at least one tests/**/*.bats file. Known-untested scripts live in an
+# allowlist; the check fails when a script is untested but not allowlisted
+# (new untested script) or when an allowlist entry is stale (script gained a
+# test or was removed) so the allowlist only ever shrinks.
+#
+# Optional environment variables (used by the BATS self-tests):
+#   REPO_ROOT      - Repository root (default: derived from this script)
+#   SCRIPTS_DIR    - Scripts root to scan (default: REPO_ROOT/scripts/ci)
+#   TESTS_DIR      - BATS tests root (default: REPO_ROOT/tests)
+#   ALLOWLIST_FILE - Allowlist path (default: alongside this script)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -z "${REPO_ROOT:-}" ]]; then
+	REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+fi
+SCRIPTS_DIR="${SCRIPTS_DIR:-${REPO_ROOT}/scripts/ci}"
+TESTS_DIR="${TESTS_DIR:-${REPO_ROOT}/tests}"
+ALLOWLIST_FILE="${ALLOWLIST_FILE:-${SCRIPT_DIR}/script-test-coverage-allowlist.txt}"
+
+if [[ ! -d "${SCRIPTS_DIR}" ]]; then
+	echo "ERROR: scripts directory not found: ${SCRIPTS_DIR}" >&2
+	exit 1
+fi
+
+if [[ ! -d "${TESTS_DIR}" ]]; then
+	echo "ERROR: tests directory not found: ${TESTS_DIR}" >&2
+	exit 1
+fi
+
+# Load allowlist (comments and blank lines ignored), entries are paths
+# relative to SCRIPTS_DIR (e.g. release/create-tag.sh).
+declare -a allowlist=()
+if [[ -f "${ALLOWLIST_FILE}" ]]; then
+	while IFS= read -r line; do
+		line="${line%%#*}"
+		line="${line#"${line%%[![:space:]]*}"}"
+		line="${line%"${line##*[![:space:]]}"}"
+		[[ -n "$line" ]] && allowlist+=("$line")
+	done <"${ALLOWLIST_FILE}"
+fi
+
+allowlisted() {
+	local candidate="$1"
+	local entry
+	for entry in "${allowlist[@]+"${allowlist[@]}"}"; do
+		if [[ "$entry" == "$candidate" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+# A script counts as tested when its basename appears in any .bats file.
+is_tested() {
+	local base="$1"
+	grep -rqF --include='*.bats' -- "$base" "${TESTS_DIR}"
+}
+
+declare -a violations=()
+declare -a untested=()
+declare -a seen_scripts=()
+tested_count=0
+
+while IFS= read -r script; do
+	rel="${script#"${SCRIPTS_DIR}/"}"
+	seen_scripts+=("$rel")
+	if is_tested "$(basename "$script")"; then
+		tested_count=$((tested_count + 1))
+		if allowlisted "$rel"; then
+			violations+=("stale allowlist entry (script now has a BATS test, remove it): $rel")
+		fi
+	else
+		untested+=("$rel")
+		if ! allowlisted "$rel"; then
+			violations+=("new untested script (add a BATS test referencing '$(basename "$script")'): $rel")
+		fi
+	fi
+done < <(find "${SCRIPTS_DIR}" -type f -name '*.sh' -not -path "${SCRIPTS_DIR}/lib/*" | sort)
+
+# Allowlist entries pointing at scripts that no longer exist are stale too.
+for entry in "${allowlist[@]+"${allowlist[@]}"}"; do
+	found=0
+	for rel in "${seen_scripts[@]+"${seen_scripts[@]}"}"; do
+		if [[ "$rel" == "$entry" ]]; then
+			found=1
+			break
+		fi
+	done
+	if [[ "$found" -eq 0 ]]; then
+		violations+=("stale allowlist entry (script does not exist, remove it): $entry")
+	fi
+done
+
+if ((${#violations[@]} > 0)); then
+	for violation in "${violations[@]}"; do
+		echo "ERROR: ${violation}" >&2
+	done
+	echo "ERROR: ${#violations[@]} script test coverage violation(s)" >&2
+	echo "Allowlist: ${ALLOWLIST_FILE}" >&2
+	exit 1
+fi
+
+total=$((tested_count + ${#untested[@]}))
+echo "OK: script test coverage ratchet satisfied (${tested_count}/${total} entrypoints tested, ${#untested[@]} allowlisted)"

--- a/scripts/ci/quality/validate-script-test-coverage.sh
+++ b/scripts/ci/quality/validate-script-test-coverage.sh
@@ -22,6 +22,7 @@ if [[ -z "${REPO_ROOT:-}" ]]; then
 	REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 fi
 SCRIPTS_DIR="${SCRIPTS_DIR:-${REPO_ROOT}/scripts/ci}"
+SCRIPTS_DIR="${SCRIPTS_DIR%/}" # normalize: a trailing slash would break rel-path stripping
 TESTS_DIR="${TESTS_DIR:-${REPO_ROOT}/tests}"
 ALLOWLIST_FILE="${ALLOWLIST_FILE:-${SCRIPT_DIR}/script-test-coverage-allowlist.txt}"
 

--- a/tests/bats/integration/test_script_test_coverage.bats
+++ b/tests/bats/integration/test_script_test_coverage.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for the script-to-BATS-test coverage ratchet
+
+load "../../helpers/common"
+
+VALIDATOR="${PROJECT_ROOT}/scripts/ci/quality/validate-script-test-coverage.sh"
+
+setup() {
+	setup_temp_dir
+
+	FIXTURE_SCRIPTS="${BATS_TEST_TMPDIR}/scripts/ci"
+	FIXTURE_TESTS="${BATS_TEST_TMPDIR}/tests"
+	FIXTURE_ALLOWLIST="${BATS_TEST_TMPDIR}/allowlist.txt"
+	mkdir -p "${FIXTURE_SCRIPTS}" "${FIXTURE_TESTS}"
+	: >"${FIXTURE_ALLOWLIST}"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+run_fixture_validator() {
+	SCRIPTS_DIR="${FIXTURE_SCRIPTS}" \
+		TESTS_DIR="${FIXTURE_TESTS}" \
+		ALLOWLIST_FILE="${FIXTURE_ALLOWLIST}" \
+		run "${VALIDATOR}"
+}
+
+@test "script-test-coverage: passes on repository state" {
+	run "${VALIDATOR}"
+	assert_success
+	assert_output --partial "OK:"
+}
+
+@test "script-test-coverage: repository allowlist has no duplicates" {
+	local allowlist="${PROJECT_ROOT}/scripts/ci/quality/script-test-coverage-allowlist.txt"
+	assert_file_exists "$allowlist"
+	run bash -c "grep -vE '^\s*(#|\$)' '$allowlist' | sort | uniq -d"
+	refute_output
+}
+
+@test "script-test-coverage: flags new untested script" {
+	mkdir -p "${FIXTURE_SCRIPTS}/actions"
+	printf '#!/usr/bin/env bash\n' >"${FIXTURE_SCRIPTS}/actions/example-untested.sh"
+
+	run_fixture_validator
+	assert_failure
+	assert_output --partial "new untested script"
+	assert_output --partial "actions/example-untested.sh"
+}
+
+@test "script-test-coverage: passes when untested script is allowlisted" {
+	mkdir -p "${FIXTURE_SCRIPTS}/actions"
+	printf '#!/usr/bin/env bash\n' >"${FIXTURE_SCRIPTS}/actions/example-untested.sh"
+	echo "actions/example-untested.sh" >"${FIXTURE_ALLOWLIST}"
+
+	run_fixture_validator
+	assert_success
+	assert_output --partial "1 allowlisted"
+}
+
+@test "script-test-coverage: passes when script basename appears in a bats test" {
+	mkdir -p "${FIXTURE_SCRIPTS}/actions" "${FIXTURE_TESTS}/bats/unit"
+	printf '#!/usr/bin/env bash\n' >"${FIXTURE_SCRIPTS}/actions/example-tested.sh"
+	echo '# exercises example-tested.sh' >"${FIXTURE_TESTS}/bats/unit/test_example.bats"
+
+	run_fixture_validator
+	assert_success
+	assert_output --partial "1/1 entrypoints tested"
+}
+
+@test "script-test-coverage: ignores basename mentions outside .bats files" {
+	mkdir -p "${FIXTURE_SCRIPTS}/actions" "${FIXTURE_TESTS}/bats/unit"
+	printf '#!/usr/bin/env bash\n' >"${FIXTURE_SCRIPTS}/actions/example-untested.sh"
+	echo '# mentions example-untested.sh' >"${FIXTURE_TESTS}/bats/unit/notes.txt"
+
+	run_fixture_validator
+	assert_failure
+	assert_output --partial "new untested script"
+}
+
+@test "script-test-coverage: flags stale allowlist entry for tested script" {
+	mkdir -p "${FIXTURE_SCRIPTS}/actions" "${FIXTURE_TESTS}/bats/unit"
+	printf '#!/usr/bin/env bash\n' >"${FIXTURE_SCRIPTS}/actions/example-tested.sh"
+	echo '# exercises example-tested.sh' >"${FIXTURE_TESTS}/bats/unit/test_example.bats"
+	echo "actions/example-tested.sh" >"${FIXTURE_ALLOWLIST}"
+
+	run_fixture_validator
+	assert_failure
+	assert_output --partial "stale allowlist entry (script now has a BATS test"
+}
+
+@test "script-test-coverage: flags stale allowlist entry for removed script" {
+	echo "actions/removed-script.sh" >"${FIXTURE_ALLOWLIST}"
+
+	run_fixture_validator
+	assert_failure
+	assert_output --partial "stale allowlist entry (script does not exist"
+}
+
+@test "script-test-coverage: excludes lib/ sourced files" {
+	mkdir -p "${FIXTURE_SCRIPTS}/lib/release"
+	printf '#!/usr/bin/env bash\n' >"${FIXTURE_SCRIPTS}/lib/sourced.sh"
+	printf '#!/usr/bin/env bash\n' >"${FIXTURE_SCRIPTS}/lib/release/sourced-nested.sh"
+
+	run_fixture_validator
+	assert_success
+	assert_output --partial "0 allowlisted"
+}
+
+@test "script-test-coverage: ignores comments and blank lines in allowlist" {
+	mkdir -p "${FIXTURE_SCRIPTS}/actions"
+	printf '#!/usr/bin/env bash\n' >"${FIXTURE_SCRIPTS}/actions/example-untested.sh"
+	cat >"${FIXTURE_ALLOWLIST}" <<'EOF'
+# comment line
+
+actions/example-untested.sh  # trailing comment
+EOF
+
+	run_fixture_validator
+	assert_success
+}

--- a/tests/bats/integration/test_script_test_coverage.bats
+++ b/tests/bats/integration/test_script_test_coverage.bats
@@ -109,6 +109,19 @@ run_fixture_validator() {
 	assert_output --partial "0 allowlisted"
 }
 
+@test "script-test-coverage: tolerates trailing slash in SCRIPTS_DIR override" {
+	mkdir -p "${FIXTURE_SCRIPTS}/actions"
+	printf '#!/usr/bin/env bash\n' >"${FIXTURE_SCRIPTS}/actions/example-untested.sh"
+	echo "actions/example-untested.sh" >"${FIXTURE_ALLOWLIST}"
+
+	SCRIPTS_DIR="${FIXTURE_SCRIPTS}/" \
+		TESTS_DIR="${FIXTURE_TESTS}" \
+		ALLOWLIST_FILE="${FIXTURE_ALLOWLIST}" \
+		run "${VALIDATOR}"
+	assert_success
+	assert_output --partial "1 allowlisted"
+}
+
 @test "script-test-coverage: ignores comments and blank lines in allowlist" {
 	mkdir -p "${FIXTURE_SCRIPTS}/actions"
 	printf '#!/usr/bin/env bash\n' >"${FIXTURE_SCRIPTS}/actions/example-untested.sh"

--- a/tests/bats/unit/actions/test_docker_login.bats
+++ b/tests/bats/unit/actions/test_docker_login.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/docker-login.sh
+
+load "../../../helpers/common"
+load "../../../helpers/github_env"
+
+SCRIPT="scripts/ci/actions/docker-login.sh"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+@test "docker-login: fails without STEP" {
+	run env -u STEP bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "STEP is required"
+}
+
+@test "docker-login: fails on unknown step" {
+	STEP="bogus" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "Unknown step"
+}
+
+@test "docker-login: validate fails without REGISTRY" {
+	run env -u REGISTRY STEP="validate" bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "REGISTRY is required"
+}
+
+@test "docker-login: validate accepts ghcr.io" {
+	STEP="validate" REGISTRY="ghcr.io" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "Registry validation passed: ghcr.io"
+}
+
+@test "docker-login: validate rejects unsupported registry" {
+	STEP="validate" REGISTRY="quay.io" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "Unsupported registry"
+}
+
+@test "docker-login: validate requires Docker Hub credentials for docker.io" {
+	STEP="validate" REGISTRY="docker.io" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "DOCKERHUB_USERNAME and DOCKERHUB_TOKEN are required"
+}
+
+@test "docker-login: validate rejects docker.io with only username" {
+	STEP="validate" REGISTRY="docker.io" DOCKERHUB_USERNAME="user" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "DOCKERHUB_USERNAME and DOCKERHUB_TOKEN are required"
+}
+
+@test "docker-login: validate accepts docker.io with credentials" {
+	STEP="validate" REGISTRY="docker.io" DOCKERHUB_USERNAME="user" \
+		DOCKERHUB_TOKEN="token" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "Registry validation passed: docker.io"
+}

--- a/tests/bats/unit/actions/test_egress_audit.bats
+++ b/tests/bats/unit/actions/test_egress_audit.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/egress-audit.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+load "../../../helpers/github_env"
+
+SCRIPT="scripts/ci/actions/egress-audit.sh"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+@test "egress-audit: fails without STEP" {
+	run env -u STEP bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "STEP is required"
+}
+
+@test "egress-audit: fails on unknown step" {
+	STEP="bogus" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "Unknown step"
+}
+
+@test "egress-audit: setup normalizes and dedupes allowed domains" {
+	STEP="setup" ALLOWED_DOMAINS="b.example.com, a.example.com,b.example.com , " \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	run cat "${RUNNER_TEMP}/egress-audit/allowed-domains.txt"
+	assert_output "a.example.com
+b.example.com"
+}
+
+@test "egress-audit: setup writes log-dir output" {
+	STEP="setup" ALLOWED_DOMAINS="example.com" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_file_contains "$GITHUB_OUTPUT" "log-dir=${RUNNER_TEMP}/egress-audit"
+}
+
+@test "egress-audit: audit initializes log and outputs" {
+	STEP="setup" ALLOWED_DOMAINS="example.com" bash "${PROJECT_ROOT}/${SCRIPT}"
+
+	STEP="audit" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	assert_file_exists "${RUNNER_TEMP}/egress-audit/egress.log"
+	assert_file_contains "$GITHUB_OUTPUT" "egress-log=${RUNNER_TEMP}/egress-audit/egress.log"
+	assert_file_contains "$GITHUB_OUTPUT" "violations-detected=false"
+}
+
+@test "egress-audit: audit notes block mode enforcement" {
+	STEP="setup" ALLOWED_DOMAINS="example.com" bash "${PROJECT_ROOT}/${SCRIPT}"
+
+	STEP="audit" MODE="block" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "harden-runner"
+}
+
+@test "egress-audit: report fails when setup has not run" {
+	STEP="report" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "Setup step must run before report"
+}
+
+@test "egress-audit: report writes summary with allowed domains" {
+	STEP="setup" ALLOWED_DOMAINS="example.com" bash "${PROJECT_ROOT}/${SCRIPT}"
+
+	STEP="report" REPORT_FORMAT="summary" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	run get_github_step_summary
+	assert_output --partial "Egress Audit Report"
+	assert_output --partial "example.com"
+}
+
+@test "egress-audit: report writes json report" {
+	STEP="setup" ALLOWED_DOMAINS="a.example.com,b.example.com" bash "${PROJECT_ROOT}/${SCRIPT}"
+
+	STEP="report" REPORT_FORMAT="json" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	local report="${RUNNER_TEMP}/egress-audit/report.json"
+	assert_file_exists "$report"
+	run jq -r '.allowed_domains | length' "$report"
+	assert_output "2"
+	run jq -r '.violations_detected' "$report"
+	assert_output "false"
+}

--- a/tests/bats/unit/actions/test_publish_gem.bats
+++ b/tests/bats/unit/actions/test_publish_gem.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/publish-gem.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+load "../../../helpers/github_env"
+
+SCRIPT="scripts/ci/actions/publish-gem.sh"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+
+	GEM_DIR="${BATS_TEST_TMPDIR}/gem"
+	mkdir -p "$GEM_DIR"
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+write_gemspec() {
+	cat >"${GEM_DIR}/testgem.gemspec" <<'EOF'
+Gem::Specification.new do |spec|
+  spec.name = "testgem"
+  spec.version = "1.2.3"
+  spec.summary = "Test gem"
+  spec.authors = ["Test"]
+end
+EOF
+}
+
+# Mock gem CLI: "gem build" creates a .gem file, other commands succeed
+mock_gem_cli() {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+	cat >"${mock_bin}/gem" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "build" ]]; then
+	touch "testgem-1.2.3.gem"
+	echo "  Successfully built RubyGem"
+	echo "  File: testgem-1.2.3.gem"
+fi
+exit 0
+EOF
+	chmod +x "${mock_bin}/gem"
+	export PATH="${mock_bin}:$PATH"
+}
+
+@test "publish-gem: fails without STEP" {
+	run env -u STEP bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "STEP is required"
+}
+
+@test "publish-gem: fails on unknown step" {
+	STEP="bogus" WORKING_DIRECTORY="$GEM_DIR" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "Unknown step"
+}
+
+@test "publish-gem: validate passes for valid gemspec" {
+	write_gemspec
+	mock_gem_cli
+
+	STEP="validate" WORKING_DIRECTORY="$GEM_DIR" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "Gemspec valid: testgem@1.2.3"
+}
+
+@test "publish-gem: validate fails when no gemspec exists" {
+	STEP="validate" WORKING_DIRECTORY="$GEM_DIR" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "No gemspec found"
+}
+
+@test "publish-gem: validate fails when explicit GEMSPEC is missing" {
+	STEP="validate" WORKING_DIRECTORY="$GEM_DIR" GEMSPEC="missing.gemspec" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "No gemspec found"
+}
+
+@test "publish-gem: build produces gem file and outputs metadata" {
+	write_gemspec
+	mock_gem_cli
+
+	STEP="build" WORKING_DIRECTORY="$GEM_DIR" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "Built:"
+
+	assert_file_contains "$GITHUB_OUTPUT" "name=testgem"
+	assert_file_contains "$GITHUB_OUTPUT" "version=1.2.3"
+	assert_file_contains "$GITHUB_OUTPUT" "gem-file=./testgem-1.2.3.gem"
+}
+
+@test "publish-gem: publish fails without GEM_FILE" {
+	run env -u GEM_FILE STEP="publish" WORKING_DIRECTORY="$GEM_DIR" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "GEM_FILE is required"
+}
+
+@test "publish-gem: publish fails when gem file does not exist" {
+	STEP="publish" WORKING_DIRECTORY="$GEM_DIR" GEM_FILE="missing.gem" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "Gem file not found"
+}
+
+@test "publish-gem: publish pushes gem to RubyGems" {
+	touch "${GEM_DIR}/testgem-1.2.3.gem"
+	mock_command_record "gem" ""
+
+	STEP="publish" WORKING_DIRECTORY="$GEM_DIR" GEM_FILE="testgem-1.2.3.gem" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "Published successfully"
+
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_gem"
+	assert_output --partial "push testgem-1.2.3.gem"
+	assert_file_contains "$GITHUB_OUTPUT" "published=true"
+}
+
+@test "publish-gem: summary reports published with URL" {
+	STEP="summary" WORKING_DIRECTORY="$GEM_DIR" GEM_NAME="testgem" \
+		GEM_VERSION="1.2.3" PUBLISHED="true" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	run get_github_step_summary
+	assert_output --partial "RubyGems Publishing"
+	assert_output --partial "https://rubygems.org/gems/testgem/versions/1.2.3"
+}
+
+@test "publish-gem: summary reports dry run" {
+	STEP="summary" WORKING_DIRECTORY="$GEM_DIR" GEM_NAME="testgem" \
+		GEM_VERSION="1.2.3" DRY_RUN="true" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	run get_github_step_summary
+	assert_output --partial "Dry Run"
+}

--- a/tests/bats/unit/actions/test_publish_npm.bats
+++ b/tests/bats/unit/actions/test_publish_npm.bats
@@ -1,0 +1,142 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/publish-npm.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+load "../../../helpers/github_env"
+
+SCRIPT="scripts/ci/actions/publish-npm.sh"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+
+	PKG_DIR="${BATS_TEST_TMPDIR}/pkg"
+	mkdir -p "$PKG_DIR"
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+write_package_json() {
+	cat >"${PKG_DIR}/package.json" <<'EOF'
+{
+  "name": "test-package",
+  "version": "1.2.3"
+}
+EOF
+}
+
+@test "publish-npm: fails without STEP" {
+	run env -u STEP bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "STEP is required"
+}
+
+@test "publish-npm: fails on unknown step" {
+	STEP="bogus" WORKING_DIRECTORY="$PKG_DIR" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "Unknown step"
+}
+
+@test "publish-npm: validate passes for valid package.json" {
+	write_package_json
+
+	STEP="validate" WORKING_DIRECTORY="$PKG_DIR" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "Package valid: test-package@1.2.3"
+}
+
+@test "publish-npm: validate fails when package.json is missing" {
+	STEP="validate" WORKING_DIRECTORY="$PKG_DIR" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "package.json not found"
+}
+
+@test "publish-npm: validate fails on invalid version" {
+	cat >"${PKG_DIR}/package.json" <<'EOF'
+{
+  "name": "test-package",
+  "version": "not-semver"
+}
+EOF
+
+	STEP="validate" WORKING_DIRECTORY="$PKG_DIR" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "validation failed"
+}
+
+@test "publish-npm: publish fails without NODE_AUTH_TOKEN" {
+	write_package_json
+
+	STEP="publish" WORKING_DIRECTORY="$PKG_DIR" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "NODE_AUTH_TOKEN is required"
+}
+
+@test "publish-npm: publish runs npm publish without provenance" {
+	write_package_json
+	mock_command_record "npm" ""
+
+	STEP="publish" WORKING_DIRECTORY="$PKG_DIR" NODE_AUTH_TOKEN="tok" \
+		PROVENANCE="false" DIST_TAG="next" ACCESS="restricted" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "Published successfully"
+
+	grep -qF -- "publish --tag next --access restricted" "${BATS_TEST_TMPDIR}/mock_calls_npm"
+	! grep -qF -- "--provenance" "${BATS_TEST_TMPDIR}/mock_calls_npm"
+	assert_file_contains "$GITHUB_OUTPUT" "published=true"
+}
+
+@test "publish-npm: publish adds --provenance on modern npm" {
+	write_package_json
+	mock_command_multi "npm" '
+		--version) echo "10.2.0";;
+		*) exit 0;;
+	'
+
+	STEP="publish" WORKING_DIRECTORY="$PKG_DIR" NODE_AUTH_TOKEN="tok" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "npm publish"
+	assert_output --partial "provenance"
+}
+
+@test "publish-npm: publish rejects provenance on old npm" {
+	write_package_json
+	mock_command_multi "npm" '
+		--version) echo "9.4.2";;
+		*) exit 0;;
+	'
+
+	STEP="publish" WORKING_DIRECTORY="$PKG_DIR" NODE_AUTH_TOKEN="tok" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "npm 9.5.0+ required for provenance"
+}
+
+@test "publish-npm: summary reports dry run" {
+	STEP="summary" WORKING_DIRECTORY="$PKG_DIR" PACKAGE_NAME="test-package" \
+		PACKAGE_VERSION="1.2.3" DRY_RUN="true" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	run get_github_step_summary
+	assert_output --partial "npm Publishing"
+	assert_output --partial "Dry Run"
+}
+
+@test "publish-npm: summary reports published with URL" {
+	STEP="summary" WORKING_DIRECTORY="$PKG_DIR" PACKAGE_NAME="test-package" \
+		PACKAGE_VERSION="1.2.3" PUBLISHED="true" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	run get_github_step_summary
+	assert_output --partial "Published"
+	assert_output --partial "https://www.npmjs.com/package/test-package/v/1.2.3"
+}

--- a/tests/bats/unit/actions/test_validate_package.bats
+++ b/tests/bats/unit/actions/test_validate_package.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/validate-package.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+load "../../../helpers/github_env"
+
+SCRIPT="scripts/ci/actions/validate-package.sh"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+
+	PKG_DIR="${BATS_TEST_TMPDIR}/pkg"
+	mkdir -p "$PKG_DIR"
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+write_package_json() {
+	cat >"${PKG_DIR}/package.json" <<'EOF'
+{
+  "name": "test-package",
+  "version": "1.2.3"
+}
+EOF
+}
+
+@test "validate-package: fails without STEP" {
+	run env -u STEP PACKAGE_TYPE="npm" bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "STEP is required"
+}
+
+@test "validate-package: fails without PACKAGE_TYPE" {
+	run env -u PACKAGE_TYPE STEP="detect" bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "PACKAGE_TYPE is required"
+}
+
+@test "validate-package: detect finds package.json for npm" {
+	write_package_json
+
+	STEP="detect" PACKAGE_TYPE="npm" PACKAGE_PATH="$PKG_DIR" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "Found package.json"
+}
+
+@test "validate-package: detect fails without package.json for npm" {
+	STEP="detect" PACKAGE_TYPE="npm" PACKAGE_PATH="$PKG_DIR" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "No package.json found"
+}
+
+@test "validate-package: detect finds pyproject.toml for pypi" {
+	printf '[project]\nname = "pkg"\nversion = "1.0.0"\n' >"${PKG_DIR}/pyproject.toml"
+
+	STEP="detect" PACKAGE_TYPE="pypi" PACKAGE_PATH="$PKG_DIR" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "Found pyproject.toml"
+}
+
+@test "validate-package: detect finds gemspec for gem" {
+	touch "${PKG_DIR}/testgem.gemspec"
+
+	STEP="detect" PACKAGE_TYPE="gem" PACKAGE_PATH="$PKG_DIR" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "Found gemspec"
+}
+
+@test "validate-package: detect fails on unknown package type" {
+	STEP="detect" PACKAGE_TYPE="cargo" PACKAGE_PATH="$PKG_DIR" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "Unknown package type"
+}
+
+@test "validate-package: validate passes for valid npm package" {
+	write_package_json
+
+	STEP="validate" PACKAGE_TYPE="npm" PACKAGE_PATH="$PKG_DIR" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "Package validation passed: test-package@1.2.3"
+
+	assert_file_contains "$GITHUB_OUTPUT" "valid=true"
+	assert_file_contains "$GITHUB_OUTPUT" "name=test-package"
+	assert_file_contains "$GITHUB_OUTPUT" "version=1.2.3"
+}
+
+@test "validate-package: validate fails for invalid npm package" {
+	printf '{}' >"${PKG_DIR}/package.json"
+
+	STEP="validate" PACKAGE_TYPE="npm" PACKAGE_PATH="$PKG_DIR" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "Package validation failed"
+	assert_file_contains "$GITHUB_OUTPUT" "valid=false"
+}
+
+@test "validate-package: validate passes for pypi metadata without dist" {
+	printf '[project]\nname = "pkg"\nversion = "1.0.0"\n' >"${PKG_DIR}/pyproject.toml"
+
+	STEP="validate" PACKAGE_TYPE="pypi" PACKAGE_PATH="$PKG_DIR" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_file_contains "$GITHUB_OUTPUT" "valid=true"
+	assert_file_contains "$GITHUB_OUTPUT" "name=pkg"
+	assert_file_contains "$GITHUB_OUTPUT" "version=1.0.0"
+}
+
+@test "validate-package: summary reports validation result" {
+	STEP="summary" PACKAGE_TYPE="npm" PACKAGE_NAME="test-package" \
+		PACKAGE_VERSION="1.2.3" VALID="true" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	run get_github_step_summary
+	assert_output --partial "Package Validation"
+	assert_output --partial "Valid"
+}
+
+@test "validate-package: fails on unknown step" {
+	STEP="bogus" PACKAGE_TYPE="npm" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "Unknown step"
+}

--- a/tests/bats/unit/actions/test_verify_attestation.bats
+++ b/tests/bats/unit/actions/test_verify_attestation.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/verify-attestation.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+load "../../../helpers/github_env"
+
+SCRIPT="scripts/ci/actions/verify-attestation.sh"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+
+	TARGET_FILE="${BATS_TEST_TMPDIR}/artifact.tar.gz"
+	echo "data" >"$TARGET_FILE"
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+@test "verify-attestation: fails without STEP" {
+	run env -u STEP bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "STEP is required"
+}
+
+@test "verify-attestation: fails on unknown step" {
+	STEP="bogus" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "Unknown step"
+}
+
+@test "verify-attestation: verify fails without OWNER" {
+	STEP="verify" TARGET="$TARGET_FILE" OWNER="" GITHUB_REPOSITORY_OWNER="" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "OWNER is required"
+}
+
+@test "verify-attestation: verify fails when target file is missing" {
+	STEP="verify" TARGET="${BATS_TEST_TMPDIR}/missing.bin" OWNER="test-org" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "File not found"
+}
+
+@test "verify-attestation: verify fails on unsupported target type" {
+	STEP="verify" TARGET="$TARGET_FILE" TARGET_TYPE="floppy" OWNER="test-org" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "Unsupported target type"
+}
+
+@test "verify-attestation: verify succeeds and parses signer identity" {
+	mock_command_record "gh" '[{"verificationResult":{"signature":{"certificate":{"subjectAlternativeName":"https://github.com/test-org/repo/.github/workflows/release.yml@refs/heads/main"}}}}]'
+
+	STEP="verify" TARGET="$TARGET_FILE" OWNER="test-org" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "Attestation verified successfully"
+
+	grep -qF -- "attestation verify $TARGET_FILE --owner test-org --format json" \
+		"${BATS_TEST_TMPDIR}/mock_calls_gh"
+
+	assert_file_contains "$GITHUB_OUTPUT" "verified=true"
+	assert_file_contains "$GITHUB_OUTPUT" "signer-identity=https://github.com/test-org/repo"
+}
+
+@test "verify-attestation: verify passes --repo when REPO is set" {
+	mock_command_record "gh" "[]"
+
+	STEP="verify" TARGET="$TARGET_FILE" OWNER="test-org" REPO="test-org/repo" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	grep -qF -- "--repo test-org/repo" "${BATS_TEST_TMPDIR}/mock_calls_gh"
+}
+
+@test "verify-attestation: verify propagates gh failure" {
+	mock_command_record "gh" "verification failed" 1
+
+	STEP="verify" TARGET="$TARGET_FILE" OWNER="test-org" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "Attestation verification failed"
+	assert_file_contains "$GITHUB_OUTPUT" "verified=false"
+}
+
+@test "verify-attestation: parse warns when verification output is missing" {
+	STEP="parse" VERIFICATION_OUTPUT="${BATS_TEST_TMPDIR}/missing.json" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "Verification output not found"
+}
+
+@test "verify-attestation: parse prints attestation details" {
+	local verification="${BATS_TEST_TMPDIR}/verification.json"
+	cat >"$verification" <<'EOF'
+[{"verificationResult":{"statement":{"subject":[{"name":"artifact.tar.gz","digest":{"sha256":"abc123"}}],"predicateType":"https://slsa.dev/provenance/v1"},"signature":{"certificate":{"subjectAlternativeName":"https://github.com/test-org"}}}}]
+EOF
+
+	STEP="parse" VERIFICATION_OUTPUT="$verification" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "Subject: artifact.tar.gz"
+	assert_output --partial "Digest: abc123"
+}
+
+@test "verify-attestation: summary reports verified state" {
+	STEP="summary" VERIFIED="true" TARGET="artifact.tar.gz" \
+		SIGNER_IDENTITY="https://github.com/test-org" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	run get_github_step_summary
+	assert_output --partial "Attestation Verified"
+	assert_output --partial "https://github.com/test-org"
+}
+
+@test "verify-attestation: summary reports failed state" {
+	STEP="summary" VERIFIED="false" TARGET="artifact.tar.gz" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	run get_github_step_summary
+	assert_output --partial "Attestation Verification Failed"
+}

--- a/tests/bats/unit/actions/test_wait_for_package.bats
+++ b/tests/bats/unit/actions/test_wait_for_package.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/wait-for-package.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+load "../../../helpers/github_env"
+
+SCRIPT="scripts/ci/actions/wait-for-package.sh"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+run_wait_for_package() {
+	run bash "${PROJECT_ROOT}/${SCRIPT}"
+}
+
+@test "wait-for-package: fails without STEP" {
+	run env -u STEP REGISTRY="npm" PACKAGE="pkg" VERSION="1.0.0" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "STEP is required"
+}
+
+@test "wait-for-package: fails without REGISTRY" {
+	run env -u REGISTRY STEP="check" PACKAGE="pkg" VERSION="1.0.0" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "REGISTRY is required"
+}
+
+@test "wait-for-package: check reports npm package available" {
+	mock_curl "200"
+
+	STEP="check" REGISTRY="npm" PACKAGE="pkg" VERSION="1.0.0" run_wait_for_package
+	assert_success
+	assert_output --partial "pkg@1.0.0 is available on npm"
+	assert_file_contains "$GITHUB_OUTPUT" "available=true"
+}
+
+@test "wait-for-package: check reports npm package not yet available" {
+	mock_curl "404"
+
+	STEP="check" REGISTRY="npm" PACKAGE="pkg" VERSION="1.0.0" run_wait_for_package
+	assert_success
+	assert_output --partial "not yet available"
+	assert_file_contains "$GITHUB_OUTPUT" "available=false"
+}
+
+@test "wait-for-package: check reports pypi package available" {
+	mock_curl "200"
+
+	STEP="check" REGISTRY="pypi" PACKAGE="pkg" VERSION="1.0.0" run_wait_for_package
+	assert_success
+	assert_file_contains "$GITHUB_OUTPUT" "available=true"
+}
+
+@test "wait-for-package: check reports gem availability from versions API" {
+	mock_curl '[{"number": "1.0.0"}]'
+
+	STEP="check" REGISTRY="gem" PACKAGE="pkg" VERSION="1.0.0" run_wait_for_package
+	assert_success
+	assert_file_contains "$GITHUB_OUTPUT" "available=true"
+}
+
+@test "wait-for-package: check fails on unknown registry" {
+	STEP="check" REGISTRY="cargo" PACKAGE="pkg" VERSION="1.0.0" run_wait_for_package
+	assert_failure
+	assert_output --partial "Unknown registry"
+}
+
+@test "wait-for-package: wait succeeds when package is available" {
+	mock_curl "200"
+
+	STEP="wait" REGISTRY="npm" PACKAGE="pkg" VERSION="1.0.0" run_wait_for_package
+	assert_success
+	assert_output --partial "is now available"
+	assert_file_contains "$GITHUB_OUTPUT" "available=true"
+	assert_file_contains "$GITHUB_OUTPUT" "elapsed="
+}
+
+@test "wait-for-package: wait times out when package never appears" {
+	mock_curl "404"
+	mock_command "sleep" ""
+
+	STEP="wait" REGISTRY="npm" PACKAGE="pkg" VERSION="1.0.0" MAX_WAIT="1" \
+		run_wait_for_package
+	assert_failure
+	assert_output --partial "Timeout waiting for pkg@1.0.0"
+	assert_file_contains "$GITHUB_OUTPUT" "available=false"
+}
+
+@test "wait-for-package: summary reports availability" {
+	STEP="summary" REGISTRY="npm" PACKAGE="pkg" VERSION="1.0.0" \
+		AVAILABLE="true" ELAPSED="12" run_wait_for_package
+	assert_success
+
+	run get_github_step_summary
+	assert_output --partial "Package Availability"
+	assert_output --partial "12s"
+	assert_output --partial "Available"
+}
+
+@test "wait-for-package: fails on unknown step" {
+	STEP="bogus" REGISTRY="npm" PACKAGE="pkg" VERSION="1.0.0" run_wait_for_package
+	assert_failure
+	assert_output --partial "Unknown step"
+}

--- a/tests/bats/unit/release/test_configure_git_remote.bats
+++ b/tests/bats/unit/release/test_configure_git_remote.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/release/configure-git-remote.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+
+SCRIPT="scripts/ci/release/configure-git-remote.sh"
+
+setup() {
+	setup_temp_dir
+	setup_mock_git_repo
+	git -C "$MOCK_GIT_REPO" remote add origin "git@github.com:old/origin.git"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "configure-git-remote: fails without GH_APP_TOKEN" {
+	run env -u GH_APP_TOKEN GH_REPOSITORY="owner/repo" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "GH_APP_TOKEN is required"
+}
+
+@test "configure-git-remote: fails without GH_REPOSITORY" {
+	run env -u GH_REPOSITORY GH_APP_TOKEN="token123" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "GH_REPOSITORY is required"
+}
+
+@test "configure-git-remote: rewrites origin URL with app token" {
+	(
+		cd "$MOCK_GIT_REPO" || exit 1
+		GH_APP_TOKEN="token123" GH_REPOSITORY="owner/repo" \
+			bash "${PROJECT_ROOT}/${SCRIPT}"
+	)
+
+	run git -C "$MOCK_GIT_REPO" remote get-url origin
+	assert_success
+	assert_output "https://x-access-token:token123@github.com/owner/repo.git"
+}

--- a/tests/bats/unit/release/test_create_github_release.bats
+++ b/tests/bats/unit/release/test_create_github_release.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/release/create-github-release.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+load "../../../helpers/github_env"
+
+SCRIPT="scripts/ci/release/create-github-release.sh"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+	mock_command_record "gh" "https://github.com/test-org/test-repo/releases/tag/v1.0.0"
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+# Assert gh was invoked with a literal substring (safe for leading dashes)
+assert_gh_called_with() {
+	if ! grep -qF -- "$1" "${BATS_TEST_TMPDIR}/mock_calls_gh"; then
+		echo "# expected gh call containing: $1" >&2
+		cat "${BATS_TEST_TMPDIR}/mock_calls_gh" >&2
+		return 1
+	fi
+}
+
+refute_gh_called_with() {
+	if grep -qF -- "$1" "${BATS_TEST_TMPDIR}/mock_calls_gh"; then
+		echo "# expected no gh call containing: $1" >&2
+		return 1
+	fi
+}
+
+@test "create-github-release: fails without TAG" {
+	run env -u TAG bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "TAG is required"
+}
+
+@test "create-github-release: creates release with repo from GITHUB_REPOSITORY" {
+	TAG="v1.0.0" BODY="notes" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "release-url=https://github.com/test-org/test-repo/releases/tag/v1.0.0"
+
+	assert_gh_called_with "release create v1.0.0 --repo test-org/test-repo --title v1.0.0"
+}
+
+@test "create-github-release: honors explicit REPO and TITLE" {
+	TAG="v1.0.0" BODY="notes" REPO="other/repo" TITLE="My Release" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	assert_gh_called_with "--repo other/repo"
+	assert_gh_called_with "--title My Release"
+}
+
+@test "create-github-release: passes --draft when DRAFT=true" {
+	TAG="v1.0.0" BODY="notes" DRAFT="true" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	assert_gh_called_with "--draft"
+}
+
+@test "create-github-release: passes --prerelease when PRERELEASE=true" {
+	TAG="v1.0.0" BODY="notes" PRERELEASE="true" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	assert_gh_called_with "--prerelease"
+}
+
+@test "create-github-release: uses --generate-notes when GENERATE_NOTES=true" {
+	TAG="v1.0.0" GENERATE_NOTES="true" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	assert_gh_called_with "--generate-notes"
+	refute_gh_called_with "--notes "
+}
+
+@test "create-github-release: uses BODY as release notes" {
+	TAG="v1.0.0" BODY="release body text" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	assert_gh_called_with "--notes release body text"
+}
+
+@test "create-github-release: attaches existing FILES and skips missing ones" {
+	local asset="${BATS_TEST_TMPDIR}/artifact.tar.gz"
+	echo "data" >"$asset"
+
+	TAG="v1.0.0" BODY="notes" FILES="$asset ${BATS_TEST_TMPDIR}/missing.zip" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "File not found, skipping"
+
+	assert_gh_called_with "$asset"
+	refute_gh_called_with "missing.zip"
+}
+
+@test "create-github-release: fails when FILE_PATTERNS matches nothing" {
+	TAG="v1.0.0" BODY="notes" FILE_PATTERNS="${BATS_TEST_TMPDIR}/nope-*.tgz" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "No release assets matched FILE_PATTERNS"
+}
+
+@test "create-github-release: fails when gh release create fails" {
+	mock_command_record "gh" "boom" 1
+
+	TAG="v1.0.0" BODY="notes" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "Failed to create release"
+}
+
+@test "create-github-release: writes GitHub Actions outputs" {
+	TAG="v1.0.0" BODY="notes" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+
+	assert_file_contains "$GITHUB_OUTPUT" "release-url=https://github.com/test-org/test-repo/releases/tag/v1.0.0"
+	assert_file_contains "$GITHUB_OUTPUT" "tag=v1.0.0"
+}

--- a/tests/bats/unit/release/test_create_tag.bats
+++ b/tests/bats/unit/release/test_create_tag.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/release/create-tag.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+load "../../../helpers/github_env"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+	setup_mock_git_repo
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+run_create_tag() {
+	(
+		cd "$MOCK_GIT_REPO" || exit 1
+		bash "${PROJECT_ROOT}/scripts/ci/release/create-tag.sh"
+	)
+}
+
+@test "create-tag: fails without VERSION" {
+	run env -u VERSION bash "${PROJECT_ROOT}/scripts/ci/release/create-tag.sh"
+	assert_failure
+	assert_output --partial "VERSION is required"
+}
+
+@test "create-tag: creates annotated tag with v prefix" {
+	add_commit "feat: add feature"
+
+	VERSION="1.2.3" run run_create_tag
+	assert_success
+	assert_output --partial "tag-name=v1.2.3"
+
+	run git -C "$MOCK_GIT_REPO" cat-file -t refs/tags/v1.2.3
+	assert_success
+	assert_output "tag"
+}
+
+@test "create-tag: strips existing v prefix from VERSION" {
+	VERSION="v2.0.0" run run_create_tag
+	assert_success
+	assert_output --partial "tag-name=v2.0.0"
+	git -C "$MOCK_GIT_REPO" rev-parse --verify refs/tags/v2.0.0
+}
+
+@test "create-tag: honors custom TAG_PREFIX" {
+	VERSION="1.0.0" TAG_PREFIX="release-" run run_create_tag
+	assert_success
+	assert_output --partial "tag-name=release-1.0.0"
+	git -C "$MOCK_GIT_REPO" rev-parse --verify refs/tags/release-1.0.0
+}
+
+@test "create-tag: fails when tag already exists" {
+	git -C "$MOCK_GIT_REPO" tag -a v1.2.3 -m "existing"
+
+	VERSION="1.2.3" run run_create_tag
+	assert_failure
+	assert_output --partial "already exists"
+}
+
+@test "create-tag: uses custom MESSAGE for tag annotation" {
+	VERSION="1.2.3" MESSAGE="custom tag message" run run_create_tag
+	assert_success
+
+	run git -C "$MOCK_GIT_REPO" tag -l --format='%(contents:subject)' v1.2.3
+	assert_success
+	assert_output "custom tag message"
+}
+
+@test "create-tag: writes GitHub Actions outputs" {
+	VERSION="1.2.3" run run_create_tag
+	assert_success
+
+	assert_file_contains "$GITHUB_OUTPUT" "tag-name=v1.2.3"
+	assert_file_contains "$GITHUB_OUTPUT" "version=1.2.3"
+	assert_file_contains "$GITHUB_OUTPUT" "tag-sha="
+	assert_file_contains "$GITHUB_OUTPUT" "commit-sha="
+}
+
+@test "create-tag: tag sha and commit sha match repo state" {
+	VERSION="1.2.3" run run_create_tag
+	assert_success
+
+	local head_sha
+	head_sha=$(git -C "$MOCK_GIT_REPO" rev-parse HEAD)
+	assert_output --partial "commit-sha=${head_sha}"
+}

--- a/tests/bats/unit/release/test_enable_auto_merge.bats
+++ b/tests/bats/unit/release/test_enable_auto_merge.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/release/enable-auto-merge.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+
+SCRIPT="scripts/ci/release/enable-auto-merge.sh"
+
+setup() {
+	setup_temp_dir
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "enable-auto-merge: fails without PR_NUMBER" {
+	run env -u PR_NUMBER bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "PR_NUMBER is required"
+}
+
+@test "enable-auto-merge: enables squash auto-merge for the PR" {
+	mock_command_record "gh" ""
+
+	PR_NUMBER="42" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "Auto-merge enabled for PR #42"
+
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_output --partial "pr merge 42 --auto --squash"
+}
+
+@test "enable-auto-merge: fails when gh fails" {
+	mock_command_record "gh" "merge failed" 1
+
+	PR_NUMBER="42" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+}

--- a/uv.lock
+++ b/uv.lock
@@ -25,12 +25,6 @@ wheels = [
 ]
 
 [[package]]
-name = "assertpy"
-version = "1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/39/720b5d4463612a40a166d00999cbb715fce3edaf08a9a7588ba5985699ec/assertpy-1.1.tar.gz", hash = "sha256:acc64329934ad71a3221de185517a43af33e373bb44dc05b5a9b174394ef4833", size = 25421, upload-time = "2020-07-19T14:39:02.462Z" }
-
-[[package]]
 name = "black"
 version = "26.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -107,15 +101,6 @@ wheels = [
 ]
 
 [[package]]
-name = "execnet"
-version = "2.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
-]
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -162,51 +147,26 @@ wheels = [
 ]
 
 [[package]]
-name = "iniconfig"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
-]
-
-[[package]]
 name = "lgtm-ci"
 version = "0.0.0"
 source = { virtual = "." }
 
 [package.optional-dependencies]
 dev = [
-    { name = "assertpy" },
     { name = "black" },
     { name = "lintro" },
-    { name = "pytest" },
     { name = "ruff" },
     { name = "tomli-w" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "pytest-timeout" },
-    { name = "pytest-xdist" },
-]
-
 [package.metadata]
 requires-dist = [
-    { name = "assertpy", marker = "extra == 'dev'", specifier = ">=1.1" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.0.0" },
     { name = "lintro", marker = "extra == 'dev'", specifier = "==0.64.1" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.0" },
     { name = "tomli-w", marker = "extra == 'dev'", specifier = ">=1.0.0" },
 ]
 provides-extras = ["dev"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest-timeout", specifier = ">=2.4.0" },
-    { name = "pytest-xdist", specifier = ">=3.8.0" },
-]
 
 [[package]]
 name = "lintro"
@@ -296,15 +256,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
-]
-
-[[package]]
-name = "pluggy"
-version = "1.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -431,47 +382,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
-]
-
-[[package]]
-name = "pytest"
-version = "9.0.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "iniconfig" },
-    { name = "packaging" },
-    { name = "pluggy" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
-]
-
-[[package]]
-name = "pytest-timeout"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
-]
-
-[[package]]
-name = "pytest-xdist"
-version = "3.8.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "execnet" },
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Adds a script-to-BATS-test coverage ratchet and the first tranche of tests closing the scripts/ci coverage gap (#370).

- **Ratchet**: `scripts/ci/quality/validate-script-test-coverage.sh` requires every `scripts/ci/**/*.sh` entrypoint (excluding `lib/` sourced files) to have its basename referenced in at least one `tests/**/*.bats` file. Known-untested scripts are tracked in `scripts/ci/quality/script-test-coverage-allowlist.txt`; the check fails on new untested scripts **and** on stale allowlist entries (script gained a test or was removed), so the allowlist only ever shrinks. Wired into the BATS integration suite via `tests/bats/integration/test_script_test_coverage.bats` (repo-invariant test plus fixture-based self-tests), so the existing `ci.yml` shell-tests job gates it.
- **First tranche** (11 scripts, 85 tests, mocked `gh`/`git`/`npm`/`gem`/`curl` per `tests/helpers/mocks.bash`): `release/create-tag.sh`, `release/create-github-release.sh`, `release/configure-git-remote.sh`, `release/enable-auto-merge.sh`, `actions/publish-npm.sh`, `actions/publish-gem.sh`, `actions/wait-for-package.sh`, `actions/validate-package.sh`, `actions/egress-audit.sh`, `actions/verify-attestation.sh`, `actions/docker-login.sh`. Allowlist: seeded set would be 53 on current main; after this tranche it ships at **42**.
- **Drive-by fix the new tests caught**: BSD/macOS-incompatible `\s` regex escapes in the name-extraction pipelines of `publish-npm.sh`, `publish-gem.sh`, and `validate-package.sh` replaced with POSIX `[[:space:]]` (extraction silently returned the whole matched line on macOS).
- **pytest decision**: removed `[tool.pytest.ini_options]` and the pytest-only dev dependencies (`pytest`, `assertpy`, `pytest-timeout`, `pytest-xdist`) from `pyproject.toml` rather than writing token pytest tests — the repo has no Python test suite and its Python helpers (`release/ecosystems/*.py`, `security/*.py`) are already exercised end-to-end through the BATS suite (`test_ecosystem_updaters.bats`, `test_vuln_suppressions.bats`). Nothing in CI invokes pytest for this repo.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

`bats --recursive tests/bats`: 2450 tests, 2449 pass — the single failure (`run-rust-coverage-html: fails when cargo-llvm-cov is missing`) is a pre-existing local-machine PATH quirk that also fails on clean main and is unrelated to this change. `uv run lintro chk`: 0 issues.

## Breaking Changes

None

## Closes

- Closes #370

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a BATS coverage ratchet for CI scripts and expands shell-script test coverage. The main changes are:

- New `validate-script-test-coverage.sh` ratchet for `scripts/ci` entrypoints.
- New allowlist for currently untested script entrypoints.
- Integration tests for the ratchet, including the trailing-slash override case.
- Unit tests for release and publish helper scripts.
- POSIX whitespace regex fixes in package metadata extraction.
- Removal of unused pytest configuration and pytest-only dev dependencies.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/quality/validate-script-test-coverage.sh | Adds the script coverage ratchet and normalizes `SCRIPTS_DIR` before relative path checks. |
| tests/bats/integration/test_script_test_coverage.bats | Adds fixture-based tests for the ratchet and the trailing-slash override case. |
| scripts/ci/quality/script-test-coverage-allowlist.txt | Adds the current allowlist of untested `scripts/ci` entrypoints. |

</details>

<sub>Reviews (4): Last reviewed commit: ["chore(quality): drop install-osv-scanner..."](https://github.com/lgtm-hq/lgtm-ci/commit/46beb4d5f6afa880cef9134c8d915acac456a336) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41927995)</sub>

<!-- /greptile_comment -->