### PR TITLE
feat(security): default verify-tags to true in action-pinning validation

### DIFF
--- a/.github/actions/validate-action-pinning/action.yml
+++ b/.github/actions/validate-action-pinning/action.yml
@@ -27,9 +27,12 @@ inputs:
     default: ".github/workflows .github/actions"
   verify-tags:
     description: >-
-      Verify Renovate version comments resolve to the pinned SHA via GitHub API
+      Verify Renovate version comments resolve to the pinned SHA via GitHub API.
+      Defaults to true so a lying `sha # vX.Y.Z` comment fails validation.
+      Offline/air-gapped or token-restricted callers can set this to false to
+      opt out of API tag resolution.
     required: false
-    default: "false"
+    default: "true"
   audit-transitive:
     description: >-
       Warn when pinned composite actions reference nested actions by mutable tag

--- a/.github/workflows/reusable-validate-action-pinning.yml
+++ b/.github/workflows/reusable-validate-action-pinning.yml
@@ -24,10 +24,13 @@ on:
         default: ".github/workflows .github/actions"
       verify-tags:
         description: >-
-          Verify Renovate version comments resolve to the pinned SHA via GitHub API
+          Verify Renovate version comments resolve to the pinned SHA via GitHub
+          API. Defaults to true so a lying `sha # vX.Y.Z` comment fails
+          validation. Offline/air-gapped or token-restricted callers can set
+          this to false to opt out of API tag resolution.
         required: false
         type: boolean
-        default: false
+        default: true
       audit-transitive:
         description: >-
           Warn when pinned composite actions reference nested actions by mutable tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **security**: default `verify-tags` to `true` in the
+  `validate-action-pinning` action and `reusable-validate-action-pinning.yml`
+  workflow (#369). A lying `sha # vX.Y.Z` comment whose SHA does not resolve to
+  the commented tag now fails validation by default instead of passing silently.
+
+  **Migration**: consumers who cannot reach the GitHub API at scan time
+  (offline/air-gapped runners, or token-restricted environments where `gh api`
+  tag resolution is unavailable) must opt out by passing `verify-tags: false`.
+  Callers that already relied on the API being reachable need no change; tag
+  resolution failures are reported as warnings, not hard failures.
+
 ### Deprecated
 
 ### Removed

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -838,6 +838,19 @@ Template expressions (for example `${{ inputs.tooling-ref }}`) are ignored.
 Bare SHA pins without version comments are invisible to Renovate and are blocked
 by design.
 
+### Tag verification (`verify-tags`)
+
+`verify-tags` defaults to **true**: each `sha # vX.Y.Z` pin is checked by
+resolving the commented tag through the GitHub API and comparing it to the
+pinned SHA. A comment that resolves to a different SHA (a lying pin) fails
+validation; a tag that cannot be resolved is reported as a warning, not a hard
+failure. This requires a `GH_TOKEN` for API access — the action falls back
+through the explicit `gh-token` input, a caller-set `GH_TOKEN` env var, then the
+workflow token.
+
+Offline/air-gapped runners, or environments where the GitHub API is
+unreachable, opt out with `verify-tags: false`.
+
 ### Composite actions calling sibling lgtm-ci actions
 
 Composite `action.yml` files must not call sibling lgtm-ci actions with a remote

--- a/tests/bats/integration/test_version_drift_workflows.bats
+++ b/tests/bats/integration/test_version_drift_workflows.bats
@@ -29,6 +29,20 @@ load "../../helpers/common"
 	assert_success
 }
 
+@test "validate-action-pinning action: verify-tags defaults to true" {
+	local action="${PROJECT_ROOT}/.github/actions/validate-action-pinning/action.yml"
+
+	run bash -c "grep -A9 '^  verify-tags:' '$action' | grep -E 'default:[[:space:]]*\"true\"'"
+	assert_success
+}
+
+@test "reusable-validate-action-pinning: verify-tags input defaults to true" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-validate-action-pinning.yml"
+
+	run bash -c "grep -A8 '^      verify-tags:' '$workflow' | grep -E 'default:[[:space:]]*true'"
+	assert_success
+}
+
 @test "dependency-review workflow: calls reusable dependency review" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/dependency-review.yml"
 

