### PR TITLE
feat(workflows): add reusable-ai-review for org-wide AI code review

### DIFF
--- a/.github/actions/harden-runner/lib/egress/presets.sh
+++ b/.github/actions/harden-runner/lib/egress/presets.sh
@@ -202,6 +202,20 @@ egress_preset_endpoints() {
 			api.osv.dev:443 \
 			api.deps.dev:443
 		;;
+	ai-review)
+		# AI code review (reusable-ai-review.yml): GitHub checkout/tooling + gh PR
+		# diff API, uv/PyPI install of pinned lintro[ai], and the Anthropic API.
+		# raw.githubusercontent.com is required (astral setup-uv/self-checks fetch
+		# from it — its omission previously broke py-lintro's dogfood workflow).
+		egress_preset_endpoints github-tooling
+		printf '%s\n' \
+			release-assets.githubusercontent.com:443 \
+			pypi.org:443 \
+			files.pythonhosted.org:443 \
+			astral.sh:443 \
+			releases.astral.sh:443 \
+			api.anthropic.com:443
+		;;
 	rust-release)
 		# Rust cross-compile release builds (reusable-build-rust-binaries.yml).
 		# Minimal base: GitHub checkout/tooling, Rust/crates, cross Docker, apt, Sigstore.

--- a/.github/actions/resolve-egress-allowlist/action.yml
+++ b/.github/actions/resolve-egress-allowlist/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: >-
       Named baseline allowlist for block policy (github-minimal, github-pages,
       github-tooling, docker, playwright, pypi, rubygems, npm-publish, quality,
-      osv-scanner, rust-release, sbom, scorecard)
+      osv-scanner, rust-release, sbom, scorecard, ai-review)
     required: false
     default: ""
   allowed-endpoints:

--- a/.github/workflows/reusable-ai-review.yml
+++ b/.github/workflows/reusable-ai-review.yml
@@ -207,7 +207,8 @@ jobs:
         id: fetch-state
         if: >-
           inputs.post &&
-          steps.preflight.outputs.skip-reason != 'not-a-pr'
+          steps.preflight.outputs.skip-reason != 'not-a-pr' &&
+          steps.preflight.outputs.skip-reason != 'fork'
         shell: bash
         env:
           STEP: fetch-state
@@ -221,7 +222,8 @@ jobs:
         id: render
         if: >-
           inputs.post &&
-          steps.preflight.outputs.skip-reason != 'not-a-pr'
+          steps.preflight.outputs.skip-reason != 'not-a-pr' &&
+          steps.preflight.outputs.skip-reason != 'fork'
         shell: bash
         env:
           STEP: render
@@ -236,7 +238,8 @@ jobs:
       - name: Post sticky review comment
         if: >-
           inputs.post &&
-          steps.preflight.outputs.skip-reason != 'not-a-pr'
+          steps.preflight.outputs.skip-reason != 'not-a-pr' &&
+          steps.preflight.outputs.skip-reason != 'fork'
         uses: ./.lgtm-ci-tooling/.github/actions/post-pr-comment
         with:
           file: ${{ runner.temp }}/ai-review-comment.md

