### PR TITLE
fix(ci): unblock path-filtered required check + repair detect-changes action

### DIFF
--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -4,18 +4,15 @@
 name: Quality Check - Action Pinning Validation
 
 'on':
+  # No path filter: this is a required check, so it must always run and report.
+  # A path-filtered required check never reports on PRs that miss the filter,
+  # which deadlocks them (and merge-queue entries). The validation is cheap
+  # (~1 min); the detect-changes early-exit pattern is reserved for the
+  # expensive path-filtered workflows.
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - '.github/workflows/**'
-      - '.github/actions/**'
-      - 'scripts/ci/actions/validate-action-pinning.sh'
   push:
     branches: [main]
-    paths:
-      - '.github/workflows/**'
-      - '.github/actions/**'
-      - 'scripts/ci/actions/validate-action-pinning.sh'
   merge_group:
   workflow_dispatch:
 

--- a/scripts/ci/actions/detect-changes.sh
+++ b/scripts/ci/actions/detect-changes.sh
@@ -40,7 +40,7 @@ elif [[ -z "$BASE_SHA" ]]; then
 	echo "detect-changes: BASE_SHA is empty; failing open (all filters true)" >&2
 	fail_open=1
 	changed=""
-elif ! changed="$(git diff --name-only "${BASE_SHA}...${HEAD_SHA}" 2>/dev/null)"; then
+elif ! changed="$(git -c core.quotePath=false diff --name-only "${BASE_SHA}...${HEAD_SHA}" 2>/dev/null)"; then
 	# Unreachable base (shallow clone, force-push): fail open, same rationale.
 	echo "detect-changes: cannot diff ${BASE_SHA}...${HEAD_SHA}; failing open (all filters true)" >&2
 	fail_open=1

--- a/tests/bats/unit/actions/test_detect_changes.bats
+++ b/tests/bats/unit/actions/test_detect_changes.bats
@@ -153,3 +153,9 @@ run_detect() {
 	run get_github_output "changes"
 	assert_output '{"tests":true,"docs":false}'
 }
+
+@test "detect-changes: script is executable (action invokes it directly)" {
+	# The composite action runs "$SCRIPTS_DIR/ci/actions/detect-changes.sh"
+	# with no bash prefix, so a missing execute bit fails at runtime (126).
+	[[ -x "${PROJECT_ROOT}/${SCRIPT}" ]]
+}


### PR DESCRIPTION
## Summary

Two required-check-plumbing fixes surfaced while unblocking #428:

1. **Drop the path filter from `validate-action-pinning.yml`** (closes #431). As a required check it must always report — a path-filtered required check never runs on PRs that miss the filter, so those PRs deadlock (context never arrives) and can't enter the merge queue. #428 (fixture-only) is stuck on exactly this. The check is cheap (~1 min); always-run is the right fix, with detect-changes early-exit reserved for the expensive workflows.

2. **Repair the detect-changes action** (fixes a #425 bug found in this PR's pre-push review). `detect-changes.sh` shipped as mode `100644`; the composite action invokes it directly (`run: "$SCRIPTS_DIR/..."`, no `bash` prefix), so it would fail with Permission denied (126) at runtime — the bats tests use `bash <script>` and masked it. Sets the execute bit, adds a regression test asserting it, and disables `core.quotePath` on the diff so non-ASCII paths match filters. This matters because detect-changes is the foundation for the pending consumer early-exit adoption.

## Type of Change

- [x] Bug fix
- [x] CI/CD improvement

## Checklist

- [x] Tested locally (detect-changes bats 14/14, contract validators, `uv run lintro chk` clean)
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`

## Closes

- Closes #431
- Refs #425, #428, #421

## Details

Pre-push review: Greptile P1 (execute bit) applied; CodeRabbit's `core.quotePath` nit applied. Deferred/declined (all on already-merged #425/#426 code, non-blocking, both reviewers were diffing a stale base): bats coverage-enhancement suggestions; the notifier `job.workflow_sha` suggestion (assessed on #426 — `job` context has no `workflow_sha`; `github.workflow_sha` matches every other reusable here).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes required-check and detect-changes CI behavior. The main changes are:

- Removed path filters from the action-pinning validation workflow.
- Made `detect-changes.sh` executable for direct composite-action invocation.
- Disabled Git path quoting for detect-changes diffs.
- Added a Bats test for the executable bit.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/validate-action-pinning.yml | Removes path filters so the required workflow always runs and reports. |
| scripts/ci/actions/detect-changes.sh | Makes the script executable and emits raw non-ASCII paths from `git diff`. |
| tests/bats/unit/actions/test_detect_changes.bats | Adds coverage that the script has the execute bit required by the composite action. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(actions): make detect-changes.sh exe..."](https://github.com/lgtm-hq/lgtm-ci/commit/326ac5e39d50b52cc81ce829337c5e40f163adb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42343979)</sub>

<!-- /greptile_comment -->