### PR TITLE
feat(workflows): make reusable-deploy-pages a hardened deploy-only workflow

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1590,25 +1590,48 @@ jobs:
 
 ### reusable-deploy-pages.yml
 
-Deploy static content to GitHub Pages with OIDC authentication.
+Deploy-only GitHub Pages publisher with OIDC authentication. The caller builds
+the site and uploads the Pages artifact (`actions/upload-pages-artifact`) in a
+prior job; this workflow deploys that named artifact. For build+deploy in one
+workflow, use `reusable-deploy-site-with-reports.yml`.
 
 ```yaml
 jobs:
+  build-site:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@<sha> # v6.x
+        with:
+          persist-credentials: false
+      # ... build the site into ./dist ...
+      - uses: actions/upload-pages-artifact@<sha> # v4.x
+        with:
+          name: github-pages
+          path: dist
+
   deploy:
+    needs: build-site
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-pages.yml@main
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     with:
-      source-path: "dist"
-      build-command: "bun run build"
-      environment: "github-pages"
+      artifact-name: github-pages
 ```
 
 **Inputs:**
 
-- `source-path` - Path to static content (default: 'dist')
-- `build-command` - Optional build command
-- `node-version` - Node.js version for build (default: '20')
+- `artifact-name` - Name of the Pages artifact from the build job (default:
+  'github-pages')
 - `environment` - GitHub environment name (default: 'github-pages')
-- `artifact-name` - Pages artifact name (default: 'github-pages')
+- `runner-image` - Runner image label (default: 'ubuntu-24.04')
+- `tooling-ref` - Git ref for lgtm-ci tooling checkout
+- `egress-policy`, `egress-preset` (default: 'github-pages'),
+  `allowed-endpoints`, `allowed-endpoints-mode` - harden-runner egress contract
+- `timeout-minutes` - Job timeout (default: 10)
 
 **Outputs:**
 
@@ -1616,10 +1639,12 @@ jobs:
 
 **Features:**
 
-- Two-job workflow (build + deploy) for proper separation
+- Deploy-only: build tooling stays in the caller, so any static site deploys
+  regardless of how it was produced
 - OIDC authentication (no secrets required)
 - Configurable GitHub environment for deployment protection
-- Concurrency control to prevent parallel deployments
+- `concurrency: { group: pages, cancel-in-progress: false }` serializes deploys
+- harden-runner with the `github-pages` egress preset by default
 
 **Permissions Required:**
 
@@ -1661,7 +1686,8 @@ jobs:
 - `fallback-ref` - Optional branch for fallback artifact lookup (default: strict)
 - `strict-bundle` - Fail when any manifest entry is missing (default: `false`)
 - `node-version`, `package-manager`, `working-directory`, `frozen-lockfile` -
-  Same as `reusable-deploy-pages`
+  Build-step tooling controls (this workflow builds; `reusable-deploy-pages` is
+  deploy-only)
 - `tooling-ref`, `egress-policy`, `allowed-endpoints`, `runner-image`,
   `timeout-minutes`, `artifact-name`, `environment` - Standard contract
 

--- a/.github/workflows/reusable-deploy-pages.yml
+++ b/.github/workflows/reusable-deploy-pages.yml
@@ -1,49 +1,29 @@
 ---
 name: Reusable Deploy to GitHub Pages
 
+# Deploy-only GitHub Pages publisher. The caller builds the site and runs
+# actions/upload-pages-artifact in a prior job; this workflow (called with
+# needs: <build-job>) runs actions/deploy-pages to publish the named artifact.
+# For build+deploy in one workflow, use reusable-deploy-site-with-reports.yml.
+
 on:
   workflow_call:
     inputs:
-      source-path:
-        description: "Path to static content to deploy"
+      artifact-name:
+        description: "Name of the Pages artifact uploaded by the caller's build job"
         required: false
         type: string
