### PR TITLE
chore(tests): replace real org-ruleset fixture with synthetic data

### DIFF
--- a/tests/bats/unit/org/test_export_ruleset.bats
+++ b/tests/bats/unit/org/test_export_ruleset.bats
@@ -5,7 +5,7 @@
 load "../../../helpers/common"
 load "../../../helpers/mocks"
 
-FIXTURE_RELATIVE="json/org_ruleset_checks_py_lintro.json"
+FIXTURE_RELATIVE="json/org_ruleset_example.json"
 
 setup() {
 	setup_temp_dir
@@ -25,46 +25,46 @@ mock_gh_with_fixture() {
 
 @test "export-ruleset: prints ruleset JSON to stdout" {
 	mock_gh_with_fixture
-	run bash "$SCRIPT" checks-py-lintro 16132640
+	run bash "$SCRIPT" checks-example 9999999
 	assert_success
-	assert_output --partial '"name": "checks-py-lintro"'
-	assert_output --partial "test-suite-coverage / 🧪 Test Suite & Coverage"
+	assert_output --partial '"name": "checks-example"'
+	assert_output --partial "tests / Example Tests"
 	run cat "${BATS_TEST_TMPDIR}/mock_calls_gh"
-	assert_output --partial "api orgs/lgtm-hq/rulesets/16132640"
+	assert_output --partial "api orgs/lgtm-hq/rulesets/9999999"
 }
 
 @test "export-ruleset: -o writes JSON to a file" {
 	mock_gh_with_fixture
 	local out="${BATS_TEST_TMPDIR}/ruleset.json"
-	run bash "$SCRIPT" checks-py-lintro 16132640 -o "$out"
+	run bash "$SCRIPT" checks-example 9999999 -o "$out"
 	assert_success
 	assert_output --partial "do not commit"
 	run jq -r '.name' "$out"
-	assert_output "checks-py-lintro"
+	assert_output "checks-example"
 }
 
 @test "export-ruleset: fails when fetched name does not match" {
 	mock_gh_with_fixture
-	run bash "$SCRIPT" checks-rustume 16132640
+	run bash "$SCRIPT" checks-mismatch 9999999
 	assert_failure
 	assert_output --partial "Ruleset name mismatch"
 }
 
 @test "export-ruleset: fails on non-numeric ruleset id" {
-	run bash "$SCRIPT" checks-py-lintro not-a-number
+	run bash "$SCRIPT" checks-example not-a-number
 	assert_failure
 	assert_output --partial "must be numeric"
 }
 
 @test "export-ruleset: fails when gh api errors" {
 	mock_command "gh" "" 1
-	run bash "$SCRIPT" checks-py-lintro 16132640
+	run bash "$SCRIPT" checks-example 9999999
 	assert_failure
 	assert_output --partial "Failed to fetch"
 }
 
 @test "export-ruleset: fails with usage when arguments are missing" {
-	run bash "$SCRIPT" checks-py-lintro
+	run bash "$SCRIPT" checks-example
 	assert_failure
 	assert_output --partial "Usage:"
 }

--- a/tests/bats/unit/org/test_sync_ruleset.bats
+++ b/tests/bats/unit/org/test_sync_ruleset.bats
@@ -5,7 +5,7 @@
 load "../../../helpers/common"
 load "../../../helpers/mocks"
 
-FIXTURE_RELATIVE="json/org_ruleset_checks_py_lintro.json"
+FIXTURE_RELATIVE="json/org_ruleset_example.json"
 
 setup() {
 	setup_temp_dir
@@ -23,7 +23,7 @@ teardown() {
 	run bash "$SCRIPT" "$FIXTURE"
 	assert_success
 	assert_output --partial "Dry run"
-	assert_output --partial "orgs/lgtm-hq/rulesets/16132640"
+	assert_output --partial "orgs/lgtm-hq/rulesets/9999999"
 	assert_output --partial "--apply"
 }
 
@@ -35,15 +35,15 @@ teardown() {
 	refute_output --partial '"updated_at"'
 	refute_output --partial '"_links"'
 	refute_output --partial '"source_type"'
-	refute_output --partial '"id": 16132640'
+	refute_output --partial '"id": 9999999'
 }
 
 @test "sync-ruleset: dry run preserves required status check contexts" {
 	run bash "$SCRIPT" "$FIXTURE"
 	assert_success
-	assert_output --partial "test-suite-coverage / 🧪 Test Suite & Coverage"
-	assert_output --partial "lintro-code-quality / 🛠️ Lintro Code Quality"
-	assert_output --partial "🔐 Security Audit"
+	assert_output --partial "tests / Example Tests"
+	assert_output --partial "quality / Example Quality"
+	assert_output --partial "🔐 Example Security Audit"
 }
 
 @test "sync-ruleset: dry run does not invoke gh" {
@@ -57,7 +57,7 @@ teardown() {
 @test "sync-ruleset: reads payload from stdin with -" {
 	run bash -c "cat '$FIXTURE' | bash '$SCRIPT' -"
 	assert_success
-	assert_output --partial "orgs/lgtm-hq/rulesets/16132640"
+	assert_output --partial "orgs/lgtm-hq/rulesets/9999999"
 }
 
 @test "sync-ruleset: --id overrides the payload ruleset id" {
@@ -69,7 +69,7 @@ teardown() {
 @test "sync-ruleset: LGTM_ORG overrides the target organization" {
 	LGTM_ORG="other-org" run bash "$SCRIPT" "$FIXTURE"
 	assert_success
-	assert_output --partial "orgs/other-org/rulesets/16132640"
+	assert_output --partial "orgs/other-org/rulesets/9999999"
 }
 
 @test "sync-ruleset: resolves id from ruleset_id when id is absent" {
@@ -82,45 +82,45 @@ teardown() {
 
 @test "sync-ruleset: --apply PUTs the sanitized payload via gh" {
 	mock_command_multi "gh" '
-	"api orgs/lgtm-hq/rulesets/16132640 --jq .name")
-		echo "checks-py-lintro"
+	"api orgs/lgtm-hq/rulesets/9999999 --jq .name")
+		echo "checks-example"
 		;;
 	*)
 		echo "$@" >>"'"${BATS_TEST_TMPDIR}"'/mock_calls_gh"
 		;;'
 	run bash "$SCRIPT" --apply "$FIXTURE"
 	assert_success
-	assert_output --partial "Updated ruleset 16132640"
+	assert_output --partial "Updated ruleset 9999999"
 	run cat "${BATS_TEST_TMPDIR}/mock_calls_gh"
-	assert_output --partial "api --method PUT orgs/lgtm-hq/rulesets/16132640 --input -"
+	assert_output --partial "api --method PUT orgs/lgtm-hq/rulesets/9999999 --input -"
 }
 
 @test "sync-ruleset: --apply fails when the identity check GET fails" {
 	mock_command "gh" "" 1
 	run bash "$SCRIPT" --apply "$FIXTURE"
 	assert_failure
-	assert_output --partial "Failed to fetch live ruleset orgs/lgtm-hq/rulesets/16132640"
+	assert_output --partial "Failed to fetch live ruleset orgs/lgtm-hq/rulesets/9999999"
 }
 
 @test "sync-ruleset: --apply refuses when live ruleset name mismatches payload" {
-	mock_command "gh" "checks-rustume"
+	mock_command "gh" "checks-mismatch"
 	run bash "$SCRIPT" --apply "$FIXTURE"
 	assert_failure
 	assert_output --partial "Ruleset identity mismatch"
-	assert_output --partial "checks-rustume"
+	assert_output --partial "checks-mismatch"
 }
 
 @test "sync-ruleset: --apply fails when the PUT returns an error" {
 	mock_command_multi "gh" '
-	"api orgs/lgtm-hq/rulesets/16132640 --jq .name")
-		echo "checks-py-lintro"
+	"api orgs/lgtm-hq/rulesets/9999999 --jq .name")
+		echo "checks-example"
 		;;
 	*)
 		exit 1
 		;;'
 	run bash "$SCRIPT" --apply "$FIXTURE"
 	assert_failure
-	assert_output --partial "Failed to update orgs/lgtm-hq/rulesets/16132640"
+	assert_output --partial "Failed to update orgs/lgtm-hq/rulesets/9999999"
 }
 
 @test "sync-ruleset: fails on missing payload file" {

--- a/tests/fixtures/json/org_ruleset_example.json
+++ b/tests/fixtures/json/org_ruleset_example.json
@@ -45,7 +45,7 @@
       "href": "https://api.github.com/orgs/example-org/rulesets/9999999"
     },
     "html": {
-      "href": "http://github.com/organizations/example-org/settings/rules/9999999"
+      "href": "https://github.com/organizations/example-org/settings/rules/9999999"
     }
   }
 }

--- a/tests/fixtures/json/org_ruleset_example.json
+++ b/tests/fixtures/json/org_ruleset_example.json
@@ -1,9 +1,9 @@
 {
-  "id": 16132640,
-  "name": "checks-py-lintro",
+  "id": 9999999,
+  "name": "checks-example",
   "target": "branch",
   "source_type": "Organization",
-  "source": "lgtm-hq",
+  "source": "example-org",
   "enforcement": "active",
   "conditions": {
     "ref_name": {
@@ -12,7 +12,7 @@
     },
     "repository_name": {
       "exclude": [],
-      "include": ["py-lintro"],
+      "include": ["example-repo"],
       "protected": false
     }
   },
@@ -23,16 +23,16 @@
         "strict_required_status_checks_policy": true,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
-          { "context": "test-suite-coverage / 🧪 Test Suite & Coverage" },
-          { "context": "🔐 Security Audit" },
-          { "context": "lintro-code-quality / 🛠️ Lintro Code Quality" }
+          { "context": "tests / Example Tests" },
+          { "context": "🔐 Example Security Audit" },
+          { "context": "quality / Example Quality" }
         ]
       }
     }
   ],
   "node_id": "RRS_TESTFIXTURE0000000000",