--- a/tests/bats/integration/test_version_drift_workflows.bats
+++ b/tests/bats/integration/test_version_drift_workflows.bats
@@ -39,7 +39,7 @@ load "../../helpers/common"
 @test "reusable-validate-action-pinning: verify-tags input defaults to true" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-validate-action-pinning.yml"
 
-	run bash -c "grep -A8 '^      verify-tags:' '$workflow' | grep -E 'default:[[:space:]]*true'"
+	run bash -c "grep -A12 '^      verify-tags:' '$workflow' | grep -E 'default:[[:space:]]*true'"
 	assert_success
 }
 


### PR DESCRIPTION
## Summary

Flips the `verify-tags` default from `false` to `true` in the
`validate-action-pinning` composite action and
`reusable-validate-action-pinning.yml`, so a lying `sha # vX.Y.Z` comment
(a pinned SHA that does not resolve to the commented tag) fails validation
by default instead of passing silently while looking audited.

This completes the follow-up deliberately deferred from #385 (requirement 2
of the issue): this repo's own caller already passes `verify-tags: true`,
and the BATS verify-tags path coverage (match passes, mismatch fails,
API-unavailable warns) already exists.

Verified locally against this repo with `verify-tags` enabled: 316 Renovate
version comments resolved, zero mismatches — no pin fixes needed.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Changes Made

- `.github/actions/validate-action-pinning/action.yml`: `verify-tags`
  default `"false"` → `"true"`, with the opt-out documented in the input
  description
- `.github/workflows/reusable-validate-action-pinning.yml`: `verify-tags`
  input default `false` → `true`, same description update
- `tests/bats/integration/test_version_drift_workflows.bats`: contract
  tests locking in the `true` defaults for both the action and the reusable
- `docs/workflow-contract.md`: new "Tag verification (`verify-tags`)"
  subsection under the action pinning policy (default, token fallback
  chain, warning-vs-failure semantics, opt-out)
- `CHANGELOG.md`: migration note under `[Unreleased]` — offline/air-gapped
  or token-restricted consumers must pass `verify-tags: false`

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

Behavioral change for consumers of the action/reusable workflow: `sha # vX.Y.Z`
pins are now verified against the GitHub API by default. Consumers that cannot
reach the API at scan time (offline/air-gapped runners, token-restricted
environments) must opt out with `verify-tags: false`. Tag resolution failures
remain warnings, not hard failures, so API-reachable callers need no change.
Migration note added to `CHANGELOG.md`.

## Closes

- Closes #369

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR flips the `verify-tags` default from `false` to `true` in both the `validate-action-pinning` composite action and `reusable-validate-action-pinning.yml`, so a SHA pin whose Renovate version comment doesn't match the actual tag SHA now fails validation by default instead of passing silently.

- **`action.yml` / `reusable-validate-action-pinning.yml`**: single-line default change (`\"false\"` → `\"true\"`) with updated descriptions covering the opt-out path for offline/token-restricted callers.
- **BATS tests**: two new contract tests assert the new `true` defaults using `grep -A` windows against the YAML files.
- **`CHANGELOG.md` / `docs/workflow-contract.md`**: migration note and new `verify-tags` subsection document the token fallback chain, warning-vs-failure semantics, and `verify-tags: false` opt-out.
- **Gap**: `scripts/ci/actions/validate-action-pinning.sh` line 22 still has `: \"${INPUT_VERIFY_TAGS:=false}\"` — the script's own fallback default was not updated, so any direct invocation without the action wrapper silently skips tag verification.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix: the underlying shell script's own fallback default was not updated to match the new action default.

The action and reusable workflow defaults are correctly flipped, documentation is thorough, and the egress preset (github-tooling) already allows api.github.com so the new API calls go through by default. The one concrete gap is scripts/ci/actions/validate-action-pinning.sh line 22, which still hard-codes :=${INPUT_VERIFY_TAGS:=false}. Any direct invocation of that script — local audits, developer spot-checks, test harnesses that omit the env var — will silently skip the tag verification that this PR intends to make the default.