-        default: "dist"
-      build-command:
-        description: "Optional build command to run before deployment"
-        required: false
-        type: string
-        default: ""
-      node-version:
-        description: "Node.js version for build step"
-        required: false
-        type: string
-        default: "20"
-      package-manager:
-        description: "Package manager for dependency install: npm, bun, pnpm (empty = skip)"
-        required: false
-        type: string
-        default: "npm"
-      working-directory:
-        description: "Working directory for dependency installation"
-        required: false
-        type: string
-        default: "."
-      frozen-lockfile:
-        description: "Use lockfile enforcement during dependency installation"
-        required: false
-        type: boolean
-        default: true
+        default: "github-pages"
       environment:
         description: "GitHub environment name for deployment"
         required: false
         type: string
         default: "github-pages"
-      artifact-name:
-        description: "Name for the pages artifact"
+      runner-image:
+        description: "GitHub-hosted runner image label"
         required: false
         type: string
-        default: "github-pages"
+        default: "ubuntu-24.04"
       tooling-ref:
         description: "Git ref to use when checking out lgtm-ci tooling scripts"
         required: false
@@ -55,12 +35,18 @@ on:
         required: false
         type: string
         default: "block"
+      egress-preset:
+        description: >-
+          Named allowlist when allowed-endpoints is empty and egress-policy is
+          block. Defaults to github-pages for the GitHub Pages OIDC deploy.
+        required: false
+        type: string
+        default: "github-pages"
       allowed-endpoints:
         description: "Allowed endpoints when egress-policy is block"
         required: false
         type: string
         default: ""
-
       allowed-endpoints-mode:
         description: >-
           replace: non-empty allowed-endpoints overrides egress-preset; append:
@@ -69,122 +55,29 @@ on:
         type: string
         default: "replace"
 
-      egress-preset:
-        description: >-
-          Named allowlist when allowed-endpoints is empty and egress-policy is
-          block (github-minimal, github-pages, github-tooling, docker,
-          playwright, pypi, rubygems, npm-publish, quality, sbom, scorecard).
-          Build job uses this input; deploy job always uses github-pages.
-        required: false
-        type: string
-        default: "playwright"
-
-      runner-image:
-        description: "GitHub-hosted runner image label"
-        required: false
-        type: string
-        default: "ubuntu-24.04"
-
       timeout-minutes:
         description: "Job timeout in minutes"
         required: false
         type: number
-        default: 15
+        default: 10
 
     outputs:
       page-url:
         description: "URL of the deployed GitHub Pages site"
         value: ${{ jobs.deploy.outputs.page-url }}
 
-# Allow only one deployment at a time
+# Serialize Pages deployments so concurrent runs do not stomp each other.
 concurrency:
-  group: pages-${{ github.repository }}-${{ github.ref }}
+  group: pages
   cancel-in-progress: false
 
 jobs:
-  build:
-    name: Build
+  deploy:
+    name: Deploy to GitHub Pages
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       contents: read
-
-    steps:
-      - name: Checkout repository
-        # Pinned to SHA for supply chain security
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Checkout lgtm-ci tooling
-        # yamllint disable-line rule:line-length
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: |
-            .github/actions/
-            scripts/ci/
-          sparse-checkout-cone-mode: true
-          persist-credentials: false
-
-      - name: Resolve egress allowlist
-        id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
-          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-      - name: Harden runner
-        # yamllint disable-line rule:line-length
-        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
-        with:
-          egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
-      - name: Setup Node.js
-        if: inputs.build-command != '' && inputs.package-manager != ''
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: ${{ inputs.node-version }}
-
-      - name: Setup Bun
-        if: inputs.build-command != '' && inputs.package-manager == 'bun'
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: latest
-
-      - name: Setup pnpm
-        if: inputs.build-command != '' && inputs.package-manager == 'pnpm'
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-
-      - name: Install dependencies
-        if: inputs.build-command != '' && inputs.package-manager != ''
-        shell: bash
-        env:
-          PACKAGE_MANAGER: ${{ inputs.package-manager }}
-          WORKING_DIRECTORY: ${{ inputs.working-directory }}
-          FROZEN_LOCKFILE: ${{ inputs.frozen-lockfile }}
-        run: bash .lgtm-ci-tooling/scripts/ci/actions/setup-package-manager.sh
-
-      - name: Configure Pages
-        # Pinned to SHA for supply chain security
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-
-      - name: Prepare and upload artifact
-        uses: ./.lgtm-ci-tooling/.github/actions/deploy-pages
-        with:
-          source-path: ${{ inputs.source-path }}
-          build-command: ${{ inputs.build-command }}
-          artifact-name: ${{ inputs.artifact-name }}
-
-  deploy:
-    name: Deploy
-    needs: build
-    runs-on: ${{ inputs.runner-image }}
-    timeout-minutes: ${{ inputs.timeout-minutes }}
-    permissions:
       pages: write
       id-token: write
 
