### PR TITLE
feat(workflows): add reusable main-failure notifier

### DIFF
--- a/.github/workflows/reusable-main-failure-notifier.yml
+++ b/.github/workflows/reusable-main-failure-notifier.yml
@@ -1,0 +1,134 @@
+---
+name: Reusable - Main Failure Notifier
+
+# Surfaces main-branch workflow failures as deduplicated GitHub issues so
+# they stay visible without a human watching Actions between auto-merges.
+# Call from a failure-gated job in any main-branch workflow:
+#
+#   notify-failure:
+#     needs: [build]
+#     if: failure() && github.ref == 'refs/heads/main'
+#     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-main-failure-notifier.yml@<sha>
+#     with:
+#       workflow-key: docker-publish
+#     permissions:
+#       actions: read
+#       contents: read
+#       issues: write
+#
+# Same dedup'd-issue mechanism as the release workflows (one open issue per
+# workflow key + branch; repeat failures comment on it). Companion convention:
+# main red = disarm pending auto-merges until a fix-forward PR lands.
+
+"on":
+  workflow_call:
+    inputs:
+      workflow-key:
+        description: >-
+          Stable key namespacing the dedup marker and issue title
+          (e.g. docker-publish, pages-deploy, dogfood-lint)
+        required: true
+        type: string
+      failure-issue-labels:
+        description: Comma-separated labels for auto-opened failure issues
+        required: false
+        type: string
+        default: "bug,ci,automation"
+      failure-target-branch:
+        description: >-
+          Branch name for failure notifications. Empty uses the repository
+          default branch.
+        required: false
+        type: string
+        default: ""
+      runner-image:
+        description: Runner image for the notifier job
+        required: false
+        type: string
+        default: ubuntu-24.04
+      timeout-minutes:
+        description: Timeout for the notifier job
+        required: false
+        type: number
+        default: 10
+      egress-policy:
+        description: Egress policy for harden-runner (audit or block)
+        required: false
+        type: string
+        default: block
+      tooling-ref:
+        description: >-
+          lgtm-ci ref for tooling checkout. Empty uses the calling workflow's
+          pinned SHA.
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    name: Report main workflow failure
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      # Read workflow/job metadata to generate failure context
+      actions: read
+      # Read repository context for issue body
+      contents: read
+      # Create or update failure notification issues
+      issues: write
+
+    steps:
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/harden-runner
+            .github/actions/resolve-egress-allowlist
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Resolve egress allowlist
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: github-minimal
+
+      - name: Harden runner
+        uses: ./.lgtm-ci-tooling/.github/actions/harden-runner
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ steps.egress.outputs['allowed-endpoints'] }}
+
+      - name: Write failure trigger summary
+        shell: bash
+        env:
+          WORKFLOW_KEY: ${{ inputs.workflow-key }}
+          FAILURE_HEADING_LABEL: Main Workflow
+          PRIMARY_JOB_FAILED: "true"
+        run: >-
+          .lgtm-ci-tooling/scripts/ci/release/report-release-failure.sh
+          write_trigger_summary
+
+      - name: Notify main workflow failure
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_KEY: ${{ inputs.workflow-key }}
+          FAILURE_MARKER_PREFIX: main-workflow-failure
+          FAILURE_TITLE_PREFIX: "fix(ci): main workflow failed:"
+          # yamllint disable-line rule:line-length
+          FAILURE_SUMMARY_TEXT: "A main-branch workflow failed after merge. This issue keeps post-merge failures visible outside the Actions history; with auto-merge there is no human watching main between merges. Convention: while this issue is open, disarm pending auto-merges (gh pr merge --disable-auto) until a fix-forward PR lands."
+          FAILURE_ISSUE_LABELS: ${{ inputs.failure-issue-labels }}
+          FAILURE_TARGET_BRANCH: ${{ inputs.failure-target-branch }}
+        run: >-
+          .lgtm-ci-tooling/scripts/ci/release/report-release-failure.sh
+          notify_failure

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -364,6 +364,32 @@ trigger context to the job step summary, then creates or updates a deduplicated
 GitHub issue with failed step details. Set `report-failures: false` to disable
 both actions. See [workflow-contract.md](workflow-contract.md) for inputs.
 
