### PR TITLE
feat(ci): add merge_group triggers for merge queue support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions:
   contents: read

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -1016,17 +1016,34 @@ caller publish job path). Outputs: `passed`, `build-passed`, `test-passed`.
 
 ## Merge queue (`merge_group`)
 
-Callers using GitHub merge queue can add `merge_group:` triggers to thin
-caller workflows alongside `pull_request:`.
+Callers using GitHub merge queue must add `merge_group:` triggers to every
+caller workflow that produces a required check, alongside `pull_request:` —
+otherwise queued PRs time out waiting for checks that never report. The
+starter examples (`examples/ci-*.yml`) include `merge_group:` by default.
 
 | Workflow                               | `merge_group` behavior                         |
 | -------------------------------------- | ---------------------------------------------- |
+| `reusable-quality-lint.yml`            | Safe to run — no PR context required           |
 | `reusable-codeql.yml`                  | Safe to run — no PR context required           |
 | `reusable-validate-action-pinning.yml` | Safe to run — no PR context required           |
 | `reusable-dependency-review.yml`       | Runs on `merge_group` (same as PR)             |
 | `reusable-security-audit.yml`          | Audit on `merge_group`; PR comment on PR only  |
 | `reusable-site-quality.yml`            | Safe to run — no PR context required           |
+| `reusable-docker.yml`                  | Safe to run — no PR context required           |
+| `reusable-test-shell.yml`              | Tests run; PR summary comment on PR only       |
+| `reusable-test-python.yml`             | Tests run; PR summary comment on PR only       |
+| `reusable-test-node.yml`               | Tests run; PR summary comment on PR only       |
+| `reusable-test-node-custom.yml`        | Tests run; PR summary comment on PR only       |
+| `reusable-test-rust-build.yml`         | Safe to run — no PR context required           |
+| `reusable-coverage.yml`                | Coverage runs; PR comment on PR only           |
 | `reusable-semantic-pr-title.yml`       | Skips on `merge_group` — title validated on PR |
+
+Test reusables gate their draft-PR skip on `github.event_name ==
+'pull_request'`, so work jobs always run in the merge queue; PR summary
+comments are gated on `pull_request` events in workflow conditions and in
+`post-pr-comment.sh`, so they skip cleanly. Caller-side summary jobs (e.g.
+the split `publish-quality-summary` pattern) already carry a
+`github.event_name == 'pull_request'` guard and skip in the queue.
 
 Semantic title validation is intentionally skipped in the merge queue because
 `amannn/action-semantic-pull-request` requires pull request context.

--- a/examples/ci-docker.yml
+++ b/examples/ci-docker.yml
@@ -12,6 +12,7 @@ name: Docker
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions: {}
 

--- a/examples/ci-node-custom.yml
+++ b/examples/ci-node-custom.yml
@@ -12,6 +12,7 @@ name: CI
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions: {}
 

--- a/examples/ci-node-vitest.yml
+++ b/examples/ci-node-vitest.yml
@@ -12,6 +12,7 @@ name: CI
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions: {}
 

--- a/examples/ci-python.yml
+++ b/examples/ci-python.yml
@@ -13,6 +13,7 @@ name: CI
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions: {}
 

--- a/examples/ci-quality-only.yml
+++ b/examples/ci-quality-only.yml
@@ -13,6 +13,7 @@ name: Quality
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions: {}
 

--- a/examples/ci-rust.yml
+++ b/examples/ci-rust.yml
@@ -13,6 +13,7 @@ name: CI
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions: {}
 


### PR DESCRIPTION
## Summary

