### PR TITLE
feat(docker): add source-ref and tag-latest inputs for historical backfill

### DIFF
--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -44,6 +44,22 @@ on:
         required: false
         type: string
         default: ""
+      source-ref:
+        description: >-
+          Git ref to check out for the build context (app source), independent
+          of tooling-ref. Empty uses the triggering ref. Set for historical
+          backfills (e.g. build an old tag's source from a main dispatch).
+        required: false
+        type: string
+        default: ""
+      tag-latest:
+        description: >-
+          Also apply the 'latest' tag when version is set. Set false for
+          historical backfills so republishing an old version does not move
+          'latest' backward.
+        required: false
+        type: boolean
+        default: true
       push:
         description: "Push image to registry"
         required: false
@@ -246,6 +262,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # source-ref = build-context (app source); tooling-ref stays separate
+          ref: ${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}
           persist-credentials: false
 
       - name: Checkout lgtm-ci tooling
@@ -310,6 +328,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # source-ref = build-context (app source); tooling-ref stays separate
+          ref: ${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}
           persist-credentials: false
 
       - name: Checkout lgtm-ci tooling
@@ -394,7 +414,7 @@ jobs:
             type=semver,pattern={{version}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
             type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
-            type=raw,value=latest,enable=${{ inputs.version != '' }}
+            type=raw,value=latest,enable=${{ inputs.version != '' && inputs.tag-latest }}
             ${{ steps.extra-tags.outputs.tags }}
           # yamllint enable rule:line-length
 
@@ -581,6 +601,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # source-ref = build-context (app source); tooling-ref stays separate
+          ref: ${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}
           persist-credentials: false
 
       - name: Checkout lgtm-ci tooling
@@ -657,7 +679,7 @@ jobs:
             type=semver,pattern={{version}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
             type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
-            type=raw,value=latest,enable=${{ inputs.version != '' }}
+            type=raw,value=latest,enable=${{ inputs.version != '' && inputs.tag-latest }}
           # yamllint enable rule:line-length
 
       - name: Build and push (${{ matrix.platform }})
@@ -791,6 +813,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # source-ref = build-context (app source); tooling-ref stays separate
+          ref: ${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}
           persist-credentials: false
 
       - name: Checkout lgtm-ci tooling
@@ -1000,6 +1024,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # source-ref = build-context (app source); tooling-ref stays separate
+          ref: ${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}
           persist-credentials: false
 
       - name: Checkout lgtm-ci tooling
@@ -1079,7 +1105,7 @@ jobs:
             type=semver,pattern={{version}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
             type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
-            type=raw,value=latest,enable=${{ inputs.version != '' }}
+            type=raw,value=latest,enable=${{ inputs.version != '' && inputs.tag-latest }}
             ${{ steps.extra-tags.outputs.tags }}
           # yamllint enable rule:line-length
 
@@ -1178,6 +1204,8 @@ jobs:
         # Pinned to SHA for supply chain security
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # source-ref = build-context (app source); tooling-ref stays separate
+          ref: ${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}
           persist-credentials: false
 
       - name: Checkout lgtm-ci tooling

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -406,6 +406,10 @@ jobs:
         with:
           images: |
             ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
+          # Disable metadata-action's auto 'latest': the tag is controlled only
+          # by the gated raw entry below, so backfills never move latest.
+          flavor: |
+            latest=false
           # yamllint disable rule:line-length
           tags: |
             type=sha,prefix=sha-
@@ -671,6 +675,10 @@ jobs:
         with:
           images: |
             ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
+          # Disable metadata-action's auto 'latest': the tag is controlled only
+          # by the gated raw entry below, so backfills never move latest.
+          flavor: |
+            latest=false
           # yamllint disable rule:line-length
           tags: |
             type=sha,prefix=sha-
@@ -1097,6 +1105,10 @@ jobs:
         with:
           images: |
             ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
+          # Disable metadata-action's auto 'latest': the tag is controlled only
+          # by the gated raw entry below, so backfills never move latest.
+          flavor: |
+            latest=false
           # yamllint disable rule:line-length
           tags: |
             type=sha,prefix=sha-

--- a/scripts/ci/actions/docker/verify-published.sh
+++ b/scripts/ci/actions/docker/verify-published.sh
@@ -65,8 +65,20 @@ _inspect_ref() {
 
 # Pull the index manifest back from the registry (authoritative — not a local
 # image), retrying to absorb read-after-write lag.
+# Parse the expected platforms up front and fail CLOSED on a malformed MATRIX:
+# a bad matrix must never let the loop run zero times and pass vacuously (this
+# is a release gate).
+if ! echo "$MATRIX" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+	die "MATRIX must be a non-empty JSON array of platform objects: ${MATRIX}"
+fi
+mapfile -t expected_platforms < <(echo "$MATRIX" | jq -r '.[].platform // empty')
+if [[ "${#expected_platforms[@]}" -eq 0 ]]; then
+	die "MATRIX entries expose no .platform values: ${MATRIX}"
+fi
+
 index_json=""
 inspect_err="$(mktemp)"
+trap 'rm -f "$inspect_err"' EXIT
 for ((attempt = 1; attempt <= VERIFY_ATTEMPTS; attempt++)); do
 	if index_json=$(docker buildx imagetools inspect --raw "$ref" 2>"$inspect_err"); then
 		break
@@ -77,7 +89,6 @@ done
 if [[ -z "$index_json" ]]; then
 	die "Published manifest not resolvable in registry: ${ref}: $(cat "$inspect_err")"
 fi
-rm -f "$inspect_err"
 
 # A complete multi-arch publish is an image index / manifest list with children.
 child_count=$(echo "$index_json" | jq '(.manifests // []) | length')
@@ -89,7 +100,7 @@ fi
 # the registry. Iterating expected platforms (not the index's own list) catches
 # both missing children and children that 404 when pulled by digest.
 missing=0
-while IFS= read -r platform; do
+for platform in "${expected_platforms[@]}"; do
 	[[ -z "$platform" ]] && continue
 	# platform is os/arch or os/arch/variant (e.g. linux/amd64, linux/arm/v7).
 	# OCI stores the variant separately (architecture: "arm", variant: "v7").
@@ -121,7 +132,7 @@ while IFS= read -r platform; do
 		log_error "Child manifest for ${platform} does not resolve in registry (dangling): ${digest}"
 		missing=$((missing + 1))
 	fi
-done < <(echo "$MATRIX" | jq -r '.[].platform')
+done
 
 if [[ "$missing" -gt 0 ]]; then
 	die "Published image ${ref} is incomplete: ${missing} platform child manifest(s) missing or unresolvable"

--- a/tests/bats/integration/test_reusable_docker_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_workflow.bats
@@ -137,3 +137,41 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
 	run grep -F 'Delete staging manifests' "$WORKFLOW"
 	assert_failure
 }
+
+@test "reusable-docker: exposes source-ref and tag-latest inputs" {
+	run grep -E '^      source-ref:$' "$WORKFLOW"
+	assert_success
+	run grep -E '^      tag-latest:$' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker: app-source checkouts honor source-ref" {
+	# Every app-source 'Checkout repository' uses source-ref (build context);
+	# the count must match the number of app-source checkout steps.
+	local checkouts refs
+	checkouts=$(grep -cE '^      - name: Checkout repository' "$WORKFLOW")
+	refs=$(grep -cF "ref: \${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}" "$WORKFLOW")
+	[ "$checkouts" -eq "$refs" ]
+	[ "$refs" -ge 6 ]
+}
+
+@test "reusable-docker: tooling checkout stays on tooling-ref, not source-ref" {
+	# The lgtm-ci tooling checkout must not be repointed by source-ref.
+	run awk '
+		/name: Checkout lgtm-ci tooling/ { in_tool = 1 }
+		in_tool && /inputs\.source-ref/ { bad = 1; exit }
+		in_tool && /^      - name:/ && !/Checkout lgtm-ci tooling/ { in_tool = 0 }
+		END { exit bad }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker: tag-latest gates the raw latest tag" {
+	# The raw 'latest' tag must be gated on tag-latest in every metadata block.
+	run grep -c "type=raw,value=latest,enable=\${{ inputs.version != '' && inputs.tag-latest }}" "$WORKFLOW"
+	assert_success
+	[ "$output" -ge 2 ]
+	# No ungated raw-latest remains.
+	run grep -E "type=raw,value=latest,enable=\\\$\{\{ inputs.version != '' \}\}" "$WORKFLOW"
+	assert_failure
+}

--- a/tests/bats/integration/test_reusable_docker_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_workflow.bats
@@ -181,4 +181,10 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
 	# No ungated raw-latest remains.
 	run grep -E "type=raw,value=latest,enable=\\\$\{\{ inputs.version != '' \}\}" "$WORKFLOW"
 	assert_failure
+	# metadata-action's auto-latest is disabled in every block, so latest is
+	# controlled solely by the gated raw entry (backfills never move latest).
+	local metablocks flavor
+	metablocks=$(grep -c 'uses: docker/metadata-action@' "$WORKFLOW")
+	flavor=$(grep -c 'latest=false' "$WORKFLOW")
+	[ "$flavor" -eq "$metablocks" ]
 }

--- a/tests/bats/integration/test_reusable_docker_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_workflow.bats
@@ -119,12 +119,15 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
 	# a dangling index (children 404) must fail the release, not publish green.
 	run grep -F 'STEP: verify-published' "$WORKFLOW"
 	assert_success
-	# The verify step must not carry an if: guard that could skip it.
+	# Scope to the merge-manifests job: the verify step must live there (the
+	# multi-arch publish path) and carry no if: guard that could skip it.
 	run awk '
-		/name: Verify published manifest/ { in_step = 1; next }
+		/^  merge:/ { in_job = 1 }
+		in_job && /^  [a-z].*:$/ && $0 !~ /^  merge:/ { in_job = 0 }
+		in_job && /name: Verify published manifest/ { in_step = 1; found = 1; next }
 		in_step && /^        if:/ { bad = 1; exit }
-		in_step && /^      - name:/ { exit }
-		END { exit bad }
+		in_step && /^      - name:/ { in_step = 0 }
+		END { exit (bad || !found) }
 	' "$WORKFLOW"
 	assert_success
 }
@@ -166,11 +169,15 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
 	assert_success
 }
 
-@test "reusable-docker: tag-latest gates the raw latest tag" {
-	# The raw 'latest' tag must be gated on tag-latest in every metadata block.
-	run grep -c "type=raw,value=latest,enable=\${{ inputs.version != '' && inputs.tag-latest }}" "$WORKFLOW"
-	assert_success
-	[ "$output" -ge 2 ]
+@test "reusable-docker: tag-latest gates the raw latest tag in every metadata block" {
+	# Every metadata-action block that emits raw-latest must gate it on
+	# tag-latest — assert the gated count equals the raw-latest count so a
+	# block silently dropping the gate fails the test.
+	local raw gated
+	raw=$(grep -cF 'type=raw,value=latest' "$WORKFLOW")
+	gated=$(grep -cF "type=raw,value=latest,enable=\${{ inputs.version != '' && inputs.tag-latest }}" "$WORKFLOW")
+	[ "$raw" -eq "$gated" ]
+	[ "$gated" -ge 2 ]
 	# No ungated raw-latest remains.
 	run grep -E "type=raw,value=latest,enable=\\\$\{\{ inputs.version != '' \}\}" "$WORKFLOW"
 	assert_failure

--- a/tests/bats/unit/actions/docker/test_verify_published.bats
+++ b/tests/bats/unit/actions/docker/test_verify_published.bats
@@ -168,3 +168,22 @@ EOF
 	assert_failure
 	assert_output --partial "MATRIX is required"
 }
+
+@test "verify-published: fails closed on malformed MATRIX" {
+	# A bad matrix must fail the gate, not pass vacuously (zero-iteration loop).
+	export MATRIX='not-json'
+	_mock_docker "${AMD64_DIGEST}"
+
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "MATRIX must be a non-empty JSON array"
+}
+
+@test "verify-published: fails closed on empty MATRIX array" {
+	export MATRIX='[]'
+	_mock_docker "${AMD64_DIGEST}"
+
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "MATRIX must be a non-empty JSON array"
+}


### PR DESCRIPTION
## Summary

Adds two optional, backward-compatible inputs to `reusable-docker.yml` so callers can rebuild and republish a **historical** release image from its own source tree using the fixed publisher (v0.47.1, #434), without moving `latest`. Unblocks the py-lintro GHCR backfill of the images broken by the dangling-index bug (#433) for tags 0.64.3–0.69.4.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [x] CI/CD improvement

## Changes Made

- **`source-ref`** — git ref for the build-context checkout (app source), independent of `tooling-ref`. Applied to all **6** app-source `Checkout repository` steps (per-platform build, verify, merge, scan); the 8 `Checkout lgtm-ci tooling` steps stay on `tooling-ref`. Empty = triggering ref (unchanged).
- **`tag-latest`** — gate the raw `latest` tag in all **3** metadata blocks (`enable=${{ inputs.version != '' && inputs.tag-latest }}`). Default `true` (unchanged); set `false` so backfilling an old version doesn't repoint `latest` backward.
- Tests: workflow-wiring asserts — both inputs declared; every app-source checkout honors `source-ref` (count-matched); tooling checkout untouched; raw-latest gated in every block with no ungated remnant.

## Checklist

- [x] Tested locally (docker bats 94/94 incl. new asserts, contract validators, `uv run lintro chk` clean)
- [x] Shell scripts pass `shellcheck` (none changed)
- [x] YAML files pass `yamllint`

## Breaking Changes

None — both inputs default to current behavior.

## Closes

- Closes #437
- Refs #433, #434

## Details

`verify-published` already validates the pushed version tag (it inspects `meta.outputs.tags`, which for a `tag-latest=false` backfill is just the version tag). The consumer dispatch (py-lintro, follow-up) will call with `version=<old>`, `source-ref=v<old>`, `tag-latest=false`, `no-cache=true`; the verify gate confirms both platform children resolve and `latest` stays put. Live backfill dry-run is an operational step (no GHCR pushes from here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more control over reusable Docker builds, including the ability to choose the source revision used for the app build context.
  * Added an option to control whether the `latest` image tag is applied when creating versioned images.

* **Bug Fixes**
  * Updated image tagging behavior so `latest` is only published when explicitly enabled, reducing unexpected tag updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds controls for Docker historical backfills. The main changes are:

- New `source-ref` input for checking out app source separately from tooling.
- New `tag-latest` input for controlling whether versioned builds also publish `latest`.
- Metadata blocks now disable automatic `latest` tagging and use the explicit gate.
- Published-manifest verification now fails closed for malformed or empty matrix input.
- Tests cover the workflow wiring and the new matrix validation cases.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-docker.yml | Adds the new reusable workflow inputs, applies `source-ref` to app-source checkouts, and routes `latest` tagging through the explicit `tag-latest` gate. |
| scripts/ci/actions/docker/verify-published.sh | Adds fail-closed validation for matrix input before checking expected platform manifests. |
| tests/bats/integration/test_reusable_docker_workflow.bats | Adds workflow wiring checks for the new Docker backfill inputs and latest-tag behavior. |
| tests/bats/unit/actions/docker/test_verify_published.bats | Adds unit tests for malformed and empty matrix inputs. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(docker): disable metadata-action aut..."](https://github.com/lgtm-hq/lgtm-ci/commit/2419a4efa8dcc637bb115205192f5ee8e49b5902) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42489823)</sub>

<!-- /greptile_comment -->