### PR TITLE
fix(workflows): fail or skip on missing node-custom coverage summary

### DIFF
--- a/.github/workflows/reusable-test-node-custom.yml
+++ b/.github/workflows/reusable-test-node-custom.yml
@@ -333,6 +333,7 @@ jobs:
         env:
           WORKING_DIRECTORY: ${{ inputs.working-directory }}
           COVERAGE_SUMMARY_FILE: ${{ inputs.coverage-summary-file }}
+          COVERAGE: ${{ inputs.coverage }}
         run: >-
           bash .lgtm-ci-tooling/scripts/ci/actions/stage-node-coverage-test-summary.sh
 

--- a/scripts/ci/actions/stage-node-coverage-test-summary.sh
+++ b/scripts/ci/actions/stage-node-coverage-test-summary.sh
@@ -6,7 +6,10 @@ set -euo pipefail
 
 : "${WORKING_DIRECTORY:=.}"
 : "${COVERAGE_SUMMARY_FILE:?COVERAGE_SUMMARY_FILE is required}"
-: "${COVERAGE:?COVERAGE is required (true or false)}"
+if [[ -z "${COVERAGE:-}" ]]; then
+	echo "::error::COVERAGE is required (true or false)."
+	exit 1
+fi
 
 source_file="${WORKING_DIRECTORY}/${COVERAGE_SUMMARY_FILE}"
 

--- a/scripts/ci/actions/stage-node-coverage-test-summary.sh
+++ b/scripts/ci/actions/stage-node-coverage-test-summary.sh
@@ -12,7 +12,7 @@ source_file="${WORKING_DIRECTORY}/${COVERAGE_SUMMARY_FILE}"
 
 if [[ ! -f "$source_file" ]]; then
 	if [[ "$COVERAGE" == "true" ]]; then
-		echo "::error::Coverage was requested (coverage: true) but the coverage summary file is missing: ${source_file}. Ensure the test command writes ${COVERAGE_SUMMARY_FILE} under ${WORKING_DIRECTORY}." >&2
+		echo "::error::Coverage was requested (coverage: true) but the coverage summary file is missing: ${source_file}. Ensure the test command writes ${COVERAGE_SUMMARY_FILE} under ${WORKING_DIRECTORY}."
 		exit 1
 	fi
 	echo "::notice::Coverage not requested and coverage summary file absent (${source_file}); skipping coverage staging."

--- a/scripts/ci/actions/stage-node-coverage-test-summary.sh
+++ b/scripts/ci/actions/stage-node-coverage-test-summary.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 : "${WORKING_DIRECTORY:=.}"
 : "${COVERAGE_SUMMARY_FILE:?COVERAGE_SUMMARY_FILE is required}"
-: "${COVERAGE:=false}"
+: "${COVERAGE:?COVERAGE is required (true or false)}"
 
 source_file="${WORKING_DIRECTORY}/${COVERAGE_SUMMARY_FILE}"
 

--- a/scripts/ci/actions/stage-node-coverage-test-summary.sh
+++ b/scripts/ci/actions/stage-node-coverage-test-summary.sh
@@ -6,11 +6,16 @@ set -euo pipefail
 
 : "${WORKING_DIRECTORY:=.}"
 : "${COVERAGE_SUMMARY_FILE:?COVERAGE_SUMMARY_FILE is required}"
+: "${COVERAGE:=false}"
 
 source_file="${WORKING_DIRECTORY}/${COVERAGE_SUMMARY_FILE}"
 
 if [[ ! -f "$source_file" ]]; then
-	echo "Coverage summary missing (${source_file}), skipping staging"
+	if [[ "$COVERAGE" == "true" ]]; then
+		echo "::error::Coverage was requested (coverage: true) but the coverage summary file is missing: ${source_file}. Ensure the test command writes ${COVERAGE_SUMMARY_FILE} under ${WORKING_DIRECTORY}." >&2
+		exit 1
+	fi
+	echo "::notice::Coverage not requested and coverage summary file absent (${source_file}); skipping coverage staging."
 	exit 0
 fi
 