--- a/.github/workflows/reusable-ai-review.yml
+++ b/.github/workflows/reusable-ai-review.yml
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+---
+name: Reusable AI Review
+
+# Org-wide AI code review. Installs a pinned lintro[ai] from PyPI, runs
+# `lintro review` hardened in CI, and publishes a single sticky, telemetry-rich
+# PR comment (updated in place; cumulative state embedded in an HTML comment).
+#
+# Trusted-install invariant (security): the job only installs a *pinned lintro
+# from PyPI* and runs `lintro review`, which reads the PR diff via the GitHub API
+# and calls the model. It never installs or executes the PR's own code (no
+# `uv sync`, no `pip install .`, no build hooks), so ANTHROPIC_API_KEY is scoped
+# to the single "Run AI review" step and is never in scope while PR-controlled
+# code could execute. The job is non-blocking (continue-on-error) and skips
+# gracefully on fork PRs, when no key is present, and off same-repo PRs.
+#
+# Org secret rollout: lgtm-hq provisions ANTHROPIC_API_KEY as an org-wide
+# secret, so callers just forward it (or `secrets: inherit`) with zero per-repo
+# setup. The missing-key skip path is the fork/safety-net case, not the norm.
+
+on:
+  workflow_call:
+    inputs:
+      depth:
+        description: "Review depth (1=checklist, 2=+questions, 3=+adversarial)"
+        required: false
+        type: number
+        default: 1
+      post:
+        description: "Post/update the sticky PR comment"
+        required: false
+        type: boolean
+        default: true
+      max-cost-usd:
+        description: "Advisory per-run cost cap in USD (annotated when exceeded)"
+        required: false
+        type: string
+        default: "0.50"
+      paths:
+        description: >-
+          Optional path prefixes to limit the review to (newline/comma/space
+          separated). Empty reviews the whole diff.
+        required: false
+        type: string
+        default: ""
+      lintro-version:
+        description: "Pinned lintro PyPI version (Renovate-managed centrally)"
+        required: false
+        type: string
+        # renovate: datasource=pypi depName=lintro
+        default: "0.65.0" # v0.65.0
+      strictness:
+        description: "Review sensitivity: focused | balanced | thorough"
+        required: false
+        type: string
+        default: "balanced"
+      model:
+        description: >-
+          Optional model override passed through to lintro (no default; lintro
+          uses its own configured default when empty)
+        required: false
+        type: string
+        default: ""
+
+      # --- Standard reusable contract inputs -------------------------------
+      tooling-ref:
+        description: "Git ref for lgtm-ci tooling checkout"
+        required: false
+        type: string
+        default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "block"
+      egress-preset:
+        description: >-
+          Named allowlist when allowed-endpoints is empty and egress-policy is
+          block (defaults to ai-review)
+        required: false
+        type: string
+        default: "ai-review"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 15
+      job-name:
+        description: "GitHub check name"
+        required: false
+        type: string
+        default: "AI Review"
+    secrets:
+      anthropic-api-key:
+        description: >-
+          Anthropic API key. Forward the lgtm-hq org secret ANTHROPIC_API_KEY
+          or use `secrets: inherit`. Absent on fork PRs (skips gracefully).
+        required: false
+
+jobs:
+  ai-review:
+    name: ${{ inputs.job-name }}
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    # Non-blocking: AI review never fails a PR check.
+    continue-on-error: true
+    permissions:
+      # Checkout repository and lgtm-ci tooling.
+      contents: read
+      # Post/update the sticky review comment on the PR.
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+            .github/actions/post-pr-comment
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+
+      - name: Harden runner
+        # yamllint disable-line rule:line-length
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Preflight guards
+        id: preflight
+        shell: bash
+        env:
+          STEP: preflight
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+          HAS_KEY: ${{ secrets.anthropic-api-key != '' }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/run-ai-review.sh
+
+      # ANTHROPIC_API_KEY is in scope ONLY here — after checkout/harden, running
+      # a pinned PyPI lintro that never executes PR-controlled code.
+      - name: Run AI review
+        id: review
+        if: steps.preflight.outputs.should-run == 'true'
+        shell: bash
+        env:
+          STEP: run
+          ANTHROPIC_API_KEY: ${{ secrets.anthropic-api-key }}
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          LINTRO_VERSION: ${{ inputs.lintro-version }}
+          DEPTH: ${{ inputs.depth }}
+          STRICTNESS: ${{ inputs.strictness }}
+          MODEL: ${{ inputs.model }}
+          MAX_COST_USD: ${{ inputs.max-cost-usd }}
+          PATHS: ${{ inputs.paths }}
+          RUN_FILE: ${{ runner.temp }}/ai-review-run.json
+          VENV_DIR: ${{ runner.temp }}/ai-review-venv
+        run: .lgtm-ci-tooling/scripts/ci/actions/run-ai-review.sh
+
+      - name: Fetch existing comment state
+        id: fetch-state
+        if: >-
+          inputs.post &&
+          steps.preflight.outputs.skip-reason != 'not-a-pr'
+        shell: bash
+        env:
+          STEP: fetch-state
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          STATE_FILE: ${{ runner.temp }}/ai-review-state.json
+        run: .lgtm-ci-tooling/scripts/ci/actions/render-ai-review-comment.sh
+
+      - name: Render comment body
+        id: render
+        if: >-
+          inputs.post &&
+          steps.preflight.outputs.skip-reason != 'not-a-pr'
+        shell: bash
+        env:
+          STEP: render
+          STATE_FILE: ${{ runner.temp }}/ai-review-state.json
+          RUN_FILE: ${{ runner.temp }}/ai-review-run.json
+          SKIP_REASON: >-
+            ${{ steps.preflight.outputs.should-run == 'true' && ''
+            || steps.preflight.outputs.skip-reason }}
+          OUTPUT_FILE: ${{ runner.temp }}/ai-review-comment.md
+        run: .lgtm-ci-tooling/scripts/ci/actions/render-ai-review-comment.sh
+
+      - name: Post sticky review comment
+        if: >-
+          inputs.post &&
+          steps.preflight.outputs.skip-reason != 'not-a-pr'
+        uses: ./.lgtm-ci-tooling/.github/actions/post-pr-comment
+        with:
+          file: ${{ runner.temp }}/ai-review-comment.md
+          marker: lintro-ai-review
+          mode: upsert
+          pr-number: ${{ github.event.pull_request.number }}

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -891,6 +891,102 @@ jobs:
       tooling-ref: "<sha>"
 ```
 
+### AI code review (`reusable-ai-review.yml`)
+
+Org-wide AI code review. Installs a pinned `lintro[ai]` from PyPI, runs
+`lintro review` hardened in CI, and publishes **one sticky, telemetry-rich PR
+comment** updated in place on every run. The engine is py-lintro (`lintro
+review`, released on PyPI); this reusable is the CI orchestration +
+comment-publishing layer — the same shape as `reusable-validate-lintro-version.yml`.
+
+**Zero-setup for consumers.** `ANTHROPIC_API_KEY` is provisioned as an lgtm-hq
+**org-wide secret**, so callers just forward it (or use `secrets: inherit`) with
+no per-repo key management:
+
+```yaml
+# any lgtm-hq repo: .github/workflows/ai-review.yml
+'on':
+  pull_request:
+
+jobs:
+  ai-review:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ai-review.yml@<sha>
+    permissions:
+      contents: read
+      pull-requests: write
+    with:
+      depth: 1 # 1=checklist, 2=+questions, 3=+adversarial
+      post: true
+      max-cost-usd: "0.50"
+    secrets:
+      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }} # inherited org secret
+```
+
+| Input            | Default       | Notes                                             |
+| ---------------- | ------------- | ------------------------------------------------- |
+| `depth`          | `1`           | Review depth (clamped to 1..3)                    |
+| `post`           | `true`        | Post/update the sticky PR comment                 |
+| `max-cost-usd`   | `"0.50"`      | Advisory per-run cost cap (annotated if exceeded) |
+| `paths`          | `""`          | Optional path prefixes; empty reviews whole diff  |
+| `lintro-version` | pinned        | Renovate-managed centrally (grouped with lintro)  |
+| `strictness`     | `balanced`    | `focused` \| `balanced` \| `thorough`             |
+| `model`          | `""`          | Optional pass-through; no default (lintro decides)|
+| `egress-preset`  | `ai-review`   | Allowlists PyPI, uv, Anthropic, GitHub + raw CDN  |
+| `timeout-minutes`| `15`          | Job timeout                                       |
+| `job-name`       | `AI Review`   | Check name                                        |
+
+**Hardening guarantees:**
+
+- **Trusted install.** The job only installs a *pinned lintro from PyPI* and
+  runs `lintro review` (which reads the PR diff via the GitHub API and calls the
+  model). It never installs or executes the PR's own code (no `uv sync`, no
+  `pip install .`, no build hooks), so `ANTHROPIC_API_KEY` is scoped to the
+  single "Run AI review" step and is never in scope while PR-controlled code
+  could execute.
+- **Graceful skip (exit 0).** Skips with an informative note when no key is
+  present, on **fork PRs** (no secret access), and off same-repo PRs. The job is
+  **non-blocking** (`continue-on-error: true`) — AI review never fails a check.
+- **Cost + depth caps.** Depth is clamped to 1..3; per-run cost is compared to
+  `max-cost-usd` and annotated when exceeded. (Pre-spend budget enforcement
+  requires a lintro budget flag — tracked upstream.)
+- **Egress allowlist.** The `ai-review` preset covers PyPI
+  (`pypi.org`, `files.pythonhosted.org`), uv (`astral.sh`, `releases.astral.sh`),
+  Anthropic (`api.anthropic.com`), GitHub, and `raw.githubusercontent.com`.
+
+**The sticky comment.** One comment per PR (marker `lintro-ai-review`), with
+machine-readable state embedded in a trailing HTML comment
+(`<!-- lintro-ai-review-state: {"runs":[...]} -->`) so cumulative data survives
+across runs without external storage. Layout, top → bottom:
+
+1. **Cumulative (always visible):** total tokens (in/out/combined), total cost
+   USD, per-model counts (e.g. `claude-sonnet-4 ×3`), and run count.
+2. **Latest run:** findings (from `lintro review --output json`) plus per-run
+   mechanics (model, provider, tokens, cost, depth, duration).
+3. **Previous runs:** collapsible `<details>` with per-run mechanics. History is
+   bounded to the last 20 runs.
+
+Errored runs are recorded (status `error`, 0 tokens) and shown in the
+collapsible, contributing 0 to cumulative totals. Provider errors are formatted
+in the comment (401 invalid key, 429 rate limited, quota/no-credits,
+5xx/timeout) rather than failing silently.
+
+**Security (untrusted model output).** Review content derives from an untrusted
+PR diff. Before posting, model-derived text has `@mentions` neutralized and HTML
+comment delimiters escaped (so injected text cannot forge the state marker), is
+length-capped, and the comment is labelled as automated.
+
+**Error-contract note.** py-lintro 0.65.0 does not yet expose a machine-readable
+error contract for `lintro review --output json` (errors surface as
+`click.ClickException` on stderr with an overloaded exit code). The workflow
+degrades gracefully: it treats "valid review JSON on stdout" as success and uses
+a narrow, documented interim heuristic on the stable `AIError` message prefixes
+for the 401/429/quota classification. A structured contract is requested in
+lgtm-hq/py-lintro#1095.
+
+**Rollout.** py-lintro will migrate its bespoke `ai-review.yml` to a thin caller
+of this reusable (out of scope here) so lintro dogfoods the same reusable
+everyone uses.
+
 ### Vulnerability suppression check (osv-scanner)
 
 `reusable-vuln-suppression-check.yml` installs `osv-scanner` directly (no Docker),

--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,14 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s*\\n\\s*[A-Za-z_]+=\"?v?(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\"?"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Track pinned lintro PyPI version in reusable-ai-review.yml",
+      "managerFilePatterns": ["/^\\.github/workflows/reusable-ai-review\\.yml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s*\\n\\s*default: \"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
+      ]
     }
   ],
   "packageRules": [

--- a/scripts/ci/actions/render-ai-review-comment.sh
+++ b/scripts/ci/actions/render-ai-review-comment.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Maintain the sticky Lintro AI Review PR comment (fetch/parse existing
+#          state, append this run, recompute cumulative, and render the body).
+#
+# The single sticky comment embeds machine-readable state in a trailing HTML
+# comment (`<!-- lintro-ai-review-state: {...} -->`) so cumulative data survives
+# across runs without external storage. History is bounded to the last MAX_RUNS.
+#
+# STEP dispatch (env-only inputs):
+#   fetch-state  Read the existing sticky comment (by state marker) and write the
+#                embedded {"runs":[...]} JSON to STATE_FILE ({"runs":[]} if none).
+#   render       Append RUN_FILE (or a skip note), recompute cumulative, and
+#                write the comment body to OUTPUT_FILE.
+#
+# Environment variables (fetch-state):
+#   GH_TOKEN, GITHUB_REPOSITORY, PR_NUMBER, STATE_FILE
+#
+# Environment variables (render):
+#   STATE_FILE   Existing state JSON ({"runs":[...]}).
+#   RUN_FILE     This run's object (omit when SKIP_REASON is set).
+#   SKIP_REASON  no-key | fork | not-a-pr (render a skip note, do not append).
+#   OUTPUT_FILE  Destination for the rendered comment body.
+#   MAX_RUNS     Bounded history size (default 20).
+
+set -euo pipefail
+
+: "${STEP:=render}"
+
+readonly AI_REVIEW_STATE_MARKER="<!-- lintro-ai-review-state:"
+
+# Portable thousands grouping (BSD + GNU): 48210 -> 48,210
+ai_review_commas() {
+	awk -v n="${1:-0}" 'BEGIN {
+		s = sprintf("%d", n); out = "";
+		while (length(s) > 3) {
+			out = "," substr(s, length(s) - 2) out;
+			s = substr(s, 1, length(s) - 3);
+		}
+		print s out;
+	}'
+}
+
+# Format a USD amount with two decimals (tiny nonzero -> <$0.01).
+ai_review_cost() {
+	awk -v c="${1:-0}" 'BEGIN {
+		if (c > 0 && c < 0.005) { printf "<$0.01"; }
+		else { printf "$%.2f", c; }
+	}'
+}
+
+# -----------------------------------------------------------------------------
+# STEP: fetch-state
+# -----------------------------------------------------------------------------
+if [[ "$STEP" == "fetch-state" ]]; then
+	: "${STATE_FILE:?STATE_FILE is required}"
+	: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+	: "${PR_NUMBER:?PR_NUMBER is required}"
+
+	body=""
+	if [[ -n "${GH_TOKEN:-}" ]]; then
+		body="$(gh api \
+			-H "Accept: application/vnd.github+json" \
+			"/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+			2>/dev/null |
+			jq -r --arg marker "$AI_REVIEW_STATE_MARKER" \
+				'[.[] | select(.body | contains($marker))] | last | .body // ""' || echo "")"
+	fi
+
+	state='{"runs":[]}'
+	if [[ -n "$body" && "$body" == *"$AI_REVIEW_STATE_MARKER"* ]]; then
+		# Extract the JSON between the marker and the closing `-->`.
+		candidate="${body#*"$AI_REVIEW_STATE_MARKER"}"
+		candidate="${candidate%%-->*}"
+		if printf '%s' "$candidate" | jq -e '.runs' >/dev/null 2>&1; then
+			state="$(printf '%s' "$candidate" | jq -c '{runs: (.runs // [])}')"
+		fi
+	fi
+	printf '%s\n' "$state" >"$STATE_FILE"
+	echo "fetch-state: $(printf '%s' "$state" | jq '.runs | length') prior run(s)"
+	exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# STEP: render
+# -----------------------------------------------------------------------------
+if [[ "$STEP" == "render" ]]; then
+	: "${OUTPUT_FILE:?OUTPUT_FILE is required}"
+	state_file="${STATE_FILE:-}"
+	max_runs="${MAX_RUNS:-20}"
+
+	existing='{"runs":[]}'
+	if [[ -n "$state_file" && -f "$state_file" ]]; then
+		if jq -e '.runs' "$state_file" >/dev/null 2>&1; then
+			existing="$(jq -c '{runs: (.runs // [])}' "$state_file")"
+		fi
+	fi
+
+	skip_reason="${SKIP_REASON:-}"
+
+	if [[ -z "$skip_reason" ]]; then
+		: "${RUN_FILE:?RUN_FILE is required when SKIP_REASON is unset}"
+		run_obj="$(jq -c '.' "$RUN_FILE")"
+		# Append this run and bound history to the last MAX_RUNS.
+		new_state="$(jq -c --argjson run "$run_obj" --argjson max "$max_runs" \
+			'.runs += [$run] | .runs |= (if length > $max then .[length-$max:] else . end)' \
+			<<<"$existing")"
+	else
+		new_state="$existing"
+	fi
+
+	compact_state="$(jq -c '.' <<<"$new_state")"
+
+	# --- Cumulative aggregates (ok runs contribute tokens/cost; errors add 0) ---
+	read -r total_in total_out total_combined run_count < <(
+		jq -r '
+			[.runs[] | select(.status=="ok")] as $ok
+			| [ ($ok | map(.input_tokens) | add // 0),
+			    ($ok | map(.output_tokens) | add // 0),
+			    ($ok | map(.total_tokens) | add // 0),
+			    (.runs | length) ]
+			| @tsv' <<<"$new_state"
+	)
+	total_cost="$(jq -r '[.runs[] | select(.status=="ok") | .cost_usd] | add // 0' <<<"$new_state")"
+	models_str="$(jq -r '
+		.runs | group_by(.model) | sort_by(-length)
+		| map("`\(.[0].model) ×\(length)`") | join(", ")' <<<"$new_state")"
+	[[ -n "$models_str" ]] || models_str="_none yet_"
+
+	# --- Assemble body ----------------------------------------------------------
+	{
+		echo "## 🔎 Lintro AI Review"
+		echo
+		printf '**Cumulative (this PR):** %s tokens (%s in / %s out) · ~%s · %s runs · models: %s\n' \
+			"$(ai_review_commas "$total_combined")" \
+			"$(ai_review_commas "$total_in")" \
+			"$(ai_review_commas "$total_out")" \
+			"$(ai_review_cost "$total_cost")" \
+			"$run_count" \
+			"$models_str"
+		echo
+		echo "---"
+
+		if [[ -n "$skip_reason" ]]; then
+			case "$skip_reason" in
+			no-key)
+				echo "### Latest — ⚠️ skipped"
+				echo
+				echo "No \`ANTHROPIC_API_KEY\` is available to this run. Forward the lgtm-hq org secret (\`anthropic-api-key: \${{ secrets.ANTHROPIC_API_KEY }}\` or \`secrets: inherit\`) to enable AI review."
+				;;
+			fork)
+				echo "### Latest — ℹ️ skipped (fork)"
+				echo
+				echo "AI review does not run on fork pull requests (no access to repository secrets)."
+				;;
+			*)
+				echo "### Latest — ℹ️ skipped"
+				echo
+				echo "AI review was skipped for this event."
+				;;
+			esac
+		else
+			# Latest run header + findings + mechanics.
+			latest_status="$(jq -r '.status' <<<"$run_obj")"
+			if [[ "$latest_status" == "error" ]]; then
+				err_msg="$(jq -r '.error' <<<"$run_obj")"
+				case "$(jq -r '.error_kind' <<<"$run_obj")" in
+				auth) echo "### Latest — ❌ Review skipped" ;;
+				quota) echo "### Latest — ❌ No credits" ;;
+				rate_limit) echo "### Latest — ⚠️ Rate limited" ;;
+				*) echo "### Latest — ⚠️ Provider unavailable" ;;
+				esac
+				echo
+				echo "$err_msg"
+			else
+				p1="$(jq -r '.p1' <<<"$run_obj")"
+				p2="$(jq -r '.p2' <<<"$run_obj")"
+				p3="$(jq -r '.p3' <<<"$run_obj")"
+				echo "### Latest — 🔴 ${p1} · 🟠 ${p2} · 🟡 ${p3}"
+				echo
+				summary="$(jq -r '.summary // ""' <<<"$run_obj")"
+				[[ -n "$summary" ]] && {
+					echo "$summary"
+					echo
+				}
+				if [[ "$(jq -r '.over_budget' <<<"$run_obj")" == "true" ]]; then
+					echo "> ⚠️ This run's estimated cost exceeded the configured \`max-cost-usd\` cap."
+					echo
+				fi
+				# Findings list (severity badge · file:line · title).
+				jq -r '.findings[]? |
+					(if .severity=="P1" then "🔴" elif .severity=="P2" then "🟠" else "🟡" end) as $b
+					| "- \($b) **\(.title)** — `\(.file):\(.line)`" +
+					  (if (.description // "") != "" then "\n  <sub>\(.description)</sub>" else "" end)' \
+					<<<"$run_obj"
+				echo
+			fi
+
+			# Per-run mechanics line.
+			jq -r '"<sub>run: `\(.model)` · \(.total_tokens) tok " +
+				"(\(.input_tokens) in / \(.output_tokens) out) · " +
+				"~$\(.cost_usd) · depth \(.depth) · \(.duration_s)s</sub>"' <<<"$run_obj"
+			echo
+		fi
+
+		# --- Previous runs (collapsible) ---
+		prev_count="$(jq -r '.runs | length | (. - 1)' <<<"$new_state")"
+		if [[ -z "$skip_reason" ]] && ((prev_count > 0)); then
+			echo
+			echo "<details><summary>⏱ Previous runs (${prev_count})</summary>"
+			echo
+			# All but the last run, most-recent first.
+			jq -r '
+				.runs[:-1] | reverse | .[] |
+				(.sha[0:7] // "-------") as $sha
+				| (.time // "") as $t
+				| if .status=="error"
+				  then "- `\($sha)` \($t) — `\(.model)` · ❌ error: \(.error_kind)"
+				  else "- `\($sha)` \($t) — `\(.model)` · \(.total_tokens) tok · ~$\(.cost_usd) · 🔴\(.p1) 🟠\(.p2) 🟡\(.p3)"
+				  end' <<<"$new_state"
+			echo
+			echo "</details>"
+		fi
+
+		echo
+		echo "<sub>🤖 automated · not a substitute for human review</sub>"
+		printf '%s %s -->\n' "$AI_REVIEW_STATE_MARKER" "$compact_state"
+	} >"$OUTPUT_FILE"
+
+	echo "render: wrote comment body ($(wc -c <"$OUTPUT_FILE") bytes; ${run_count} cumulative runs)"
+	exit 0
+fi
+
+echo "render-ai-review-comment.sh: unknown STEP '$STEP'" >&2
+exit 1

--- a/scripts/ci/actions/run-ai-review.sh
+++ b/scripts/ci/actions/run-ai-review.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Orchestrate `lintro review` for the reusable AI code-review workflow.
+#
+# STEP dispatch (env-only inputs; never interpolate untrusted GitHub context):
+#   preflight  Decide whether the review should run (same-repo + key + PR guards).
+#   run        Install pinned lintro[ai] from PyPI and run the review, emitting a
+#              single-run state object with mechanics + sanitized findings.
+#
+# Trusted-install invariant: this script only installs a *pinned lintro from
+# PyPI* and runs `lintro review`, which reads the PR diff via the GitHub API and
+# calls the model. It never installs or executes the PR's own code (no
+# `uv sync`, no `pip install .`, no build hooks), so ANTHROPIC_API_KEY is never
+# in scope while PR-controlled code could execute.
+#
+# Environment variables (preflight):
+#   EVENT_NAME   GitHub event name (pull_request / pull_request_target).
+#   HEAD_REPO    github.event.pull_request.head.repo.full_name (may be empty).
+#   BASE_REPO    github.repository (owner/name).
+#   HAS_KEY      "true" when the anthropic-api-key secret is non-empty.
+#   PR_NUMBER    Pull request number.
+#
+# Environment variables (run):
+#   ANTHROPIC_API_KEY  Provider key (ONLY in scope for this step).
+#   LINTRO_VERSION     Pinned lintro version (e.g. 0.65.0).
+#   DEPTH              Review depth (clamped to 1..3).
+#   STRICTNESS         focused | balanced | thorough.
+#   MODEL              Optional model override (no default).
+#   MAX_COST_USD       Advisory per-run cost cap (e.g. 0.50).
+#   PATHS              Optional newline/comma/space-separated path prefixes.
+#   PR_NUMBER          Pull request number.
+#   HEAD_SHA           Head commit SHA (for the run record).
+#   GITHUB_REPOSITORY  owner/name.
+#   GH_TOKEN           GitHub token for `lintro review --pr`.
+#   RUN_FILE           Output path for the single-run JSON object.
+#   VENV_DIR           Directory for the scratch venv (default: $RUNNER_TEMP/ai-review-venv).
+#   LINTRO_BIN         Test hook: use this binary instead of installing.
+
+set -euo pipefail
+
+: "${STEP:=run}"
+
+# Maximum characters retained from any model-derived text field before it is
+# embedded in the PR comment (prompt-injection surface bound).
+readonly AI_REVIEW_TEXT_CAP="${AI_REVIEW_TEXT_CAP:-600}"
+# Maximum number of findings rendered from a single run.
+readonly AI_REVIEW_FINDINGS_CAP="${AI_REVIEW_FINDINGS_CAP:-30}"
+
+# -----------------------------------------------------------------------------
+# Sanitize a single untrusted (model-derived) string for safe Markdown embed:
+#   - neutralize @mentions so the bot cannot ping users from injected text
+#   - neutralize HTML comment delimiters so injected text cannot break out of
+#     (or forge) the embedded state comment
+#   - collapse newlines and cap length
+# Reads stdin, writes sanitized text to stdout.
+# -----------------------------------------------------------------------------
+ai_review_sanitize() {
+	local text
+	text="$(cat)"
+	# Neutralize HTML comment delimiters (state-marker breakout / forgery).
+	text="${text//<!--/<!‑‑}"
+	text="${text//-->/‑‑>}"
+	# Collapse CR/LF to spaces so a finding stays on one logical line.
+	text="${text//$'\r'/ }"
+	text="${text//$'\n'/ }"
+	# Neutralize @mentions: wrap `@name` in backticks (no notification, readable).
+	# shellcheck disable=SC2016 # sed replacement is intentionally literal.
+	text="$(printf '%s' "$text" | sed -E 's/@([A-Za-z0-9_][A-Za-z0-9_-]*)/`@\1`/g')"
+	# Cap length.
+	if ((${#text} > AI_REVIEW_TEXT_CAP)); then
+		text="${text:0:AI_REVIEW_TEXT_CAP}…"
+	fi
+	printf '%s' "$text"
+}
+
+emit_output() {
+	local key="$1" value="$2"
+	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+		printf '%s=%s\n' "$key" "$value" >>"$GITHUB_OUTPUT"
+	fi
+}
+
+# -----------------------------------------------------------------------------
+# STEP: preflight
+# -----------------------------------------------------------------------------
+if [[ "$STEP" == "preflight" ]]; then
+	should_run=true
+	skip_reason=""
+
+	case "${EVENT_NAME:-}" in
+	pull_request | pull_request_target) ;;
+	*)
+		should_run=false
+		skip_reason="not-a-pr"
+		;;
+	esac
+
+	if [[ "$should_run" == "true" ]]; then
+		head_repo="${HEAD_REPO:-}"
+		if [[ -n "$head_repo" && "$head_repo" != "${BASE_REPO:-}" ]]; then
+			should_run=false
+			skip_reason="fork"
+		fi
+	fi
+
+	if [[ "$should_run" == "true" && "${HAS_KEY:-false}" != "true" ]]; then
+		should_run=false
+		skip_reason="no-key"
+	fi
+
+	emit_output "should-run" "$should_run"
+	emit_output "skip-reason" "$skip_reason"
+	echo "preflight: should-run=${should_run} skip-reason=${skip_reason:-<none>}"
+	exit 0
+fi
+
+# -----------------------------------------------------------------------------
+# STEP: run
+# -----------------------------------------------------------------------------
+if [[ "$STEP" == "run" ]]; then
+	: "${RUN_FILE:?RUN_FILE is required}"
+	: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+	: "${PR_NUMBER:?PR_NUMBER is required}"
+
+	depth="${DEPTH:-1}"
+	if ! [[ "$depth" =~ ^[0-9]+$ ]]; then
+		depth=1
+	fi
+	if ((depth < 1)); then depth=1; fi
+	if ((depth > 3)); then depth=3; fi
+
+	strictness="${STRICTNESS:-balanced}"
+	model="${MODEL:-}"
+	max_cost="${MAX_COST_USD:-0.50}"
+	head_sha="${HEAD_SHA:-}"
+
+	# --- Resolve the lintro binary (install pinned lintro[ai] unless overridden) -
+	lintro_bin="${LINTRO_BIN:-}"
+	if [[ -z "$lintro_bin" ]]; then
+		: "${LINTRO_VERSION:?LINTRO_VERSION is required}"
+		venv_dir="${VENV_DIR:-${RUNNER_TEMP:-/tmp}/ai-review-venv}"
+		echo "Installing lintro[ai]==${LINTRO_VERSION} from PyPI (pinned, trusted)…"
+		uv venv "$venv_dir" >/dev/null
+		uv pip install --python "$venv_dir" "lintro[ai]==${LINTRO_VERSION}" >/dev/null
+		lintro_bin="$venv_dir/bin/lintro"
+	fi
+
+	# --- Force ai.enabled and optional model via a generated config -------------
+	# Written into the disposable CI checkout only; merges with any existing
+	# .lintro-config.yaml so consumer review settings are preserved.
+	if [[ "${AI_REVIEW_SKIP_CONFIG:-false}" != "true" ]]; then
+		config_python="${VENV_PYTHON:-${venv_dir:-}/bin/python}"
+		[[ -x "$config_python" ]] || config_python="python3"
+		AI_REVIEW_MODEL="$model" "$config_python" - <<'PY'
+import os
+from pathlib import Path
+
+try:
+    import yaml
+except ModuleNotFoundError:
+    raise SystemExit(0)
+
+path = Path(".lintro-config.yaml")
+data = {}
+if path.exists():
+    loaded = yaml.safe_load(path.read_text()) or {}
+    if isinstance(loaded, dict):
+        data = loaded
+
+ai = data.get("ai")
+if not isinstance(ai, dict):
+    ai = {}
+ai["enabled"] = True
+model = os.environ.get("AI_REVIEW_MODEL", "").strip()
+if model:
+    ai["model"] = model
+data["ai"] = ai
+path.write_text(yaml.safe_dump(data, sort_keys=False))
+PY
+	fi
+
+	# --- Build review arguments -------------------------------------------------
+	args=(review --pr "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"
+		--depth "$depth" --strictness "$strictness" --output json)
+	if [[ -n "${PATHS:-}" ]]; then
+		# Split on newline, comma, or whitespace; pass each as a --path prefix.
+		while IFS= read -r path_token; do
+			[[ -n "$path_token" ]] && args+=(--path "$path_token")
+		done < <(printf '%s' "$PATHS" | tr ',\r\n' '   ' | tr ' ' '\n')
+	fi
+
+	out_file="$(mktemp)"
+	err_file="$(mktemp)"
+	start_epoch="$(date +%s)"
+	set +e
+	ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-}" GH_TOKEN="${GH_TOKEN:-}" \
+		"$lintro_bin" "${args[@]}" >"$out_file" 2>"$err_file"
+	exit_code=$?
+	set -e
+	end_epoch="$(date +%s)"
+	duration=$((end_epoch - start_epoch))
+
+	timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+	# --- Classify outcome -------------------------------------------------------
+	# Success signal = valid review JSON on stdout (has .metadata). Exit code is
+	# overloaded (1 == P1 findings OR provider error), so it is NOT the primary
+	# signal. Provider-error subtype uses a narrow, documented interim heuristic
+	# on the stable AIError message prefixes pending py-lintro's structured error
+	# contract (lgtm-hq/py-lintro#1095).
+	status="error"
+	if jq -e '.metadata' "$out_file" >/dev/null 2>&1; then
+		status="ok"
+	fi
+
+	if [[ "$status" == "ok" ]]; then
+		model="$(jq -r '.metadata.model // "unknown"' "$out_file")"
+		provider="$(jq -r '.metadata.provider // "unknown"' "$out_file")"
+		in_tok="$(jq -r '.metadata.token_usage.prompt // 0' "$out_file")"
+		out_tok="$(jq -r '.metadata.token_usage.completion // 0' "$out_file")"
+		total_tok="$(jq -r '.metadata.token_usage.total // ((.metadata.token_usage.prompt // 0) + (.metadata.token_usage.completion // 0))' "$out_file")"
+		cost="$(jq -r '.metadata.cost_estimate_usd // 0' "$out_file")"
+		summary_raw="$(jq -r '.summary // ""' "$out_file")"
+		summary="$(printf '%s' "$summary_raw" | ai_review_sanitize)"
+		p1="$(jq -r '[.findings[]? | select(.severity=="P1")] | length' "$out_file")"
+		p2="$(jq -r '[.findings[]? | select(.severity=="P2")] | length' "$out_file")"
+		p3="$(jq -r '[.findings[]? | select(.severity=="P3")] | length' "$out_file")"
+
+		# Sanitize each finding's untrusted text fields, cap the count.
+		findings_json="$(jq -c --argjson cap "$AI_REVIEW_FINDINGS_CAP" \
+			'[.findings[]? | {severity, category, file, line, title, description, cause, fix}] | .[:$cap]' \
+			"$out_file")"
+		sanitized_findings='[]'
+		count="$(printf '%s' "$findings_json" | jq 'length')"
+		for ((i = 0; i < count; i++)); do
+			f="$(printf '%s' "$findings_json" | jq -c ".[$i]")"
+			s_title="$(printf '%s' "$f" | jq -r '.title // ""' | ai_review_sanitize)"
+			s_desc="$(printf '%s' "$f" | jq -r '.description // ""' | ai_review_sanitize)"
+			s_file="$(printf '%s' "$f" | jq -r '.file // ""' | ai_review_sanitize)"
+			s_cat="$(printf '%s' "$f" | jq -r '.category // ""' | ai_review_sanitize)"
+			sev="$(printf '%s' "$f" | jq -r '.severity // "P3"')"
+			line="$(printf '%s' "$f" | jq -r '.line // 0')"
+			sanitized_findings="$(jq -c \
+				--arg sev "$sev" --arg cat "$s_cat" --arg file "$s_file" \
+				--argjson line "${line:-0}" --arg title "$s_title" --arg desc "$s_desc" \
+				'. + [{severity:$sev, category:$cat, file:$file, line:$line, title:$title, description:$desc}]' \
+				<<<"$sanitized_findings")"
+		done
+
+		over_budget=false
+		if awk -v c="$cost" -v m="$max_cost" 'BEGIN{exit !(c+0 > m+0)}'; then
+			over_budget=true
+			echo "::warning::AI review run cost \$${cost} exceeds max-cost-usd \$${max_cost}"
+		fi
+
+		jq -n \
+			--arg sha "$head_sha" --arg time "$timestamp" --arg model "$model" \
+			--arg provider "$provider" --argjson in_tok "${in_tok:-0}" \
+			--argjson out_tok "${out_tok:-0}" --argjson total_tok "${total_tok:-0}" \
+			--argjson cost "${cost:-0}" --argjson depth "$depth" \
+			--argjson duration "$duration" --argjson p1 "${p1:-0}" \
+			--argjson p2 "${p2:-0}" --argjson p3 "${p3:-0}" \
+			--arg summary "$summary" --argjson findings "$sanitized_findings" \
+			--argjson over_budget "$over_budget" \
+			'{sha:$sha, time:$time, model:$model, provider:$provider,
+			  input_tokens:$in_tok, output_tokens:$out_tok, total_tokens:$total_tok,
+			  cost_usd:$cost, depth:$depth, duration_s:$duration, status:"ok",
+			  error_kind:"", error:"", p1:$p1, p2:$p2, p3:$p3,
+			  summary:$summary, findings:$findings, over_budget:$over_budget}' \
+			>"$RUN_FILE"
+		emit_output "status" "ok"
+		echo "AI review ok: model=${model} tokens=${total_tok} cost=\$${cost} P1=${p1} P2=${p2} P3=${p3}"
+		exit 0
+	fi
+
+	# --- Error path: classify subtype (interim heuristic) -----------------------
+	err_text="$(tr '[:upper:]' '[:lower:]' <"$err_file")"
+	error_kind="transient"
+	error_msg="Provider unavailable (5xx/timeout) — transient, will retry next run."
+	if grep -Eq 'authentication|invalid.*key|401|unauthorized' <<<"$err_text"; then
+		error_kind="auth"
+		error_msg="Anthropic API returned 401 (invalid or missing API key). Check the ANTHROPIC_API_KEY secret."
+	elif grep -Eq 'insufficient|credit|quota|402|billing' <<<"$err_text"; then
+		error_kind="quota"
+		error_msg="No credits — the Anthropic account has insufficient credits."
+	elif grep -Eq 'rate.?limit|429|too many requests' <<<"$err_text"; then
+		error_kind="rate_limit"
+		error_msg="Rate limited (429) — try again shortly."
+	fi
+
+	# Record the effective model even on error (org-configured or override) so the
+	# per-model cumulative counts stay complete.
+	err_model="${model:-unknown}"
+	[[ -n "$err_model" ]] || err_model="unknown"
+
+	jq -n \
+		--arg sha "$head_sha" --arg time "$timestamp" --arg model "$err_model" \
+		--argjson depth "$depth" --argjson duration "$duration" \
+		--arg error_kind "$error_kind" --arg error "$error_msg" \
+		'{sha:$sha, time:$time, model:$model, provider:"anthropic",
+		  input_tokens:0, output_tokens:0, total_tokens:0, cost_usd:0,
+		  depth:$depth, duration_s:$duration, status:"error",
+		  error_kind:$error_kind, error:$error, p1:0, p2:0, p3:0,
+		  summary:"", findings:[], over_budget:false}' \
+		>"$RUN_FILE"
+	emit_output "status" "error"
+	echo "::warning::AI review error (${error_kind}): ${error_msg}"
+	echo "lintro exit=${exit_code}; stderr head:"
+	head -c 500 "$err_file" || true
+	exit 0
+fi
+
+echo "run-ai-review.sh: unknown STEP '$STEP'" >&2
+exit 1

--- a/scripts/ci/lib/egress/presets.sh
+++ b/scripts/ci/lib/egress/presets.sh
@@ -202,6 +202,20 @@ egress_preset_endpoints() {
 			api.osv.dev:443 \
 			api.deps.dev:443
 		;;
+	ai-review)
+		# AI code review (reusable-ai-review.yml): GitHub checkout/tooling + gh PR
+		# diff API, uv/PyPI install of pinned lintro[ai], and the Anthropic API.
+		# raw.githubusercontent.com is required (astral setup-uv/self-checks fetch
+		# from it — its omission previously broke py-lintro's dogfood workflow).
+		egress_preset_endpoints github-tooling
+		printf '%s\n' \
+			release-assets.githubusercontent.com:443 \
+			pypi.org:443 \
+			files.pythonhosted.org:443 \
+			astral.sh:443 \
+			releases.astral.sh:443 \
+			api.anthropic.com:443
+		;;
 	rust-release)
 		# Rust cross-compile release builds (reusable-build-rust-binaries.yml).
 		# Minimal base: GitHub checkout/tooling, Rust/crates, cross Docker, apt, Sigstore.

--- a/tests/bats/integration/test_reusable_ai_review.bats
+++ b/tests/bats/integration/test_reusable_ai_review.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract + structure tests for reusable-ai-review.yml (#416)
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-ai-review.yml"
+
+# --- Repo contract validators must accept the new reusable --------------------
+
+@test "reusable-ai-review: satisfies runner contract validator" {
+	run "${PROJECT_ROOT}/scripts/ci/quality/validate-runner-contract.sh"
+	assert_success
+	assert_output --partial "OK:"
+}
+
+@test "reusable-ai-review: satisfies static job-name validator" {
+	run "${PROJECT_ROOT}/scripts/ci/quality/validate-static-job-names.sh"
+	assert_success
+}
+
+@test "reusable-ai-review: satisfies tooling sparse-checkout validator" {
+	run "${PROJECT_ROOT}/scripts/ci/quality/validate-tooling-sparse-checkout.sh"
+	assert_success
+}
+
+# --- Interface / inputs -------------------------------------------------------
+
+@test "reusable-ai-review: exposes the documented inputs" {
+	run grep -E '^      (depth|post|max-cost-usd|paths|lintro-version|strictness|model):' "$WORKFLOW"
+	assert_success
+	assert_line --partial "depth:"
+	assert_line --partial "post:"
+	assert_line --partial "max-cost-usd:"
+	assert_line --partial "lintro-version:"
+	assert_line --partial "strictness:"
+	assert_line --partial "model:"
+}
+
+@test "reusable-ai-review: model input has no hardcoded default value" {
+	run awk '/^      model:$/{f=1;next} f&&/^      [a-z]/{exit} f&&/default:/{print}' "$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: ""'
+}
+
+@test "reusable-ai-review: lintro-version is pinned with a Renovate annotation" {
+	run grep -F "# renovate: datasource=pypi depName=lintro" "$WORKFLOW"
+	assert_success
+	run grep -E 'default: "[0-9]+\.[0-9]+\.[0-9]+"' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-ai-review: declares anthropic-api-key as an optional secret" {
+	run awk '/^    secrets:/{f=1} f&&/anthropic-api-key:/{print}' "$WORKFLOW"
+	assert_success
+	assert_output --partial "anthropic-api-key:"
+}
+
+@test "reusable-ai-review: timeout-minutes input is type number" {
+	run awk '/^      timeout-minutes:$/{f=1;next} f&&/^      [a-z]/{exit} f{print}' "$WORKFLOW"
+	assert_success
+	assert_output --partial "type: number"
+}
+
+# --- Hardening ----------------------------------------------------------------
+
+@test "reusable-ai-review: job is non-blocking (continue-on-error)" {
+	run grep -F "continue-on-error: true" "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-ai-review: defaults to the ai-review egress preset" {
+	run awk '/^      egress-preset:$/{f=1;next} f&&/^      [a-z]/{exit} f&&/default:/{print}' "$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: "ai-review"'
+}
+
+@test "reusable-ai-review: resolves egress before harden-runner" {
+	run egress_tooling_checkout_order_ok "$WORKFLOW" ai-review
+	assert_success
+}
+
+@test "reusable-ai-review: ANTHROPIC_API_KEY is scoped only to the run step" {
+	# The key must appear exactly once (the Run AI review step), never at job
+	# level nor in the preflight/checkout/comment steps.
+	run grep -c "ANTHROPIC_API_KEY: \${{ secrets.anthropic-api-key }}" "$WORKFLOW"
+	assert_success
+	assert_output "1"
+}
+
+@test "reusable-ai-review: run step is gated on preflight should-run" {
+	run awk '
+		/- name: Run AI review/ { seen = 1 }
+		seen && /if: steps.preflight.outputs.should-run == .true./ { found = 1; exit }
+		seen && /- name:/ && !/Run AI review/ { exit }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-ai-review: never installs or runs PR code (no uv sync / pip install .)" {
+	# Ignore documentation comment lines; only executable YAML must be clean.
+	run bash -c "grep -vE '^[[:space:]]*#' '$WORKFLOW' | grep -E 'uv sync|pip install \\.|pip install -e'"
+	assert_failure
+}
+
+@test "reusable-ai-review: sparse-checkout includes scripts/ci and post-pr-comment" {
+	run grep -F "scripts/ci/" "$WORKFLOW"
+	assert_success
+	run grep -F ".github/actions/post-pr-comment" "$WORKFLOW"
+	assert_success
+}
+
+# --- Action pinning -----------------------------------------------------------
+
+@test "reusable-ai-review: third-party actions are SHA-pinned with version comments" {
+	run awk '/uses: [a-z][^ ]*\// && !/\.\/\.lgtm-ci-tooling/ {print}' "$WORKFLOW"
+	assert_success
+	while IFS= read -r line; do
+		[[ "$line" =~ uses:\ [^@]+@[0-9a-f]{40}\ #\ v[0-9] ]] || {
+			echo "unpinned action: $line"
+			return 1
+		}
+	done <<<"$output"
+}
+
+@test "reusable-ai-review: uses post-pr-comment with the sticky marker" {
+	run awk '/uses: .*post-pr-comment/{f=1} f&&/marker:/{print;exit}' "$WORKFLOW"
+	assert_success
+	assert_output --partial "marker: lintro-ai-review"
+}

--- a/tests/bats/integration/test_reusable_ai_review.bats
+++ b/tests/bats/integration/test_reusable_ai_review.bats
@@ -128,3 +128,12 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-ai-review.yml"
 	assert_success
 	assert_output --partial "marker: lintro-ai-review"
 }
+
+@test "reusable-ai-review: comment steps skip fork PRs (no upsert with read-only token)" {
+	# Each comment step (fetch-state, render, post) must exclude skip-reason
+	# 'fork' as well as 'not-a-pr', so fork PRs take the graceful skip path
+	# instead of attempting a sticky-comment upsert with a read-only token.
+	run grep -c "steps.preflight.outputs.skip-reason != 'fork'" "$WORKFLOW"
+	assert_success
+	assert_output "3"
+}

--- a/tests/bats/unit/actions/test_render_ai_review_comment.bats
+++ b/tests/bats/unit/actions/test_render_ai_review_comment.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/render-ai-review-comment.sh
+#          (state parse/append/recompute, cumulative math, rendering)
+
+load "../../../helpers/common"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/render-ai-review-comment.sh"
+
+setup() {
+	setup_temp_dir
+	STATE="${BATS_TEST_TMPDIR}/state.json"
+	RUN="${BATS_TEST_TMPDIR}/run.json"
+	OUT="${BATS_TEST_TMPDIR}/comment.md"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+# Emit a run object; args: model status total_tok cost p1 [extra-jq]
+make_run() {
+	local model="$1" status="$2" total="$3" cost="$4" p1="${5:-0}"
+	jq -n --arg m "$model" --arg s "$status" --argjson t "$total" \
+		--argjson c "$cost" --argjson p1 "$p1" \
+		'{sha:"abcdef1234",time:"12:00",model:$m,provider:"anthropic",
+		  input_tokens:($t/2|floor),output_tokens:($t - ($t/2|floor)),
+		  total_tokens:$t,cost_usd:$c,depth:1,duration_s:10,status:$s,
+		  error_kind:(if $s=="error" then "auth" else "" end),
+		  error:(if $s=="error" then "401 invalid key" else "" end),
+		  p1:$p1,p2:0,p3:0,summary:"summary text",findings:[]}'
+}
+
+extract_state() {
+	tail -1 "$OUT" | sed -E 's/^<!-- lintro-ai-review-state: //; s/ -->$//'
+}
+
+@test "render: appends run to empty state and shows cumulative" {
+	echo '{"runs":[]}' >"$STATE"
+	make_run claude-sonnet-4 ok 12004 0.02 1 >"$RUN"
+	STEP=render STATE_FILE="$STATE" RUN_FILE="$RUN" OUTPUT_FILE="$OUT" run bash "$SCRIPT"
+	assert_success
+	run cat "$OUT"
+	assert_output --partial "## 🔎 Lintro AI Review"
+	assert_output --partial "**Cumulative (this PR):** 12,004 tokens"
+	assert_output --partial "1 runs"
+	assert_output --partial '`claude-sonnet-4 ×1`'
+	run extract_state
+	run jq '.runs|length' <<<"$output"
+	assert_output "1"
+}
+
+@test "render: cumulative sums tokens and cost across ok runs only" {
+	jq -n '{runs:[]}' >"$STATE"
+	# seed two ok runs + one error run into state
+	s="$(jq -c '.runs += ['"$(make_run a ok 10000 0.05 0)"']' "$STATE")"
+	s="$(jq -c '.runs += ['"$(make_run b error 0 0 0)"']' <<<"$s")"
+	echo "$s" >"$STATE"
+	make_run c ok 5000 0.01 0 >"$RUN"
+	STEP=render STATE_FILE="$STATE" RUN_FILE="$RUN" OUTPUT_FILE="$OUT" run bash "$SCRIPT"
+	assert_success
+	run cat "$OUT"
+	# 10000 + 5000 = 15000 tokens (error contributes 0); 3 runs total
+	assert_output --partial "15,000 tokens"
+	assert_output --partial "3 runs"
+}
+
+@test "render: per-model counts aggregate and sort by frequency" {
+	jq -n '{runs:[]}' >"$STATE"
+	s="$(jq -c '.runs += ['"$(make_run claude-sonnet-4 ok 100 0 0)"']' "$STATE")"
+	s="$(jq -c '.runs += ['"$(make_run claude-sonnet-4 ok 100 0 0)"']' <<<"$s")"
+	s="$(jq -c '.runs += ['"$(make_run claude-opus-4 ok 100 0 0)"']' <<<"$s")"
+	echo "$s" >"$STATE"
+	make_run claude-sonnet-4 ok 100 0 0 >"$RUN"
+	STEP=render STATE_FILE="$STATE" RUN_FILE="$RUN" OUTPUT_FILE="$OUT" run bash "$SCRIPT"
+	assert_success
+	run cat "$OUT"
+	assert_output --partial '`claude-sonnet-4 ×3`, `claude-opus-4 ×1`'
+}
+
+@test "render: latest ok run shows severity header and mechanics" {
+	echo '{"runs":[]}' >"$STATE"
+	make_run claude-sonnet-4 ok 12004 0.02 2 >"$RUN"
+	STEP=render STATE_FILE="$STATE" RUN_FILE="$RUN" OUTPUT_FILE="$OUT" run bash "$SCRIPT"
+	assert_success
+	run cat "$OUT"
+	assert_output --partial "### Latest — 🔴 2 · 🟠 0 · 🟡 0"
+	assert_output --partial "run: \`claude-sonnet-4\`"
+	assert_output --partial "depth 1"
+}
+
+@test "render: previous runs collapse into details with mechanics" {
+	echo "{\"runs\":[$(make_run claude-opus-4 ok 15900 0.05 0)]}" >"$STATE"
+	make_run claude-sonnet-4 ok 12004 0.02 1 >"$RUN"
+	STEP=render STATE_FILE="$STATE" RUN_FILE="$RUN" OUTPUT_FILE="$OUT" run bash "$SCRIPT"
+	assert_success
+	run cat "$OUT"
+	assert_output --partial "<details><summary>⏱ Previous runs (1)</summary>"
+	assert_output --partial '`claude-opus-4` · 15900 tok'
+}
+
+@test "render: bounded history truncates to MAX_RUNS" {
+	jq -n '{runs: [range(25) | {sha:("s"+(.|tostring)),time:"t",model:"m",provider:"p",input_tokens:1,output_tokens:1,total_tokens:2,cost_usd:0,depth:1,duration_s:1,status:"ok",error_kind:"",error:"",p1:0,p2:0,p3:0,summary:"",findings:[]}]}' >"$STATE"
+	make_run m ok 2 0 0 >"$RUN"
+	STEP=render STATE_FILE="$STATE" RUN_FILE="$RUN" OUTPUT_FILE="$OUT" MAX_RUNS=20 run bash "$SCRIPT"
+	assert_success
+	run extract_state
+	run jq '.runs|length' <<<"$output"
+	assert_output "20"
+}
+
+@test "render: errored run header maps each error kind" {
+	echo '{"runs":[]}' >"$STATE"
+	for kind_pair in "auth:❌ Review skipped" "quota:❌ No credits" "rate_limit:⚠️ Rate limited" "transient:⚠️ Provider unavailable"; do
+		kind="${kind_pair%%:*}"
+		header="${kind_pair#*:}"
+		jq -n --arg k "$kind" \
+			'{sha:"s",time:"t",model:"m",provider:"anthropic",input_tokens:0,output_tokens:0,total_tokens:0,cost_usd:0,depth:1,duration_s:1,status:"error",error_kind:$k,error:("msg-"+$k),p1:0,p2:0,p3:0,summary:"",findings:[]}' >"$RUN"
+		STEP=render STATE_FILE="$STATE" RUN_FILE="$RUN" OUTPUT_FILE="$OUT" run bash "$SCRIPT"
+		assert_success
+		run cat "$OUT"
+		assert_output --partial "### Latest — ${header}"
+		assert_output --partial "msg-${kind}"
+	done
+}
+
+@test "render: errored run appears in previous-runs list with error kind" {
+	echo "{\"runs\":[$(make_run claude-sonnet-4 error 0 0 0)]}" >"$STATE"
+	make_run claude-sonnet-4 ok 100 0.01 0 >"$RUN"
+	STEP=render STATE_FILE="$STATE" RUN_FILE="$RUN" OUTPUT_FILE="$OUT" run bash "$SCRIPT"
+	assert_success
+	run cat "$OUT"
+	assert_output --partial "❌ error: auth"
+}
+
+@test "render: skip note preserves cumulative and does not append a run" {
+	echo "{\"runs\":[$(make_run claude-sonnet-4 ok 12004 0.02 0)]}" >"$STATE"
+	STEP=render STATE_FILE="$STATE" SKIP_REASON=no-key OUTPUT_FILE="$OUT" run bash "$SCRIPT"
+	assert_success
+	run cat "$OUT"
+	assert_output --partial "12,004 tokens"
+	assert_output --partial "### Latest — ⚠️ skipped"
+	assert_output --partial "ANTHROPIC_API_KEY"
+	# state unchanged: still 1 run
+	run extract_state
+	run jq '.runs|length' <<<"$output"
+	assert_output "1"
+}
+
+@test "render: fork skip note explains no-secret behaviour" {
+	echo '{"runs":[]}' >"$STATE"
+	STEP=render STATE_FILE="$STATE" SKIP_REASON=fork OUTPUT_FILE="$OUT" run bash "$SCRIPT"
+	assert_success
+	run cat "$OUT"
+	assert_output --partial "skipped (fork)"
+}
+
+@test "render: embedded state round-trips as valid JSON" {
+	echo '{"runs":[]}' >"$STATE"
+	make_run claude-sonnet-4 ok 12004 0.02 1 >"$RUN"
+	STEP=render STATE_FILE="$STATE" RUN_FILE="$RUN" OUTPUT_FILE="$OUT" run bash "$SCRIPT"
+	assert_success
+	run extract_state
+	run jq -e '.runs[0].model == "claude-sonnet-4"' <<<"$output"
+	assert_success
+}
+
+@test "render: labels comment as automated and includes state marker" {
+	echo '{"runs":[]}' >"$STATE"
+	make_run claude-sonnet-4 ok 12004 0.02 0 >"$RUN"
+	STEP=render STATE_FILE="$STATE" RUN_FILE="$RUN" OUTPUT_FILE="$OUT" run bash "$SCRIPT"
+	assert_success
+	run cat "$OUT"
+	assert_output --partial "🤖 automated · not a substitute for human review"
+	assert_output --partial "<!-- lintro-ai-review-state:"
+}

--- a/tests/bats/unit/actions/test_run_ai_review.bats
+++ b/tests/bats/unit/actions/test_run_ai_review.bats
@@ -1,0 +1,198 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/run-ai-review.sh (preflight + run parsing)
+
+load "../../../helpers/common"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/run-ai-review.sh"
+
+setup() {
+	setup_temp_dir
+	export GITHUB_OUTPUT="${BATS_TEST_TMPDIR}/github-output"
+	touch "$GITHUB_OUTPUT"
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+# Write a fake lintro binary that prints $1 to stdout, $2 to stderr, exits $3.
+write_fake_lintro() {
+	local out="$1" err="$2" code="$3"
+	local bin="${BATS_TEST_TMPDIR}/lintro"
+	{
+		echo '#!/usr/bin/env bash'
+		printf 'cat <<'\''LINTRO_OUT'\''\n%s\nLINTRO_OUT\n' "$out"
+		printf 'cat <<'\''LINTRO_ERR'\''>&2\n%s\nLINTRO_ERR\n' "$err"
+		echo "exit ${code}"
+	} >"$bin"
+	chmod +x "$bin"
+	echo "$bin"
+}
+
+success_json() {
+	cat <<'JSON'
+{"metadata":{"model":"claude-sonnet-4","provider":"anthropic","context_window":200000,"depth":1,"chunks_total":1,"chunks_current":1,"files_reviewed":1,"files_total":1,"checklist_items":5,"token_usage":{"prompt":100,"completion":40,"total":140},"cost_estimate_usd":0.01,"timestamp":"t","strictness":"balanced"},"summary":"ok summary","checklist":[],"findings":[{"severity":"P1","category":"sec","file":"a.py","line":1,"title":"t1","description":"d1","cause":"c","fix":"f","confidence":"high","checklist_ids":[]},{"severity":"P3","category":"style","file":"b.py","line":2,"title":"t3","description":"d3","cause":"c","fix":"f","confidence":"low","checklist_ids":[]}]}
+JSON
+}
+
+run_review() {
+	env STEP=run AI_REVIEW_SKIP_CONFIG=true \
+		GITHUB_REPOSITORY="x/y" PR_NUMBER=1 HEAD_SHA=abcdef1 \
+		RUN_FILE="${BATS_TEST_TMPDIR}/run.json" \
+		"$@" bash "$SCRIPT"
+}
+
+# --- preflight ---------------------------------------------------------------
+
+@test "preflight: same-repo PR with key runs" {
+	STEP=preflight EVENT_NAME=pull_request HEAD_REPO="x/y" BASE_REPO="x/y" \
+		HAS_KEY=true PR_NUMBER=1 run bash "$SCRIPT"
+	assert_success
+	run cat "$GITHUB_OUTPUT"
+	assert_output --partial "should-run=true"
+	assert_output --partial "skip-reason="
+}
+
+@test "preflight: fork PR skips with fork reason" {
+	STEP=preflight EVENT_NAME=pull_request HEAD_REPO="fork/y" BASE_REPO="x/y" \
+		HAS_KEY=true PR_NUMBER=1 run bash "$SCRIPT"
+	assert_success
+	run cat "$GITHUB_OUTPUT"
+	assert_output --partial "should-run=false"
+	assert_output --partial "skip-reason=fork"
+}
+
+@test "preflight: missing key skips with no-key reason" {
+	STEP=preflight EVENT_NAME=pull_request HEAD_REPO="x/y" BASE_REPO="x/y" \
+		HAS_KEY=false PR_NUMBER=1 run bash "$SCRIPT"
+	assert_success
+	run cat "$GITHUB_OUTPUT"
+	assert_output --partial "should-run=false"
+	assert_output --partial "skip-reason=no-key"
+}
+
+@test "preflight: non-PR event skips with not-a-pr reason" {
+	STEP=preflight EVENT_NAME=push HAS_KEY=true run bash "$SCRIPT"
+	assert_success
+	run cat "$GITHUB_OUTPUT"
+	assert_output --partial "skip-reason=not-a-pr"
+}
+
+# --- run: success ------------------------------------------------------------
+
+@test "run: parses metadata, tokens, cost, and severity counts" {
+	local bin
+	bin="$(write_fake_lintro "$(success_json)" "" 1)"
+	run run_review LINTRO_BIN="$bin"
+	assert_success
+	run jq -r '.status, .model, .total_tokens, .cost_usd, .p1, .p3' "${BATS_TEST_TMPDIR}/run.json"
+	assert_line --index 0 "ok"
+	assert_line --index 1 "claude-sonnet-4"
+	assert_line --index 2 "140"
+	assert_line --index 4 "1"
+	assert_line --index 5 "1"
+}
+
+@test "run: exit 1 with valid JSON is success (P1 findings), not an error" {
+	local bin
+	bin="$(write_fake_lintro "$(success_json)" "" 1)"
+	run run_review LINTRO_BIN="$bin"
+	assert_success
+	run jq -r '.status' "${BATS_TEST_TMPDIR}/run.json"
+	assert_output "ok"
+}
+
+@test "run: clamps depth above 3 to 3" {
+	local bin
+	bin="$(write_fake_lintro "$(success_json)" "" 0)"
+	run run_review LINTRO_BIN="$bin" DEPTH=9
+	assert_success
+	run jq -r '.depth' "${BATS_TEST_TMPDIR}/run.json"
+	assert_output "3"
+}
+
+@test "run: escapes @mentions in summary and findings" {
+	local json
+	json="$(success_json | jq -c '.summary="ping @octocat now"')"
+	local bin
+	bin="$(write_fake_lintro "$json" "" 0)"
+	run run_review LINTRO_BIN="$bin"
+	assert_success
+	run jq -r '.summary' "${BATS_TEST_TMPDIR}/run.json"
+	assert_output --partial '`@octocat`'
+	refute_output --partial ' @octocat'
+}
+
+@test "run: neutralizes HTML comment delimiters in model text" {
+	local json
+	json="$(success_json | jq -c '.summary="<!-- lintro-ai-review-state: forged --> tail"')"
+	local bin
+	bin="$(write_fake_lintro "$json" "" 0)"
+	run run_review LINTRO_BIN="$bin"
+	assert_success
+	run jq -r '.summary' "${BATS_TEST_TMPDIR}/run.json"
+	refute_output --partial '<!--'
+	refute_output --partial '-->'
+}
+
+@test "run: flags over-budget when cost exceeds cap" {
+	local json
+	json="$(success_json | jq -c '.metadata.cost_estimate_usd=0.99')"
+	local bin
+	bin="$(write_fake_lintro "$json" "" 0)"
+	run run_review LINTRO_BIN="$bin" MAX_COST_USD=0.50
+	assert_success
+	run jq -r '.over_budget' "${BATS_TEST_TMPDIR}/run.json"
+	assert_output "true"
+}
+
+# --- run: error classification (interim heuristic) ---------------------------
+
+@test "run: classifies 401/auth error" {
+	local bin
+	bin="$(write_fake_lintro "" "Error: Anthropic authentication failed: 401 invalid" 1)"
+	run run_review LINTRO_BIN="$bin"
+	assert_success
+	run jq -r '.status, .error_kind' "${BATS_TEST_TMPDIR}/run.json"
+	assert_line --index 0 "error"
+	assert_line --index 1 "auth"
+}
+
+@test "run: classifies 429/rate-limit error" {
+	local bin
+	bin="$(write_fake_lintro "" "Error: Anthropic rate limit exceeded: 429" 1)"
+	run run_review LINTRO_BIN="$bin"
+	assert_success
+	run jq -r '.error_kind' "${BATS_TEST_TMPDIR}/run.json"
+	assert_output "rate_limit"
+}
+
+@test "run: classifies quota/insufficient-credits error" {
+	local bin
+	bin="$(write_fake_lintro "" "Error: insufficient_quota — no credits" 1)"
+	run run_review LINTRO_BIN="$bin"
+	assert_success
+	run jq -r '.error_kind' "${BATS_TEST_TMPDIR}/run.json"
+	assert_output "quota"
+}
+
+@test "run: unknown provider failure classified as transient" {
+	local bin
+	bin="$(write_fake_lintro "" "Error: connection reset by peer" 1)"
+	run run_review LINTRO_BIN="$bin"
+	assert_success
+	run jq -r '.error_kind, .total_tokens, .cost_usd' "${BATS_TEST_TMPDIR}/run.json"
+	assert_line --index 0 "transient"
+	assert_line --index 1 "0"
+	assert_line --index 2 "0"
+}
+
+@test "run: records effective model on error for cumulative counts" {
+	local bin
+	bin="$(write_fake_lintro "" "Error: Anthropic authentication failed: 401" 1)"
+	run run_review LINTRO_BIN="$bin" MODEL=claude-opus-4
+	assert_success
+	run jq -r '.model' "${BATS_TEST_TMPDIR}/run.json"
+	assert_output "claude-opus-4"
+}

--- a/tests/bats/unit/lib/egress/test_presets.bats
+++ b/tests/bats/unit/lib/egress/test_presets.bats
@@ -97,6 +97,18 @@ PRESETS="${PROJECT_ROOT}/scripts/ci/lib/egress/presets.sh"
 	assert_output --partial 'pipelines.actions.githubusercontent.com:443'
 }
 
+@test "egress preset ai-review includes PyPI, uv, and Anthropic hosts" {
+	run bash -c "source '$PRESETS' && egress_preset_endpoints ai-review"
+	assert_success
+	assert_output --partial 'pypi.org:443'
+	assert_output --partial 'files.pythonhosted.org:443'
+	assert_output --partial 'astral.sh:443'
+	assert_output --partial 'releases.astral.sh:443'
+	assert_output --partial 'api.anthropic.com:443'
+	assert_output --partial 'raw.githubusercontent.com:443'
+	assert_output --partial 'api.github.com:443'
+}
+
 @test "egress preset osv-scanner includes release assets and OSV API hosts" {
 	run bash -c "source '$PRESETS' && egress_preset_endpoints osv-scanner"
 	assert_success
@@ -164,6 +176,7 @@ PRESETS="${PROJECT_ROOT}/scripts/ci/lib/egress/presets.sh"
 		rust-release
 		sbom
 		scorecard
+		ai-review
 	)
 	for preset in "${presets[@]}"; do
 		run bash -c "source '$PRESETS' && egress_preset_endpoints '$preset' | grep -c ."


### PR DESCRIPTION
Closes #416

Adds `reusable-ai-review.yml` — an org-wide AI code review reusable that installs a pinned `lintro[ai]` from PyPI, runs `lintro review` hardened in CI, and publishes a single sticky, telemetry-rich PR comment. Same orchestration shape as `reusable-validate-lintro-version.yml`.

## Interface

Consumers forward the inherited **org secret** (zero per-repo setup):

```yaml
jobs:
  ai-review:
    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-ai-review.yml@<sha>
    permissions:
      contents: read
      pull-requests: write
    with:
      depth: 1
      post: true
      max-cost-usd: "0.50"
    secrets:
      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
