### PR TITLE
feat(actions): add detect-changes for required-check-safe conditional workflows

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -991,6 +991,51 @@ Build and push Docker images with multi-platform support.
 
 ## Quality Actions
 
+### detect-changes
+
+Maps changed paths to named filters so conditional jobs **always run and
+early-exit green** when their paths didn't change. This is the
+required-check-safe replacement for `on.<event>.paths` filters, which
+deadlock required checks (a check that never reports blocks the PR and
+times out merge-queue entries). Resolves the diff range from
+`pull_request`, `merge_group`, and `push` contexts; an unresolvable base
+fails open (all filters report changed).
+
+```yaml
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      changes: ${{ steps.detect.outputs.changes }}
+    steps:
+      - uses: actions/checkout@<sha> # vX.Y.Z
+        with:
+          fetch-depth: 0
+      - uses: lgtm-hq/lgtm-ci/.github/actions/detect-changes@<sha> # vX.Y.Z
+        id: detect
+        with:
+          filters: |
+            examples=examples/* packages/*
+            docs=docs/* *.md
+
+  validate-examples:
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate examples
+        if: fromJSON(needs.changes.outputs.changes).examples
+        run: bash scripts/ci/validate-examples.sh
+      - name: Skip (no example changes)
+        if: ${{ !fromJSON(needs.changes.outputs.changes).examples }}
+        run: echo "No example changes; validation not required."
+```
+
+**Outputs:** `changes` (JSON object of filter name → boolean),
+`any-changed`. Keep the downstream job name static — it is the required
+check's identity.
+
+---
+
 ### run-quality
 
 Runs **lintro inside the full [`py-lintro`](https://github.com/lgtm-hq/py-lintro)

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1022,6 +1022,9 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     steps:
+      # Each job runs in a fresh workspace — checkout again here.
+      - uses: actions/checkout@<sha> # vX.Y.Z
+        if: fromJSON(needs.changes.outputs.changes).examples
       - name: Validate examples
         if: fromJSON(needs.changes.outputs.changes).examples
         run: bash scripts/ci/validate-examples.sh

--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -1,0 +1,58 @@
+---
+name: "Detect Changes"
+description: >-
+  Map changed paths to named filters so conditional jobs always run and
+  early-exit green when their paths didn't change (required-check-safe
+  replacement for on.<event>.paths). Resolves the diff range from
+  pull_request, merge_group, and push contexts.
+author: "lgtm-hq"
+
+inputs:
+  filters:
+    description: >-
+      One filter per line: `name=pattern [pattern...]`. Patterns are
+      bash-style globs matched against full repo-relative paths; `*`
+      crosses directory separators.
+    required: true
+  base:
+    description: >-
+      Base SHA override. Default: pull_request base, merge_group base,
+      or push before-SHA. Empty base fails open (all filters true).
+    required: false
+    default: ""
+  head:
+    description: "Head SHA override (default: event head or HEAD)"
+    required: false
+    default: ""
+
+outputs:
+  changes:
+    description: 'JSON object mapping each filter name to true/false'
+    value: ${{ steps.detect.outputs.changes }}
+  any-changed:
+    description: "Whether any filter matched"
+    value: ${{ steps.detect.outputs.any-changed }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
+
+    - name: Detect changed paths
+      id: detect
+      shell: bash
+      env:
+        FILTERS: ${{ inputs.filters }}
+        # yamllint disable rule:line-length
+        BASE_SHA: ${{ inputs.base || github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+        HEAD_SHA: ${{ inputs.head || github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+        # yamllint enable rule:line-length
+      run: $SCRIPTS_DIR/ci/actions/detect-changes.sh
+
+branding:
+  icon: "filter"
+  color: "blue"

--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -51,7 +51,7 @@ runs:
         BASE_SHA: ${{ inputs.base || github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
         HEAD_SHA: ${{ inputs.head || github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
         # yamllint enable rule:line-length
-      run: $SCRIPTS_DIR/ci/actions/detect-changes.sh
+      run: "$SCRIPTS_DIR/ci/actions/detect-changes.sh"
 
 branding:
   icon: "filter"

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -1048,6 +1048,32 @@ the split `publish-quality-summary` pattern) already carry a
 Semantic title validation is intentionally skipped in the merge queue because
 `amannn/action-semantic-pull-request` requires pull request context.
 
+## Required-check-safe conditional workflows
+
+`on.<event>.paths` filters must not be used on workflows that produce
+**required checks**: when the paths don't match, the workflow never runs,
+the check never reports, and the PR deadlocks (docs-only PRs block forever;
+merge-queue entries time out). Paired no-op shim workflows are also
+discouraged — duplicated job names and path filters drift apart silently.
+
+Instead, drop the `paths:` filter, always run the workflow (including on
+`merge_group`), and early-exit green via the `detect-changes` action:
+
+1. A `changes` job runs `lgtm-hq/lgtm-ci/.github/actions/detect-changes`
+   (checkout with `fetch-depth: 0` first) and exposes its `changes` output.
+2. Downstream jobs keep their **static job name** (the required check's
+   identity) and gate their steps on
+   `fromJSON(needs.changes.outputs.changes).<filter>`, running a cheap
+   "skipped" step (~seconds) when the filter didn't match.
+
+The action resolves the diff base from `pull_request`
+(`event.pull_request.base.sha`), `merge_group` (`event.merge_group.base_sha`),
+and `push` (`event.before`); when no base is resolvable it **fails open** and
+reports every filter as changed, so a required check runs its full job rather
+than silently early-exiting. See `.github/actions/README.md`
+("detect-changes") for a complete caller example, and homebrew-tap's
+`validate-homebrew-formula.yml` for the pattern's prior art.
+
 Callers need `pull-requests: write` when `post-failure-comment` is enabled
 (default). With `post-failure-comment: false`, `pull-requests: read` suffices.
 Tooling is loaded from `lgtm-ci` via `prepare-semantic-pr-lists.sh` (supports

--- a/scripts/ci/actions/detect-changes.sh
+++ b/scripts/ci/actions/detect-changes.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Map changed paths to named filters so conditional jobs can
+# early-exit green instead of being skipped by on.<event>.paths (which
+# deadlocks required checks: a check that never reports blocks the PR and
+# times out merge-queue entries).
+#
+# Writes to GITHUB_OUTPUT:
+#   changes        JSON object mapping each filter name to "true"/"false"
+#   any-changed    "true" if any filter matched
+#
+# Environment:
+#   GITHUB_OUTPUT        Required. File to append outputs to.
+#   FILTERS              Required. One filter per line: `name=pattern [pattern...]`.
+#                        Patterns are bash-style globs matched against full
+#                        repo-relative paths; `*` crosses directory separators
+#                        (so `docs/*` and `docs/**` are equivalent).
+#   BASE_SHA             Base commit for the diff. Empty -> fail open (all
+#                        filters report true) so required checks stay safe.
+#   HEAD_SHA             Head commit for the diff (default: HEAD).
+#   CHANGED_FILES        Optional test seam: newline-separated file list used
+#                        instead of computing a git diff.
+
+set -euo pipefail
+
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+: "${FILTERS:?FILTERS is required}"
+
+BASE_SHA="${BASE_SHA:-}"
+HEAD_SHA="${HEAD_SHA:-HEAD}"
+
+# Resolve the changed-file list. No base ref (push without before-SHA, manual
+# dispatch, shallow history) -> fail open: report every filter as changed so
+# a required check runs its full job rather than silently early-exiting.
+fail_open=0
+if [[ -n "${CHANGED_FILES:-}" ]]; then
+	changed="$CHANGED_FILES"
+elif [[ -z "$BASE_SHA" ]]; then
+	fail_open=1
+	changed=""
+elif ! changed="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" 2>/dev/null)"; then
+	# Unreachable base (shallow clone, force-push): fail open, same rationale.
+	fail_open=1
+	changed=""
+fi
+
+matches_any_pattern() {
+	local file="$1"
+	shift
+	local pattern
+	for pattern in "$@"; do
+		# shellcheck disable=SC2254
+		case "$file" in
+		$pattern) return 0 ;;
+		esac
+	done
+	return 1
+}
+
+json="{"
+any="false"
+first=1
+while IFS= read -r line; do
+	# Skip blanks and comments.
+	[[ -z "${line// /}" || "$line" == \#* ]] && continue
+	if [[ "$line" != *=* ]]; then
+		echo "detect-changes: invalid filter line (expected name=patterns): $line" >&2
+		exit 1
+	fi
+	name="${line%%=*}"
+	name="${name// /}"
+	read -r -a patterns <<<"${line#*=}"
+	if [[ -z "$name" || "${#patterns[@]}" -eq 0 ]]; then
+		echo "detect-changes: invalid filter line (empty name or patterns): $line" >&2
+		exit 1
+	fi
+
+	result="false"
+	if [[ "$fail_open" -eq 1 ]]; then
+		result="true"
+	else
+		while IFS= read -r file; do
+			[[ -z "$file" ]] && continue
+			if matches_any_pattern "$file" "${patterns[@]}"; then
+				result="true"
+				break
+			fi
+		done <<<"$changed"
+	fi
+	[[ "$result" == "true" ]] && any="true"
+
+	[[ "$first" -eq 0 ]] && json+=","
+	json+="\"${name}\":${result}"
+	first=0
+done <<<"$FILTERS"
+json+="}"
+
+if [[ "$first" -eq 1 ]]; then
+	echo "detect-changes: FILTERS contained no filter lines" >&2
+	exit 1
+fi
+
+{
+	echo "changes=${json}"
+	echo "any-changed=${any}"
+} >>"$GITHUB_OUTPUT"

--- a/scripts/ci/actions/detect-changes.sh
+++ b/scripts/ci/actions/detect-changes.sh
@@ -33,13 +33,16 @@ HEAD_SHA="${HEAD_SHA:-HEAD}"
 # dispatch, shallow history) -> fail open: report every filter as changed so
 # a required check runs its full job rather than silently early-exiting.
 fail_open=0
-if [[ -n "${CHANGED_FILES:-}" ]]; then
+if [[ -n "${CHANGED_FILES+x}" ]]; then
+	# Test seam: set-but-empty means "no files changed".
 	changed="$CHANGED_FILES"
 elif [[ -z "$BASE_SHA" ]]; then
+	echo "detect-changes: BASE_SHA is empty; failing open (all filters true)" >&2
 	fail_open=1
 	changed=""
 elif ! changed="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" 2>/dev/null)"; then
 	# Unreachable base (shallow clone, force-push): fail open, same rationale.
+	echo "detect-changes: cannot diff ${BASE_SHA}...${HEAD_SHA}; failing open (all filters true)" >&2
 	fail_open=1
 	changed=""
 fi
@@ -61,8 +64,10 @@ json="{"
 any="false"
 first=1
 while IFS= read -r line; do
-	# Skip blanks and comments.
-	[[ -z "${line// /}" || "$line" == \#* ]] && continue
+	# Skip blanks and comments (allowing leading whitespace).
+	trimmed="${line#"${line%%[![:space:]]*}"}"
+	[[ -z "$trimmed" || "$trimmed" == \#* ]] && continue
+	line="$trimmed"
 	if [[ "$line" != *=* ]]; then
 		echo "detect-changes: invalid filter line (expected name=patterns): $line" >&2
 		exit 1
@@ -72,6 +77,12 @@ while IFS= read -r line; do
 	read -r -a patterns <<<"${line#*=}"
 	if [[ -z "$name" || "${#patterns[@]}" -eq 0 ]]; then
 		echo "detect-changes: invalid filter line (empty name or patterns): $line" >&2
+		exit 1
+	fi
+	# Names become JSON keys verbatim; restrict to characters that need no
+	# escaping so the output can never be malformed JSON.
+	if [[ ! "$name" =~ ^[A-Za-z0-9_-]+$ ]]; then
+		echo "detect-changes: invalid filter name (allowed: [A-Za-z0-9_-]): $name" >&2
 		exit 1
 	fi
 

--- a/tests/bats/unit/actions/test_detect_changes.bats
+++ b/tests/bats/unit/actions/test_detect_changes.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/detect-changes.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+load "../../../helpers/github_env"
+
+SCRIPT="scripts/ci/actions/detect-changes.sh"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+run_detect() {
+	run env "$@" bash "${PROJECT_ROOT}/${SCRIPT}"
+}
+
+@test "detect-changes: fails without FILTERS" {
+	run env -u FILTERS bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "FILTERS is required"
+}
+
+@test "detect-changes: fails on invalid filter line" {
+	run_detect FILTERS="no-equals-sign" CHANGED_FILES="a.txt"
+	assert_failure
+	assert_output --partial "invalid filter line"
+}
+
+@test "detect-changes: fails on empty filter list" {
+	run_detect FILTERS=$'\n  \n' CHANGED_FILES="a.txt"
+	assert_failure
+	assert_output --partial "no filter lines"
+}
+
+@test "detect-changes: matching filter reports true" {
+	run_detect \
+		FILTERS="tests=tests/* src/*" \
+		CHANGED_FILES=$'tests/unit/a_test.rs'
+	assert_success
+	run get_github_output "changes"
+	assert_output '{"tests":true}'
+	run get_github_output "any-changed"
+	assert_output "true"
+}
+
+@test "detect-changes: non-matching filter reports false" {
+	run_detect \
+		FILTERS="tests=tests/* src/*" \
+		CHANGED_FILES=$'docs/readme.md'
+	assert_success
+	run get_github_output "changes"
+	assert_output '{"tests":false}'
+	run get_github_output "any-changed"
+	assert_output "false"
+}
+
+@test "detect-changes: multiple filters evaluated independently" {
+	run_detect \
+		FILTERS=$'tests=tests/* src/*\ndocs=docs/* *.md' \
+		CHANGED_FILES=$'docs/guide.md\nsrc/main.rs'
+	assert_success
+	run get_github_output "changes"
+	assert_output '{"tests":true,"docs":true}'
+}
+
+@test "detect-changes: glob star crosses directory separators" {
+	run_detect \
+		FILTERS="examples=examples/*" \
+		CHANGED_FILES=$'examples/react/src/App.tsx'
+	assert_success
+	run get_github_output "changes"
+	assert_output '{"examples":true}'
+}
+
+@test "detect-changes: comments and blank filter lines are ignored" {
+	run_detect \
+		FILTERS=$'# tests below\n\ntests=tests/*' \
+		CHANGED_FILES=$'tests/a.rs'
+	assert_success
+	run get_github_output "changes"
+	assert_output '{"tests":true}'
+}
+
+@test "detect-changes: empty base fails open (all filters true)" {
+	run_detect \
+		FILTERS=$'tests=tests/*\ndocs=docs/*' \
+		BASE_SHA=""
+	assert_success
+	run get_github_output "changes"
+	assert_output '{"tests":true,"docs":true}'
+	run get_github_output "any-changed"
+	assert_output "true"
+}
+
+@test "detect-changes: unreachable base fails open" {
+	cd "$BATS_TEST_TMPDIR"
+	git init -q repo
+	cd repo
+	git commit -q --allow-empty -m init
+	run env \
+		FILTERS="tests=tests/*" \
+		BASE_SHA="0000000000000000000000000000000000000001" \
+		GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	run get_github_output "changes"
+	assert_output '{"tests":true}'
+}
+
+@test "detect-changes: computes diff from git when no seam provided" {
+	cd "$BATS_TEST_TMPDIR"
+	git init -q repo
+	cd repo
+	git commit -q --allow-empty -m init
+	base="$(git rev-parse HEAD)"
+	mkdir -p tests
+	echo "x" >tests/a.rs
+	git add tests/a.rs
+	git commit -q -m "add test"
+	run env \
+		FILTERS=$'tests=tests/*\ndocs=docs/*' \
+		BASE_SHA="$base" \
+		GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	run get_github_output "changes"
+	assert_output '{"tests":true,"docs":false}'
+}

--- a/tests/bats/unit/actions/test_detect_changes.bats
+++ b/tests/bats/unit/actions/test_detect_changes.bats
@@ -34,6 +34,12 @@ run_detect() {
 	assert_output --partial "invalid filter line"
 }
 
+@test "detect-changes: fails on JSON-unsafe filter name" {
+	run_detect FILTERS='bad"name=tests/*' CHANGED_FILES="a.txt"
+	assert_failure
+	assert_output --partial "invalid filter name"
+}
+
 @test "detect-changes: fails on empty filter list" {
 	run_detect FILTERS=$'\n  \n' CHANGED_FILES="a.txt"
 	assert_failure
@@ -82,11 +88,22 @@ run_detect() {
 
 @test "detect-changes: comments and blank filter lines are ignored" {
 	run_detect \
-		FILTERS=$'# tests below\n\ntests=tests/*' \
+		FILTERS=$'# tests below\n  # indented comment\n\ntests=tests/*' \
 		CHANGED_FILES=$'tests/a.rs'
 	assert_success
 	run get_github_output "changes"
 	assert_output '{"tests":true}'
+}
+
+@test "detect-changes: set-but-empty CHANGED_FILES means no changes" {
+	run_detect \
+		FILTERS=$'tests=tests/*\ndocs=docs/*' \
+		CHANGED_FILES=""
+	assert_success
+	run get_github_output "changes"
+	assert_output '{"tests":false,"docs":false}'
+	run get_github_output "any-changed"
+	assert_output "false"
 }
 
 @test "detect-changes: empty base fails open (all filters true)" {
@@ -104,11 +121,12 @@ run_detect() {
 	cd "$BATS_TEST_TMPDIR"
 	git init -q repo
 	cd repo
+	git config user.email "test@example.com"
+	git config user.name "Test"
 	git commit -q --allow-empty -m init
 	run env \
 		FILTERS="tests=tests/*" \
 		BASE_SHA="0000000000000000000000000000000000000001" \
-		GITHUB_OUTPUT="$GITHUB_OUTPUT" \
 		bash "${PROJECT_ROOT}/${SCRIPT}"
 	assert_success
 	run get_github_output "changes"
@@ -119,6 +137,8 @@ run_detect() {
 	cd "$BATS_TEST_TMPDIR"
 	git init -q repo
 	cd repo
+	git config user.email "test@example.com"
+	git config user.name "Test"
 	git commit -q --allow-empty -m init
 	base="$(git rev-parse HEAD)"
 	mkdir -p tests
@@ -128,7 +148,6 @@ run_detect() {
 	run env \
 		FILTERS=$'tests=tests/*\ndocs=docs/*' \
 		BASE_SHA="$base" \
-		GITHUB_OUTPUT="$GITHUB_OUTPUT" \
 		bash "${PROJECT_ROOT}/${SCRIPT}"
 	assert_success
 	run get_github_output "changes"


### PR DESCRIPTION
## Summary

Implements #36 (scope extended for the merge-queue rollout, #421): a `detect-changes` composite action + contract pattern replacing `on.<event>.paths` filters on workflows that produce required checks. Path-filtered required checks deadlock PRs (check never reports) and time out merge-queue entries; with this pattern the workflow always runs, a `changes` job maps changed paths to named filters, and downstream jobs keep their static names and early-exit green when their paths didn't change.

Bespoke over `dorny/paths-filter`: the mandate requires base/head resolution on `merge_group` and `push` events, which dorny doesn't cleanly support, and house rules require shell-in-files + full pinning anyway. Prior art: homebrew-tap's `changes` job.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Changes Made

- `.github/actions/detect-changes/action.yml` — composite action; resolves diff SHAs from `pull_request` / `merge_group` / `push` contexts; outputs `changes` (JSON name→bool) + `any-changed`
- `scripts/ci/actions/detect-changes.sh` — detection logic; filter format `name=glob [glob...]`; fails open (all filters true, logged) on unresolvable base; filter names validated to `[A-Za-z0-9_-]` so output JSON can't be malformed
- `tests/bats/unit/actions/test_detect_changes.bats` — 13 cases: parsing, validation, matching, fail-open, set-but-empty seam, live-git diff
- `docs/workflow-contract.md` — new "Required-check-safe conditional workflows" section
- `.github/actions/README.md` — usage entry with full caller example

## Checklist

- [x] I have tested these changes locally (bats 13/13, contract validators, `uv run lintro chk` clean)
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black` (none changed)

## Breaking Changes

None.

## Closes

- Closes #36
- Relates to #421

## Details

Pre-push review findings addressed in `219841c`: Greptile P1 (JSON-unsafe filter names) fixed via name validation; CodeRabbit majors (silent fail-open, indented comments) and minors (CHANGED_FILES seam semantics, quoting, git identity in tests) all fixed. Consumer follow-ups (separate PRs per the mandate): turbo-themes `quality-examples.yml` + `quality-coverage-multi.yml`, py-lintro `test-built-package.yml`.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a required-check-safe change detection pattern for conditional workflows. The main changes are:

- A new `detect-changes` composite action.
- A shell script that maps changed paths to named filters.
- Bats coverage for parsing, matching, fail-open behavior, and git diff handling.
- Documentation and README examples for using the action in required checks.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/README.md | Adds the `detect-changes` usage example with a downstream checkout before running repository scripts. |
| .github/actions/detect-changes/action.yml | Defines the composite action inputs, outputs, SHA resolution, and script invocation. |
| scripts/ci/actions/detect-changes.sh | Implements filter parsing, changed-file detection, fail-open handling, and JSON output generation. |
| tests/bats/unit/actions/test_detect_changes.bats | Adds unit tests for validation, glob matching, empty inputs, fail-open behavior, and live git diffs. |
| docs/workflow-contract.md | Documents the required-check-safe workflow contract and the `detect-changes` pattern. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(actions): add checkout to detect-ch..."](https://github.com/lgtm-hq/lgtm-ci/commit/1fae93f23ea94ccc5a0114c89037ec814b3be499) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42189234)</sub>

<!-- /greptile_comment -->