### PR TITLE
feat(workflows): add reusable-publish-artifact-preview for artifact download links

### DIFF
--- a/.github/workflows/reusable-publish-artifact-preview.yml
+++ b/.github/workflows/reusable-publish-artifact-preview.yml
@@ -1,0 +1,152 @@
+---
+name: Reusable Publish Artifact Preview Workflow
+
+# Posts (or updates) one sticky PR comment containing a direct download link to
+# a named build artifact, optionally prefixed with a short build summary. The
+# link comes from actions/upload-artifact v4+'s `artifact-url` output.
+#
+# Constraint (documented honestly): the link downloads a `.zip` and requires the
+# viewer to be signed in to GitHub with access to the repository. It is a
+# reviewer convenience, not a public preview URL. Re-running on the same PR
+# updates the existing comment (marker upsert) rather than adding a duplicate.
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: "Name of the uploaded artifact (used in the download link text)"
+        required: true
+        type: string
+      artifact-url:
+        description: >-
+          Download URL from actions/upload-artifact v4 `artifact-url` output.
+          Empty/missing degrades gracefully (warning, no broken comment).
+        required: true
+        type: string
+      marker:
+        description: "Upsert marker identifying the sticky preview comment"
+        required: true
+        type: string
+      summary:
+        description: "Optional inline markdown summary prepended to the comment"
+        required: false
+        type: string
+        default: ""
+      summary-file:
+        description: >-
+          Optional path to a markdown summary file (takes precedence over
+          `summary` when it exists and is non-empty)
+        required: false
+        type: string
+        default: ""
+      tooling-ref:
+        description: "Git ref to use when checking out lgtm-ci tooling scripts"
+        required: false
+        type: string
+        default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "block"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
+      egress-preset:
+        description: >-
+          Named allowlist when allowed-endpoints is empty and egress-policy is
+          block (github-minimal, github-pages, github-tooling, docker, playwright, pypi,
+          rubygems, npm-publish, quality, sbom, scorecard)
+        required: false
+        type: string
+        default: "github-minimal"
+      job-name:
+        description: "Display name for the artifact preview comment job"
+        required: false
+        type: string
+        default: "Publish artifact preview"
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 10
+
+jobs:
+  publish-artifact-preview:
+    name: ${{ inputs.job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        # Pinned to SHA for supply chain security
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+
+      - name: Compose artifact preview comment
+        shell: bash
+        env:
+          ARTIFACT_NAME: ${{ inputs.artifact-name }}
+          ARTIFACT_URL: ${{ inputs.artifact-url }}
+          SUMMARY: ${{ inputs.summary }}
+          SUMMARY_FILE: ${{ inputs.summary-file }}
+          COMMENT_OUTPUT: artifact-preview-comment.md
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/compose-artifact-preview-comment.sh
+
+      # Missing/empty artifact-url yields an empty body above; delete-on-empty
+      # removes any stale comment instead of posting a broken link. Fork-PR skip
+      # is handled inside the post-pr-comment action.
+      - name: Publish artifact preview comment
+        uses: ./.lgtm-ci-tooling/.github/actions/post-pr-comment
+        with:
+          file: artifact-preview-comment.md
+          marker: ${{ inputs.marker }}
+          delete-on-empty: "true"

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -559,6 +559,75 @@ allowlist, and `workflow_run` caller patterns.
 See [python-release-publish.md](python-release-publish.md) for a full production
 tag-push layout (quality, SBOM, split publish, release assets).
 
+### Artifact download preview comment (`reusable-publish-artifact-preview.yml`)
+
+Posts (or updates) one **sticky PR comment** with a direct **download link** to a
+named build artifact, optionally prefixed with a short build summary. Use it when
+a PR uploads an artifact (a generated static site, a rendered report, a built
+bundle) and reviewers want to grab it in one click instead of hunting through the
+run page.
+
+The link is the `artifact-url` output of `actions/upload-artifact` v4+
+(`https://github.com/<owner>/<repo>/actions/runs/<run_id>/artifacts/<artifact_id>`).
+
+> **Constraint (honest):** the link downloads a **`.zip`** and requires the viewer
+> to be **signed in to GitHub with access to the repository**. It is a reviewer
+> convenience, not a public preview URL.
+
+Re-running on the same PR **updates** the existing comment (marker upsert — no
+duplicates). A missing/empty `artifact-url` degrades gracefully: a warning is
+emitted and any stale comment is removed (delete-on-empty) rather than posting a
+broken link. Fork PRs are skipped (they cannot receive workflow comments).
+
+```yaml
+jobs:
+  build-site:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      artifact-url: ${{ steps.upload.outputs.artifact-url }}
+    steps:
+      # ... build the site into ./dist ...
+      - id: upload
+        uses: actions/upload-artifact@<sha> # v4+
+        with:
+          name: site-preview
+          path: dist
+
+  preview-comment:
+    needs: build-site
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-publish-artifact-preview.yml@<sha>
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      artifact-name: site-preview
+      artifact-url: ${{ needs.build-site.outputs.artifact-url }}
+      marker: site-preview
+      summary: "Rendered landing site from this PR's formulae."
+      tooling-ref: "<sha>" # vX.Y.Z
+```
+
+<!-- markdownlint-disable MD013 -- input reference table -->
+
+| Input           | Type   | Required | Default                     | Purpose                                                      |
+| --------------- | ------ | -------- | --------------------------- | ----------------------------------------------------------- |
+| `artifact-name` | string | yes      | —                           | Name shown in the "⬇ Download …" link text                  |
+| `artifact-url`  | string | yes      | —                           | `upload-artifact` v4 `artifact-url` output (empty degrades) |
+| `marker`        | string | yes      | —                           | Sticky-comment upsert identity                              |
+| `summary`       | string | no       | `""`                        | Inline markdown prepended to the comment                    |
+| `summary-file`  | string | no       | `""`                        | Markdown file (wins over `summary` when non-empty)          |
+| `job-name`      | string | no       | `Publish artifact preview`  | Job display name                                            |
+
+<!-- markdownlint-enable MD013 -->
+
+Plus the standard contract inputs (`tooling-ref`, `egress-policy`,
+`egress-preset`, `allowed-endpoints`, `allowed-endpoints-mode`, `runner-image`,
+`timeout-minutes`). Unlike `reusable-publish-artifact-report.yml` (which posts
+the **contents** of a markdown file from inside a downloaded artifact), this
+workflow does not download the artifact — it only links to it.
+
 ## Build, Coverage, And Supply Chain
 
 ### Push (publish to registry)

--- a/scripts/ci/actions/compose-artifact-preview-comment.sh
+++ b/scripts/ci/actions/compose-artifact-preview-comment.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Compose a sticky PR comment body that links to a build artifact for
+#          download, optionally prefixed with a caller-provided build summary.
+#
+# Environment variables expected:
+#   ARTIFACT_NAME - Display name of the uploaded artifact (required)
+#   ARTIFACT_URL  - actions/upload-artifact v4 `artifact-url` output. When empty
+#                   the script emits a warning and writes an empty body so the
+#                   caller can delete-on-empty rather than post a broken link.
+#   SUMMARY       - Optional inline markdown summary prepended to the comment
+#   SUMMARY_FILE  - Optional path to a markdown file; takes precedence over
+#                   SUMMARY when it exists and is non-empty
+#   COMMENT_OUTPUT - Optional output file. When unset, the body is printed to
+#                   stdout (used by unit tests).
+#
+# Security: all values arrive via the environment and are emitted with printf
+# (no eval, no shell interpolation of untrusted data).
+
+set -euo pipefail
+
+ARTIFACT_NAME="${ARTIFACT_NAME:-}"
+ARTIFACT_URL="${ARTIFACT_URL:-}"
+
+emit() {
+	if [[ -n "${COMMENT_OUTPUT:-}" ]]; then
+		cat >"$COMMENT_OUTPUT"
+	else
+		cat
+	fi
+}
+
+# Graceful degrade: without a download URL there is nothing to link. Emit an
+# empty body so a delete-on-empty upsert removes any stale comment, and warn.
+if [[ -z "$ARTIFACT_URL" ]]; then
+	echo "::warning::artifact-url is empty — skipping artifact preview comment (upstream upload may have failed)"
+	printf '' | emit
+	exit 0
+fi
+
+if [[ -z "$ARTIFACT_NAME" ]]; then
+	echo "::error::ARTIFACT_NAME is required when ARTIFACT_URL is provided"
+	exit 1
+fi
+
+# Resolve the optional summary: a non-empty file wins over the inline input.
+SUMMARY_TEXT=""
+if [[ -n "${SUMMARY_FILE:-}" ]]; then
+	if [[ -f "$SUMMARY_FILE" && -s "$SUMMARY_FILE" ]]; then
+		SUMMARY_TEXT="$(cat "$SUMMARY_FILE")"
+	else
+		echo "::warning::summary-file not found or empty: ${SUMMARY_FILE}"
+	fi
+fi
+if [[ -z "$SUMMARY_TEXT" && -n "${SUMMARY:-}" ]]; then
+	SUMMARY_TEXT="$SUMMARY"
+fi
+
+{
+	if [[ -n "$SUMMARY_TEXT" ]]; then
+		printf '%s\n\n' "$SUMMARY_TEXT"
+	fi
+	printf '⬇ **[Download %s](%s)**\n\n' "$ARTIFACT_NAME" "$ARTIFACT_URL"
+	printf '%s\n' "<sub>Downloads a \`.zip\`; requires being signed in to GitHub with access to this repository. This is a reviewer convenience, not a public preview URL.</sub>"
+} | emit

--- a/tests/bats/integration/test_reusable_publish_artifact_preview.bats
+++ b/tests/bats/integration/test_reusable_publish_artifact_preview.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-publish-artifact-preview workflow
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-publish-artifact-preview.yml"
+
+@test "reusable-publish-artifact-preview: workflow file exists" {
+	[[ -f "$WORKFLOW" ]]
+}
+
+@test "reusable-publish-artifact-preview: declares required preview inputs" {
+	run grep -F 'artifact-name:' "$WORKFLOW"
+	assert_success
+	run grep -F 'artifact-url:' "$WORKFLOW"
+	assert_success
+	run grep -F 'marker:' "$WORKFLOW"
+	assert_success
+	run grep -F 'summary:' "$WORKFLOW"
+	assert_success
+	run grep -F 'summary-file:' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-publish-artifact-preview: exposes #393 contract inputs" {
+	for input in tooling-ref egress-policy egress-preset allowed-endpoints \
+		allowed-endpoints-mode runner-image timeout-minutes job-name; do
+		run grep -F "${input}:" "$WORKFLOW"
+		assert_success
+	done
+}
+
+@test "reusable-publish-artifact-preview: egress-preset defaults to github-minimal" {
+	run grep -F 'default: "github-minimal"' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-publish-artifact-preview: job grants read/write PR permissions" {
+	run grep -F 'contents: read' "$WORKFLOW"
+	assert_success
+	run grep -F 'pull-requests: write' "$WORKFLOW"
+	assert_success
+	run grep -F 'contents: write' "$WORKFLOW"
+	assert_failure
+}
+
+@test "reusable-publish-artifact-preview: job uses static name and runner-image" {
+	run grep -F 'name: ${{ inputs.job-name }}' "$WORKFLOW"
+	assert_success
+	run grep -F 'runs-on: ${{ inputs.runner-image }}' "$WORKFLOW"
+	assert_success
+	run grep -F 'timeout-minutes: ${{ inputs.timeout-minutes }}' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-publish-artifact-preview: composes body via tooling script" {
+	run grep -F 'compose-artifact-preview-comment.sh' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-publish-artifact-preview: reuses post-pr-comment with delete-on-empty" {
+	run grep -F '.github/actions/post-pr-comment' "$WORKFLOW"
+	assert_success
+	run grep -F 'delete-on-empty: "true"' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-publish-artifact-preview: sparse-checkout includes scripts/ci" {
+	run grep -F 'scripts/ci/' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-publish-artifact-preview: preserves egress checkout order" {
+	run egress_tooling_checkout_order_ok "$WORKFLOW" "publish-artifact-preview"
+	assert_success
+}
+
+@test "reusable-publish-artifact-preview: passes runner contract validator" {
+	run bash "${PROJECT_ROOT}/scripts/ci/quality/validate-runner-contract.sh"
+	assert_success
+}
+
+@test "reusable-publish-artifact-preview: passes tooling sparse-checkout validator" {
+	run bash "${PROJECT_ROOT}/scripts/ci/quality/validate-tooling-sparse-checkout.sh"
+	assert_success
+}
+
+@test "reusable-publish-artifact-preview: passes static job names validator" {
+	run bash "${PROJECT_ROOT}/scripts/ci/quality/validate-static-job-names.sh"
+	assert_success
+}

--- a/tests/bats/unit/actions/test_compose_artifact_preview_comment.bats
+++ b/tests/bats/unit/actions/test_compose_artifact_preview_comment.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/compose-artifact-preview-comment.sh
+
+load "../../../helpers/common"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/compose-artifact-preview-comment.sh"
+
+setup() {
+	setup_temp_dir
+	export COMMENT_OUTPUT="${BATS_TEST_TMPDIR}/comment.md"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "compose-artifact-preview: renders download link with artifact name" {
+	run env \
+		ARTIFACT_NAME="site-preview" \
+		ARTIFACT_URL="https://github.com/o/r/actions/runs/1/artifacts/2" \
+		COMMENT_OUTPUT="$COMMENT_OUTPUT" \
+		bash "$SCRIPT"
+
+	assert_success
+	assert_file_contains_literal "$COMMENT_OUTPUT" "Download site-preview"
+	assert_file_contains_literal "$COMMENT_OUTPUT" \
+		"https://github.com/o/r/actions/runs/1/artifacts/2"
+	assert_file_contains_literal "$COMMENT_OUTPUT" "⬇"
+}
+
+@test "compose-artifact-preview: documents login-required zip constraint" {
+	run env \
+		ARTIFACT_NAME="site-preview" \
+		ARTIFACT_URL="https://github.com/o/r/actions/runs/1/artifacts/2" \
+		COMMENT_OUTPUT="$COMMENT_OUTPUT" \
+		bash "$SCRIPT"
+
+	assert_success
+	assert_file_contains_literal "$COMMENT_OUTPUT" "signed in to GitHub"
+	assert_file_contains_literal "$COMMENT_OUTPUT" ".zip"
+}
+
+@test "compose-artifact-preview: prepends inline summary" {
+	run env \
+		ARTIFACT_NAME="bundle" \
+		ARTIFACT_URL="https://example/artifacts/9" \
+		SUMMARY="Built 42 pages in 3s" \
+		COMMENT_OUTPUT="$COMMENT_OUTPUT" \
+		bash "$SCRIPT"
+
+	assert_success
+	assert_file_contains_literal "$COMMENT_OUTPUT" "Built 42 pages in 3s"
+	assert_file_contains_literal "$COMMENT_OUTPUT" "Download bundle"
+}
+
+@test "compose-artifact-preview: summary-file takes precedence over inline summary" {
+	local summary_file="${BATS_TEST_TMPDIR}/summary.md"
+	printf '## Site build\nfrom file\n' >"$summary_file"
+
+	run env \
+		ARTIFACT_NAME="bundle" \
+		ARTIFACT_URL="https://example/artifacts/9" \
+		SUMMARY="inline should be ignored" \
+		SUMMARY_FILE="$summary_file" \
+		COMMENT_OUTPUT="$COMMENT_OUTPUT" \
+		bash "$SCRIPT"
+
+	assert_success
+	assert_file_contains_literal "$COMMENT_OUTPUT" "from file"
+	run grep -F "inline should be ignored" "$COMMENT_OUTPUT"
+	assert_failure
+}
+
+@test "compose-artifact-preview: falls back to inline summary when file missing" {
+	run env \
+		ARTIFACT_NAME="bundle" \
+		ARTIFACT_URL="https://example/artifacts/9" \
+		SUMMARY="inline fallback" \
+		SUMMARY_FILE="${BATS_TEST_TMPDIR}/does-not-exist.md" \
+		COMMENT_OUTPUT="$COMMENT_OUTPUT" \
+		bash "$SCRIPT"
+
+	assert_success
+	assert_file_contains_literal "$COMMENT_OUTPUT" "inline fallback"
+}
+
+@test "compose-artifact-preview: empty artifact-url warns and writes empty body" {
+	run env \
+		ARTIFACT_NAME="bundle" \
+		ARTIFACT_URL="" \
+		COMMENT_OUTPUT="$COMMENT_OUTPUT" \
+		bash "$SCRIPT"
+
+	assert_success
+	assert_output --partial "::warning::"
+	assert_file_exists "$COMMENT_OUTPUT"
+	[[ ! -s "$COMMENT_OUTPUT" ]]
+}
+
+@test "compose-artifact-preview: missing artifact-name with url errors" {
+	run env \
+		ARTIFACT_NAME="" \
+		ARTIFACT_URL="https://example/artifacts/9" \
+		COMMENT_OUTPUT="$COMMENT_OUTPUT" \
+		bash "$SCRIPT"
+
+	assert_failure
+	assert_output --partial "::error::"
+}
+
+@test "compose-artifact-preview: prints to stdout when COMMENT_OUTPUT unset" {
+	run env -u COMMENT_OUTPUT \
+		ARTIFACT_NAME="site" \
+		ARTIFACT_URL="https://example/artifacts/9" \
+		bash "$SCRIPT"
+
+	assert_success
+	assert_output --partial "Download site"
+}


### PR DESCRIPTION
Closes #405

Adds a new reusable workflow `reusable-publish-artifact-preview.yml` that posts (or updates) a **sticky PR comment with a direct download link to a named build artifact**, optionally prefixed with a build summary. Gives artifact-producing PRs the same one-comment, update-in-place UX as the quality/test summaries.

### What it does
- Composes a comment: optional summary + a `⬇ **[Download <artifact-name>](<artifact-url>)**` link.
- Link is the `actions/upload-artifact` v4 `artifact-url` output.
- Reuses `.github/actions/post-pr-comment` for marker upsert (re-runs update in place, no duplicates).
- Graceful degrade: empty/missing `artifact-url` emits a warning and `delete-on-empty` removes any stale comment instead of posting a broken link. Fork PRs are skipped by the shared action.
- Honestly documents the constraint: the link downloads a **`.zip`** and requires the viewer to be signed in to GitHub with repo access — reviewer convenience, not a public preview URL.

### Interface
Inputs: `artifact-name` (req), `artifact-url` (req), `marker` (req), `summary` (opt), `summary-file` (opt), plus the standard #393 contract inputs (`tooling-ref`, `egress-policy`, `egress-preset` default `github-minimal`, `allowed-endpoints`, `allowed-endpoints-mode`, `runner-image`, `timeout-minutes`, `job-name`). Job permissions: `contents: read`, `pull-requests: write`.

Body composition lives in `scripts/ci/actions/compose-artifact-preview-comment.sh` (env-only, no untrusted interpolation).

### Tests
- BATS unit tests for the compose script (`test_compose_artifact_preview_comment.bats`).
- Integration contract test (`test_reusable_publish_artifact_preview.bats`) asserting the workflow passes `validate-runner-contract`, `validate-tooling-sparse-checkout`, and `validate-static-job-names`.
- `uv run lintro chk` clean; full `bats` suite green (except the known local `run-rust-coverage-html` cargo-llvm-cov PATH flake).

Unblocks lgtm-hq/homebrew-tap#84 (`pages.yml` needs a download link for its generated GitHub Pages landing site preview).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a reusable workflow for artifact download preview comments. The main changes are:

- A new workflow that posts or updates a sticky PR comment with an artifact download link.
- A compose script for optional summaries and graceful empty-link handling.
- Documentation for usage, inputs, and GitHub download constraints.
- BATS coverage for the workflow contract and comment rendering behavior.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-publish-artifact-preview.yml | Adds the reusable workflow that composes and publishes the artifact preview comment. |
| scripts/ci/actions/compose-artifact-preview-comment.sh | Adds markdown body composition for artifact links, optional summaries, and empty URL handling. |
| docs/reusable-workflows.md | Documents the artifact preview workflow, example usage, inputs, and download constraints. |
| tests/bats/integration/test_reusable_publish_artifact_preview.bats | Adds contract tests for the reusable workflow configuration. |
| tests/bats/unit/actions/test_compose_artifact_preview_comment.bats | Adds unit tests for artifact comment rendering and fallback behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(workflows): add reusable-publish-ar..."](https://github.com/lgtm-hq/lgtm-ci/commit/b98a63c19564bc7160c6ab7545856c30c38dc3ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41955607)</sub>

<!-- /greptile_comment -->