```

Inputs: `depth` (1), `post` (true), `max-cost-usd` ("0.50"), `paths` (""), `lintro-version` (pinned `0.65.0`, Renovate-managed), `strictness` (balanced), `model` (optional pass-through, no default), plus the standard contract inputs (`tooling-ref`, `egress-policy`, `egress-preset` default `ai-review`, `allowed-endpoints`, `allowed-endpoints-mode`, `runner-image`, `timeout-minutes` as `type: number`, `job-name`). Secret: `anthropic-api-key` (optional).

## Hardening guarantees

- **Trusted install** — only installs a pinned lintro from PyPI and runs `lintro review` (reads the diff via the GitHub API); never installs or runs the PR's own code (no `uv sync` / `pip install .` / build hooks). `ANTHROPIC_API_KEY` is scoped to the single "Run AI review" step, never in scope while PR-controlled code could execute.
- **Graceful skip (exit 0)** on fork PRs, missing key, and non-PR events; same-repo guard; job is **non-blocking** (`continue-on-error: true`).
- **Cost + depth caps** — depth clamped 1..3; per-run cost compared to `max-cost-usd` and annotated when exceeded.
- **Egress allowlist** — new `ai-review` preset covers PyPI (`pypi.org`, `files.pythonhosted.org`), uv (`astral.sh`, `releases.astral.sh`), Anthropic (`api.anthropic.com`), GitHub, and `raw.githubusercontent.com` (the endpoint that previously broke py-lintro's dogfood). Added to the canonical `presets.sh` and synced into the harden-runner bundle (BATS-validated).
- Actions SHA-pinned with `# vX.Y.Z` comments; reuses `post-pr-comment` for the sticky upsert (marker `lintro-ai-review`).