-  "created_at": "2026-05-08T11:55:38.677+02:00",
-  "updated_at": "2026-06-20T17:13:02.093+02:00",
+  "created_at": "2026-01-01T00:00:00.000+00:00",
+  "updated_at": "2026-01-02T00:00:00.000+00:00",
   "bypass_actors": [
     {
       "actor_id": null,
@@ -42,10 +42,10 @@
   ],
   "_links": {
     "self": {
-      "href": "https://api.github.com/orgs/lgtm-hq/rulesets/16132640"
+      "href": "https://api.github.com/orgs/example-org/rulesets/9999999"
     },
     "html": {
-      "href": "http://github.com/organizations/lgtm-hq/settings/rules/16132640"
+      "href": "http://github.com/organizations/example-org/settings/rules/9999999"
     }
   }
 }


### PR DESCRIPTION
## Summary

Implements #427: `tests/fixtures/json/org_ruleset_checks_py_lintro.json` was a verbatim snapshot of the live `checks-py-lintro` org ruleset (real id, repo, check contexts) — contradicting PR #404's own "(no committed JSON)" design where `docs/org-rulesets.md` + `gh api` are the source of truth. A realistic committed snapshot reads as ruleset state and was already stale.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Changes Made

- Fixture renamed to `org_ruleset_example.json` with fully synthetic data: id 9999999, `example-org`/`example-repo`, generic check contexts
- `test_export_ruleset.bats` / `test_sync_ruleset.bats`: references and content-coupled assertions updated in lockstep; all 22 tests pass unchanged in logic