--- a/tests/bats/unit/actions/test_stage_node_coverage_test_summary.bats
+++ b/tests/bats/unit/actions/test_stage_node_coverage_test_summary.bats
@@ -20,16 +20,42 @@ teardown() {
 
 	WORKING_DIRECTORY=apps/web \
 		COVERAGE_SUMMARY_FILE=coverage/coverage-summary.json \
+		COVERAGE=true \
 		run bash "$SCRIPT"
 	assert_success
 	assert_file_exists node-coverage-staged/apps/web/coverage/coverage-summary.json
 }
 
-@test "stage-node-coverage-test-summary: skips when coverage summary is missing" {
+@test "stage-node-coverage-test-summary: fails when coverage requested but summary missing" {
 	WORKING_DIRECTORY=apps/web \
 		COVERAGE_SUMMARY_FILE=coverage/coverage-summary.json \
+		COVERAGE=true \
+		run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "::error::"
+	assert_output --partial "apps/web/coverage/coverage-summary.json"
+	run test ! -e node-coverage-staged
+	assert_success
+}
+
+@test "stage-node-coverage-test-summary: skips with notice when coverage not requested and summary missing" {
+	WORKING_DIRECTORY=apps/web \
+		COVERAGE_SUMMARY_FILE=coverage/coverage-summary.json \
+		COVERAGE=false \
 		run bash "$SCRIPT"
 	assert_success
+	assert_output --partial "::notice::"
+	run test ! -e node-coverage-staged
+	assert_success
+}
+
+@test "stage-node-coverage-test-summary: never zero-falls-back on missing summary" {
+	WORKING_DIRECTORY=apps/web \
+		COVERAGE_SUMMARY_FILE=coverage/coverage-summary.json \
+		COVERAGE=false \
+		run bash "$SCRIPT"
+	assert_success
+	refute_output --partial '"total"'
 	run test ! -e node-coverage-staged
 	assert_success
 }

--- a/tests/bats/unit/actions/test_stage_node_coverage_test_summary.bats
+++ b/tests/bats/unit/actions/test_stage_node_coverage_test_summary.bats
@@ -55,7 +55,7 @@ teardown() {
 		COVERAGE_SUMMARY_FILE=coverage/coverage-summary.json \
 		bash "$SCRIPT"
 	assert_failure
-	assert_output --partial "COVERAGE is required"
+	assert_output --partial "::error::COVERAGE is required"
 	run test ! -e node-coverage-staged
 	assert_success
 }

--- a/tests/bats/unit/actions/test_stage_node_coverage_test_summary.bats
+++ b/tests/bats/unit/actions/test_stage_node_coverage_test_summary.bats
@@ -49,6 +49,17 @@ teardown() {
 	assert_success
 }
 
+@test "stage-node-coverage-test-summary: fails when coverage flag omitted" {
+	run env -u COVERAGE \
+		WORKING_DIRECTORY=apps/web \
+		COVERAGE_SUMMARY_FILE=coverage/coverage-summary.json \
+		bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "COVERAGE is required"
+	run test ! -e node-coverage-staged
+	assert_success
+}
+
 @test "stage-node-coverage-test-summary: never zero-falls-back on missing summary" {
 	WORKING_DIRECTORY=apps/web \
 		COVERAGE_SUMMARY_FILE=coverage/coverage-summary.json \


### PR DESCRIPTION
## Summary

When the expected coverage summary file is absent, `reusable-test-node-custom`'s summary staging path silently exited zero, letting the publish leg fall back to a misleading 0% coverage PR comment. This PR makes the missing-file behavior explicit: if the caller set `coverage: true`, the staging step now fails with a clear `::error` naming the expected path; if coverage was not requested, the staging leg is skipped with a `::notice`. There is no zero-fallback in either branch.

## Type of Change

- [x] Bug fix

## Changes Made

- `scripts/ci/actions/stage-node-coverage-test-summary.sh`: add a `COVERAGE` env input; on missing summary file, fail with `::error` (naming the expected path) when `COVERAGE=true`, otherwise skip with `::notice`
- `.github/workflows/reusable-test-node-custom.yml`: pass `COVERAGE: ${{ inputs.coverage }}` to the "Stage coverage for test summary" step
- `tests/bats/unit/actions/test_stage_node_coverage_test_summary.bats`: BATS coverage for all branches — file present (happy path unchanged), coverage requested + missing (fails, nothing staged), not requested + missing (skips with notice), and a never-zero-fallback guard

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None for callers producing the expected coverage file. Callers that set `coverage: true` but never produce the summary file will now fail visibly at the staging step instead of posting a misleading 0% coverage comment — this is the intended behavior change.

## Closes

- Closes #408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI coverage staging: the pipeline now consistently reacts when the coverage report is missing.
  * When coverage is expected, the job fails with a clear error; when not requested, it skips staging and logs a notice.
  * The coverage behavior is now controlled via a dedicated flag in the CI step.

* **Tests**
  * Updated and expanded coverage-staging test scenarios to verify all flag/missing-report outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent failure in `reusable-test-node-custom` where a missing coverage summary file was quietly ignored, causing the publish step to fall back to a misleading 0% comment. The staging script now explicitly fails with a `::error::` annotation when coverage is requested but the file is absent, and skips with a `::notice::` when coverage was never requested.

- **`stage-node-coverage-test-summary.sh`**: Adds a required `COVERAGE` env-var guard (fails on unset/empty), then branches on the boolean value — `COVERAGE=true` with a missing file exits 1, `COVERAGE=false` exits 0 with a notice.
- **`reusable-test-node-custom.yml`**: Threads `COVERAGE: ${{ inputs.coverage }}` into the staging step's env so the script receives the caller's intent.
- **`test_stage_node_coverage_test_summary.bats`**: Four new/updated BATS cases covering happy path, missing-file-with-coverage, missing-file-without-coverage, and the COVERAGE-omitted regression guard.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change tightens existing CI behavior by making a previously silent failure mode explicit and well-annotated.

The logic is straightforward: a required env-var guard followed by a two-branch missing-file handler, both emitting stdout-bound workflow commands that GitHub Actions will correctly parse as annotations. All four code paths are covered by BATS tests, the omitted-COVERAGE regression case is explicitly exercised with env -u COVERAGE, and the workflow correctly threads the boolean input into the step env. No pre-existing behavior is changed for callers that already produce the expected file.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/actions/stage-node-coverage-test-summary.sh | Adds explicit COVERAGE env-var validation and fail/skip branching on missing summary file; all workflow-command outputs go to stdout (correct for GitHub Actions annotations). |
| .github/workflows/reusable-test-node-custom.yml | Adds COVERAGE: ${{ inputs.coverage }} to the staging step env; the step-level if condition already gates on inputs.coverage, so the script always receives 'true' in practice from this workflow. |
| tests/bats/unit/actions/test_stage_node_coverage_test_summary.bats | Comprehensive BATS suite covering all four script branches; the omitted-COVERAGE regression test uses env -u COVERAGE correctly to unset the variable. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([stage-node-coverage-test-summary.sh]) --> B{COVERAGE\nunset or empty?}
    B -- yes --> C["echo ::error:: COVERAGE is required\nexit 1"]
    B -- no --> D{source_file\nexists?}
    D -- yes --> E["cp source_file to node-coverage-staged/\nexit 0"]
    D -- no --> F{COVERAGE == 'true'?}
    F -- yes --> G["echo ::error:: summary missing\nexit 1"]
    F -- no --> H["echo ::notice:: skipping\nexit 0"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([stage-node-coverage-test-summary.sh]) --> B{COVERAGE\nunset or empty?}
    B -- yes --> C["echo ::error:: COVERAGE is required\nexit 1"]
    B -- no --> D{source_file\nexists?}
    D -- yes --> E["cp source_file to node-coverage-staged/\nexit 0"]
    D -- no --> F{COVERAGE == 'true'?}
    F -- yes --> G["echo ::error:: summary missing\nexit 1"]
    F -- no --> H["echo ::notice:: skipping\nexit 0"]
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: annotate missing COVERAGE with ::er..."](https://github.com/lgtm-hq/lgtm-ci/commit/fd8071d13821505019d99fae42812ba1d6b04f2b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42788419)</sub>

<!-- /greptile_comment -->