### PR TITLE
feat(supply-chain): surface MIT license for composite actions in dependency review

### DIFF
--- a/.github/actions/attest-build/action.yml
+++ b/.github/actions/attest-build/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Attest Build"
 description: "Create build attestations using GitHub attestations"

--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Build Docker Image"
 description: "Build and optionally push Docker images with multi-platform support"

--- a/.github/actions/build-python-package/action.yml
+++ b/.github/actions/build-python-package/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Build Python package"
 description: >-

--- a/.github/actions/bundle-workflow-artifacts/action.yml
+++ b/.github/actions/bundle-workflow-artifacts/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Bundle Workflow Artifacts"
 description: "Download CI workflow artifacts into a GitHub Pages site tree via manifest"

--- a/.github/actions/calculate-version/action.yml
+++ b/.github/actions/calculate-version/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Calculate Next Version"
 description: "Calculate the next semantic version based on conventional commits"

--- a/.github/actions/check-coverage-threshold/action.yml
+++ b/.github/actions/check-coverage-threshold/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Check Coverage Threshold"
 description: "Check if coverage meets a minimum threshold"

--- a/.github/actions/checkout-and-harden/action.yml
+++ b/.github/actions/checkout-and-harden/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Checkout and harden"
 description: >-

--- a/.github/actions/collect-coverage/action.yml
+++ b/.github/actions/collect-coverage/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Collect Coverage"
 description: "Aggregate coverage from multiple sources and formats"

--- a/.github/actions/create-github-release/action.yml
+++ b/.github/actions/create-github-release/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Create GitHub Release"
 description: "Create a GitHub release with changelog and optional assets"

--- a/.github/actions/create-release-tag/action.yml
+++ b/.github/actions/create-release-tag/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Create Release Tag"
 description: "Create an annotated git tag for release"

--- a/.github/actions/deploy-pages/action.yml
+++ b/.github/actions/deploy-pages/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Deploy to GitHub Pages"
 description: "Prepare and upload content for GitHub Pages deployment"

--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Detect Changes"
 description: >-

--- a/.github/actions/docker-login/action.yml
+++ b/.github/actions/docker-login/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: Docker Registry Login
 description: Login to GHCR or Docker Hub based on registry input

--- a/.github/actions/egress-audit/action.yml
+++ b/.github/actions/egress-audit/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Egress Audit"
 description: "Audit and restrict network egress from workflows"

--- a/.github/actions/generate-changelog/action.yml
+++ b/.github/actions/generate-changelog/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Generate Changelog"
 description: "Generate changelog from conventional commits"

--- a/.github/actions/generate-coverage-badge/action.yml
+++ b/.github/actions/generate-coverage-badge/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Generate Coverage Badge"
 description: "Generate coverage badge SVG/JSON for README display"

--- a/.github/actions/generate-coverage-comment/action.yml
+++ b/.github/actions/generate-coverage-comment/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Generate Coverage Comment"
 description: "Generate coverage test summary markdown from coverage results"

--- a/.github/actions/generate-lighthouse-comment/action.yml
+++ b/.github/actions/generate-lighthouse-comment/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Generate Lighthouse Comment"
 description: "Generate Lighthouse audit summary markdown from CI results"

--- a/.github/actions/generate-playwright-comment/action.yml
+++ b/.github/actions/generate-playwright-comment/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Generate Playwright Comment"
 description: "Generate Playwright test summary markdown from test results"

--- a/.github/actions/generate-sbom/action.yml
+++ b/.github/actions/generate-sbom/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Generate SBOM"
 description: "Generate Software Bill of Materials (SBOM) using Syft"

--- a/.github/actions/harden-runner/action.yml
+++ b/.github/actions/harden-runner/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Harden Runner"
 description: "Security hardening for GitHub Actions runners using StepSecurity"

--- a/.github/actions/merge-playwright-reports/action.yml
+++ b/.github/actions/merge-playwright-reports/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Merge Playwright Reports"
 description: "Merge multiple Playwright reports from sharded or matrix test runs"

--- a/.github/actions/post-pr-comment/action.yml
+++ b/.github/actions/post-pr-comment/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Post PR Comment"
 description: "Post or update a comment on a pull request with marker-based identification"

--- a/.github/actions/prepare-pypi-upload/action.yml
+++ b/.github/actions/prepare-pypi-upload/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Prepare Python distribution for PyPI upload"
 description: >-

--- a/.github/actions/publish-gem/action.yml
+++ b/.github/actions/publish-gem/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Publish to RubyGems"
 description: "Build and publish Ruby gem to RubyGems using OIDC trusted publishing"

--- a/.github/actions/publish-npm/action.yml
+++ b/.github/actions/publish-npm/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Publish to npm"
 description: "Build and publish Node.js package to npm with provenance"

