### PR TITLE
feat(security): flag expired vuln suppressions for review instead of auto-removing

### DIFF
--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -1016,8 +1016,10 @@ everyone uses.
 ### Vulnerability suppression check (osv-scanner)
 
 `reusable-vuln-suppression-check.yml` installs `osv-scanner` directly (no Docker),
-probes the repository without suppressions, and opens a cleanup PR when entries are
-stale (vulnerability resolved upstream) or expired (past `ignoreUntil`).
+probes the repository without suppressions, and opens a cleanup PR removing
+suppressions that are stale (vulnerability resolved upstream). Expired entries
+(past `ignoreUntil`) are left untouched and flagged for manual review, failing
+the job so a human re-evaluates each one.
 
 | Input                    | Default                 | Notes                                      |
 | ------------------------ | ----------------------- | ------------------------------------------ |

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -928,7 +928,9 @@ Outputs: `exit-code`, `has-vulns`, `audit-failed`, `status`.
 suppression cleanup pattern used by Rustume, py-lintro, and turbo-themes. The job
 installs `osv-scanner` directly (no Docker), runs
 `scripts/ci/security/check-vuln-suppressions.sh`, and may open a cleanup PR
-removing stale and expired entries.
+removing stale entries (vulnerability resolved). Expired entries (past
+`ignoreUntil`) are left untouched and flagged for manual review with a
+non-zero exit.
 
 <!-- markdownlint-disable MD013 MD060 -- wide input reference table -->
 

--- a/scripts/ci/security/check-vuln-suppressions.sh
+++ b/scripts/ci/security/check-vuln-suppressions.sh
@@ -80,12 +80,12 @@ STALE_IDS=()
 EXPIRED_IDS=()
 ACTIVE_IDS=()
 declare -A EXPIRED_UNTIL=()
-while IFS=$'\t' read -r category vid until; do
+while IFS=$'\t' read -r category vid expire_date; do
 	case "$category" in
 	STALE) STALE_IDS+=("$vid") ;;
 	EXPIRED)
 		EXPIRED_IDS+=("$vid")
-		EXPIRED_UNTIL["$vid"]="$until"
+		EXPIRED_UNTIL["$vid"]="$expire_date"
 		;;
 	ACTIVE) ACTIVE_IDS+=("$vid") ;;
 	esac
