### PR TITLE
refactor(actions): create shared checkout-and-harden composite action

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -118,11 +118,48 @@ Setup Rust toolchain with cargo caching.
 
 ## Security Actions
 
+### checkout-and-harden
+
+Shared reusable-workflow preamble (#379): checks out lgtm-ci tooling into
+`.lgtm-ci-tooling/`, resolves the egress allowlist, and hardens the runner in one
+step. Requires a prior bootstrap sparse checkout of
+`.github/actions/checkout-and-harden` (the composite lives in lgtm-ci).
+
+```yaml
+- name: Checkout lgtm-ci tooling
+  uses: actions/checkout@<pin>
+  with:
+    repository: lgtm-hq/lgtm-ci
+    path: .lgtm-ci-tooling
+    ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+    sparse-checkout: |
+      .github/actions/checkout-and-harden
+    sparse-checkout-cone-mode: true
+    persist-credentials: false
+
+- name: Checkout and harden
+  id: egress
+  uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+  with:
+    tooling-ref: ${{ inputs.tooling-ref }}
+    egress-preset: quality
+    sparse-checkout-extra: |
+      scripts/ci/
+```
+
+**Inputs:** `tooling-ref`, `egress-policy` (default `block`), `egress-preset`,
+`allowed-endpoints`, `allowed-endpoints-mode` (default `replace`),
+`sparse-checkout-extra`, `persist-credentials` (default `false`).
+
+**Outputs:** `allowed-endpoints` (resolved allowlist), `scripts-dir` (absolute
+path to `.lgtm-ci-tooling/scripts`).
+
 ### resolve-egress-allowlist
 
-Resolves `allowed-endpoints` from explicit lists or `egress-preset` names. Run as a
-**workflow step before** `harden-runner` so step-security's pre-hook receives the
-allowlist (composite step outputs are not available at pre-hook time).
+Resolves `allowed-endpoints` from explicit lists or `egress-preset` names. Run
+**before** `harden-runner` — as a prior workflow step, or as the preceding sibling
+step inside `checkout-and-harden` — so the resolved allowlist is available when
+the harden step's inputs are evaluated.
 
 ```yaml
 - name: Checkout lgtm-ci tooling

--- a/.github/actions/checkout-and-harden/action.yml
+++ b/.github/actions/checkout-and-harden/action.yml
@@ -1,0 +1,107 @@
+---
+name: "Checkout and harden"
+description: >-
+  Shared reusable-workflow preamble: sparse-checkout lgtm-ci tooling into
+  .lgtm-ci-tooling, resolve the egress allowlist, and harden the runner.
+  The repository checkout stays a separate workflow step before this action;
+  a bootstrap sparse checkout of .github/actions/checkout-and-harden must
+  precede it because the composite lives in lgtm-ci.
+author: "lgtm-hq"
+
+inputs:
+  tooling-ref:
+    description: >-
+      Git ref for the lgtm-ci tooling checkout. Empty falls back to
+      github.workflow_sha so the tooling matches the reusable workflow ref.
+    required: false
+    default: ""
+  egress-policy:
+    description: "Egress policy: audit (log) or block (enforce allowlist)"
+    required: false
+    default: "block"
+  egress-preset:
+    description: >-
+      Named baseline allowlist for block policy (github-minimal, github-pages,
+      github-tooling, docker, playwright, pypi, rubygems, npm-publish, quality,
+      osv-scanner, rust-release, sbom, scorecard)
+    required: false
+    default: ""
+  allowed-endpoints:
+    description: >-
+      Host:port list (multiline). replace mode: overrides preset when
+      non-empty; append mode: merged with preset (deduped)
+    required: false
+    default: ""
+  allowed-endpoints-mode:
+    description: "replace (override preset) or append (merge with preset, deduped)"
+    required: false
+    default: "replace"
+  sparse-checkout-extra:
+    description: >-
+      Additional sparse-checkout paths (multiline) appended to the base egress
+      tooling paths, e.g. scripts/ci/ or extra .github/actions/ composites.
+    required: false
+    default: ""
+  persist-credentials:
+    description: "Persist credentials on the tooling checkout"
+    required: false
+    default: "false"
+
+outputs:
+  allowed-endpoints:
+    description: "Resolved allowlist passed to step-security/harden-runner"
+    value: ${{ steps.egress.outputs['allowed-endpoints'] }}
+  scripts-dir:
+    description: "Absolute path to the checked-out lgtm-ci scripts directory"
+    value: ${{ steps.paths.outputs['scripts-dir'] }}
+
+runs:
+  using: "composite"
+  steps:
+    # Re-checkout tooling with the full sparse set. The bootstrap workflow
+    # checkout only materialises this action's directory; this step adds the
+    # egress composites (and any sparse-checkout-extra paths) at the same ref.
+    - name: Checkout lgtm-ci tooling
+      # Pinned to SHA for supply chain security
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        repository: lgtm-hq/lgtm-ci
+        path: .lgtm-ci-tooling
+        ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+        sparse-checkout: |
+          .github/actions/checkout-and-harden
+          .github/actions/harden-runner
+          .github/actions/resolve-egress-allowlist
+          ${{ inputs.sparse-checkout-extra }}
+        sparse-checkout-cone-mode: true
+        persist-credentials: ${{ inputs.persist-credentials }}
+
+    # Sibling ordering matters: resolve must complete before the harden step
+    # evaluates its inputs. The runner skips `pre` for workspace-local actions
+    # (warning: "`pre` execution is not supported for local action"), so
+    # step-security inputs are evaluated when the step itself runs — identical
+    # timing to the previous workflow-level resolve -> harden pattern.
+    - name: Resolve egress allowlist
+      id: egress
+      uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+      with:
+        egress-policy: ${{ inputs.egress-policy }}
+        egress-preset: ${{ inputs.egress-preset }}
+        allowed-endpoints: ${{ inputs.allowed-endpoints }}
+        allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+
+    - name: Harden runner
+      uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+      with:
+        egress-policy: ${{ inputs.egress-policy }}
+        allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+
+    - name: Resolve scripts directory
+      id: paths
+      shell: bash
+      run: |
+        echo "scripts-dir=${GITHUB_WORKSPACE}/.lgtm-ci-tooling/scripts" >>"${GITHUB_OUTPUT}"
+
+branding:
+  icon: "shield"
+  color: "blue"

--- a/.github/workflows/reusable-build-python-dist.yml
+++ b/.github/workflows/reusable-build-python-dist.yml
@@ -130,25 +130,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
 
       - name: Setup Python
         uses: ./.lgtm-ci-tooling/.github/actions/setup-python

--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -102,26 +102,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/actions/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/actions/
 
       - name: Generate CodeQL matrix
         id: matrix
@@ -159,25 +154,19 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Initialize CodeQL
         if: inputs.config-file == '' && matrix.language != ''

--- a/.github/workflows/reusable-coverage.yml
+++ b/.github/workflows/reusable-coverage.yml
@@ -145,25 +145,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
       - name: Download coverage artifacts
         # Pinned to SHA for supply chain security
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -244,25 +241,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: github-pages
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
       - name: Download coverage report
         # Pinned to SHA for supply chain security
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/reusable-dependency-review.yml
+++ b/.github/workflows/reusable-dependency-review.yml
@@ -91,25 +91,19 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Dependency review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/reusable-deploy-pages.yml
+++ b/.github/workflows/reusable-deploy-pages.yml
@@ -107,25 +107,19 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/reusable-deploy-site-with-reports.yml
+++ b/.github/workflows/reusable-deploy-site-with-reports.yml
@@ -183,15 +183,15 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: >-
             ${{ inputs.egress-build-preset != '' && inputs.egress-build-preset ||
@@ -200,13 +200,9 @@ jobs:
           allowed-endpoints: >-
             ${{ inputs.allowed-endpoints-build != '' && inputs.allowed-endpoints-build ||
             inputs.allowed-endpoints }}
-
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
       - name: Setup Node.js
         if: inputs.build-command != '' && inputs.package-manager != ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -295,15 +291,15 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: >-
             ${{ inputs.egress-deploy-preset != '' && inputs.egress-deploy-preset ||
@@ -312,13 +308,6 @@ jobs:
           allowed-endpoints: >-
             ${{ inputs.allowed-endpoints-deploy != '' && inputs.allowed-endpoints-deploy ||
             inputs.allowed-endpoints }}
-
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -256,26 +256,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
       - name: Classify platforms
         id: classify
         shell: bash
@@ -325,26 +320,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
       - name: Setup QEMU
         # Pinned to SHA for supply chain security
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
@@ -601,26 +591,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
       - name: Setup QEMU
         if: ${{ matrix.qemu }}
         # Pinned to SHA for supply chain security
@@ -816,26 +801,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
       - name: Setup QEMU
         if: ${{ matrix.qemu }}
         # Pinned to SHA for supply chain security
@@ -922,26 +902,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
       - name: Setup QEMU
         if: ${{ matrix.qemu }}
         # Pinned to SHA for supply chain security
@@ -1035,26 +1010,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
       - name: Setup Docker Buildx
         # Pinned to SHA for supply chain security
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -1211,26 +1181,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Build summary
         if: always()
@@ -1273,24 +1238,19 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Run Trivy vulnerability scanner
         # Pinned to SHA for supply chain security

--- a/.github/workflows/reusable-ghcr-cleanup.yml
+++ b/.github/workflows/reusable-ghcr-cleanup.yml
@@ -118,26 +118,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Clean untagged GHCR images
         shell: bash

--- a/.github/workflows/reusable-github-release.yml
+++ b/.github/workflows/reusable-github-release.yml
@@ -129,26 +129,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Download release assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/reusable-link-check.yml
+++ b/.github/workflows/reusable-link-check.yml
@@ -125,26 +125,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Build Lychee arguments
         id: args

--- a/.github/workflows/reusable-pr-auto-assign.yml
+++ b/.github/workflows/reusable-pr-auto-assign.yml
@@ -86,27 +86,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-
-      - name: Harden Runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Assign random CODEOWNER
         env:

--- a/.github/workflows/reusable-pr-labeler.yml
+++ b/.github/workflows/reusable-pr-labeler.yml
@@ -85,26 +85,19 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-
-      - name: Harden Runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Apply labels based on changed files
         uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0

--- a/.github/workflows/reusable-publish-artifact-preview.yml
+++ b/.github/workflows/reusable-publish-artifact-preview.yml
@@ -111,25 +111,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
 
       - name: Compose artifact preview comment
         shell: bash

--- a/.github/workflows/reusable-publish-artifact-report.yml
+++ b/.github/workflows/reusable-publish-artifact-report.yml
@@ -98,25 +98,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
 
       - name: Download report artifact
         id: download

--- a/.github/workflows/reusable-publish-file-breakdown.yml
+++ b/.github/workflows/reusable-publish-file-breakdown.yml
@@ -87,28 +87,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            .github/actions/post-pr-comment
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/post-pr-comment
+            scripts/ci/
 
       - name: Detect PR number
         id: pr

--- a/.github/workflows/reusable-publish-gem.yml
+++ b/.github/workflows/reusable-publish-gem.yml
@@ -111,25 +111,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
 
       - name: Setup Ruby
         uses: ./.lgtm-ci-tooling/.github/actions/setup-ruby

--- a/.github/workflows/reusable-publish-npm.yml
+++ b/.github/workflows/reusable-publish-npm.yml
@@ -125,25 +125,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
 
       - name: Publish to npm
         id: npm

--- a/.github/workflows/reusable-publish-quality-summary.yml
+++ b/.github/workflows/reusable-publish-quality-summary.yml
@@ -85,26 +85,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Download linting report
         id: download

--- a/.github/workflows/reusable-publish-security-audit-comment.yml
+++ b/.github/workflows/reusable-publish-security-audit-comment.yml
@@ -96,28 +96,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            .github/actions/post-pr-comment
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/post-pr-comment
+            scripts/ci/
 
       - name: Download comment artifact
         id: download

--- a/.github/workflows/reusable-publish-test-summary.yml
+++ b/.github/workflows/reusable-publish-test-summary.yml
@@ -141,27 +141,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            .github/actions/generate-coverage-comment
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/generate-coverage-comment
+            scripts/ci/
 
       - name: Validate rich coverage inputs
         if: >-

--- a/.github/workflows/reusable-quality-lint.yml
+++ b/.github/workflows/reusable-quality-lint.yml
@@ -128,26 +128,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/.github/workflows/reusable-registry-health-check.yml
+++ b/.github/workflows/reusable-registry-health-check.yml
@@ -96,27 +96,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -155,26 +149,20 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress-issue
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           # Issue job: GitHub API only; do not inherit docker preset
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: github-minimal
-
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress-issue.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Open issue for unreachable digests
         shell: bash

--- a/.github/workflows/reusable-required-check.yml
+++ b/.github/workflows/reusable-required-check.yml
@@ -118,26 +118,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Assert required check
         id: gate

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -202,26 +202,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: github-tooling
           allowed-endpoints: ""
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Validate compat/coverage contract
         shell: bash
@@ -287,25 +282,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
 
       - name: Setup Rust
         uses: ./.lgtm-ci-tooling/.github/actions/setup-rust
@@ -527,26 +519,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: github-tooling
           allowed-endpoints: ""
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Download matrix test summaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/reusable-sbom.yml
+++ b/.github/workflows/reusable-sbom.yml
@@ -139,25 +139,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
       - name: Generate SBOM
         id: generate
         uses: ./.lgtm-ci-tooling/.github/actions/generate-sbom

--- a/.github/workflows/reusable-scorecards.yml
+++ b/.github/workflows/reusable-scorecards.yml
@@ -101,25 +101,19 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Run OpenSSF Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3

--- a/.github/workflows/reusable-security-audit.yml
+++ b/.github/workflows/reusable-security-audit.yml
@@ -136,27 +136,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/.github/workflows/reusable-semantic-pr-title.yml
+++ b/.github/workflows/reusable-semantic-pr-title.yml
@@ -119,27 +119,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/post-pr-comment
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/post-pr-comment
+            scripts/ci/
 
       - name: Prepare semantic PR lists
         id: prepare

--- a/.github/workflows/reusable-site-quality.yml
+++ b/.github/workflows/reusable-site-quality.yml
@@ -262,27 +262,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -454,17 +448,15 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            .github/actions/setup-python
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: >-
             ${{ inputs.test-egress-preset != '' && inputs.test-egress-preset
@@ -473,13 +465,9 @@ jobs:
             ${{ inputs.test-allowed-endpoints != '' && inputs.test-allowed-endpoints
             || inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/setup-python
+            scripts/ci/
 
       - name: Setup Python and uv
         if: inputs.python-version != ''

--- a/.github/workflows/reusable-test-e2e-matrix.yml
+++ b/.github/workflows/reusable-test-e2e-matrix.yml
@@ -148,25 +148,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: github-tooling
           allowed-endpoints: ""
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
       - name: Generate matrix
         id: matrix
         shell: bash
@@ -205,25 +202,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
       - name: Cache Playwright browsers
         # Pinned to SHA for supply chain security
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -294,25 +288,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: github-tooling
           allowed-endpoints: ""
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
       - name: Download all reports
         # Pinned to SHA for supply chain security
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -373,25 +364,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.publish-egress-preset }}
           allowed-endpoints: ${{ inputs.publish-allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
       - name: Download merged report
         # Pinned to SHA for supply chain security
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/reusable-test-e2e.yml
+++ b/.github/workflows/reusable-test-e2e.yml
@@ -153,25 +153,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
       - name: Run Playwright
         id: test
         uses: ./.lgtm-ci-tooling/.github/actions/run-playwright

--- a/.github/workflows/reusable-test-node-custom.yml
+++ b/.github/workflows/reusable-test-node-custom.yml
@@ -175,26 +175,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Validate compat/coverage contract
         shell: bash
@@ -249,25 +244,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -456,25 +448,19 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
 
       - name: Aggregate matrix custom test results
         id: aggregate
@@ -515,26 +501,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Download pages coverage artifact
         id: download-pages-coverage

--- a/.github/workflows/reusable-test-node-publish.yml
+++ b/.github/workflows/reusable-test-node-publish.yml
@@ -107,27 +107,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
-          disable-sudo: false
-          disable-telemetry: false
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
 
       - name: Download coverage
         if: inputs.upload-coverage

--- a/.github/workflows/reusable-test-node.yml
+++ b/.github/workflows/reusable-test-node.yml
@@ -216,26 +216,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Validate compat/coverage contract
         shell: bash
@@ -296,25 +291,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -592,26 +584,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Download pages coverage artifact
         id: download-pages-coverage
@@ -670,26 +657,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Download matrix test summaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/reusable-test-python-publish.yml
+++ b/.github/workflows/reusable-test-python-publish.yml
@@ -102,27 +102,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
-          disable-sudo: false
-          disable-telemetry: false
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
 
       - name: Download coverage
         if: inputs.upload-coverage

--- a/.github/workflows/reusable-test-python.yml
+++ b/.github/workflows/reusable-test-python.yml
@@ -180,26 +180,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: github-tooling
           allowed-endpoints: ""
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Validate compat/coverage contract
         shell: bash
@@ -258,25 +253,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
@@ -462,26 +454,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: github-tooling
           allowed-endpoints: ""
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Download matrix test summaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/reusable-test-rust-build.yml
+++ b/.github/workflows/reusable-test-rust-build.yml
@@ -100,25 +100,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
 
       - name: Setup Rust
         uses: ./.lgtm-ci-tooling/.github/actions/setup-rust

--- a/.github/workflows/reusable-test-shell.yml
+++ b/.github/workflows/reusable-test-shell.yml
@@ -163,26 +163,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
       - name: Install BATS and helpers
         shell: bash
         env:

--- a/.github/workflows/reusable-validate-action-pinning.yml
+++ b/.github/workflows/reusable-validate-action-pinning.yml
@@ -102,25 +102,22 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            .github/actions/
+            scripts/ci/
 
       - name: Validate action pinning
         uses: ./.lgtm-ci-tooling/.github/actions/validate-action-pinning

--- a/.github/workflows/reusable-validate.yml
+++ b/.github/workflows/reusable-validate.yml
@@ -119,26 +119,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Run setup commands
         if: inputs.setup-commands != ''

--- a/.github/workflows/reusable-vuln-suppression-check.yml
+++ b/.github/workflows/reusable-vuln-suppression-check.yml
@@ -118,27 +118,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
 
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+          sparse-checkout-extra: |
+            scripts/ci/
 
       - name: Install osv-scanner
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `configure-git-remote.sh`, `enable-auto-merge.sh`, `publish-npm.sh`,
   `publish-gem.sh`, `wait-for-package.sh`, `validate-package.sh`,
   `egress-audit.sh`, `verify-attestation.sh`, `docker-login.sh`
+- **actions**: `checkout-and-harden` composite — shared reusable-workflow
+  preamble that checks out lgtm-ci tooling into `.lgtm-ci-tooling/`, resolves
+  the egress allowlist, and hardens the runner in one step; outputs
+  `allowed-endpoints` and `scripts-dir` (#379)
 
 ### Changed
 
@@ -30,9 +34,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `needs: <build-job>` to deploy the named artifact via `actions/deploy-pages`.
   The build-related inputs (`source-path`, `build-command`, `node-version`,
   `package-manager`, `working-directory`, `frozen-lockfile`) are removed and the
-  in-workflow `build` job is gone; the concurrency group is now `pages`. Callers
-  that relied on the old build+deploy behavior should migrate to
+  in-workflow `build` job is gone; the concurrency group is shared with the
+  other Pages publishers
+  (`pages-${{ github.repository }}-${{ github.ref }}`). Callers that relied on
+  the old build+deploy behavior should migrate to
   `reusable-deploy-site-with-reports.yml` (which still builds and deploys).
+- **workflows**: 65 job preambles across 40 reusable workflows now use a
+  bootstrap sparse checkout of `.github/actions/checkout-and-harden` plus a
+  single `Checkout and harden` step instead of the four-step
+  checkout → resolve → harden sequence; sparse-checkout paths are preserved
+  per workflow via `sparse-checkout-extra`. Exempt (unchanged): the release
+  dual-checkout workflows (`reusable-release-auto-tag`,
+  `reusable-release-version-pr`), the tiered Rust workflows where
+  `validate-runner-policy` runs between checkout and resolve
+  (`reusable-build-rust-binaries`, `reusable-publish-rust-release`), and
+  `reusable-validate-lintro-version` (bootstrap/fallback checkout flow) (#379)
 - **scripts**: parameterize near-duplicate language-family scripts (#372):
   `aggregate-{node,python,rust}-results.sh` merged into `aggregate-results.sh`
   (`RESULTS_DIR`), `write-{node,python,rust}-summary.sh` merged into

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -398,6 +398,11 @@ and fails when those directories are absent. Do **not** use
 allow expressions in action `@ref` segments ([runner#895](https://github.com/actions/runner/issues/895));
 actionlint reports errors and workflows may fail validation.
 
+Most reusable workflows use the shared `checkout-and-harden` composite (#379):
+a bootstrap sparse checkout materialises only the composite directory, and the
+composite then performs the full tooling checkout (base egress paths plus
+`sparse-checkout-extra`), resolves the allowlist, and hardens the runner.
+
 ```yaml
 - name: Checkout repository
   uses: actions/checkout@<pin> # v6.0.2
@@ -411,12 +416,32 @@ actionlint reports errors and workflows may fail validation.
     path: .lgtm-ci-tooling
     ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
     sparse-checkout: |
-      .github/actions/harden-runner
-      .github/actions/resolve-egress-allowlist
-      scripts/ci/
+      .github/actions/checkout-and-harden
     sparse-checkout-cone-mode: true
     persist-credentials: false
 
+- name: Checkout and harden
+  id: egress
+  uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+  with:
+    tooling-ref: ${{ inputs.tooling-ref }}
+    egress-policy: ${{ inputs.egress-policy }}
+    egress-preset: ${{ inputs.egress-preset }}
+    allowed-endpoints: ${{ inputs.allowed-endpoints }}
+    allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+    sparse-checkout-extra: |
+      scripts/ci/
+```
+
+Workflows that cannot use the composite keep the explicit
+tooling checkout → `resolve-egress-allowlist` → `harden-runner` step sequence:
+the release workflows' two-phase checkouts (`reusable-release-auto-tag`,
+`reusable-release-version-pr`), the tiered Rust workflows where
+`validate-runner-policy` must run between checkout and resolve
+(`reusable-build-rust-binaries`, `reusable-publish-rust-release`), and the
+bootstrap/fallback flow in `reusable-validate-lintro-version`.
+
+```yaml
 - name: Resolve egress allowlist
   id: egress
   uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
@@ -459,9 +484,12 @@ Keep `Create GitHub App installation token` before any step that uses
 The `harden-runner` bundle is **self-contained** (`lib/egress/`). Canonical preset
 definitions live in `scripts/ci/lib/egress/presets.sh`; release maintainers run
 `scripts/ci/actions/sync-harden-runner-bundle.sh` before tagging.
-`resolve-egress-allowlist` invokes the bundled resolver script in a **prior workflow
-step** because step-security's pre-hook runs before composite steps and cannot read
-`steps.resolve.outputs` from inside `harden-runner`.
+`resolve-egress-allowlist` runs **before** `harden-runner` — as a prior workflow
+step in the exempt workflows, or as the preceding sibling step inside
+`checkout-and-harden`. The runner does not execute step-security's pre-hook for
+workspace-local actions (it warns "`pre` execution is not supported for local
+action"), so harden-runner inputs are evaluated when the step itself runs; the
+resolve output is available in both arrangements.
 
 Do **not** use `.lgtm-ci-egress` sparse checkouts for the composite.
 

--- a/scripts/ci/actions/validate-harden-runner-action-ref.sh
+++ b/scripts/ci/actions/validate-harden-runner-action-ref.sh
@@ -196,6 +196,10 @@ _check_checkout_and_harden() {
 		violations=$((violations + 1))
 	fi
 	if ! awk '
+		BEGIN { in_jobs = 0; tooling = 0 }
+		/^jobs:/ { in_jobs = 1; next }
+		!in_jobs { next }
+		/^  [a-zA-Z_][a-zA-Z0-9_-]*: *$/ { tooling = 0; next }
 		/- name: Checkout lgtm-ci tooling/ { tooling = NR }
 		/uses:[[:space:]]+\.\/\.lgtm-ci-tooling\/\.github\/actions\/checkout-and-harden/ {
 			if (tooling == 0 || tooling >= NR) {

--- a/scripts/ci/actions/validate-harden-runner-action-ref.sh
+++ b/scripts/ci/actions/validate-harden-runner-action-ref.sh
@@ -44,6 +44,7 @@ _check_job_egress_order() {
 				in_jobs = 0
 				tooling_line = 0
 				resolve_line = 0
+				job_indent = -1
 			}
 			/^jobs:/ {
 				in_jobs = 1
@@ -52,11 +53,24 @@ _check_job_egress_order() {
 			!in_jobs {
 				next
 			}
-			# Recognize quoted job keys as boundaries too (\047 = single quote).
-			/^  (["\047][^"\047]*["\047]|[a-zA-Z_][a-zA-Z0-9_-]*): *$/ {
-				tooling_line = 0
-				resolve_line = 0
-				next
+			# Job-key boundary at the actual job indent, detected from the
+			# first key under jobs:. This resets carried state for 2-space,
+			# 4-space, or quoted job keys alike, so a deeper-indented job
+			# cannot inherit a prior job tooling checkout and bypass the
+			# contract (\047 = single quote).
+			{
+				if ($0 ~ /^ +(["\047][^"\047]*["\047]|[a-zA-Z_][a-zA-Z0-9_-]*): *$/) {
+					lead = $0
+					sub(/[^ ].*$/, "", lead)
+					if (job_indent < 0) {
+						job_indent = length(lead)
+					}
+					if (length(lead) == job_indent) {
+						tooling_line = 0
+						resolve_line = 0
+						next
+					}
+				}
 			}
 			$0 ~ /^[[:space:]]+- name: Checkout lgtm-ci egress tooling/ {
 				tooling_line = NR
@@ -200,15 +214,22 @@ _check_checkout_and_harden() {
 		violations=$((violations + 1))
 	fi
 	if ! awk '
-		BEGIN { in_jobs = 0; tooling = 0 }
+		BEGIN { in_jobs = 0; tooling = 0; job_indent = -1 }
 		/^jobs:/ { in_jobs = 1; next }
 		!in_jobs { next }
 		# Job-key boundary: reset the tooling checkout carried from a
-		# previous job. Recognize quoted job keys (e.g. a double- or
-		# single-quoted "release":) as well as bare keys, so a quoted job
-		# cannot inherit a prior job tooling checkout and bypass this
-		# contract (\047 is the octal escape for a single quote).
-		/^  (["\047][^"\047]*["\047]|[a-zA-Z_][a-zA-Z0-9_-]*): *$/ { tooling = 0; next }
+		# previous job. The boundary indent is detected from the first key
+		# under jobs:, so bare or quoted job keys at any indentation
+		# (2-space, 4-space, single- or double-quoted "release":) reset the
+		# carried checkout and cannot bypass this contract (\047 = single quote).
+		{
+			if ($0 ~ /^ +(["\047][^"\047]*["\047]|[a-zA-Z_][a-zA-Z0-9_-]*): *$/) {
+				lead = $0
+				sub(/[^ ].*$/, "", lead)
+				if (job_indent < 0) { job_indent = length(lead) }
+				if (length(lead) == job_indent) { tooling = 0; next }
+			}
+		}
 		/- name: Checkout lgtm-ci tooling/ { tooling = NR }
 		/uses:[[:space:]]+\.\/\.lgtm-ci-tooling\/\.github\/actions\/checkout-and-harden/ {
 			if (tooling == 0 || tooling >= NR) {

--- a/scripts/ci/actions/validate-harden-runner-action-ref.sh
+++ b/scripts/ci/actions/validate-harden-runner-action-ref.sh
@@ -184,9 +184,40 @@ if grep -qE "^\s+egress-preset:" "$HARDEN_ACTION"; then
 	violations=$((violations + 1))
 fi
 
+TOOLING_CAH_RE='^[[:space:]]+uses:[[:space:]]+\./\.lgtm-ci-tooling/\.github/actions/checkout-and-harden[[:space:]]*$'
+
+_check_checkout_and_harden() {
+	local workflow="$1"
+	local wf_name="${workflow##*/}"
+
+	grep -qE "$TOOLING_CAH_RE" "$workflow" || return 0
+	if ! grep -qE 'Checkout lgtm-ci (egress )?tooling' "$workflow"; then
+		echo "${wf_name}: missing bootstrap Checkout lgtm-ci tooling step before checkout-and-harden" >&2
+		violations=$((violations + 1))
+	fi
+	if ! awk '
+		/- name: Checkout lgtm-ci tooling/ { tooling = NR }
+		/uses:[[:space:]]+\.\/\.lgtm-ci-tooling\/\.github\/actions\/checkout-and-harden/ {
+			if (tooling == 0 || tooling >= NR) {
+				bad = 1
+			}
+			tooling = 0
+		}
+		END { exit bad }
+	' "$workflow"; then
+		echo "${wf_name}: Checkout lgtm-ci tooling must precede checkout-and-harden" >&2
+		violations=$((violations + 1))
+	fi
+	if grep -qE "$IN_REPO_RESOLVE_RE" "$workflow" || grep -qE "$IN_REPO_HARDEN_RE" "$workflow"; then
+		echo "${wf_name}: caller-local ./.github/actions egress paths are forbidden in reusables" >&2
+		violations=$((violations + 1))
+	fi
+}
+
 while IFS= read -r -d '' workflow; do
 	[[ -f "$workflow" ]] || continue
 	wf_name="${workflow##*/}"
+	_check_checkout_and_harden "$workflow"
 	if ! grep -qE "$TOOLING_HARDEN_RE" "$workflow"; then
 		continue
 	fi

--- a/scripts/ci/actions/validate-harden-runner-action-ref.sh
+++ b/scripts/ci/actions/validate-harden-runner-action-ref.sh
@@ -10,7 +10,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 HARDEN_ACTION="$REPO_ROOT/.github/actions/harden-runner/action.yml"
-WORKFLOWS_DIR="$REPO_ROOT/.github/workflows"
+# Overridable so tests can point the validator at a fixture directory. The
+# release/renovate-specific checks below tolerate missing files, so a fixture
+# dir containing only reusable-*.yml is safe.
+WORKFLOWS_DIR="${WORKFLOWS_DIR:-$REPO_ROOT/.github/workflows}"
 
 TOOLING_RESOLVE_RE='^[[:space:]]+uses:[[:space:]]+\./\.lgtm-ci-tooling/\.github/actions/resolve-egress-allowlist[[:space:]]*$'
 TOOLING_HARDEN_RE='^[[:space:]]+uses:[[:space:]]+\./\.lgtm-ci-tooling/\.github/actions/harden-runner[[:space:]]*$'
@@ -49,7 +52,8 @@ _check_job_egress_order() {
 			!in_jobs {
 				next
 			}
-			/^  [a-zA-Z_][a-zA-Z0-9_-]*: *$/ {
+			# Recognize quoted job keys as boundaries too (\047 = single quote).
+			/^  (["\047][^"\047]*["\047]|[a-zA-Z_][a-zA-Z0-9_-]*): *$/ {
 				tooling_line = 0
 				resolve_line = 0
 				next
@@ -199,7 +203,12 @@ _check_checkout_and_harden() {
 		BEGIN { in_jobs = 0; tooling = 0 }
 		/^jobs:/ { in_jobs = 1; next }
 		!in_jobs { next }
-		/^  [a-zA-Z_][a-zA-Z0-9_-]*: *$/ { tooling = 0; next }
+		# Job-key boundary: reset the tooling checkout carried from a
+		# previous job. Recognize quoted job keys (e.g. a double- or
+		# single-quoted "release":) as well as bare keys, so a quoted job
+		# cannot inherit a prior job tooling checkout and bypass this
+		# contract (\047 is the octal escape for a single quote).
+		/^  (["\047][^"\047]*["\047]|[a-zA-Z_][a-zA-Z0-9_-]*): *$/ { tooling = 0; next }
 		/- name: Checkout lgtm-ci tooling/ { tooling = NR }
 		/uses:[[:space:]]+\.\/\.lgtm-ci-tooling\/\.github\/actions\/checkout-and-harden/ {
 			if (tooling == 0 || tooling >= NR) {

--- a/scripts/ci/quality/validate-tooling-sparse-checkout.sh
+++ b/scripts/ci/quality/validate-tooling-sparse-checkout.sh
@@ -37,7 +37,7 @@ for action_yml in actions_dir.glob("*/action.yml"):
     text = action_yml.read_text()
     if re.search(r"scripts/ci|SCRIPTS_DIR/ci/|GITHUB_ACTION_PATH.*scripts", text):
         script_composites.add(action_yml.parent.name)
-script_composites -= {"harden-runner", "resolve-egress-allowlist"}
+script_composites -= {"checkout-and-harden", "harden-runner", "resolve-egress-allowlist"}
 
 
 def parse_sparse(block: str) -> list[str]:
@@ -46,6 +46,13 @@ def parse_sparse(block: str) -> list[str]:
         return [line[12:].strip() for line in match.group(1).splitlines() if line.strip()]
     single = re.search(r"sparse-checkout:\s*([^\n]+)", block)
     return [single.group(1).strip()] if single else []
+
+
+def parse_sparse_extra(block: str) -> list[str]:
+    match = re.search(r"sparse-checkout-extra:\s*\|\s*\n((?:\s{12}.+\n)+)", block)
+    if not match:
+        return []
+    return [line[12:].strip() for line in match.group(1).splitlines() if line.strip()]
 
 
 def has_scripts_ci(paths: list[str]) -> bool:
@@ -73,6 +80,13 @@ for workflow in sorted(workflows_dir.glob("reusable-*.yml")):
                 continue
 
             paths = parse_sparse(block)
+            # checkout-and-harden performs the full tooling checkout itself;
+            # its sparse-checkout-extra paths count toward the contract.
+            if re.search(
+                r"uses:\s+\./\.lgtm-ci-tooling/\.github/actions/checkout-and-harden",
+                block,
+            ):
+                paths = paths + parse_sparse_extra(block)
             block_composites = set(
                 re.findall(
                     r"uses:\s+\./\.lgtm-ci-tooling/\.github/actions/([^\s#]+)",

--- a/tests/bats/integration/test_harden_runner_action_ref.bats
+++ b/tests/bats/integration/test_harden_runner_action_ref.bats
@@ -83,3 +83,83 @@ EOF
 	assert_failure
 	assert_output --partial "Checkout lgtm-ci tooling must precede checkout-and-harden"
 }
+
+# A workflow may indent job keys deeper than two spaces (valid YAML). The job
+# boundary must still be recognized at that indent so a later job cannot inherit
+# a prior job tooling checkout. Discriminating: the old fixed two-space boundary
+# missed 4-space job keys and let the leak pass.
+@test "validate-harden-runner-action-ref: flags a 4-space-indented job that skips its bootstrap" {
+	local dir="$BATS_TEST_TMPDIR/wf"
+	mkdir -p "$dir"
+	cat >"$dir/reusable-fixture.yml" <<'EOF'
+name: Fixture
+on:
+  workflow_call:
+jobs:
+    first:
+        runs-on: ubuntu-24.04
+        steps:
+            - name: Checkout lgtm-ci tooling
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: |
+                      .github/actions/checkout-and-harden
+                  sparse-checkout-cone-mode: true
+                  persist-credentials: false
+            - name: Use tooling
+              run: bash .lgtm-ci-tooling/scripts/ci/actions/noop.sh
+    deploy:
+        runs-on: ubuntu-24.04
+        steps:
+            - name: Checkout and harden
+              id: egress
+              uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+              with:
+                  egress-policy: block
+EOF
+	WORKFLOWS_DIR="$dir" run bash "$VALIDATE"
+	assert_failure
+	assert_output --partial "Checkout lgtm-ci tooling must precede checkout-and-harden"
+}
+
+# Companion: the same 4-space layout must PASS when the second job bootstraps its
+# own tooling checkout (guards against the fix over-flagging valid workflows).
+@test "validate-harden-runner-action-ref: accepts a 4-space-indented job that bootstraps its own checkout" {
+	local dir="$BATS_TEST_TMPDIR/wf"
+	mkdir -p "$dir"
+	cat >"$dir/reusable-fixture.yml" <<'EOF'
+name: Fixture
+on:
+  workflow_call:
+jobs:
+    first:
+        runs-on: ubuntu-24.04
+        steps:
+            - name: Checkout lgtm-ci tooling
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: |
+                      .github/actions/checkout-and-harden
+                  sparse-checkout-cone-mode: true
+                  persist-credentials: false
+            - name: Use tooling
+              run: bash .lgtm-ci-tooling/scripts/ci/actions/noop.sh
+    deploy:
+        runs-on: ubuntu-24.04
+        steps:
+            - name: Checkout lgtm-ci tooling
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: |
+                      .github/actions/checkout-and-harden
+                  sparse-checkout-cone-mode: true
+                  persist-credentials: false
+            - name: Checkout and harden
+              id: egress
+              uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+              with:
+                  egress-policy: block
+EOF
+	WORKFLOWS_DIR="$dir" run bash "$VALIDATE"
+	assert_success
+}

--- a/tests/bats/integration/test_harden_runner_action_ref.bats
+++ b/tests/bats/integration/test_harden_runner_action_ref.bats
@@ -10,3 +10,76 @@ VALIDATE="${PROJECT_ROOT}/scripts/ci/actions/validate-harden-runner-action-ref.s
 	run bash "$VALIDATE"
 	assert_success
 }
+
+# Write a fixture reusable workflow. The FIRST job bootstraps the tooling
+# checkout but does NOT consume it via checkout-and-harden (so `tooling`
+# stays set across the job boundary). The SECOND job key is $2 (e.g. deploy
+# or '"deploy"'); when $3 is "leak" it uses checkout-and-harden WITHOUT its
+# own bootstrap Checkout step, so it would inherit the first job's tooling
+# checkout unless the job boundary is recognized.
+_write_two_job_fixture() {
+	local dir="$1" key="$2" mode="$3"
+	local bootstrap=""
+	if [[ "$mode" != "leak" ]]; then
+		bootstrap='      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github/actions/checkout-and-harden
+          sparse-checkout-cone-mode: true
+          persist-credentials: false'
+	fi
+	cat >"$dir/reusable-fixture.yml" <<EOF
+name: Fixture
+on:
+  workflow_call:
+jobs:
+  first:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github/actions/checkout-and-harden
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+      - name: Use tooling
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/noop.sh
+  ${key}:
+    runs-on: ubuntu-24.04
+    steps:
+${bootstrap:+$bootstrap
+}      - name: Checkout and harden
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+        with:
+          egress-policy: block
+EOF
+}
+
+@test "validate-harden-runner-action-ref: flags a quoted job that skips its bootstrap checkout" {
+	local dir="$BATS_TEST_TMPDIR/wf"
+	mkdir -p "$dir"
+	_write_two_job_fixture "$dir" '"deploy"' leak
+	WORKFLOWS_DIR="$dir" run bash "$VALIDATE"
+	assert_failure
+	assert_output --partial "Checkout lgtm-ci tooling must precede checkout-and-harden"
+}
+
+@test "validate-harden-runner-action-ref: accepts a quoted job that bootstraps its own checkout" {
+	local dir="$BATS_TEST_TMPDIR/wf"
+	mkdir -p "$dir"
+	_write_two_job_fixture "$dir" '"deploy"' ok
+	WORKFLOWS_DIR="$dir" run bash "$VALIDATE"
+	assert_success
+}
+
+@test "validate-harden-runner-action-ref: still flags an unquoted job that skips its bootstrap" {
+	local dir="$BATS_TEST_TMPDIR/wf"
+	mkdir -p "$dir"
+	_write_two_job_fixture "$dir" deploy leak
+	WORKFLOWS_DIR="$dir" run bash "$VALIDATE"
+	assert_failure
+	assert_output --partial "Checkout lgtm-ci tooling must precede checkout-and-harden"
+}

--- a/tests/bats/integration/test_reusable_publish_file_breakdown.bats
+++ b/tests/bats/integration/test_reusable_publish_file_breakdown.bats
@@ -33,15 +33,24 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-publish-file-breakdown.yml"
 	assert_success
 }
 
-@test "publish-file-breakdown: sparse checkout includes scripts and post-pr-comment" {
+@test "publish-file-breakdown: uses checkout-and-harden with scripts and post-pr-comment extras" {
+	# Bootstrap sparse-checkout of the composite, then the single composite step.
+	run grep -F '.github/actions/checkout-and-harden' "$WORKFLOW"
+	assert_success
+	run grep -F 'uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden' "$WORKFLOW"
+	assert_success
+	# Workflow-specific paths are preserved via sparse-checkout-extra.
+	run grep -F 'sparse-checkout-extra:' "$WORKFLOW"
+	assert_success
 	run grep -F 'scripts/ci/' "$WORKFLOW"
 	assert_success
 	run grep -F '.github/actions/post-pr-comment' "$WORKFLOW"
 	assert_success
+	# The four-step harden preamble is gone (folded into the composite).
 	run grep -F '.github/actions/harden-runner' "$WORKFLOW"
-	assert_success
+	assert_failure
 	run grep -F '.github/actions/resolve-egress-allowlist' "$WORKFLOW"
-	assert_success
+	assert_failure
 }
 
 @test "publish-file-breakdown: defaults to github-minimal egress preset" {

--- a/tests/bats/integration/test_reusable_quality_lint_workflow.bats
+++ b/tests/bats/integration/test_reusable_quality_lint_workflow.bats
@@ -37,20 +37,17 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-quality-lint.yml"
 	assert_success
 }
 
-@test "reusable-quality-lint: resolve egress before harden-runner composite" {
-	run grep -E '^\s*uses:\s*\./\.lgtm-ci-tooling/\.github/actions/resolve-egress-allowlist\s*$' "$WORKFLOW"
-	assert_success
-	run grep -E '^\s*uses:\s*\./\.lgtm-ci-tooling/\.github/actions/harden-runner\s*$' "$WORKFLOW"
+@test "reusable-quality-lint: hardens via checkout-and-harden composite" {
+	run grep -E '^\s*uses:\s*\./\.lgtm-ci-tooling/\.github/actions/checkout-and-harden\s*$' "$WORKFLOW"
 	assert_success
 	run grep -F 'egress-preset: ${{ inputs.egress-preset }}' "$WORKFLOW"
 	assert_success
-	run grep -F "allowed-endpoints: \${{ steps.egress.outputs['allowed-endpoints'] }}" "$WORKFLOW"
+	run grep -F 'allowed-endpoints: ${{ inputs.allowed-endpoints }}' "$WORKFLOW"
 	assert_success
 	run awk '
 		/- name: Checkout repository/ { checkout = 1 }
 		/- name: Checkout lgtm-ci tooling/ { tooling = 1 }
-		tooling && /- name: Resolve egress allowlist/ { resolve = 1 }
-		resolve && /- name: Harden runner/ { found = 1 }
+		tooling && /- name: Checkout and harden/ { found = 1 }
 		END { exit !(checkout && tooling && found) }
 	' "$WORKFLOW"
 	assert_success

--- a/tests/bats/integration/test_reusable_required_check.bats
+++ b/tests/bats/integration/test_reusable_required_check.bats
@@ -52,16 +52,13 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-required-check.yml"
 	assert_success
 }
 
-@test "reusable-required-check: uses harden-runner and tooling checkout" {
-	run grep -E '^\s*uses:\s*\./\.lgtm-ci-tooling/\.github/actions/resolve-egress-allowlist\s*$' "$WORKFLOW"
-	assert_success
-	run grep -E '^\s*uses:\s*\./\.lgtm-ci-tooling/\.github/actions/harden-runner\s*$' "$WORKFLOW"
+@test "reusable-required-check: uses checkout-and-harden and tooling checkout" {
+	run grep -E '^\s*uses:\s*\./\.lgtm-ci-tooling/\.github/actions/checkout-and-harden\s*$' "$WORKFLOW"
 	assert_success
 	run awk '
 		/- name: Checkout repository/ { checkout = 1 }
 		/- name: Checkout lgtm-ci tooling/ { tooling = 1 }
-		tooling && /- name: Resolve egress allowlist/ { resolve = 1 }
-		resolve && /- name: Harden runner/ { found = 1 }
+		tooling && /- name: Checkout and harden/ { found = 1 }
 		END { exit !(checkout && tooling && found) }
 	' "$WORKFLOW"
 	assert_success

--- a/tests/bats/integration/test_reusable_security_audit.bats
+++ b/tests/bats/integration/test_reusable_security_audit.bats
@@ -99,14 +99,13 @@ PUBLISH_WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-publish-security-au
 	assert_success
 }
 
-@test "reusable-security-audit: resolve egress before harden-runner composite" {
+@test "reusable-security-audit: hardens via checkout-and-harden composite" {
 	run awk '
 		/^  security-audit:/ { in_job = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  security-audit:/ { in_job = 0 }
 		in_job && /- name: Checkout repository/ { checkout = 1 }
 		in_job && /- name: Checkout lgtm-ci tooling/ { tooling = 1 }
-		in_job && /- name: Resolve egress allowlist/ { resolve = 1 }
-		in_job && resolve && /- name: Harden runner/ { found = 1 }
+		in_job && tooling && /- name: Checkout and harden/ { found = 1 }
 		END { exit !(checkout && tooling && found) }
 	' "$WORKFLOW"
 	assert_success

--- a/tests/bats/integration/test_reusable_tooling_sparse_checkout.bats
+++ b/tests/bats/integration/test_reusable_tooling_sparse_checkout.bats
@@ -239,3 +239,107 @@ YAML
 	assert_failure
 	assert_output --partial "validate-action-pinning"
 }
+
+@test "validate-tooling-sparse-checkout: allows checkout-and-harden with scripts/ci/ extra" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	local actions_dir="${BATS_TEST_TMPDIR}/.github/actions"
+	mkdir -p "${workflows_dir}" \
+		"${actions_dir}/checkout-and-harden" \
+		"${actions_dir}/validate-action-pinning"
+	cat >"${actions_dir}/checkout-and-harden/action.yml" <<'YAML'
+---
+name: Checkout and harden
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          scripts/ci/
+YAML
+	cat >"${actions_dir}/validate-action-pinning/action.yml" <<'YAML'
+---
+name: Validate action pinning
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: $SCRIPTS_DIR/ci/actions/validate-action-pinning.sh
+YAML
+	cat >"${workflows_dir}/reusable-composite-preamble.yml" <<'YAML'
+---
+name: Composite preamble example
+on:
+  workflow_call:
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/checkout-and-harden
+      - name: Checkout and harden
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+        with:
+          sparse-checkout-extra: |
+            scripts/ci/
+      - name: Validate action pinning
+        uses: ./.lgtm-ci-tooling/.github/actions/validate-action-pinning
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" ACTIONS_DIR="${actions_dir}" run "${VALIDATOR}"
+	assert_success
+}
+
+@test "validate-tooling-sparse-checkout: flags checkout-and-harden missing scripts/ci/ extra" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	local actions_dir="${BATS_TEST_TMPDIR}/.github/actions"
+	mkdir -p "${workflows_dir}" \
+		"${actions_dir}/checkout-and-harden" \
+		"${actions_dir}/validate-action-pinning"
+	cat >"${actions_dir}/checkout-and-harden/action.yml" <<'YAML'
+---
+name: Checkout and harden
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        sparse-checkout: |
+          scripts/ci/
+YAML
+	cat >"${actions_dir}/validate-action-pinning/action.yml" <<'YAML'
+---
+name: Validate action pinning
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: $SCRIPTS_DIR/ci/actions/validate-action-pinning.sh
+YAML
+	cat >"${workflows_dir}/reusable-composite-preamble-bad.yml" <<'YAML'
+---
+name: Composite preamble bad example
+on:
+  workflow_call:
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout lgtm-ci tooling
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/checkout-and-harden
+      - name: Checkout and harden
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+      - name: Validate action pinning
+        uses: ./.lgtm-ci-tooling/.github/actions/validate-action-pinning
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" ACTIONS_DIR="${actions_dir}" run "${VALIDATOR}"
+	assert_failure
+	assert_output --partial "validate-action-pinning"
+}

--- a/tests/bats/integration/test_reusable_vuln_suppression_check.bats
+++ b/tests/bats/integration/test_reusable_vuln_suppression_check.bats
@@ -62,14 +62,13 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-vuln-suppression-check.yml"
 	assert_success
 }
 
-@test "reusable-vuln-suppression-check: resolve egress before harden-runner composite" {
+@test "reusable-vuln-suppression-check: hardens via checkout-and-harden composite" {
 	run awk '
 		/^  vuln-suppression-check:/ { in_job = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  vuln-suppression-check:/ { in_job = 0 }
 		in_job && /- name: Checkout repository/ { checkout = 1 }
 		in_job && /- name: Checkout lgtm-ci tooling/ { tooling = 1 }
-		in_job && /- name: Resolve egress allowlist/ { resolve = 1 }
-		in_job && resolve && /- name: Harden runner/ { found = 1 }
+		in_job && tooling && /- name: Checkout and harden/ { found = 1 }
 		END { exit !(checkout && tooling && found) }
 	' "$WORKFLOW"
 	assert_success

--- a/tests/bats/integration/test_version_drift_workflows.bats
+++ b/tests/bats/integration/test_version_drift_workflows.bats
@@ -120,7 +120,7 @@ load "../../helpers/common"
 		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /open-registry-health-issue:/ {
 			in_job = 0
 		}
-		in_job && /harden-runner/ { found = 1; exit }
+		in_job && /harden-runner|checkout-and-harden/ { found = 1; exit }
 		END { exit !found }
 	' "$workflow"
 	assert_success

--- a/tests/bats/unit/actions/test_checkout_and_harden.bats
+++ b/tests/bats/unit/actions/test_checkout_and_harden.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for the checkout-and-harden composite action
+
+load "../../../helpers/common"
+
+ACTION="${PROJECT_ROOT}/.github/actions/checkout-and-harden/action.yml"
+
+@test "checkout-and-harden: action.yml exists" {
+	[ -f "$ACTION" ]
+}
+
+@test "checkout-and-harden: declares the contract inputs" {
+	for input in tooling-ref egress-policy egress-preset allowed-endpoints \
+		allowed-endpoints-mode sparse-checkout-extra persist-credentials; do
+		run grep -E "^  ${input}:" "$ACTION"
+		assert_success
+	done
+}
+
+@test "checkout-and-harden: declares allowed-endpoints and scripts-dir outputs" {
+	run grep -E "^  allowed-endpoints:" "$ACTION"
+	assert_success
+	run grep -E "^  scripts-dir:" "$ACTION"
+	assert_success
+}
+
+@test "checkout-and-harden: egress-policy defaults to block" {
+	run awk '
+		/^  egress-policy:/ { found = 1 }
+		found && /^    default: "block"/ { ok = 1; exit }
+		found && /^  [a-z]/ && !/^  egress-policy:/ { exit }
+		END { exit !ok }
+	' "$ACTION"
+	assert_success
+}
+
+@test "checkout-and-harden: allowed-endpoints-mode defaults to replace" {
+	run awk '
+		/^  allowed-endpoints-mode:/ { found = 1 }
+		found && /^    default: "replace"/ { ok = 1; exit }
+		found && /^  [a-z]/ && !/^  allowed-endpoints-mode:/ { exit }
+		END { exit !ok }
+	' "$ACTION"
+	assert_success
+}
+
+@test "checkout-and-harden: tooling checkout falls back to github.workflow_sha" {
+	run grep -F \
+		"ref: \${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}" \
+		"$ACTION"
+	assert_success
+}
+
+@test "checkout-and-harden: base sparse checkout covers egress composites and itself" {
+	for path in ".github/actions/checkout-and-harden" \
+		".github/actions/harden-runner" \
+		".github/actions/resolve-egress-allowlist"; do
+		run grep -F "          ${path}" "$ACTION"
+		assert_success
+	done
+}
+
+@test "checkout-and-harden: appends sparse-checkout-extra to the sparse set" {
+	run grep -F '${{ inputs.sparse-checkout-extra }}' "$ACTION"
+	assert_success
+}
+
+@test "checkout-and-harden: resolve step runs before harden step" {
+	run awk '
+		/uses: \.\/\.lgtm-ci-tooling\/\.github\/actions\/resolve-egress-allowlist/ { resolve = NR }
+		/uses: \.\/\.lgtm-ci-tooling\/\.github\/actions\/harden-runner/ { harden = NR }
+		END { exit !(resolve && harden && resolve < harden) }
+	' "$ACTION"
+	assert_success
+}
+
+@test "checkout-and-harden: harden step consumes the resolve sibling output" {
+	run grep -F \
+		"allowed-endpoints: \${{ steps.egress.outputs['allowed-endpoints'] }}" \
+		"$ACTION"
+	assert_success
+}
+
+@test "checkout-and-harden: tooling checkout is pinned to the workflow checkout SHA" {
+	local pin
+	pin=$(grep -oE 'actions/checkout@[0-9a-f]{40}' \
+		"${PROJECT_ROOT}/.github/workflows/reusable-quality-lint.yml" | head -1)
+	run grep -F "$pin" "$ACTION"
+	assert_success
+}

--- a/tests/helpers/common.bash
+++ b/tests/helpers/common.bash
@@ -528,6 +528,8 @@ assert_readonly_var() {
 }
 
 # Assert repository → tooling → resolve → harden step order (#279 egress contract).
+# Also accepts the checkout-and-harden composite form (#379): repository →
+# bootstrap tooling checkout → Checkout and harden.
 # Usage: egress_tooling_checkout_order_ok "$workflow" [job-name]
 egress_tooling_checkout_order_ok() {
 	local workflow="$1"
@@ -539,7 +541,7 @@ egress_tooling_checkout_order_ok() {
 		job != "" && $0 ~ "^  " job ":" {
 			in_job = 1
 			in_steps = 0
-			repo = tooling = resolve = harden = 0
+			repo = tooling = resolve = harden = cah = 0
 			next
 		}
 		job != "" && in_job && /^  [a-zA-Z0-9_-]+:/ && $0 !~ "^  " job ":" {
@@ -553,9 +555,13 @@ egress_tooling_checkout_order_ok() {
 				tooling = NR
 			}
 		}
+		active_job() && in_steps && /^      - name: Checkout and harden/ { cah = NR }
 		active_job() && in_steps && /^      - name: Resolve egress allowlist/ { resolve = NR }
 		active_job() && in_steps && /^      - name: Harden runner/ { harden = NR }
 		END {
+			if (cah > 0 && harden == 0 && resolve == 0) {
+				exit !(repo > 0 && tooling > 0 && repo < tooling && tooling < cah)
+			}
 			ok = (repo > 0 && tooling > 0 && harden > 0 && repo < tooling && tooling < harden)
 			if (resolve > 0) {
 				ok = ok && tooling < resolve && resolve < harden


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Adds a shared `checkout-and-harden` composite action and migrates 65 job preambles across 40 reusable workflows from the duplicated four-step sequence (tooling sparse checkout → `resolve-egress-allowlist` → `harden-runner`) to a bootstrap sparse checkout plus a single `Checkout and harden` step. Net -75 lines with behavior preserved exactly (same sparse-checkout paths per workflow via `sparse-checkout-extra`, same egress inputs, same step ids).

### Spike outcome (pre-hook timing)

The contract docs said step-security's pre-hook "cannot read composite step outputs". The spike found the operative behavior is stronger and simpler:

- The Actions runner **never executes `pre` for workspace-local actions** (`ActionRunner.cs` emits ``"`pre` execution is not supported for local action"``). Live CI logs for this repo confirm it: every job shows that warning and only `[harden-runner] main-step` / `post-step` lines — the pre-hook does not run today either.
- Therefore step-security inputs are evaluated when the step itself runs, and a prior **sibling step inside the same composite** provides `steps.egress.outputs['allowed-endpoints']` with identical timing to the previous workflow-level pattern. No regression is possible via the pre-hook; the docs paragraph was corrected accordingly.
- Nested local refs load just-in-time (`PrepareRepositoryActionAsync` returns early for self-alias refs), so the composite can perform the full tooling checkout itself and then invoke `resolve-egress-allowlist` / `harden-runner` from the directory it just materialized. `prepare-pypi-upload` already relies on the same workspace-relative nesting.

### Design

- Workflow bootstrap checkout materializes only `.github/actions/checkout-and-harden` at the same ref expression as before (`tooling-ref` falling back to `github.workflow_sha`); the composite re-checks-out `.lgtm-ci-tooling` with the base egress paths plus `sparse-checkout-extra`.
- Inputs: `tooling-ref`, `egress-policy` (block), `egress-preset`, `allowed-endpoints`, `allowed-endpoints-mode` (replace), `sparse-checkout-extra`, `persist-credentials` (false). Outputs: `allowed-endpoints`, `scripts-dir`.
- Migration was fully mechanical (scripted transform, re-run verified byte-identical); the one-off script is not committed, matching the repo's removal of the previous `migrate-egress-via-tooling-checkout.py` as dead code.

### Exemptions (unchanged workflows)

- `reusable-release-auto-tag`, `reusable-release-version-pr` — two-phase egress/scripts checkouts around the app token.
- `reusable-build-rust-binaries`, `reusable-publish-rust-release` — `validate-runner-policy` must run between the tooling checkout and resolve/harden (tier gating with `if:` conditions).
- `reusable-validate-lintro-version` — bootstrap/fallback tooling checkout flow.

### Contract check changes (shape genuinely changed)

- `validate-tooling-sparse-checkout.sh`: merges the composite's `sparse-checkout-extra` paths into the checkout block before applying the `scripts/ci/` rule; exempts `checkout-and-harden` alongside the egress composites. New pass/fail BATS cases cover the composite form.
- `validate-harden-runner-action-ref.sh`: new checks for composite users (bootstrap checkout must exist and precede the composite; caller-local egress paths still forbidden). The explicit triplet checks continue to apply to the exempt workflows.
- `egress_tooling_checkout_order_ok` helper and four workflow-specific BATS suites accept the single-step form.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally (`bats --recursive tests/bats`: 2354 tests, sole failure is a pre-existing local-env case that also fails on `main`; new composite unit suite passes)
- [x] I have updated documentation if needed (`docs/workflow-contract.md`, `.github/actions/README.md`, `CHANGELOG.md`)
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint` (and `actionlint`)
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. Reusable workflow inputs and job/step contracts observable by consumers are unchanged; the tooling checkout additionally materializes `.github/actions/checkout-and-harden`.

## Closes

- Closes #379

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a shared checkout-and-harden workflow preamble. The main changes are:

- New composite action for tooling checkout, egress resolution, and runner hardening.
- Reusable workflows migrated from separate preamble steps to the composite action.
- Contract checks and BATS coverage updated for the new workflow shape.
- Docs updated to describe the composite action and runner timing behavior.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The latest validator changes cover the job-boundary cases raised earlier.
- The added tests cover the quoted and indented job forms that previously leaked state.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/actions/validate-harden-runner-action-ref.sh | Updates the hardening contract validator to reset checkout tracking at job boundaries. |
| .github/actions/checkout-and-harden/action.yml | Adds the shared composite action for tooling checkout, egress resolution, runner hardening, and output wiring. |
| tests/bats/integration/test_harden_runner_action_ref.bats | Adds tests for checkout-and-harden ordering across quoted and indented job keys. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(actions): detect job boundary at any..."](https://github.com/lgtm-hq/lgtm-ci/commit/c836ad542926021702e2a2058399c8510d1d5b11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41930338)</sub>

<!-- /greptile_comment -->