+### Main failure notifier
+
+`reusable-main-failure-notifier.yml` generalizes the same dedup'd-issue
+mechanism for **any** main-branch workflow (docker publish, Pages deploy,
+dogfood lint, …) — with auto-merge and merge queue landing PRs unattended,
+nobody is watching main between merges. Call it from a failure-gated job:
+
+```yaml
+notify-failure:
+  needs: [build]
+  if: failure() && github.ref == 'refs/heads/main'
+  # yamllint disable-line rule:line-length
+  uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-main-failure-notifier.yml@<sha> # vX.Y.Z
+  with:
+    workflow-key: docker-publish # stable key: one open issue per key+branch
+  permissions:
+    actions: read
+    contents: read
+    issues: write
+```
+
+Repeat failures comment on the existing open issue instead of filing new
+ones (tracking key `main-workflow-failure:<key>:<branch>`). Companion
+convention: while such an issue is open, treat main as red — disarm pending
+auto-merges (`gh pr merge --disable-auto`) until a fix-forward PR lands.
+
 `report-failures` defaults to `true`. GitHub rejects a reusable-workflow call at
 startup when the caller job does not grant every permission the reusable
 workflow declares. Grant at least `actions: read` and `issues: write` on the

--- a/scripts/ci/release/report-release-failure.sh
+++ b/scripts/ci/release/report-release-failure.sh
@@ -8,12 +8,13 @@
 #   write_trigger_summary — append trigger context to $GITHUB_STEP_SUMMARY
 #   notify_failure        — create or comment on a deduplicated GitHub issue
 #
-# Required environment variables (notify_failure):
-#   GH_TOKEN            — GitHub token with issues: write
-#   GITHUB_REPOSITORY   — Target repository (owner/name)
+# Required environment variables:
 #   WORKFLOW_KEY        — Stable workflow key for marker namespacing
 #                         (e.g. release-version-pr, docker-publish).
 #                         RELEASE_WORKFLOW_KEY is honored as a fallback.
+#                         Required by both subcommands.
+#   GH_TOKEN            — GitHub token with issues: write (notify_failure only)
+#   GITHUB_REPOSITORY   — Target repository (owner/name) (notify_failure only)
 #
 # Optional parameterization (defaults preserve the release wording so existing
 # callers and open dedup'd issues keep working):