@@ -128,11 +128,11 @@ vulnerability or renew the suppression with a new \`ignoreUntil\`.
 | ID | ignoreUntil | Required action |
 | --- | --- | --- |
 "
-	local id until
+	local id expire_date
 	for id in "${EXPIRED_IDS[@]+"${EXPIRED_IDS[@]}"}"; do
-		until="${EXPIRED_UNTIL[$id]:-unknown}"
-		log_error "  - ${id} (ignoreUntil ${until}) — remediate the vulnerability or renew the suppression"
-		summary="${summary}| \`${id}\` | ${until} | Remediate the vulnerability or renew the suppression |
+		expire_date="${EXPIRED_UNTIL[$id]:-unknown}"
+		log_error "  - ${id} (ignoreUntil ${expire_date}) — remediate the vulnerability or renew the suppression"
+		summary="${summary}| \`${id}\` | ${expire_date} | Remediate the vulnerability or renew the suppression |
 "
 	done
 	if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then

--- a/scripts/ci/security/check-vuln-suppressions.sh
+++ b/scripts/ci/security/check-vuln-suppressions.sh
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: MIT
 #
 # check-vuln-suppressions.sh — Detect stale or expired vulnerability
-# suppressions in .osv-scanner.toml and open a cleanup PR removing them.
+# suppressions in .osv-scanner.toml. Stale entries (vulnerability resolved)
+# are auto-removed via a cleanup PR; expired entries (past ignoreUntil) are
+# left untouched and flagged for manual review with a non-zero exit.
 #
 # Usage:
 #   check-vuln-suppressions.sh
@@ -23,8 +25,9 @@ Detect stale or expired vulnerability suppressions in .osv-scanner.toml.
 
 Runs osv-scanner recursively without suppressions to scan all
 supported lockfiles and see which suppressed vulnerabilities are still
-present. Opens a PR removing entries that are stale (vuln resolved) or
-expired (past ignoreUntil).
+present. Opens a PR removing entries that are stale (vuln resolved).
+Expired entries (past ignoreUntil) are left untouched and flagged for
+manual review, causing a non-zero exit.
 
 Requires GH_TOKEN for PR management.
 EOF
@@ -76,23 +79,32 @@ CLASSIFICATION_JSON=$(echo "$PROBE_OUTPUT" | python3 "$SCRIPTS_DIR/classify-supp
 STALE_IDS=()
 EXPIRED_IDS=()
 ACTIVE_IDS=()
-while IFS= read -r line; do
-	category="${line%%:*}"
-	vid="${line#*:}"
+declare -A EXPIRED_UNTIL=()
+while IFS=$'\t' read -r category vid until; do
 	case "$category" in
 	STALE) STALE_IDS+=("$vid") ;;
-	EXPIRED) EXPIRED_IDS+=("$vid") ;;
+	EXPIRED)
+		EXPIRED_IDS+=("$vid")
+		EXPIRED_UNTIL["$vid"]="$until"
+		;;
 	ACTIVE) ACTIVE_IDS+=("$vid") ;;
 	esac
 done < <(echo "$CLASSIFICATION_JSON" | python3 -c "
 import json, sys
 d = json.load(sys.stdin)
-for k in ('stale', 'expired', 'active'):
-    for i in d.get(k, []):
-        print(f'{k.upper()}:{i}')
+details = d.get('expired_until', {})
+for i in d.get('stale', []):
+    print(f'STALE\t{i}\t')
+for i in d.get('active', []):
+    print(f'ACTIVE\t{i}\t')
+for i in d.get('expired', []):
+    print(f'EXPIRED\t{i}\t{details.get(i, \"\")}')
 ")
 
-REMOVE_IDS=("${STALE_IDS[@]+"${STALE_IDS[@]}"}" "${EXPIRED_IDS[@]+"${EXPIRED_IDS[@]}"}")
+# Only stale suppressions are auto-removed. Expired entries are left untouched
+# and flagged for manual review (see issue #377): expiry means the timebox
+# lapsed and a human must re-evaluate, not that the vulnerability is gone.
+REMOVE_IDS=("${STALE_IDS[@]+"${STALE_IDS[@]}"}")
 
 for id in "${ACTIVE_IDS[@]+"${ACTIVE_IDS[@]}"}"; do
 	log_success "Active: $id"
@@ -100,17 +112,45 @@ done
 for id in "${STALE_IDS[@]+"${STALE_IDS[@]}"}"; do
 	log_warning "Stale: $id"
 done
-for id in "${EXPIRED_IDS[@]+"${EXPIRED_IDS[@]}"}"; do
-	log_warning "Expired: $id"
-done
+
+# Emit expired suppressions to the log and job summary. Callers exit non-zero
+# after invoking this so expired entries are surfaced as a failing check.
+flag_expired_suppressions() {
+	log_error "Expired suppression(s) require manual review (left untouched in $OSV_TOML):"
+	local summary
+	summary="## Expired vulnerability suppressions require manual review
+
+The following suppressions in \`${OSV_TOML}\` are past their \`ignoreUntil\` date
+and were **left untouched**. Expiry means the timebox lapsed, not that the
+vulnerability is resolved. Re-evaluate each entry and either remediate the
+vulnerability or renew the suppression with a new \`ignoreUntil\`.
+
+| ID | ignoreUntil | Required action |
+| --- | --- | --- |
+"
+	local id until
+	for id in "${EXPIRED_IDS[@]+"${EXPIRED_IDS[@]}"}"; do
+		until="${EXPIRED_UNTIL[$id]:-unknown}"
+		log_error "  - ${id} (ignoreUntil ${until}) — remediate the vulnerability or renew the suppression"
+		summary="${summary}| \`${id}\` | ${until} | Remediate the vulnerability or renew the suppression |
+"
+	done
+	if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+		printf '%s\n' "$summary" >>"$GITHUB_STEP_SUMMARY"
+	fi
+}
 
 if [[ ${#REMOVE_IDS[@]} -eq 0 ]]; then
+	if [[ ${#EXPIRED_IDS[@]} -gt 0 ]]; then
+		flag_expired_suppressions
+		exit 1
+	fi
 	log_success "All suppressions are active. Nothing to do."
 	exit 0
 fi
 
-# Check for an existing cleanup PR. If one exists and the current run found
-# new expired suppressions, fail instead of silently masking them.
+# Check for an existing cleanup PR. Stale removal for one is already pending,
+# so skip re-opening it, but still flag any expired entries for manual review.
 PR_LIST_OUTPUT=""
 PR_LIST_EXIT=0
 PR_LIST_OUTPUT=$(
@@ -123,11 +163,11 @@ if [[ "$PR_LIST_EXIT" -ne 0 ]]; then
 	exit 1
 fi
 if [[ -n "$PR_LIST_OUTPUT" ]]; then
+	log_info "Cleanup PR #${PR_LIST_OUTPUT} already open. Skipping stale removal."
 	if [[ ${#EXPIRED_IDS[@]} -gt 0 ]]; then
-		log_error "Cleanup PR #${PR_LIST_OUTPUT} already open, but new expired suppressions found. Manual review required."
+		flag_expired_suppressions
 		exit 1
 	fi
-	log_info "Cleanup PR #${PR_LIST_OUTPUT} already open. Skipping."
 	exit 0
 fi
 
@@ -152,12 +192,7 @@ if ! git diff --quiet; then
 		STALE_LIST="${STALE_LIST}- \`${id}\` (stale — vulnerability resolved)
 "
 	done
-	EXPIRED_LIST=""
-	for id in "${EXPIRED_IDS[@]+"${EXPIRED_IDS[@]}"}"; do
-		EXPIRED_LIST="${EXPIRED_LIST}- \`${id}\` (expired — past ignoreUntil date)
-"
-	done
-	REMOVED_LIST="${STALE_LIST}${EXPIRED_LIST}"
+	REMOVED_LIST="${STALE_LIST}"
 
 	BRANCH="chore/remove-stale-vulns-$(date +%Y%m%d%H%M%S)"
 	configure_git_ci_user
@@ -181,17 +216,12 @@ EOF
 	fi
 
 	PR_BODY="## Summary
-- Remove stale/expired vulnerability suppressions that are no longer needed
+- Remove stale vulnerability suppressions whose vulnerability is resolved
 "
 	if [[ -n "$STALE_LIST" ]]; then
 		PR_BODY="${PR_BODY}
 ### Removed (stale)
 ${STALE_LIST}"
-	fi
-	if [[ -n "$EXPIRED_LIST" ]]; then
-		PR_BODY="${PR_BODY}
-### Removed (expired)
-${EXPIRED_LIST}"
 	fi
 	PR_BODY="${PR_BODY}
 ## Test plan
@@ -223,14 +253,13 @@ ${EXPIRED_LIST}"
 	fi
 
 	log_success "Cleanup PR created on branch $BRANCH"
-
-	# Expired suppressions may indicate still-active vulnerabilities
-	# past their ignoreUntil date. Fail the workflow so the team
-	# reviews the PR before the next scan.
-	if [[ ${#EXPIRED_IDS[@]} -gt 0 ]]; then
-		log_error "Expired suppression(s) removed; review the cleanup PR before merging"
-		exit 1
-	fi
 else
 	log_info "No file changes needed."
+fi
+
+# Expired suppressions are left untouched. Flag them and fail the workflow so
+# the team re-evaluates each one, independent of any stale cleanup PR above.
+if [[ ${#EXPIRED_IDS[@]} -gt 0 ]]; then
+	flag_expired_suppressions
+	exit 1
 fi

--- a/scripts/ci/security/classify-suppressions.py
+++ b/scripts/ci/security/classify-suppressions.py
@@ -5,7 +5,12 @@
 Standalone version — does not depend on the lintro Python package.
 Reads osv-scanner probe output from stdin and the suppression TOML from
 CONFIG_PATH (default: .osv-scanner.toml). Outputs a JSON object with stale,
-expired, and active ID arrays.
+expired, and active ID arrays plus an ``expired_until`` map of expired ID to
+its ISO ``ignoreUntil`` date.
+
+Stale and expired are distinct outcomes: stale means the vulnerability is no
+longer present (safe to auto-remove), while expired means the suppression
+timebox lapsed and a human must re-evaluate it (flag, do not remove).
 
 Usage:
     osv-scanner scan --recursive --format json --config /dev/null . \
@@ -26,7 +31,7 @@ import os
 import sys
 import tomllib
 import traceback
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import date, datetime
 from pathlib import Path
 
@@ -38,6 +43,23 @@ class SuppressionEntry:
     id: str
     ignore_until: date | None
     reason: str
+
+
+@dataclass(frozen=True)
+class Classification:
+    """Result of classifying suppressions into their handling categories.
+
+    Attributes:
+        active: IDs whose vulnerability is still present and not expired.
+        stale: IDs whose vulnerability is resolved (safe to auto-remove).
+        expired: IDs past their ignoreUntil date (flag for manual review).
+        expired_until: Map of expired ID to its ISO ignoreUntil date.
+    """
+
+    active: list[str]
+    stale: list[str]
+    expired: list[str]
+    expired_until: dict[str, str]
 
 
 def parse_suppressions(toml_path: Path) -> list[SuppressionEntry]:
@@ -107,20 +129,39 @@ def classify(
     entries: list[SuppressionEntry],
     probe_ids: set[str],
     today: date | None = None,
-) -> dict[str, list[str]]:
-    """Classify suppressions as active, stale, or expired."""
+) -> Classification:
+    """Classify suppressions as active, stale, or expired.
+
+    Args:
+        entries: Parsed [[IgnoredVulns]] entries.
+        probe_ids: Vulnerability IDs still present in the unsuppressed scan.
+        today: Reference date for expiry checks (defaults to today).
+
+    Returns:
+        A Classification splitting IDs into active, stale, and expired, with an
+        expired_until map from each expired ID to its ISO ignoreUntil date.
+    """
     if today is None:
         today = date.today()
 
-    result: dict[str, list[str]] = {"active": [], "stale": [], "expired": []}
+    active: list[str] = []
+    stale: list[str] = []
+    expired: list[str] = []
+    expired_until: dict[str, str] = {}
     for entry in entries:
         if entry.ignore_until is not None and today > entry.ignore_until:
-            result["expired"].append(entry.id)
+            expired.append(entry.id)
+            expired_until[entry.id] = entry.ignore_until.isoformat()
         elif entry.id in probe_ids:
-            result["active"].append(entry.id)
+            active.append(entry.id)
         else:
-            result["stale"].append(entry.id)
-    return result
+            stale.append(entry.id)
+    return Classification(
+        active=active,
+        stale=stale,
+        expired=expired,
+        expired_until=expired_until,
+    )
 
 
 def main() -> None:
@@ -139,7 +180,7 @@ def main() -> None:
 
     probe_ids = parse_probe_vuln_ids(probe_output)
     result = classify(entries, probe_ids)
-    print(json.dumps(result))
+    print(json.dumps(asdict(result)))
 
 
 if __name__ == "__main__":

--- a/tests/bats/integration/test_vuln_suppressions.bats
+++ b/tests/bats/integration/test_vuln_suppressions.bats
@@ -201,7 +201,7 @@ EOF
 	[[ "$calls" != *"--label"* ]]
 }
 
-@test "vuln-suppressions: removes expired suppressions via cleanup PR and exits 1" {
+@test "vuln-suppressions: flags expired-only for review without a PR and exits 1" {
 	setup_suppression_repo
 	cat >"$MOCK_GIT_REPO/.osv-scanner.toml" <<'EOF'
 [[IgnoredVulns]]
@@ -220,13 +220,20 @@ EOF
 
 	run_check_script
 	assert_failure
-	assert_output --partial "Cleanup PR created"
-	assert_output --partial "Expired suppression(s) removed"
+	assert_output --partial "Expired suppression(s) require manual review"
+	assert_output --partial "GHSA-expired-3333 (ignoreUntil 2020-01-01)"
+	refute_output --partial "Cleanup PR created"
 
-	[[ ! -f "$MOCK_GIT_REPO/.osv-scanner.toml" ]] || ! grep -q 'GHSA-expired-3333' "$MOCK_GIT_REPO/.osv-scanner.toml"
+	# Expired entry is left untouched in the TOML.
+	grep -q 'GHSA-expired-3333' "$MOCK_GIT_REPO/.osv-scanner.toml"
+
+	# No cleanup PR is opened for an expired-only run.
+	local calls
+	calls=$(cat "$BATS_TEST_TMPDIR/mock_calls_gh")
+	[[ "$calls" != *"pr create"* ]]
 }
 
-@test "vuln-suppressions: removes stale and expired in one cleanup PR and exits 1" {
+@test "vuln-suppressions: removes only stale in cleanup PR, retains expired, exits 1" {
 	setup_suppression_repo
 	cat >"$MOCK_GIT_REPO/.osv-scanner.toml" <<'EOF'
 [[IgnoredVulns]]
@@ -245,18 +252,18 @@ EOF
 		git commit -q --amend --no-edit
 	)
 
-	mock_osv_probe '{"results":[{"packages":[{"vulnerabilities":[]}]}]}'
+	mock_osv_probe '{"results":[{"packages":[{"vulnerabilities":[{"id":"GHSA-expired-3333"}]}]}]}'
 	mock_gh_for_cleanup_pr "https://github.com/test-org/test-repo/pull/44"
 
 	run_check_script
 	assert_failure
 	assert_output --partial "Cleanup PR created"
-	assert_output --partial "Expired suppression(s) removed"
+	assert_output --partial "Expired suppression(s) require manual review"
 
-	[[ ! -f "$MOCK_GIT_REPO/.osv-scanner.toml" ]] || {
-		! grep -q 'GHSA-stale-2222' "$MOCK_GIT_REPO/.osv-scanner.toml" &&
-			! grep -q 'GHSA-expired-3333' "$MOCK_GIT_REPO/.osv-scanner.toml"
-	}
+	# Stale entry removed, expired entry retained.
+	run grep -q 'GHSA-stale-2222' "$MOCK_GIT_REPO/.osv-scanner.toml"
+	assert_failure
+	grep -q 'GHSA-expired-3333' "$MOCK_GIT_REPO/.osv-scanner.toml"
 }
 
 @test "vuln-suppressions: skips when cleanup PR already open for stale-only" {
@@ -284,9 +291,14 @@ EOF
 	assert_output --partial "Cleanup PR #99 already open"
 }
 
-@test "vuln-suppressions: fails when cleanup PR open but new expired found" {
+@test "vuln-suppressions: flags expired for review even when a cleanup PR is open" {
 	setup_suppression_repo
 	cat >"$MOCK_GIT_REPO/.osv-scanner.toml" <<'EOF'
+[[IgnoredVulns]]
+id = "GHSA-stale-2222"
+ignoreUntil = 2099-12-31
+reason = "resolved upstream"
+
 [[IgnoredVulns]]
 id = "GHSA-expired-4444"
 ignoreUntil = 2020-01-01
@@ -306,5 +318,11 @@ EOF
 
 	run_check_script
 	assert_failure
-	assert_output --partial "new expired suppressions found"
+	assert_output --partial "Cleanup PR #99 already open"
+	assert_output --partial "Expired suppression(s) require manual review"
+	assert_output --partial "GHSA-expired-4444 (ignoreUntil 2020-01-01)"
+
+	# Nothing removed when a cleanup PR is already open.
+	grep -q 'GHSA-stale-2222' "$MOCK_GIT_REPO/.osv-scanner.toml"
+	grep -q 'GHSA-expired-4444' "$MOCK_GIT_REPO/.osv-scanner.toml"
 }

--- a/tests/bats/unit/security/test_classify_suppressions.bats
+++ b/tests/bats/unit/security/test_classify_suppressions.bats
@@ -57,6 +57,7 @@ EOF
 	assert_output --partial '"active": ["GHSA-active-1111"]'
 	assert_output --partial '"stale": ["GHSA-stale-2222"]'
 	assert_output --partial '"expired": ["GHSA-expired-3333"]'
+	assert_output --partial '"expired_until": {"GHSA-expired-3333": "2020-01-01"}'
 }
 
 @test "classify-suppressions: honors CONFIG_PATH override" {


### PR DESCRIPTION
## Summary

Splits stale and expired suppression handling in the vuln suppression check.
Only **stale** suppressions (vulnerability resolved) are auto-removed via the
cleanup PR. **Expired** suppressions (past `ignoreUntil`) are now left
untouched in `.osv-scanner.toml` and flagged for manual review: each expired
ID is logged with its `ignoreUntil` date and required action, written to the
GitHub job summary, and the run exits 1 — independent of the stale early-exit,
so an expired-only run still fails instead of going silently green.

Behavior matrix:

| Run contains | Cleanup PR | TOML change | Exit |
|---|---|---|---|
| stale only | opened, removes stale | stale removed | 0 |
| expired only | none | none | 1 (flagged) |
| stale + expired | opened, removes stale only | stale removed, expired retained | 1 (flagged) |
| active only | none | none | 0 |

Changes:

- `check-vuln-suppressions.sh`: drop `EXPIRED_IDS` from `REMOVE_IDS`; add
  `flag_expired_suppressions` (log + job summary table of ID / ignoreUntil /
  required action) invoked with `exit 1` on every path where expired entries
  exist, including when a cleanup PR is already open
- `classify-suppressions.py`: emit an `expired_until` map (expired ID → ISO
  `ignoreUntil`) alongside the existing category arrays, via a typed
  `Classification` dataclass
- Cleanup PR commit/body now lists only the "Removed (stale)" section
- BATS coverage updated: expired-only (exit 1, TOML untouched, no PR),
  stale+expired (PR removes only stale, expired retained, exit 1), expired
  flagged even when a cleanup PR is already open, stale-only and active-only
  unchanged

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None to workflow inputs/secrets. Behavioral change: expired suppressions are
no longer removed by the cleanup PR — the job now fails and asks for manual
re-evaluation, and consumers must renew or remediate expired entries
themselves.

## Closes

- Closes #377

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR splits the previously unified \"stale or expired → auto-remove\" cleanup path into two distinct behaviors: stale suppressions (vulnerability resolved) continue to be removed via a cleanup PR (exit 0), while expired suppressions (past `ignoreUntil`) are now left untouched in `.osv-scanner.toml`, flagged to the log and the GitHub job summary, and cause an exit 1 — on every path, including when a stale cleanup PR is already open.

- **`classify-suppressions.py`**: the return type is promoted from a plain `dict` to a typed `Classification` dataclass that adds an `expired_until` map (expired ID → ISO date); `asdict()` keeps JSON serialization identical to what the shell consumer expects.
- **`check-vuln-suppressions.sh`**: `EXPIRED_IDS` is removed from `REMOVE_IDS`; a new `flag_expired_suppressions` function writes a Markdown table to `$GITHUB_STEP_SUMMARY` and logs each expired ID with its date; `exit 1` is placed after every code path where `EXPIRED_IDS` is non-empty.
- **BATS tests**: all four behavior-matrix scenarios (expired-only, stale+expired, existing-PR-with-expired, stale-only/active-only unchanged) are exercised with updated assertions.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; all four scenarios from the behavior matrix are tested and the logic is consistent across the shell and Python layers.

The behavioral change is clearly scoped: expired suppressions are left untouched and surfaced as a failing check rather than silently removed. The control flow in the shell script reaches flag_expired_suppressions on every path where expired IDs exist (expired-only early exit, existing-PR branch, and post-stale-cleanup tail), and each path is backed by a BATS integration test. The Python classifier change is minimal and the asdict() serialization produces output the shell inline-script already expects. No correctness issues were found.

No files require special attention. The stale+expired integration test is the only case missing a per-ID output assertion, but this does not affect runtime correctness.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/security/check-vuln-suppressions.sh | Core behavioral change: EXPIRED_IDS no longer added to REMOVE_IDS; new flag_expired_suppressions() writes log + job-summary table and is followed by exit 1 on every code path where expired entries exist (expired-only, existing-PR, and post-stale-cleanup). Logic is correct and handles all four scenarios from the behavior matrix. |
| scripts/ci/security/classify-suppressions.py | Adds a typed Classification dataclass replacing the plain dict return type; emits expired_until map (expired ID → ISO date) alongside existing arrays; asdict() serialization is correct; classification precedence (expired before active) is unchanged and sound. |
| tests/bats/integration/test_vuln_suppressions.bats | Tests updated to cover all four behavior-matrix scenarios; expired-only, stale+expired, existing-PR-with-expired, and unchanged stale-only paths are all exercised. The stale+expired test does not assert the specific expired ID in the log output, leaving a minor coverage gap. |
| tests/bats/unit/security/test_classify_suppressions.bats | Adds assertion for the new expired_until field in the classifier output; existing tests are unmodified and continue to pass. |
| docs/reusable-workflows.md | Documentation updated to accurately describe the new split behavior: stale entries are auto-removed via PR, expired entries are flagged and fail the job. |
| docs/workflow-contract.md | Contract docs updated to reflect that expired entries now produce a non-zero exit with manual-review guidance instead of being silently removed. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([check-vuln-suppressions.sh]) --> B{.osv-scanner.toml\nexists?}
    B -- No --> Z1([exit 0])
    B -- Yes --> C[osv-scanner probe\n--config /dev/null]
    C --> D[classify-suppressions.py\nclassify entries]
    D --> E{Classification}
    E -- active --> F[log_success\nActive: id]
    E -- stale --> G[log_warning\nStale: id\nAdd to REMOVE_IDS]
    E -- expired --> H[Add to EXPIRED_IDS\nStore ignoreUntil in EXPIRED_UNTIL]
    G & H & F --> I{REMOVE_IDS\nempty?}
    I -- Yes + no expired --> Z2([exit 0])
    I -- Yes + expired --> J[flag_expired_suppressions\nlog + write job summary]
    J --> Z3([exit 1])
    I -- No --> K{Existing\ncleanup PR?}
    K -- Yes + expired --> L[flag_expired_suppressions]
    L --> Z4([exit 1])
    K -- Yes + no expired --> Z5([exit 0])
    K -- No --> M[remove_stale_suppressions.py\nonly stale IDs]
    M --> N{git diff\nnon-empty?}
    N -- Yes --> O[git push + gh pr create\nstale only in PR body]
    O --> P{EXPIRED_IDS\nnon-empty?}
    N -- No --> P
    P -- Yes --> Q[flag_expired_suppressions\nlog + write job summary]
    Q --> Z6([exit 1])
    P -- No --> Z7([exit 0])
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([check-vuln-suppressions.sh]) --> B{.osv-scanner.toml\nexists?}
    B -- No --> Z1([exit 0])
    B -- Yes --> C[osv-scanner probe\n--config /dev/null]
    C --> D[classify-suppressions.py\nclassify entries]
    D --> E{Classification}
    E -- active --> F[log_success\nActive: id]
    E -- stale --> G[log_warning\nStale: id\nAdd to REMOVE_IDS]
    E -- expired --> H[Add to EXPIRED_IDS\nStore ignoreUntil in EXPIRED_UNTIL]
    G & H & F --> I{REMOVE_IDS\nempty?}
    I -- Yes + no expired --> Z2([exit 0])
    I -- Yes + expired --> J[flag_expired_suppressions\nlog + write job summary]
    J --> Z3([exit 1])
    I -- No --> K{Existing\ncleanup PR?}
    K -- Yes + expired --> L[flag_expired_suppressions]
    L --> Z4([exit 1])
    K -- Yes + no expired --> Z5([exit 0])
    K -- No --> M[remove_stale_suppressions.py\nonly stale IDs]
    M --> N{git diff\nnon-empty?}
    N -- Yes --> O[git push + gh pr create\nstale only in PR body]
    O --> P{EXPIRED_IDS\nnon-empty?}
    N -- No --> P
    P -- Yes --> Q[flag_expired_suppressions\nlog + write job summary]
    Q --> Z6([exit 1])
    P -- No --> Z7([exit 0])
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: rename expired suppression date var..."](https://github.com/lgtm-hq/lgtm-ci/commit/e40fe3e20c70c9fcf3b4ca244583e7652a1880d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42790149)</sub>

<!-- /greptile_comment -->