### PR TITLE
fix(workflows): report semantic-title check on merge_group events

### DIFF
--- a/.github/workflows/reusable-semantic-pr-title.yml
+++ b/.github/workflows/reusable-semantic-pr-title.yml
@@ -98,7 +98,12 @@ jobs:
     name: ${{ inputs.job-name }}
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
-    if: github.event_name != 'merge_group'
+    # Do NOT skip this job on merge_group: GitHub cannot evaluate the dynamic
+    # name of a skipped job, so its check would report as "inputs.job-name"
+    # and the required context would never arrive (queue timeout). Instead the
+    # job always runs and every PR-dependent step no-ops on merge_group — the
+    # job succeeds in seconds and satisfies the required check (the title was
+    # already validated on the pull_request event).
     permissions:
       contents: read
       # post-pr-comment upserts failure comments on the pull request
@@ -106,12 +111,14 @@ jobs:
 
     steps:
       - name: Checkout repository
+        if: github.event_name != 'merge_group'
         # Pinned to SHA for supply chain security
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Checkout lgtm-ci tooling
+        if: github.event_name != 'merge_group'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -125,6 +132,7 @@ jobs:
 
       - name: Checkout and harden
         id: egress
+        if: github.event_name != 'merge_group'
         uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
           tooling-ref: ${{ inputs.tooling-ref }}
@@ -138,6 +146,7 @@ jobs:
 
       - name: Prepare semantic PR lists
         id: prepare
+        if: github.event_name != 'merge_group'
         env:
           TYPES_INPUT: ${{ inputs.types }}
           SCOPES_INPUT: ${{ inputs.scopes }}
@@ -157,6 +166,7 @@ jobs:
 
       - name: Validate semantic PR title
         id: semantic
+        if: github.event_name != 'merge_group'
         continue-on-error: true
         uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -1036,7 +1036,7 @@ starter examples (`examples/ci-*.yml`) include `merge_group:` by default.
 | `reusable-test-node-custom.yml`        | Tests run; PR summary comment on PR only       |
 | `reusable-test-rust-build.yml`         | Safe to run — no PR context required           |
 | `reusable-coverage.yml`                | Coverage runs; PR comment on PR only           |
-| `reusable-semantic-pr-title.yml`       | Skips on `merge_group` — title validated on PR |
+| `reusable-semantic-pr-title.yml`       | No-op on `merge_group` — title validated on PR |
 
 Test reusables gate their draft-PR skip on `github.event_name ==
 'pull_request'`, so work jobs always run in the merge queue; PR summary
@@ -1045,8 +1045,14 @@ comments are gated on `pull_request` events in workflow conditions and in
 the split `publish-quality-summary` pattern) already carry a
 `github.event_name == 'pull_request'` guard and skip in the queue.
 
-Semantic title validation is intentionally skipped in the merge queue because
-`amannn/action-semantic-pull-request` requires pull request context.
+Semantic title validation is intentionally a no-op in the merge queue because
+`amannn/action-semantic-pull-request` requires pull request context. The job
+itself still runs (finishing in seconds with every step skipped): a job with a
+dynamic `name:` that is skipped at job level reports its check under the raw
+expression text (`semantic-title / inputs.job-name`), so the required context
+would never arrive and queue entries would time out. Required checks produced
+by reusables with configurable job names must therefore never carry job-level
+event skips — skip at step level instead.
 
 Callers need `pull-requests: write` when `post-failure-comment` is enabled
 (default). With `post-failure-comment: false`, `pull-requests: read` suffices.

--- a/tests/bats/integration/test_merge_group_workflows.bats
+++ b/tests/bats/integration/test_merge_group_workflows.bats
@@ -19,9 +19,25 @@ load "../../helpers/common"
 	assert_success
 }
 