--- a/.github/actions/publish-test-results/action.yml
+++ b/.github/actions/publish-test-results/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Publish Test Results"
 description: "Publish test results and coverage to GitHub Pages"

--- a/.github/actions/resolve-egress-allowlist/action.yml
+++ b/.github/actions/resolve-egress-allowlist/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Resolve egress allowlist"
 description: >-

--- a/.github/actions/run-lighthouse/action.yml
+++ b/.github/actions/run-lighthouse/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Run Lighthouse"
 description: "Run Lighthouse CI audits with configurable thresholds"

--- a/.github/actions/run-playwright/action.yml
+++ b/.github/actions/run-playwright/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Run Playwright"
 description: "Run E2E tests using Playwright"

--- a/.github/actions/run-pytest/action.yml
+++ b/.github/actions/run-pytest/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Run pytest"
 description: "Run Python tests using pytest with coverage support"

--- a/.github/actions/run-quality/action.yml
+++ b/.github/actions/run-quality/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Lintro Quality Checks"
 description: "Run lintro via full ghcr.io/lgtm-hq/py-lintro image (all bundled tools)"

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Run Tests"
 description: "Generic test runner that delegates to language-specific runners"

--- a/.github/actions/run-vitest/action.yml
+++ b/.github/actions/run-vitest/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Run vitest"
 description: "Run JavaScript/TypeScript tests using vitest with coverage support"

--- a/.github/actions/scan-vulnerabilities/action.yml
+++ b/.github/actions/scan-vulnerabilities/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Scan Vulnerabilities"
 description: "Scan for vulnerabilities using Grype"

--- a/.github/actions/secure-checkout/action.yml
+++ b/.github/actions/secure-checkout/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Secure Checkout"
 description: "Checkout repository with security-hardened defaults"

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Setup Environment"
 description: "Configure common CI environment variables and PATH"

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Setup Node.js"
 description: "Setup Node.js with bun package manager and caching"

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Setup Python"
 description: "Setup Python with uv package manager and caching"

--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Setup Ruby"
 description: "Setup Ruby with bundler and gem caching"

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Setup Rust"
 description: "Setup Rust toolchain with cargo caching"

--- a/.github/actions/sign-artifact/action.yml
+++ b/.github/actions/sign-artifact/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Sign Artifact"
 description: "Sign release artifacts with Sigstore/Cosign keyless signing"

--- a/.github/actions/trigger-homebrew-update/action.yml
+++ b/.github/actions/trigger-homebrew-update/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Trigger Homebrew Update"
 description: >-

--- a/.github/actions/validate-action-pinning/action.yml
+++ b/.github/actions/validate-action-pinning/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Validate Action Pinning"
 description: >-

--- a/.github/actions/validate-package/action.yml
+++ b/.github/actions/validate-package/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Validate Package"
 description: "Validate package before publishing to PyPI, npm, or RubyGems"

--- a/.github/actions/validate-runner-policy/action.yml
+++ b/.github/actions/validate-runner-policy/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Validate runner policy"
 description: >-

--- a/.github/actions/verify-attestation/action.yml
+++ b/.github/actions/verify-attestation/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Verify Attestation"
 description: "Verify build attestations using gh attestation verify"

--- a/.github/actions/verify-signature/action.yml
+++ b/.github/actions/verify-signature/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Verify Signature"
 description: "Verify Sigstore/Cosign signatures on artifacts"

--- a/.github/actions/wait-for-package/action.yml
+++ b/.github/actions/wait-for-package/action.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
 ---
 name: "Wait for Package"
 description: "Wait for a package to be available on a registry"

--- a/.github/workflows/reusable-dependency-review.yml
+++ b/.github/workflows/reusable-dependency-review.yml
@@ -19,6 +19,15 @@ on:
         required: false
         type: string
         default: ""