--- a/scripts/ci/release/report-release-failure.sh
+++ b/scripts/ci/release/report-release-failure.sh
@@ -131,6 +131,10 @@ write_trigger_summary() {
 		exit 1
 	fi
 
+	# Validate up front: later uses run in command substitutions, where the
+	# :? expansion would kill only the subshell and the script would exit 0.
+	workflow_key >/dev/null
+
 	branch="$(release_branch)"
 	sha="$(release_sha)"
 	current_run_url="$(run_url)"
@@ -386,6 +390,10 @@ notify_failure() {
 		log_error "gh CLI is required to report release automation failures"
 		exit 1
 	fi
+
+	# Validate up front: later uses run in command substitutions, where the
+	# :? expansion would kill only the subshell and the script would exit 0.
+	workflow_key >/dev/null
 
 	branch="$(release_branch)"
 	target_branch="$(resolve_target_branch)"

--- a/scripts/ci/release/report-release-failure.sh
+++ b/scripts/ci/release/report-release-failure.sh
@@ -1,16 +1,29 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
-# Purpose: Surface reusable release workflow failures via step summary and issues
+# Purpose: Surface workflow failures via step summary and deduplicated issues.
+# Originally release-specific; now parameterized so any main-branch workflow
+# (via reusable-main-failure-notifier.yml) can use the same mechanism.
 #
 # Subcommands:
-#   write_trigger_summary — append release trigger context to $GITHUB_STEP_SUMMARY
+#   write_trigger_summary — append trigger context to $GITHUB_STEP_SUMMARY
 #   notify_failure        — create or comment on a deduplicated GitHub issue
 #
 # Required environment variables (notify_failure):
 #   GH_TOKEN            — GitHub token with issues: write
 #   GITHUB_REPOSITORY   — Target repository (owner/name)
-#   RELEASE_WORKFLOW_KEY — Stable workflow key for marker namespacing
-#                          (e.g. release-version-pr, release-auto-tag)
+#   WORKFLOW_KEY        — Stable workflow key for marker namespacing
+#                         (e.g. release-version-pr, docker-publish).
+#                         RELEASE_WORKFLOW_KEY is honored as a fallback.
+#
+# Optional parameterization (defaults preserve the release wording so existing
+# callers and open dedup'd issues keep working):
+#   FAILURE_MARKER_PREFIX — dedup marker/tracking-key prefix
+#                           (default: release-automation-failure)
+#   FAILURE_TITLE_PREFIX  — issue title prefix
+#                           (default: "fix(release): release automation failed on")
+#   FAILURE_SUMMARY_TEXT  — first body sentence (default: release wording)
+#   FAILURE_HEADING_LABEL — step-summary heading label
+#                           (default: "Release Automation")
 
 set -euo pipefail
 
@@ -63,12 +76,20 @@ upstream_run_url() {
 }
 
 workflow_key() {
-	echo "${RELEASE_WORKFLOW_KEY:?RELEASE_WORKFLOW_KEY is required}"
+	if [[ -n "${WORKFLOW_KEY:-}" ]]; then
+		echo "$WORKFLOW_KEY"
+	else
+		echo "${RELEASE_WORKFLOW_KEY:?WORKFLOW_KEY (or RELEASE_WORKFLOW_KEY) is required}"
+	fi
+}
+
+marker_prefix() {
+	echo "${FAILURE_MARKER_PREFIX:-release-automation-failure}"
 }
 
 marker_key() {
 	local branch="${1:-$(release_branch)}"
-	echo "release-automation-failure:$(workflow_key):${branch}"
+	echo "$(marker_prefix):$(workflow_key):${branch}"
 }
 
 issue_marker() {
@@ -78,8 +99,8 @@ issue_marker() {
 
 failure_issue_title() {
 	local target_branch="${1:?target_branch is required}"
-	printf 'fix(release): release automation failed on %s (%s)' \
-		"$target_branch" "$(workflow_key)"
+	local prefix="${FAILURE_TITLE_PREFIX:-fix(release): release automation failed on}"
+	printf '%s %s (%s)' "$prefix" "$target_branch" "$(workflow_key)"
 }
 
 resolve_target_branch() {
@@ -102,7 +123,8 @@ write_trigger_summary() {
 	local sha
 	local current_run_url
 	local upstream_url
-	local heading="## Release Automation Context"
+	local heading_label="${FAILURE_HEADING_LABEL:-Release Automation}"
+	local heading="## ${heading_label} Context"
 
 	if [[ -z "${GITHUB_STEP_SUMMARY:-}" ]]; then
 		log_error "GITHUB_STEP_SUMMARY is required"
@@ -115,7 +137,7 @@ write_trigger_summary() {
 	upstream_url="$(upstream_run_url)"
 
 	if [[ "${PRIMARY_JOB_FAILED:-false}" == "true" ]]; then
-		heading="## Release Automation Failure"
+		heading="## ${heading_label} Failure"
 	fi
 
 	add_github_summary "$heading"
@@ -185,7 +207,7 @@ $marker
 
 ## Summary
 
-Release automation failed on \`${target_branch}\`. This issue keeps post-merge release failures visible outside the Actions history.
+${FAILURE_SUMMARY_TEXT:-Release automation failed on \`${target_branch}\`. This issue keeps post-merge release failures visible outside the Actions history.}
 
 ## Failure Context
 

--- a/tests/bats/integration/test_reusable_main_failure_notifier.bats
+++ b/tests/bats/integration/test_reusable_main_failure_notifier.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-main-failure-notifier.yml
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-main-failure-notifier.yml"
+
+@test "main-failure-notifier: requires a workflow-key input" {
+	run awk '
+		/^      workflow-key:/ { in_input = 1 }
+		in_input && /required: true/ { found = 1; exit }
+		in_input && /^      [a-z-]+:/ && $0 !~ /workflow-key:/ { in_input = 0 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "main-failure-notifier: notify job grants issues write and reads actions" {
+	run grep -F "issues: write" "$WORKFLOW"
+	assert_success
+	run grep -F "actions: read" "$WORKFLOW"
+	assert_success
+}
+
+@test "main-failure-notifier: hardens egress before reporting" {
+	run grep -F "harden-runner" "$WORKFLOW"
+	assert_success
+	run grep -F "resolve-egress-allowlist" "$WORKFLOW"
+	assert_success
+}
+
+@test "main-failure-notifier: delegates to the parameterized failure reporter" {
+	run grep -F "report-release-failure.sh" "$WORKFLOW"
+	assert_success
+	run grep -F "WORKFLOW_KEY: \${{ inputs.workflow-key }}" "$WORKFLOW"
+	assert_success
+	run grep -F "FAILURE_MARKER_PREFIX: main-workflow-failure" "$WORKFLOW"
+	assert_success
+	run grep -F "notify_failure" "$WORKFLOW"
+	assert_success
+	run grep -F "write_trigger_summary" "$WORKFLOW"
+	assert_success
+}
+
+@test "main-failure-notifier: tooling checkout includes failure reporter script" {
+	run grep -F "sparse-checkout" "$WORKFLOW"
+	assert_success
+	run grep -F "scripts/ci/" "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_main_failure_notifier.bats
+++ b/tests/bats/integration/test_reusable_main_failure_notifier.bats
@@ -37,6 +37,8 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-main-failure-notifier.yml"
 	assert_success
 	run grep -F "FAILURE_MARKER_PREFIX: main-workflow-failure" "$WORKFLOW"
 	assert_success
+	run grep -F "FAILURE_TITLE_PREFIX:" "$WORKFLOW"
+	assert_success
 	run grep -F "notify_failure" "$WORKFLOW"
 	assert_success
 	run grep -F "write_trigger_summary" "$WORKFLOW"

--- a/tests/bats/unit/release/test_report_release_failure.bats
+++ b/tests/bats/unit/release/test_report_release_failure.bats
@@ -319,3 +319,99 @@ EOF
 	assert_failure
 	assert_output --partial "GH_TOKEN is required"
 }
+
+@test "report-release-failure: WORKFLOW_KEY takes precedence over RELEASE_WORKFLOW_KEY" {
+	export WORKFLOW_KEY=docker-publish
+
+	run bash "$SCRIPT" write_trigger_summary
+	assert_success
+	run grep -F "docker-publish" "$GITHUB_STEP_SUMMARY"
+	assert_success
+}
+
+@test "report-release-failure: WORKFLOW_KEY alone satisfies the key requirement" {
+	unset RELEASE_WORKFLOW_KEY
+	export WORKFLOW_KEY=pages-deploy
+
+	run bash "$SCRIPT" write_trigger_summary
+	assert_success
+	run grep -F "pages-deploy" "$GITHUB_STEP_SUMMARY"
+	assert_success
+}
+
+@test "report-release-failure: reports missing WORKFLOW_KEY and RELEASE_WORKFLOW_KEY" {
+	unset RELEASE_WORKFLOW_KEY
+
+	# The :? expansion fires inside command substitutions, so the message is
+	# surfaced in output (matching the script's historical behavior).
+	run bash "$SCRIPT" write_trigger_summary
+	assert_output --partial "WORKFLOW_KEY (or RELEASE_WORKFLOW_KEY) is required"
+}
+
+@test "report-release-failure: FAILURE_HEADING_LABEL customizes summary heading" {
+	export FAILURE_HEADING_LABEL="Main Workflow"
+	export PRIMARY_JOB_FAILED=true
+
+	run bash "$SCRIPT" write_trigger_summary
+	assert_success
+	run grep -F "## Main Workflow Failure" "$GITHUB_STEP_SUMMARY"
+	assert_success
+}
+
+@test "report-release-failure: custom marker and title prefixes namespace the issue" {
+	mkdir -p "${BATS_TEST_TMPDIR}/bin"
+	cat >"${BATS_TEST_TMPDIR}/bin/gh" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> '${BATS_TEST_TMPDIR}/mock_calls_gh'
+case "\$*" in
+	*repo*view*)
+		echo "main"
+		;;
+	*issue*list*)
+		echo ""
+		;;
+	*label*view*)
+		exit 0
+		;;
+	*issue*create*)
+		echo "https://github.com/lgtm-hq/lgtm-ci/issues/43"
+		exit 0
+		;;
+	*run*view*)
+		exit 0
+		;;
+	*)
+		exit 1
+		;;
+esac
+EOF
+	chmod +x "${BATS_TEST_TMPDIR}/bin/gh"
+	export PATH="${BATS_TEST_TMPDIR}/bin:${PATH}"
+	export WORKFLOW_KEY=docker-publish
+	export FAILURE_MARKER_PREFIX=main-workflow-failure
+	export FAILURE_TITLE_PREFIX="fix(ci): main workflow failed:"
+
+	run bash "$SCRIPT" notify_failure
+	assert_success
+	run grep -F 'main-workflow-failure:docker-publish:main' \
+		"${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_success
+	run grep -F 'fix(ci): main workflow failed: main (docker-publish)' \
+		"${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_success
+}
+
+@test "report-release-failure: FAILURE_SUMMARY_TEXT overrides the issue summary" {
+	mock_command_multi "gh" '
+		*repo*view*) echo "main";;
+		*issue*list*) echo "";;
+		*label*view*) exit 0;;
+		*issue*create*) echo "https://github.com/lgtm-hq/lgtm-ci/issues/44"; exit 0;;
+		*run*view*) exit 0;;
+		*) exit 1;;
+	'
+	export FAILURE_SUMMARY_TEXT="Custom failure summary sentence."
+
+	run bash "$SCRIPT" notify_failure
+	assert_success
+}

--- a/tests/bats/unit/release/test_report_release_failure.bats
+++ b/tests/bats/unit/release/test_report_release_failure.bats
@@ -339,12 +339,22 @@ EOF
 	assert_success
 }
 
-@test "report-release-failure: reports missing WORKFLOW_KEY and RELEASE_WORKFLOW_KEY" {
+@test "report-release-failure: fails without WORKFLOW_KEY or RELEASE_WORKFLOW_KEY" {
 	unset RELEASE_WORKFLOW_KEY
 
-	# The :? expansion fires inside command substitutions, so the message is
-	# surfaced in output (matching the script's historical behavior).
 	run bash "$SCRIPT" write_trigger_summary
+	assert_failure
+	assert_output --partial "WORKFLOW_KEY (or RELEASE_WORKFLOW_KEY) is required"
+}
+
+@test "report-release-failure: notify_failure fails without a workflow key" {
+	unset RELEASE_WORKFLOW_KEY
+	mock_command_multi "gh" '
+		*) exit 1;;
+	'
+
+	run bash "$SCRIPT" notify_failure
+	assert_failure
 	assert_output --partial "WORKFLOW_KEY (or RELEASE_WORKFLOW_KEY) is required"
 }
 
@@ -402,16 +412,44 @@ EOF
 }
 
 @test "report-release-failure: FAILURE_SUMMARY_TEXT overrides the issue summary" {
-	mock_command_multi "gh" '
-		*repo*view*) echo "main";;
-		*issue*list*) echo "";;
-		*label*view*) exit 0;;
-		*issue*create*) echo "https://github.com/lgtm-hq/lgtm-ci/issues/44"; exit 0;;
-		*run*view*) exit 0;;
-		*) exit 1;;
-	'
+	mkdir -p "${BATS_TEST_TMPDIR}/bin"
+	cat >"${BATS_TEST_TMPDIR}/bin/gh" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+	*repo*view*)
+		echo "main"
+		;;
+	*issue*list*)
+		echo ""
+		;;
+	*label*view*)
+		exit 0
+		;;
+	*issue*create*)
+		while [[ \$# -gt 0 ]]; do
+			if [[ "\$1" == "--body-file" && -n "\${2:-}" ]]; then
+				cp "\$2" '${BATS_TEST_TMPDIR}/issue-body.md'
+			fi
+			shift
+		done
+		echo "https://github.com/lgtm-hq/lgtm-ci/issues/44"
+		exit 0
+		;;
+	*run*view*)
+		exit 0
+		;;
+	*)
+		exit 1
+		;;
+esac
+EOF
+	chmod +x "${BATS_TEST_TMPDIR}/bin/gh"
+	export PATH="${BATS_TEST_TMPDIR}/bin:${PATH}"
 	export FAILURE_SUMMARY_TEXT="Custom failure summary sentence."
 
 	run bash "$SCRIPT" notify_failure
+	assert_success
+	[[ -f "${BATS_TEST_TMPDIR}/issue-body.md" ]]
+	run grep -F "Custom failure summary sentence." "${BATS_TEST_TMPDIR}/issue-body.md"
 	assert_success
 }


### PR DESCRIPTION
## Summary

Implements #424 (scope from #421 "main-health alerting + red-main convention"): with auto-merge/queue landing PRs unattended, non-release main-only jobs (docker publish, Pages deploy, dogfood lint) fail silently. This generalizes the release failure reporter's dedup'd-issue mechanism so any main-branch workflow can use it.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Changes Made

- `scripts/ci/release/report-release-failure.sh`: parameterized — `WORKFLOW_KEY` (with `RELEASE_WORKFLOW_KEY` fallback), `FAILURE_MARKER_PREFIX`, `FAILURE_TITLE_PREFIX`, `FAILURE_SUMMARY_TEXT`, `FAILURE_HEADING_LABEL`; all defaults preserve the release wording and existing dedup markers, so release callers and open issues are unaffected
- Latent bug fixed en route: a missing workflow key previously exited 0 (the `:?` expansion fired only inside command substitutions, killing just the subshell) — both subcommands now validate the key up front
- `.github/workflows/reusable-main-failure-notifier.yml`: new reusable; call from a `if: failure() && github.ref == 'refs/heads/main'` job with a stable `workflow-key`; repeat failures comment on the existing open issue (`main-workflow-failure:<key>:<branch>`)
- `docs/reusable-workflows.md`: caller example + the red-main convention (open notifier issue ⇒ disarm pending auto-merges until fix-forward lands)
- Tests: 7 new unit cases (parameterization, key precedence/validation, body content) + 5 contract tests for the new reusable

## Checklist

- [x] I have tested these changes locally (bats 27/27 across both files, contract validators, `uv run lintro chk` clean)
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black` (none changed)

## Breaking Changes

None — all new envs default to the previous behavior.

## Closes

- Closes #424
- Relates to #421

## Details

Pre-push review: Greptile P2s fixed (title-prefix contract test; the missing-key test gap exposed the exit-0 bug above, fixed in script rather than weakening the test). CodeRabbit: doc-header finding fixed; its `job.workflow_sha` suggestion skipped — `job` context has no `workflow_sha` property, and `github.workflow_sha` matches every other reusable in this repo.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a reusable notifier for failed main-branch workflows. The main changes are:

- New reusable workflow for opening or updating failure issues.
- Parameterized release failure reporter for non-release workflows.
- Documentation for the red-main convention and caller setup.
- Unit and contract tests for the new reporter behavior.
</details>

<h3>Confidence Score: 4/5</h3>

The changed flow looks mergeable after fixing the main-branch target default.

- Existing release reporter defaults are preserved.
- The workflow key validation now fails early on missing keys.
- The new reusable can skip notifications when `main` is not the repository default branch.

.github/workflows/reusable-main-failure-notifier.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-main-failure-notifier.yml | Adds the reusable notifier workflow; the branch target default can conflict with the documented main-branch gate. |
| scripts/ci/release/report-release-failure.sh | Parameterizes the failure reporter while preserving release defaults and adding early workflow-key validation. |
| docs/reusable-workflows.md | Documents the new notifier and red-main operating convention. |
| tests/bats/integration/test_reusable_main_failure_notifier.bats | Adds contract checks for the reusable notifier wiring. |
| tests/bats/unit/release/test_report_release_failure.bats | Adds unit coverage for custom workflow keys, labels, marker prefixes, titles, and summary text. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Freusable-main-failure-notifier.yml%3A39%0A**Main%20Gate%20Targets%20Default%20Branch**%0A%0AWhen%20a%20caller%20follows%20the%20documented%20%60github.ref%20%3D%3D%20'refs%2Fheads%2Fmain'%60%20gate%20but%20the%20repository%20default%20branch%20is%20not%20%60main%60%2C%20the%20empty%20target%20here%20makes%20%60notify_failure%60%20resolve%20the%20default%20branch%20instead.%20The%20reporter%20then%20compares%20%60main%60%20to%20that%20default%20branch%20and%20skips%20the%20issue%2C%20so%20a%20real%20main%20failure%20is%20not%20surfaced.%0A%0A&pr=426&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Freusable-main-failure-notifier.yml%3A39%0A**Main%20Gate%20Targets%20Default%20Branch**%0A%0AWhen%20a%20caller%20follows%20the%20documented%20%60github.ref%20%3D%3D%20'refs%2Fheads%2Fmain'%60%20gate%20but%20the%20repository%20default%20branch%20is%20not%20%60main%60%2C%20the%20empty%20target%20here%20makes%20%60notify_failure%60%20resolve%20the%20default%20branch%20instead.%20The%20reporter%20then%20compares%20%60main%60%20to%20that%20default%20branch%20and%20skips%20the%20issue%2C%20so%20a%20real%20main%20failure%20is%20not%20surfaced.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=426&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F424-main-failure-notifier%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F424-main-failure-notifier%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Freusable-main-failure-notifier.yml%3A39%0A**Main%20Gate%20Targets%20Default%20Branch**%0A%0AWhen%20a%20caller%20follows%20the%20documented%20%60github.ref%20%3D%3D%20'refs%2Fheads%2Fmain'%60%20gate%20but%20the%20repository%20default%20branch%20is%20not%20%60main%60%2C%20the%20empty%20target%20here%20makes%20%60notify_failure%60%20resolve%20the%20default%20branch%20instead.%20The%20reporter%20then%20compares%20%60main%60%20to%20that%20default%20branch%20and%20skips%20the%20issue%2C%20so%20a%20real%20main%20failure%20is%20not%20surfaced.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=426&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(release): clarify WORKFLOW\_KEY appl..."](https://github.com/lgtm-hq/lgtm-ci/commit/c5e2b2783757eb6f621f2b72a78ce972fcf206bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42196426)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->