-@test "reusable-semantic-pr-title: skips merge_group events" {
+@test "reusable-semantic-pr-title: no-ops merge_group at step level" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-semantic-pr-title.yml"
 
-	run grep -E "if: github.event_name != 'merge_group'" "$workflow"
+	run grep -cE "if: github.event_name != 'merge_group'" "$workflow"
+	assert_success
+	[[ "$output" -ge 5 ]]
+}
+
+@test "reusable-semantic-pr-title: job itself must not skip on merge_group" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-semantic-pr-title.yml"
+
+	# A skipped job with a dynamic name reports its check as
+	# "inputs.job-name", so the required context never arrives and merge
+	# queue entries time out. The skip must live on the steps, not the job.
+	run awk '
+		/^  semantic-title:/ { in_job = 1; next }
+		in_job && /^    steps:/ { exit }
+		in_job && /if: github.event_name != ..merge_group./ { bad = 1; exit }
+		END { exit bad }
+	' "$workflow"
 	assert_success
 }

--- a/tests/bats/integration/test_merge_group_workflows.bats
+++ b/tests/bats/integration/test_merge_group_workflows.bats
@@ -22,9 +22,11 @@ load "../../helpers/common"
 @test "reusable-semantic-pr-title: no-ops merge_group at step level" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-semantic-pr-title.yml"
 
+	# Exact count: a new PR-dependent step must add its guard (count goes up,
+	# bump this deliberately); a dropped guard lowers it. Both directions fail.
 	run grep -cE "if: github.event_name != 'merge_group'" "$workflow"
 	assert_success
-	[[ "$output" -ge 5 ]]
+	[[ "$output" -eq 5 ]]
 }
 
 @test "reusable-semantic-pr-title: job itself must not skip on merge_group" {


### PR DESCRIPTION
## Summary

Fixes the real cause of the merge-queue `checks_timed_out` evictions (#425 ×2, #426 — including after the GitGuardian removal): `reusable-semantic-pr-title.yml` skipped its job at job level on `merge_group`, and GitHub cannot evaluate a skipped job's dynamic `name: ${{ inputs.job-name }}` — the check reports as literal `semantic-title / inputs.job-name`, so the required context `semantic-title / Semantic PR Title` never arrives and every queue entry times out. Affects every repo whose required checks include a semantic-title context from this reusable (lgtm-ci, podex, winnow, py-lintro, Rustume — pin bumps follow the next release).

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Changes Made

- `reusable-semantic-pr-title.yml`: job always runs; the merge_group skip moved to step level on all five PR-dependent steps (remaining steps were already gated on `pull_request`/failure outcomes). On merge_group the job succeeds in seconds under its evaluated name.
- `docs/workflow-contract.md`: table row "Skips" → "No-op"; paragraph explains the skipped-job/dynamic-name limitation and the rule: required checks from reusables with configurable job names must never carry job-level event skips.
- `tests/bats/integration/test_merge_group_workflows.bats`: asserts the job block has no merge_group skip (awk) and exactly 5 step-level guards (exact count per both reviewers' feedback).

## Checklist

- [x] I have tested these changes locally (bats, contract validators, `uv run lintro chk` clean)
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck` (none changed)
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black` (none changed)

## Breaking Changes

None — PR-event behavior identical.

## Closes

- Closes #429
- Relates to #421

## Details

The lgtm-ci caller uses the local `./` reusable path, so this PR's own merge-group run exercises the fixed workflow — the queue passage is the verification. Pre-push review: Greptile P2 and CodeRabbit trivial (same finding: exact guard count) both applied.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes the semantic-title reusable workflow so merge queue runs produce the expected check. The main changes are:

- The semantic-title job now runs on `merge_group` events.
- PR-only workflow steps now skip individually on `merge_group`.
- The workflow contract now documents the no-op merge queue behavior.
- Bats tests now check the step-level guards and the absence of a job-level skip.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-semantic-pr-title.yml | Moves the merge queue skip from the job to the PR-dependent steps so the required check name can resolve. |
| docs/workflow-contract.md | Documents the semantic-title merge queue no-op behavior and the rule against job-level skips for configurable check names. |
| tests/bats/integration/test_merge_group_workflows.bats | Adds static checks for the expected five step guards and for the missing job-level merge queue skip. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(workflows): assert exact merge\_grou..."](https://github.com/lgtm-hq/lgtm-ci/commit/6ce4e5ddabcde6ba6333e34de3ffc84072420225) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42307042)</sub>

<!-- /greptile_comment -->