## Checklist

- [x] I have tested these changes locally (bats 22/22, `uv run lintro chk` clean)
- [x] I have updated documentation if needed (n/a)
- [x] Shell scripts pass `shellcheck` (none changed)
- [x] YAML files pass `yamllint` (none changed)
- [x] Python code passes `ruff` and `black` (none changed)

## Breaking Changes

None (test-only).

## Closes

- Closes #427
- Relates to #404

## Details

Pre-push review: CodeRabbit's http→https link nit fixed. Greptile's P2 (fixture `source: example-org` vs tests asserting the `lgtm-hq` default endpoint) intentionally not taken: the scripts read the org from `LGTM_ORG` (fixture `source` is ignored — there's a dedicated override test), and putting the real org back into the fixture would partially defeat the purpose of this change.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the committed org ruleset snapshot with synthetic test data. The main changes are:

- Renamed the ruleset fixture to `org_ruleset_example.json`.
- Replaced real org, repo, ruleset id, and check-context values with example values.
- Updated the export and sync Bats tests to expect the synthetic fixture values.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/bats/unit/org/test_export_ruleset.bats | Updated export ruleset tests to use the synthetic fixture name, id, and check context. |
| tests/bats/unit/org/test_sync_ruleset.bats | Updated sync ruleset tests to use the synthetic fixture values across dry-run, apply, override, and mismatch cases. |
| tests/fixtures/json/org_ruleset_example.json | Replaced the live ruleset snapshot with synthetic org, repo, id, link, timestamp, and check-context data. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(tests): use https in synthetic fix..."](https://github.com/lgtm-hq/lgtm-ci/commit/b3f217e802b03097f73ca9da9a0dd06aab530268) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42277215)</sub>

<!-- /greptile_comment -->