Part of the org-wide merge queue rollout (#421). Merge queue requires every required check to report on `merge_group` events; `ci.yml` — producer of both required checks in the `checks-lgtm-ci` ruleset (`quality / Lintro Quality Checks`, `Shell Library Tests / Shell Tests`) — triggered only on `push`/`pull_request`, so a queued PR would time out. This adds `merge_group:` to `ci.yml` and all starter example callers, and documents `merge_group` behavior for the quality/test reusables in the workflow contract.

No reusable-workflow logic changes: publish/PR-comment jobs are already gated on `github.event_name == 'pull_request'` (and in `post-pr-comment.sh`), and draft-skip conditions pass through on non-PR events — everything degrades gracefully in the queue.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Changes Made

- `.github/workflows/ci.yml`: add `merge_group:` trigger
- `examples/ci-{python,node-vitest,node-custom,rust,docker,quality-only}.yml`: add `merge_group:` so newly onboarded repos are queue-ready by default
- `docs/workflow-contract.md`: expand the "Merge queue (`merge_group`)" table from 6 to 14 reusables and document the caller-side guard pattern

## Checklist

- [x] I have tested these changes locally (`validate-runner-contract.sh`, `validate-static-job-names.sh`, `uv run lintro chk` all pass)
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck` (none changed)
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black` (none changed)

## Breaking Changes

None.

## Closes

- Closes #422
- Closes #421

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds merge queue support to CI workflows and docs. The main changes are:

- Added `merge_group` to the main CI workflow.
- Added `merge_group` to starter CI examples.
- Expanded the workflow contract docs for merge queue behavior.
</details>

<h3>Confidence Score: 4/5</h3>

The Docker starter workflow can publish images during merge queue validation.

- The main CI trigger looks guarded for PR-only summary jobs.
- The added `merge_group` syntax matches existing workflow patterns.
- The Docker example treats every non-PR event as publishable, so queue runs can create unwanted image tags.

examples/ci-docker.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds `merge_group` to the repository CI workflow while keeping PR-only publishing jobs guarded. |
| docs/workflow-contract.md | Documents required merge queue triggers and reusable workflow behavior. |
| examples/ci-docker.yml | Adds `merge_group`, which interacts with the existing non-PR Docker push condition. |
| examples/ci-node-custom.yml | Adds a standard `merge_group` trigger to the Node custom starter workflow. |
| examples/ci-node-vitest.yml | Adds a standard `merge_group` trigger to the Node/Vitest starter workflow. |
| examples/ci-python.yml | Adds a standard `merge_group` trigger to the Python starter workflow. |
| examples/ci-quality-only.yml | Adds a standard `merge_group` trigger to the quality-only starter workflow. |
| examples/ci-rust.yml | Adds a standard `merge_group` trigger to the Rust starter workflow. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aexamples%2Fci-docker.yml%3A16%0A**Merge%20Queue%20Publishes%20Images**%0A%0AWhen%20this%20starter%20workflow%20runs%20on%20%60merge_group%60%2C%20the%20existing%20Docker%20input%20%60push%3A%20%24%7B%7B%20github.event_name%20!%3D%20'pull_request'%20%7D%7D%60%20evaluates%20to%20true.%20A%20repo%20copying%20this%20example%20can%20publish%20merge-queue%20validation%20images%20for%20temporary%20queue%20SHAs%20instead%20of%20only%20publishing%20from%20real%20%60push%60%20runs%2C%20leaving%20unwanted%20registry%20artifacts.%0A%0A&pr=423&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aexamples%2Fci-docker.yml%3A16%0A**Merge%20Queue%20Publishes%20Images**%0A%0AWhen%20this%20starter%20workflow%20runs%20on%20%60merge_group%60%2C%20the%20existing%20Docker%20input%20%60push%3A%20%24%7B%7B%20github.event_name%20!%3D%20'pull_request'%20%7D%7D%60%20evaluates%20to%20true.%20A%20repo%20copying%20this%20example%20can%20publish%20merge-queue%20validation%20images%20for%20temporary%20queue%20SHAs%20instead%20of%20only%20publishing%20from%20real%20%60push%60%20runs%2C%20leaving%20unwanted%20registry%20artifacts.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=423&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F422-add-merge-group-triggers%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F422-add-merge-group-triggers%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aexamples%2Fci-docker.yml%3A16%0A**Merge%20Queue%20Publishes%20Images**%0A%0AWhen%20this%20starter%20workflow%20runs%20on%20%60merge_group%60%2C%20the%20existing%20Docker%20input%20%60push%3A%20%24%7B%7B%20github.event_name%20!%3D%20'pull_request'%20%7D%7D%60%20evaluates%20to%20true.%20A%20repo%20copying%20this%20example%20can%20publish%20merge-queue%20validation%20images%20for%20temporary%20queue%20SHAs%20instead%20of%20only%20publishing%20from%20real%20%60push%60%20runs%2C%20leaving%20unwanted%20registry%20artifacts.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=423&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(ci): add merge\_group triggers for m..."](https://github.com/lgtm-hq/lgtm-ci/commit/66aceae8e50d80a5f26e07187a7695b7efcf1fc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42172682)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->