scripts/ci/actions/validate-action-pinning.sh — the script's built-in fallback default on line 22 needs to be updated from false to true.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/actions/validate-action-pinning/action.yml | Flips verify-tags default from "false" to "true" with updated description; correct and consistent with the reusable workflow change. |
| .github/workflows/reusable-validate-action-pinning.yml | Flips verify-tags boolean default from false to true; forwards to the composite action correctly. Missing gh-token forwarding (flagged in prior review). |
| tests/bats/integration/test_version_drift_workflows.bats | Adds two contract tests asserting the new true defaults for both the action and the reusable workflow using grep -A windows. |
| CHANGELOG.md | Migration note added under [Unreleased] covering offline/token-restricted opt-out; accurate and complete. |
| docs/workflow-contract.md | New subsection documents verify-tags default, token fallback chain, warning-vs-failure semantics, and opt-out; accurate. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller invokes action/reusable workflow] --> B{verify-tags input provided?}
    B -- No --> C[Use default: true NEW]
    B -- Yes --> D[Use caller-provided value]
    C --> E[Tag verification enabled]
    D -- true --> E
    D -- false --> F[Tag verification skipped]
    E --> G{GH_TOKEN available?}
    G -- gh-token input --> H[Use explicit gh-token]
    G -- GH_TOKEN env var --> I[Use caller env GH_TOKEN]
    G -- fallback --> J[Use github.token]
    H & I & J --> K[Resolve tag via GitHub API]
    K --> L{Tag resolves?}
    L -- SHA matches comment --> M[Pass]
    L -- SHA mismatch --> N[FAIL]
    L -- API unreachable --> O[Warning only]
    F --> P[Skip - pass unchanged]
    subgraph Script fallback
        Q[Script run directly] --> R[INPUT_VERIFY_TAGS:=false still defaults false]
        R --> F
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Caller invokes action/reusable workflow] --> B{verify-tags input provided?}
    B -- No --> C[Use default: true NEW]
    B -- Yes --> D[Use caller-provided value]
    C --> E[Tag verification enabled]
    D -- true --> E
    D -- false --> F[Tag verification skipped]
    E --> G{GH_TOKEN available?}
    G -- gh-token input --> H[Use explicit gh-token]
    G -- GH_TOKEN env var --> I[Use caller env GH_TOKEN]
    G -- fallback --> J[Use github.token]
    H & I & J --> K[Resolve tag via GitHub API]
    K --> L{Tag resolves?}
    L -- SHA matches comment --> M[Pass]
    L -- SHA mismatch --> N[FAIL]
    L -- API unreachable --> O[Warning only]
    F --> P[Skip - pass unchanged]
    subgraph Script fallback
        Q[Script run directly] --> R[INPUT_VERIFY_TAGS:=false still defaults false]
        R --> F
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/reusable-validate-action-pinning.yml`, line 125-132 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/c8ff0994a665c05c012ac792733602a4bd362c79/.github/workflows/reusable-validate-action-pinning.yml#L125-L132)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing `gh-token` forwarding in reusable workflow**

   The composite action supports a `gh-token` input and falls back through `gh-token` → `GH_TOKEN` env var → `github.token` for tag resolution. The reusable workflow exposes no equivalent input, so callers whose `github.token` cannot resolve cross-org or private-repo action tags have no way to supply a custom token through this interface. Before this PR that gap was silent because `verify-tags` defaulted to `false`; now that it defaults to `true`, those callers will begin seeing tag-resolution warnings on every run with no path to fix them short of switching to the composite action directly.

   Adding a `gh-token` secret input to the reusable workflow and forwarding it via `with: gh-token: ${{ secrets.gh-token || '' }}` would close the gap.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-validate-action-pinning.yml%0ALine%3A%20125-132%0A%0AComment%3A%0A**Missing%20%60gh-token%60%20forwarding%20in%20reusable%20workflow**%0A%0AThe%20composite%20action%20supports%20a%20%60gh-token%60%20input%20and%20falls%20back%20through%20%60gh-token%60%20%E2%86%92%20%60GH_TOKEN%60%20env%20var%20%E2%86%92%20%60github.token%60%20for%20tag%20resolution.%20The%20reusable%20workflow%20exposes%20no%20equivalent%20input%2C%20so%20callers%20whose%20%60github.token%60%20cannot%20resolve%20cross-org%20or%20private-repo%20action%20tags%20have%20no%20way%20to%20supply%20a%20custom%20token%20through%20this%20interface.%20Before%20this%20PR%20that%20gap%20was%20silent%20because%20%60verify-tags%60%20defaulted%20to%20%60false%60%3B%20now%20that%20it%20defaults%20to%20%60true%60%2C%20those%20callers%20will%20begin%20seeing%20tag-resolution%20warnings%20on%20every%20run%20with%20no%20path%20to%20fix%20them%20short%20of%20switching%20to%20the%20composite%20action%20directly.%0A%0AAdding%20a%20%60gh-token%60%20secret%20input%20to%20the%20reusable%20workflow%20and%20forwarding%20it%20via%20%60with%3A%20gh-token%3A%20%24%7B%7B%20secrets.gh-token%20%7C%7C%20''%20%7D%7D%60%20would%20close%20the%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=447&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-validate-action-pinning.yml%0ALine%3A%20125-132%0A%0AComment%3A%0A**Missing%20%60gh-token%60%20forwarding%20in%20reusable%20workflow**%0A%0AThe%20composite%20action%20supports%20a%20%60gh-token%60%20input%20and%20falls%20back%20through%20%60gh-token%60%20%E2%86%92%20%60GH_TOKEN%60%20env%20var%20%E2%86%92%20%60github.token%60%20for%20tag%20resolution.%20The%20reusable%20workflow%20exposes%20no%20equivalent%20input%2C%20so%20callers%20whose%20%60github.token%60%20cannot%20resolve%20cross-org%20or%20private-repo%20action%20tags%20have%20no%20way%20to%20supply%20a%20custom%20token%20through%20this%20interface.%20Before%20this%20PR%20that%20gap%20was%20silent%20because%20%60verify-tags%60%20defaulted%20to%20%60false%60%3B%20now%20that%20it%20defaults%20to%20%60true%60%2C%20those%20callers%20will%20begin%20seeing%20tag-resolution%20warnings%20on%20every%20run%20with%20no%20path%20to%20fix%20them%20short%20of%20switching%20to%20the%20composite%20action%20directly.%0A%0AAdding%20a%20%60gh-token%60%20secret%20input%20to%20the%20reusable%20workflow%20and%20forwarding%20it%20via%20%60with%3A%20gh-token%3A%20%24%7B%7B%20secrets.gh-token%20%7C%7C%20''%20%7D%7D%60%20would%20close%20the%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=447&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F369-verify-tags-default%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F369-verify-tags-default%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Freusable-validate-action-pinning.yml%0ALine%3A%20125-132%0A%0AComment%3A%0A**Missing%20%60gh-token%60%20forwarding%20in%20reusable%20workflow**%0A%0AThe%20composite%20action%20supports%20a%20%60gh-token%60%20input%20and%20falls%20back%20through%20%60gh-token%60%20%E2%86%92%20%60GH_TOKEN%60%20env%20var%20%E2%86%92%20%60github.token%60%20for%20tag%20resolution.%20The%20reusable%20workflow%20exposes%20no%20equivalent%20input%2C%20so%20callers%20whose%20%60github.token%60%20cannot%20resolve%20cross-org%20or%20private-repo%20action%20tags%20have%20no%20way%20to%20supply%20a%20custom%20token%20through%20this%20interface.%20Before%20this%20PR%20that%20gap%20was%20silent%20because%20%60verify-tags%60%20defaulted%20to%20%60false%60%3B%20now%20that%20it%20defaults%20to%20%60true%60%2C%20those%20callers%20will%20begin%20seeing%20tag-resolution%20warnings%20on%20every%20run%20with%20no%20path%20to%20fix%20them%20short%20of%20switching%20to%20the%20composite%20action%20directly.%0A%0AAdding%20a%20%60gh-token%60%20secret%20input%20to%20the%20reusable%20workflow%20and%20forwarding%20it%20via%20%60with%3A%20gh-token%3A%20%24%7B%7B%20secrets.gh-token%20%7C%7C%20''%20%7D%7D%60%20would%20close%20the%20gap.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=447&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["test: widen verify-tags default fixture ..."](https://github.com/lgtm-hq/lgtm-ci/commit/cf345db226f7e1f980afb26039f12dccde1097e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42790326)</sub>

<!-- /greptile_comment -->