+      allow-dependencies-licenses:
+        description: >-
+          Comma-separated PURLs exempted from license checks regardless of
+          allow-licenses/deny-licenses (e.g. lgtm-ci composite actions that
+          report Unknown license in the actions ecosystem — see
+          docs/workflow-contract.md#dependency-review for canonical PURLs).
+        required: false
+        type: string
+        default: ""
 
       tooling-ref:
         description: >-
@@ -111,3 +120,4 @@ jobs:
           fail-on-severity: ${{ inputs.fail-on-severity }}
           deny-licenses: ${{ inputs.deny-licenses }}
           allow-licenses: ${{ inputs.allow-licenses }}
+          allow-dependencies-licenses: ${{ inputs.allow-dependencies-licenses }}

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -889,6 +889,77 @@ tooling checkout need egress for `codeload.github.com`, `astral.sh`, and
 events. Do not invoke it from plain `push` workflows unless you accept the job
 being skipped.
 
+### Licensing: "Unknown License" on lgtm-ci composite actions
+
+Consumers pinning `lgtm-hq/lgtm-ci/.github/actions/*@<sha>` may see
+**License: Null / Unknown** for those rows in GitHub Dependency Review and
+OpenSSF Scorecard's license check, even though this repository is **MIT**
+(`LICENSE` at the repo root). This is a known GitHub platform limitation, not
+a missing license:
+
+- The `action.yml` metadata schema (`name`, `author`, `description`, `inputs`,
+  `outputs`, `runs`, `branding`) has **no license/SPDX field**. There is
+  nothing for a composite action to declare that GitHub's dependency graph
+  will read.
+- GitHub's `actions` ecosystem in the dependency graph does not currently
+  inherit the referencing repository's `LICENSE` for cross-repo composite
+  action paths (`owner/repo/path@ref`), so `dependency-review-action` and
+  Scorecard report the license as unknown regardless of the upstream repo's
+  actual license.
+
+Every `action.yml` under `.github/actions/` carries an
+`SPDX-License-Identifier: MIT` header comment for humans and license-scanning
+tools that read files directly; it does not change what GitHub's dependency
+graph reports, since the field isn't part of the schema GitHub parses.
+
+**Consumer workaround:** pass `allow-dependencies-licenses` through
+`reusable-dependency-review.yml` with the PURLs of the lgtm-ci composites you
+consume, pinned to the tag/SHA you use. The dependency-review-action matches
+`allow-dependencies-licenses` entries on namespace/name only (version is
+ignored), so a single PURL per action covers every ref you pin to it. Slashes
+in the composite subpath are percent-encoded (`%2F`):
+
+<!-- markdownlint-disable MD013 -- long PURL examples -->
+
+```yaml
+jobs:
+  dependency-review:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-dependency-review.yml@<sha> # vX.Y.Z
+    with:
+      allow-dependencies-licenses: >-
+        pkg:githubactions/lgtm-hq/lgtm-ci%2F.github%2Factions%2Fharden-runner,
+        pkg:githubactions/lgtm-hq/lgtm-ci%2F.github%2Factions%2Fcheckout-and-harden,
+        pkg:githubactions/lgtm-hq/lgtm-ci%2F.github%2Factions%2Fsecure-checkout,
+        pkg:githubactions/lgtm-hq/lgtm-ci%2F.github%2Factions%2Fsetup-rust,
+        pkg:githubactions/lgtm-hq/lgtm-ci%2F.github%2Factions%2Fcreate-github-release
+```
+
+<!-- markdownlint-enable MD013 -->
+
+Canonical PURLs for common composites (swap the trailing action name for any
+other directory under `.github/actions/`):
+
+<!-- markdownlint-disable MD013 -- wide PURL reference table -->
+
+| Composite               | PURL (namespace/name)                                            |
+| ------------------------ | ----------------------------------------------------------------- |
+| `harden-runner`          | `pkg:githubactions/lgtm-hq/lgtm-ci%2F.github%2Factions%2Fharden-runner` |
+| `checkout-and-harden`    | `pkg:githubactions/lgtm-hq/lgtm-ci%2F.github%2Factions%2Fcheckout-and-harden` |
+| `secure-checkout`        | `pkg:githubactions/lgtm-hq/lgtm-ci%2F.github%2Factions%2Fsecure-checkout` |
+| `setup-rust`             | `pkg:githubactions/lgtm-hq/lgtm-ci%2F.github%2Factions%2Fsetup-rust` |
+| `setup-python`           | `pkg:githubactions/lgtm-hq/lgtm-ci%2F.github%2Factions%2Fsetup-python` |
+| `setup-node`             | `pkg:githubactions/lgtm-hq/lgtm-ci%2F.github%2Factions%2Fsetup-node` |
+| `create-github-release`  | `pkg:githubactions/lgtm-hq/lgtm-ci%2F.github%2Factions%2Fcreate-github-release` |
+
+<!-- markdownlint-enable MD013 -->
+
+For OpenSSF Scorecard, there is no equivalent per-dependency allowlist for the
+license check today; document the expected "Unknown" result for lgtm-ci
+composite rows rather than treating it as a regression. Re-check this section
+if GitHub ships license enrichment for the `actions` ecosystem or adds a
+`license` field to the action metadata schema — at that point the
+`allow-dependencies-licenses` workaround and this note can be retired.
+
 ## Security audit (osv-scanner)
 
 `reusable-security-audit.yml` centralizes the lintro Docker + osv-scanner audit


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Surfaces the repository's MIT license for lgtm-ci composite actions and gives
consumers a supported path to clean "Unknown License" rows out of GitHub
Dependency Review reports.

Research outcome (documented in `docs/workflow-contract.md`): GitHub's
`action.yml` metadata schema has no license/SPDX field, and the dependency
graph's `actions` ecosystem does not inherit the upstream repo `LICENSE` for
cross-repo composite paths (`owner/repo/path@ref`). Graph enrichment is a
GitHub platform limitation we cannot fix upstream today, so this PR ships the
consumer-side pattern instead:

- `SPDX-License-Identifier: MIT` header comments on all 49
  `.github/actions/*/action.yml` manifests (for humans and file-level license
  scanners; repo root `LICENSE` remains the source of truth).
- New `allow-dependencies-licenses` input on
  `reusable-dependency-review.yml`, passed through to
  `actions/dependency-review-action`, so callers can exempt lgtm-ci composite
  PURLs from license checks.
- New "Licensing" subsection under "Dependency review" in
  `docs/workflow-contract.md`: why the graph shows Unknown, canonical
  `pkg:githubactions/lgtm-hq/lgtm-ci%2F.github%2Factions%2F<name>` PURLs for
  common composites, a copy-paste caller example, and the explicit note that
  the platform limitation remains until GitHub enriches the actions
  ecosystem.

No action logic or workflow behavior changes; the new input defaults to `""`
(no-op for existing callers).

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Testing

- `uv run lintro chk`: 0 issues across all tools.
- Full BATS suite (200 files, 2699 tests): 2698 passed, 1 failed —
  `run-rust-coverage-html: fails when cargo-llvm-cov is missing`. This
  failure reproduces identically on pristine `origin/main` (the test pins
  `PATH=/usr/local/bin`, which lacks `rm` on Apple Silicon macOS, so the
  script exits before reaching the asserted error). Pre-existing local
  environment issue, unrelated to this change; passes in CI on ubuntu
  runners.

## Breaking Changes

None. The new `allow-dependencies-licenses` input is optional and defaults to
an empty string, matching the previous behavior exactly.

## Closes

- Closes #293

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds license metadata and a dependency review workaround for composite actions. The main changes are:

- MIT SPDX header comments on composite action manifests.
- A new reusable workflow input for dependency license exemptions.
- Documentation for Unknown License rows and canonical GitHub Actions PURLs.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after confirming the forwarded action input name against the pinned dependency review action.

- No blocking issues found in the changed code.
- The only note is a conditional workflow contract check for the new pass-through input.

.github/workflows/reusable-dependency-review.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-dependency-review.yml | Adds an optional workflow input and forwards it to dependency-review-action. |
| docs/workflow-contract.md | Documents the composite action license limitation and consumer allowlist pattern. |
| .github/actions/*/action.yml | Adds valid YAML comment headers with MIT SPDX information. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Freusable-dependency-review.yml%3A123%0A**Allowlist%20Input%20Can%20Be%20Ignored**%0A%0AIf%20the%20pinned%20%60actions%2Fdependency-review-action%60%20version%20does%20not%20define%20%60allow-dependencies-licenses%60%20exactly%2C%20GitHub%20Actions%20will%20still%20run%20this%20step%20but%20the%20exemption%20list%20will%20not%20be%20applied.%20Callers%20copying%20the%20new%20workflow%20input%20would%20keep%20seeing%20Unknown%20License%20failures%20with%20no%20clear%20signal%20that%20the%20forwarded%20key%20was%20ignored.%0A%0A&pr=445&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Freusable-dependency-review.yml%3A123%0A**Allowlist%20Input%20Can%20Be%20Ignored**%0A%0AIf%20the%20pinned%20%60actions%2Fdependency-review-action%60%20version%20does%20not%20define%20%60allow-dependencies-licenses%60%20exactly%2C%20GitHub%20Actions%20will%20still%20run%20this%20step%20but%20the%20exemption%20list%20will%20not%20be%20applied.%20Callers%20copying%20the%20new%20workflow%20input%20would%20keep%20seeing%20Unknown%20License%20failures%20with%20no%20clear%20signal%20that%20the%20forwarded%20key%20was%20ignored.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=445&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F293-action-license-metadata%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F293-action-license-metadata%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Freusable-dependency-review.yml%3A123%0A**Allowlist%20Input%20Can%20Be%20Ignored**%0A%0AIf%20the%20pinned%20%60actions%2Fdependency-review-action%60%20version%20does%20not%20define%20%60allow-dependencies-licenses%60%20exactly%2C%20GitHub%20Actions%20will%20still%20run%20this%20step%20but%20the%20exemption%20list%20will%20not%20be%20applied.%20Callers%20copying%20the%20new%20workflow%20input%20would%20keep%20seeing%20Unknown%20License%20failures%20with%20no%20clear%20signal%20that%20the%20forwarded%20key%20was%20ignored.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=445&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(workflows): add allow-dependencies-..."](https://github.com/lgtm-hq/lgtm-ci/commit/2ea05c7ff4438113ad7600dac8131d262a8819db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42788538)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->