## Sticky comment / state design

One comment per PR, updated in place, with machine-readable state in a trailing HTML comment `<!-- lintro-ai-review-state: {"runs":[...]} -->` (survives across runs, no external storage; history bounded to last 20). Layout:

1. **Cumulative (always visible)** — total tokens (in/out/combined), total cost USD, per-model counts (`claude-sonnet-4 ×3`), run count.
2. **Latest run** — findings from `lintro review --output json` + per-run mechanics (model, provider, tokens, cost, depth, duration).
3. **Previous runs** — collapsible `<details>` with per-run mechanics.

Errored runs are recorded (status=error, 0 tokens) and shown in the collapsible, contributing 0 to cumulative. Provider errors are formatted in the comment (401 invalid key, 429 rate limited, quota/no-credits, 5xx/timeout).

**Security (untrusted model output):** `@mentions` neutralized, HTML-comment delimiters escaped (can't forge the state marker), length-capped, labelled automated.

## py-lintro error-contract gap (filed)

py-lintro 0.65.0 has **no machine-readable error contract** for `lintro review --output json` — provider errors surface as `click.ClickException` on stderr with an overloaded exit code (1 == P1 findings *or* error). Per instructions I did **not** scrape human stderr as the contract; instead:
- **Filed lgtm-hq/py-lintro#1095** requesting a structured error envelope (references #777).
- The workflow degrades gracefully: "valid review JSON on stdout" = success; the 401/429/quota classification uses a narrow, documented **interim heuristic** on the stable `AIError` message prefixes, swappable for the structured contract once it lands.

## Tests / docs

- BATS unit tests for both scripts (state parse/append/recompute, cumulative math, per-model counts, bounded-history truncation, each error-code rendering, @mention escaping, skip paths).
- Integration test asserting the workflow passes `validate-runner-contract`, `validate-static-job-names`, `validate-tooling-sparse-checkout`, plus interface/hardening/pinning assertions.
- `bats --recursive tests/bats`: 2468 pass, only the known-local `run-rust-coverage-html`/cargo-llvm-cov PATH flake fails. `uv run lintro chk`: 0 issues.
- Docs section added to `docs/reusable-workflows.md`.

## Out of scope / follow-ups

- py-lintro migrating its bespoke `ai-review.yml` to a thin caller of this reusable (dogfood) is **out of scope** for this PR.
- **Preamble note:** built against current main's reusable preamble (resolve-egress → harden-runner, as in `reusable-validate-lintro-version.yml`). If the in-flight #411 (checkout-and-harden composite) lands first and changes the convention, this reusable's preamble may need migration at rebase time.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a reusable AI code review workflow for organization-wide use. The main changes are:

- New `reusable-ai-review.yml` workflow with preflight guards and sticky PR comment publishing.
- New scripts for running `lintro review` and rendering cumulative review state.
- New `ai-review` egress preset in both preset locations.
- Documentation, Renovate tracking, and BATS coverage for the workflow and scripts.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The fork skip path now prevents the fetch, render, and post comment steps from running.
- No blocking issues were found in the changed code reviewed here.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-ai-review.yml | Adds the reusable workflow and gates comment steps for fork skips. |
| scripts/ci/actions/run-ai-review.sh | Adds preflight checks and the pinned `lintro review` runner. |
| scripts/ci/actions/render-ai-review-comment.sh | Adds sticky comment state parsing, aggregation, and rendering. |
| .github/actions/harden-runner/lib/egress/presets.sh | Adds the `ai-review` egress preset. |
| scripts/ci/lib/egress/presets.sh | Adds the mirrored `ai-review` egress preset. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(workflows): skip AI-review comment s..."](https://github.com/lgtm-hq/lgtm-ci/commit/707fd03b5c55c1caa24e7659f77eec4fc57b892e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42004311)</sub>

<!-- /greptile_comment -->