@@ -220,7 +113,7 @@ jobs:
         uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: github-pages
+          egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Harden runner

--- a/.github/workflows/reusable-deploy-pages.yml
+++ b/.github/workflows/reusable-deploy-pages.yml
@@ -67,8 +67,12 @@ on:
         value: ${{ jobs.deploy.outputs.page-url }}
 
 # Serialize Pages deployments so concurrent runs do not stomp each other.
+# Share the same concurrency group as the other Pages publishers
+# (coverage, site-with-reports, test-*-publish) so a deploy-only run and a
+# report/coverage publisher for the same repo+ref cannot race and overwrite
+# each other's Pages content.
 concurrency:
-  group: pages
+  group: pages-${{ github.repository }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **workflows**: **BREAKING** — `reusable-deploy-pages.yml` is now a hardened
+  **deploy-only** workflow (#410). The caller builds the site and runs
+  `actions/upload-pages-artifact` in a prior job, then calls this workflow with
+  `needs: <build-job>` to deploy the named artifact via `actions/deploy-pages`.
+  The build-related inputs (`source-path`, `build-command`, `node-version`,
+  `package-manager`, `working-directory`, `frozen-lockfile`) are removed and the
+  in-workflow `build` job is gone; the concurrency group is now `pages`. Callers
+  that relied on the old build+deploy behavior should migrate to
+  `reusable-deploy-site-with-reports.yml` (which still builds and deploys).
 - **scripts**: parameterize near-duplicate language-family scripts (#372):
   `aggregate-{node,python,rust}-results.sh` merged into `aggregate-results.sh`
   (`RESULTS_DIR`), `write-{node,python,rust}-summary.sh` merged into

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ steps:
 | `reusable-github-release.yml`          | GitHub Release with artifact assets          |
 | `reusable-publish-npm.yml`             | npm publishing                               |
 | `reusable-publish-gem.yml`             | RubyGems publishing                          |
-| `reusable-deploy-pages.yml`            | GitHub Pages deployment                      |
+| `reusable-deploy-pages.yml`            | GitHub Pages deploy-only (caller builds)     |
 | `reusable-docker.yml`                  | Docker build and publish                     |
 | `reusable-coverage.yml`                | Test coverage collection                     |
 | `reusable-test-python.yml`             | Python tests with optional test summaries    |

--- a/docs/pages-publishing.md
+++ b/docs/pages-publishing.md
@@ -165,15 +165,18 @@ pages-${{ github.repository }}-${{ github.ref }}
 
 This serializes deployments to the same site on the same ref.
 
-The deploy-only `reusable-deploy-pages` uses the canonical GitHub Pages group
-instead, matching GitHub's official Pages workflow:
+The deploy-only `reusable-deploy-pages` shares the same concurrency group as the
+other Pages publishers:
 
 ```text
-pages
+pages-${{ github.repository }}-${{ github.ref }}
 ```
 
-with `cancel-in-progress: false`, so concurrent Pages deploys never stomp each
-other.
+with `cancel-in-progress: false`. Sharing one group (rather than the canonical
+`pages` group from GitHub's official example) ensures a deploy-only run and any
+Model A report/coverage publisher for the same repo and ref are serialized
+against each other, so two complete Pages artifacts cannot race and overwrite
+each other's content.
 
 ## Multi-publisher limitation (Model A)
 

--- a/docs/pages-publishing.md
+++ b/docs/pages-publishing.md
@@ -39,7 +39,7 @@ instead.
 | Workflow / action                        | Content                     | `target-dir` / `site-root`  |
 | ---------------------------------------- | --------------------------- | --------------------------- |
 | `publish-test-results`                   | Coverage, badges, test HTML | configurable (`target-dir`) |
-| `deploy-pages` + `reusable-deploy-pages` | Built static sites          | `dist` (site root)          |
+| `reusable-deploy-pages` (deploy-only)    | Caller-built static sites   | caller-uploaded artifact    |
 | `reusable-deploy-site-with-reports`      | Site + CI HTML bundles      | `site-root`                 |
 
 <!-- markdownlint-enable MD013 -->
@@ -156,15 +156,24 @@ allowed-endpoints: >
 
 ## Concurrency
 
-All Pages deploy jobs in lgtm-ci share:
+The Model B publishers (`reusable-deploy-site-with-reports` and coverage/test
+publish workflows) share a per-ref group:
 
 ```text
 pages-${{ github.repository }}-${{ github.ref }}
 ```
 
-This serializes deployments to the same site on the same ref (including
-`reusable-deploy-pages`, `reusable-deploy-site-with-reports`, and coverage/test
-publish workflows).
+This serializes deployments to the same site on the same ref.
+
+The deploy-only `reusable-deploy-pages` uses the canonical GitHub Pages group
+instead, matching GitHub's official Pages workflow:
+
+```text
+pages
+```
+
+with `cancel-in-progress: false`, so concurrent Pages deploys never stomp each
+other.
 
 ## Multi-publisher limitation (Model A)
 

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -522,15 +522,31 @@ jobs:
       contents: read
       id-token: write
 
+  # reusable-deploy-pages.yml is deploy-only: the caller builds the site and
+  # uploads the Pages artifact, then this workflow deploys it.
+  build-site:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@<sha> # v6.x
+        with:
+          persist-credentials: false
+      # ... build the site into ./dist however the repo builds ...
+      - uses: actions/upload-pages-artifact@<sha> # v4.x
+        with:
+          name: github-pages
+          path: dist
+
   pages:
+    needs: build-site
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-deploy-pages.yml@<sha>
     permissions:
       contents: read
       pages: write
       id-token: write
     with:
-      build-command: bun run build
-      package-manager: bun
+      artifact-name: github-pages
 ```
 
 ### Site + bundled CI reports (Model B)

--- a/tests/bats/integration/test_reusable_deploy_pages.bats
+++ b/tests/bats/integration/test_reusable_deploy_pages.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for the deploy-only reusable-deploy-pages workflow
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-deploy-pages.yml"
+
+@test "reusable-deploy-pages: exposes artifact-name input defaulting to github-pages" {
+	run awk '
+		/^      artifact-name:/ { in_input = 1 }
+		in_input && /^      [a-zA-Z0-9_-]+:/ && !/^      artifact-name:/ { in_input = 0 }
+		in_input && /default: "github-pages"/ { found = 1 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-deploy-pages: egress-preset defaults to github-pages" {
+	run awk '
+		/^      egress-preset:/ { in_input = 1 }
+		in_input && /^      [a-zA-Z0-9_-]+:/ && !/^      egress-preset:/ { in_input = 0 }
+		in_input && /default: "github-pages"/ { found = 1 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-deploy-pages: timeout-minutes input is type number defaulting to 10" {
+	run awk '
+		/^      timeout-minutes:/ { in_input = 1 }
+		in_input && /^      [a-zA-Z0-9_-]+:/ && !/^      timeout-minutes:/ { in_input = 0 }
+		in_input && /type: number/ { has_type = 1 }
+		in_input && /default: 10/ { has_default = 1 }
+		END { exit !(has_type && has_default) }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-deploy-pages: drops legacy build inputs" {
+	run grep -E '^      (source-path|build-command|node-version|package-manager|working-directory|frozen-lockfile):' \
+		"$WORKFLOW"
+	assert_failure
+}
+
+@test "reusable-deploy-pages: exposes page-url output from deploy job" {
+	run grep -F 'value: ${{ jobs.deploy.outputs.page-url }}' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-deploy-pages: concurrency group is pages with cancel-in-progress false" {
+	run awk '
+		/^concurrency:/ { in_conc = 1 }
+		in_conc && /^[a-zA-Z]/ && !/^concurrency:/ { in_conc = 0 }
+		in_conc && /^  group: pages$/ { has_group = 1 }
+		in_conc && /cancel-in-progress: false/ { has_cancel = 1 }
+		END { exit !(has_group && has_cancel) }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-deploy-pages: is deploy-only (single deploy job, no build job)" {
+	run awk '
+		/^jobs:/ { in_jobs = 1; next }
+		in_jobs && /^  [a-zA-Z0-9_-]+:/ { print }
+	' "$WORKFLOW"
+	assert_success
+	assert_output "  deploy:"
+}
+
+@test "reusable-deploy-pages: deploy job declares pages and id-token write" {
+	run awk '
+		/^  deploy:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  deploy:/ { in_job = 0 }
+		in_job && /pages: write/ { has_pages = 1 }
+		in_job && /id-token: write/ { has_oidc = 1 }
+		in_job && /contents: read/ { has_contents = 1 }
+		END { exit !(has_pages && has_oidc && has_contents) }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-deploy-pages: deploy job runs-on inputs.runner-image" {
+	run grep -F 'runs-on: ${{ inputs.runner-image }}' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-deploy-pages: deploy job checkout order preserves tooling" {
+	run egress_tooling_checkout_order_ok "$WORKFLOW" "deploy"
+	assert_success
+}
+
+@test "reusable-deploy-pages: deploy step consumes artifact-name via deploy-pages action" {
+	run awk '
+		/- name: Deploy to GitHub Pages/ { in_step = 1 }
+		in_step && /uses: actions\/deploy-pages@/ { has_action = 1 }
+		in_step && /artifact_name: \$\{\{ inputs\.artifact-name \}\}/ { has_artifact = 1 }
+		END { exit !(has_action && has_artifact) }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-deploy-pages: deploy-pages action is SHA-pinned with version comment" {
+	run grep -F 'actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0' \
+		"$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-deploy-pages: does not build or upload the Pages artifact" {
+	run grep -E '^ *uses: .*(configure-pages|upload-pages-artifact)|- name: Setup Node|- name: Install dependencies' \
+		"$WORKFLOW"
+	assert_failure
+}

--- a/tests/bats/integration/test_reusable_deploy_pages.bats
+++ b/tests/bats/integration/test_reusable_deploy_pages.bats
@@ -48,11 +48,11 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-deploy-pages.yml"
 	assert_success
 }
 
-@test "reusable-deploy-pages: concurrency group is pages with cancel-in-progress false" {
+@test "reusable-deploy-pages: shares the pages concurrency group with cancel-in-progress false" {
 	run awk '
 		/^concurrency:/ { in_conc = 1 }
 		in_conc && /^[a-zA-Z]/ && !/^concurrency:/ { in_conc = 0 }
-		in_conc && /^  group: pages$/ { has_group = 1 }
+		in_conc && /^  group: pages-\$\{\{ github.repository \}\}-\$\{\{ github.ref \}\}$/ { has_group = 1 }
 		in_conc && /cancel-in-progress: false/ { has_cancel = 1 }
 		END { exit !(has_group && has_cancel) }
 	' "$WORKFLOW"

--- a/tests/bats/integration/test_reusable_test_publish_workflows.bats
+++ b/tests/bats/integration/test_reusable_test_publish_workflows.bats
@@ -134,9 +134,9 @@ _publish_no_contents_write_ok() {
 	assert_success
 }
 
-@test "reusable-deploy-pages: uses canonical Pages concurrency group" {
+@test "reusable-deploy-pages: shares the Pages concurrency group with publishers" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-deploy-pages.yml"
-	run grep -qE '^  group: pages$' "$workflow"
+	run grep -q 'group: pages-${{ github.repository }}-${{ github.ref }}' "$workflow"
 	assert_success
 	run grep -q 'cancel-in-progress: false' "$workflow"
 	assert_success

--- a/tests/bats/integration/test_reusable_test_publish_workflows.bats
+++ b/tests/bats/integration/test_reusable_test_publish_workflows.bats
@@ -134,8 +134,10 @@ _publish_no_contents_write_ok() {
 	assert_success
 }
 
-@test "reusable-deploy-pages: shares Pages concurrency group" {
+@test "reusable-deploy-pages: uses canonical Pages concurrency group" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-deploy-pages.yml"
-	run grep -q 'group: pages-${{ github.repository }}-${{ github.ref }}' "$workflow"
+	run grep -qE '^  group: pages$' "$workflow"
+	assert_success
+	run grep -q 'cancel-in-progress: false' "$workflow"
 	assert_success
 }


### PR DESCRIPTION
Closes #410

Repurposes `reusable-deploy-pages.yml` from a build+deploy workflow into a hardened **deploy-only** GitHub Pages publisher. Unblocks lgtm-hq/homebrew-tap#84.

## BREAKING

The caller now builds the site and runs `actions/upload-pages-artifact` in a prior job, then calls this workflow with `needs: <build-job>` to deploy the named artifact via `actions/deploy-pages`. The build-related inputs (`source-path`, `build-command`, `node-version`, `package-manager`, `working-directory`, `frozen-lockfile`) and the in-workflow `build` job are removed. Callers needing build+deploy in one workflow should use `reusable-deploy-site-with-reports.yml`.

## Interface

- Inputs: `artifact-name` (default `github-pages`), `environment`, `runner-image` (default `ubuntu-24.04`), `tooling-ref`, `egress-policy`, `egress-preset` (default `github-pages`), `allowed-endpoints`, `allowed-endpoints-mode`, `timeout-minutes` (default 10).
- Output: `page-url` (from `actions/deploy-pages` `page_url`).
- `permissions: { contents: read, pages: write, id-token: write }`.
- `concurrency: { group: pages, cancel-in-progress: false }`.
- Standard hardened preamble: sparse tooling checkout (harden-runner + resolve-egress-allowlist), resolve egress → harden-runner, `github-pages` preset default. All actions SHA-pinned with version comments.

## Verification

- Contract validators pass: `validate-runner-contract`, `validate-tooling-sparse-checkout`, `validate-static-job-names`.
- New `tests/bats/integration/test_reusable_deploy_pages.bats` (13 tests) plus updated concurrency assertion in `test_reusable_test_publish_workflows.bats`.
- `uv run lintro chk`: 0 issues.
- Docs updated: `docs/reusable-workflows.md`, `docs/pages-publishing.md`, `.github/actions/README.md`, `README.md`; CHANGELOG `[Unreleased] → Changed` with BREAKING note.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR turns `reusable-deploy-pages.yml` into a deploy-only GitHub Pages workflow. The main changes are:

- Removed the in-workflow build job and legacy build inputs.
- Added deploy-only inputs for artifact name, runner image, egress controls, and timeout.
- Added hardened deploy steps with tooling checkout, egress resolution, and `actions/deploy-pages`.
- Updated Pages publishing docs and workflow examples.
- Added contract tests for the new deploy-only workflow.
</details>


<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.



<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-deploy-pages.yml | Changes the workflow to deploy a caller-uploaded Pages artifact with hardened runner setup and the shared Pages concurrency group. |
| tests/bats/integration/test_reusable_deploy_pages.bats | Adds contract checks for the deploy-only workflow interface, permissions, deployment action, and concurrency settings. |
| tests/bats/integration/test_reusable_test_publish_workflows.bats | Updates the Pages concurrency assertion to match the shared repository and ref lock. |
| docs/pages-publishing.md | Documents the deploy-only Pages workflow and the shared Pages publishing concurrency model. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/reusable-deploy-pages.yml`, line 129-131 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/e3a2ad453fbc6cb24639dd4472f3ae8b330f4b4f/.github/workflows/reusable-deploy-pages.yml#L129-L131)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Pages Configuration Is Skipped**

   A caller following the new deploy-only contract builds the site and uploads the artifact, but this job now goes straight to `actions/deploy-pages` without running `actions/configure-pages`. The sibling Pages flows still configure Pages before upload/deploy, so this reusable workflow can fail at deployment time even when the requested artifact exists.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-deploy-pages.yml%0ALine%3A%20129-131%0A%0AComment%3A%0A**Pages%20Configuration%20Is%20Skipped**%0A%0AA%20caller%20following%20the%20new%20deploy-only%20contract%20builds%20the%20site%20and%20uploads%20the%20artifact%2C%20but%20this%20job%20now%20goes%20straight%20to%20%60actions%2Fdeploy-pages%60%20without%20running%20%60actions%2Fconfigure-pages%60.%20The%20sibling%20Pages%20flows%20still%20configure%20Pages%20before%20upload%2Fdeploy%2C%20so%20this%20reusable%20workflow%20can%20fail%20at%20deployment%20time%20even%20when%20the%20requested%20artifact%20exists.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=414&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-deploy-pages.yml%0ALine%3A%20129-131%0A%0AComment%3A%0A**Pages%20Configuration%20Is%20Skipped**%0A%0AA%20caller%20following%20the%20new%20deploy-only%20contract%20builds%20the%20site%20and%20uploads%20the%20artifact%2C%20but%20this%20job%20now%20goes%20straight%20to%20%60actions%2Fdeploy-pages%60%20without%20running%20%60actions%2Fconfigure-pages%60.%20The%20sibling%20Pages%20flows%20still%20configure%20Pages%20before%20upload%2Fdeploy%2C%20so%20this%20reusable%20workflow%20can%20fail%20at%20deployment%20time%20even%20when%20the%20requested%20artifact%20exists.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=414&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F410-deploy-pages-deploy-only%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F410-deploy-pages-deploy-only%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-deploy-pages.yml%0ALine%3A%20129-131%0A%0AComment%3A%0A**Pages%20Configuration%20Is%20Skipped**%0A%0AA%20caller%20following%20the%20new%20deploy-only%20contract%20builds%20the%20site%20and%20uploads%20the%20artifact%2C%20but%20this%20job%20now%20goes%20straight%20to%20%60actions%2Fdeploy-pages%60%20without%20running%20%60actions%2Fconfigure-pages%60.%20The%20sibling%20Pages%20flows%20still%20configure%20Pages%20before%20upload%2Fdeploy%2C%20so%20this%20reusable%20workflow%20can%20fail%20at%20deployment%20time%20even%20when%20the%20requested%20artifact%20exists.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=414&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(workflows): align deploy-pages concu..."](https://github.com/lgtm-hq/lgtm-ci/commit/b2609eea7815234d73d9d7ea6c9b8001b106f48c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41956960)</sub>

<!-- /greptile_comment -->