### PR TITLE
feat(maintenance): safely prune stale build-* Docker staging tags

### DIFF
--- a/.github/workflows/prune-build-staging-tags.yml
+++ b/.github/workflows/prune-build-staging-tags.yml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+---
+name: Maintenance - Prune Build Staging Tags
+
+'on':
+  schedule:
+    # Weekly, Mondays 03:00 UTC (after the registry health check at 02:00).
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+    inputs:
+      package-name:
+        description: "GHCR package whose build-* staging tags to prune"
+        required: false
+        type: string
+        default: "py-lintro"
+      dry-run:
+        description: "Log only, no deletions"
+        required: false
+        type: boolean
+        default: true
+
+permissions: {}
+
+concurrency:
+  group: prune-build-staging-tags
+  cancel-in-progress: false
+
+jobs:
+  prune-staging:
+    uses: ./.github/workflows/reusable-prune-build-staging-tags.yml
+    with:
+      package-name: ${{ inputs.package-name || 'py-lintro' }}
+      # Scheduled runs never delete; deletion requires an explicit dispatch.
+      dry-run: ${{ github.event_name != 'workflow_dispatch' || inputs.dry-run }}
+      tooling-ref: ${{ github.sha }}
+    permissions:
+      # Read repository and lgtm-ci tooling for the pruner scripts
+      contents: read
+      # Delete stale build-* staging package versions
+      packages: write
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-prune-build-staging-tags.yml
+++ b/.github/workflows/reusable-prune-build-staging-tags.yml
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+---
+name: Reusable Prune Build Staging Tags
+
+on:
+  workflow_call:
+    inputs:
+      package-name:
+        description: "GHCR package name whose build-* staging tags to prune"
+        required: true
+        type: string
+      threshold-days:
+        description: "Minimum staging-tag age in days before deletion"
+        required: false
+        type: number
+        default: 30
+      keep-recent:
+        description: "Always keep N most recent staging tags regardless of age"
+        required: false
+        type: number
+        default: 0
+      protect-referenced:
+        description: >-
+          Collect digests referenced by tagged non-build indexes and skip prune
+          when collection is incomplete (safety gate against #433)
+        required: false
+        type: boolean
+        default: true
+      dry-run:
+        description: "Log only, no deletions (default on the scheduled path)"
+        required: false
+        type: boolean
+        default: true
+      tooling-ref:
+        description: "Git ref to use when checking out lgtm-ci tooling scripts"
+        required: false
+        type: string
+        default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "block"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+
+      egress-preset:
+        description: >-
+          Named allowlist when allowed-endpoints is empty and egress-policy is
+          block (github-minimal, github-pages, github-tooling, docker, playwright, pypi,
+          rubygems, npm-publish, quality, sbom, scorecard)
+        required: false
+        type: string
+        default: "docker"
+
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 10
+
+    secrets:
+      token:
+        description: "GitHub token with packages:write scope"
+        required: true
+
+jobs:
+  prune-staging:
+    name: Prune Build Staging Tags
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      packages: write
+    concurrency:
+      group: prune-build-staging-${{ github.repository_owner }}-${{ inputs.package-name }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/checkout-and-harden
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Checkout and harden
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+        with:
+          tooling-ref: ${{ inputs.tooling-ref }}
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+          sparse-checkout-extra: |
+            scripts/ci/
+
+      - name: Prune build-* staging tags
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.token }}
+          PACKAGE_NAME: ${{ inputs.package-name }}
+          GITHUB_ORG: ${{ github.repository_owner }}
+          THRESHOLD_DAYS: ${{ inputs.threshold-days }}
+          KEEP_RECENT: ${{ inputs.keep-recent }}
+          PROTECT_REFERENCED: ${{ inputs.protect-referenced }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: .lgtm-ci-tooling/scripts/ci/maintenance/prune-build-staging-tags.sh

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -1108,6 +1108,62 @@ jobs:
     secrets: inherit
 ```
 
+### Prune build staging tags
+
+`reusable-prune-build-staging-tags.yml` prunes the per-platform
+`build-<run_id>-<slug>` staging tags that the multi-arch publish retains (the
+release index's own children — see #433/#434). It deletes a staging tag only
+when **both** hold: the tag is older than `threshold-days` (and not among the
+`keep-recent` newest), **and** its manifest digest is **not** referenced by any
+current tagged, non-build image index. That referenced-digest set is collected
+from every live release index (children, subjects, cosign/SLSA referrers); when
+collection is incomplete the entire prune is skipped (fail-closed), so a
+transient registry error can never orphan a live index. Dry-run is the default.
+
+| Input | Default | Notes |
+| --- | --- | --- |
+| `package-name` | — | Required GHCR package name |
+| `threshold-days` | `30` | Min staging-tag age before deletion |
+| `keep-recent` | `0` | Keep N most recent staging tags |
+| `protect-referenced` | `true` | Skip when refs incomplete (#433 gate) |
+| `dry-run` | `true` | Log only, no deletions |
+| `egress-policy` | `block` | `audit` or `block` |
+| `egress-preset` | `docker` | API + GHCR registry hosts |
+| `allowed-endpoints` | `""` | Custom endpoints |
+| `allowed-endpoints-mode` | `replace` | `replace` or `append` |
+| `tooling-ref` | `""` | lgtm-ci tooling git ref |
+| `runner-image` | `ubuntu-24.04` | Runner image label |
+
+Grant `contents: read` and `packages: write` on the caller job. Forward a token
+with `packages:write` via `secrets.token`. Scheduled callers should stay in
+dry-run and delete only on an explicit `workflow_dispatch`.
+
+```yaml
+'on':
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        type: boolean
+        default: true
+
+permissions: {}
+
+jobs:
+  prune-staging:
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-prune-build-staging-tags.yml@<sha>
+    permissions:
+      contents: read
+      packages: write
+    with:
+      package-name: my-image
+      # Never delete on the scheduled path.
+      dry-run: ${{ github.event_name != 'workflow_dispatch' || inputs.dry-run }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+```
+
 ### Documentation site quality
 
 `reusable-site-quality.yml` runs Astro (or similar) docs build, lychee link

--- a/scripts/ci/lib/ghcr/tags.sh
+++ b/scripts/ci/lib/ghcr/tags.sh
@@ -11,6 +11,11 @@ readonly _LGTM_CI_GHCR_TAGS_LOADED=1
 
 readonly _GHCR_EPHEMERAL_TAG_PATTERN='^(pr-[a-zA-Z0-9_.-]+|mq-[a-zA-Z0-9_.-]+|dispatch-[a-zA-Z0-9_.-]+)$'
 
+# Per-platform staging tags produced by the multi-arch publish
+# (merge-manifests.sh: build-${RUN_ID}-${slug}). RUN_ID is a numeric GitHub
+# Actions run id; slug is a platform slug such as linux-amd64 or linux-arm-v7.
+readonly _GHCR_BUILD_STAGING_TAG_PATTERN='^build-[0-9]+-[a-zA-Z0-9._-]+$'
+
 # Return 0 when every tag on the version matches the ephemeral pattern.
 # Args:
 #   $1 - JSON array of tag strings
@@ -30,4 +35,25 @@ ghcr_is_ephemeral_only_tagged() {
 	[[ "$ephemeral_count" -eq "$tag_count" ]]
 }
 
-export -f ghcr_is_ephemeral_only_tagged
+# Return 0 when every tag on the version is a build-<run_id>-<slug> staging tag.
+# Versions carrying any release/permanent tag (latest, vX.Y.Z, ...) are rejected
+# so the pruner never mistakes a live release index for a staging manifest.
+# Args:
+#   $1 - JSON array of tag strings
+ghcr_is_build_staging_only_tagged() {
+	local tags_json="${1:-[]}"
+	local tag_count staging_count
+
+	tag_count=$(jq -r 'length' <<<"$tags_json")
+	[[ "$tag_count" -eq 0 ]] && return 1
+
+	staging_count=$(
+		jq -r --arg pattern "$_GHCR_BUILD_STAGING_TAG_PATTERN" '
+			[.[] | select(test($pattern))] | length
+		' <<<"$tags_json"
+	)
+
+	[[ "$staging_count" -eq "$tag_count" ]]
+}
+
+export -f ghcr_is_ephemeral_only_tagged ghcr_is_build_staging_only_tagged

--- a/scripts/ci/maintenance/prune-build-staging-tags.sh
+++ b/scripts/ci/maintenance/prune-build-staging-tags.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Safely prune stale per-platform build-<run_id>-<slug> staging tags
+#          from a GHCR package without ever orphaning a live multi-arch index.
+#
+# Background (#433/#434): the multi-arch publish retains the per-platform
+# staging manifests because they are the merged release index's own children.
+# Deleting a staging manifest that a published index still points at reproduces
+# the #433 dangling-index bug (children 404). This pruner therefore deletes a
+# build-* staging tag only when BOTH hold:
+#   1. its run is older than THRESHOLD_DAYS (and not among KEEP_RECENT newest), and
+#   2. its manifest digest is NOT referenced by any current tagged, non-build-*
+#      image index in the package (the referenced-digest safety gate).
+# When the referenced-digest set cannot be collected completely, the whole
+# prune is skipped (fail-closed) so a transient registry error can never lead
+# to an unprotected deletion.
+#
+# Environment variables:
+#   PACKAGE_NAME       - GHCR package name to prune (required)
+#   GITHUB_ORG         - GitHub org or user owning the package (required)
+#   GH_TOKEN           - GitHub token with packages:write scope (required)
+#   THRESHOLD_DAYS     - Minimum staging-tag age in days before deletion (default: 30)
+#   KEEP_RECENT        - Always keep N most recent staging tags regardless of age (default: 0)
+#   PROTECT_REFERENCED - Skip prune when referenced-digest collection fails (default: true)
+#   DRY_RUN            - Log only, no deletions (default: true)
+
+set -euo pipefail
+
+: "${PACKAGE_NAME:?PACKAGE_NAME is required}"
+: "${GITHUB_ORG:?GITHUB_ORG is required}"
+: "${THRESHOLD_DAYS:=30}"
+: "${KEEP_RECENT:=0}"
+: "${PROTECT_REFERENCED:=true}"
+: "${DRY_RUN:=true}"
+
+[[ "$THRESHOLD_DAYS" =~ ^[0-9]+$ ]] || {
+	echo "ERROR: THRESHOLD_DAYS must be a non-negative integer, got: '$THRESHOLD_DAYS'" >&2
+	exit 1
+}
+[[ "$KEEP_RECENT" =~ ^[0-9]+$ ]] || {
+	echo "ERROR: KEEP_RECENT must be a non-negative integer, got: '$KEEP_RECENT'" >&2
+	exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/actions.sh
+source "$SCRIPT_DIR/../lib/actions.sh"
+# shellcheck source=../lib/ghcr/registry.sh
+source "$SCRIPT_DIR/../lib/ghcr/registry.sh"
+# shellcheck source=../lib/ghcr/tags.sh
+source "$SCRIPT_DIR/../lib/ghcr/tags.sh"
+
+# GitHub Packages REST API encodes nested path slashes; registry v2 paths do not.
+PACKAGE_NAME_API="${PACKAGE_NAME//\//%2F}"
+
+# jq snippet: a version is a build staging version when it carries at least one
+# tag and every tag matches build-<run_id>-<slug>. Single-quoted on purpose so
+# jq (not the shell) evaluates the expression.
+# shellcheck disable=SC2016
+readonly BUILD_STAGING_FILTER='
+	def is_build_staging_only:
+		(.metadata.container.tags // []) as $tags
+		| ($tags | length) > 0
+			and (all($tags[]; test("^build-[0-9]+-[a-zA-Z0-9._-]+$")));
+'
+
+ghcr_fetch_versions() {
+	all_versions=$(gh api --paginate \
+		"/orgs/${GITHUB_ORG}/packages/container/${PACKAGE_NAME_API}/versions" \
+		2>/dev/null | jq -s 'add // []') || {
+		all_versions=$(gh api --paginate \
+			"/users/${GITHUB_ORG}/packages/container/${PACKAGE_NAME_API}/versions" \
+			2>/dev/null | jq -s 'add // []') || die "Failed to fetch package versions"
+	}
+}
+
+ghcr_delete_version() {
+	local version_id="$1"
+
+	if [[ "$DRY_RUN" == "true" ]]; then
+		return 0
+	fi
+
+	local err=""
+	if err=$(gh api --method DELETE \
+		"/orgs/${GITHUB_ORG}/packages/container/${PACKAGE_NAME_API}/versions/${version_id}" \
+		2>&1); then
+		return 0
+	fi
+
+	if err=$(gh api --method DELETE \
+		"/users/${GITHUB_ORG}/packages/container/${PACKAGE_NAME_API}/versions/${version_id}" \
+		2>&1); then
+		return 0
+	fi
+
+	log_error "Failed to delete version ${version_id}: ${err}"
+	return 1
+}
+
+emit_skip_summary() {
+	local status="$1"
+	add_github_summary "## Prune Build Staging Tags"
+	add_github_summary ""
+	add_github_summary "| Property | Value |"
+	add_github_summary "| -------- | ----- |"
+	add_github_summary "| Package | \`${GITHUB_ORG}/${PACKAGE_NAME}\` |"
+	add_github_summary "| Status | ${status} |"
+}
+
+# =============================================================================
+# Fetch all package versions
+# =============================================================================
+log_info "Fetching versions for package: ${GITHUB_ORG}/${PACKAGE_NAME}"
+
+ghcr_fetch_versions
+
+total_count=$(echo "$all_versions" | jq 'length')
+log_info "Found $total_count total version(s)"
+
+# =============================================================================
+# Identify build-<run_id>-<slug> staging candidates
+# =============================================================================
+staging_versions=$(echo "$all_versions" | jq "
+	$BUILD_STAGING_FILTER
+	[ .[]
+	  | select(is_build_staging_only)
+	  | { id, name, tags: (.metadata.container.tags // []), t: (.updated_at // .created_at // \"\") }
+	]
+	| sort_by(.t) | reverse
+")
+staging_count=$(echo "$staging_versions" | jq 'length')
+log_info "Found $staging_count build-* staging tag(s)"
+
+if [[ "$staging_count" -eq 0 ]]; then
+	log_info "No build-* staging tags to prune for ${PACKAGE_NAME}"
+	emit_skip_summary ":white_check_mark: Nothing to prune"
+	exit 0
+fi
+
+# =============================================================================
+# Referenced-digest safety gate (#433 regression guard)
+# Collect the digests referenced by every tagged NON-build-* index. A staging
+# manifest is only prunable when it is absent from this set. Build staging
+# versions are excluded from the collection input so their own root digests do
+# not falsely protect them; a staging digest lands in the set only when it is a
+# child (or subject/referrer) of a live release index.
+# =============================================================================
+referenced_digests=()
+
+if [[ "$PROTECT_REFERENCED" == "true" ]]; then
+	non_build_versions=$(echo "$all_versions" | jq "
+		$BUILD_STAGING_FILTER
+		[ .[] | select(is_build_staging_only | not) ]
+	")
+
+	registry_token=""
+	if ! registry_token=$(ghcr_exchange_registry_token \
+		"$GITHUB_ORG" \
+		"$PACKAGE_NAME" \
+		"${GH_TOKEN:-}"); then
+		log_warning "Skipping prune for ${PACKAGE_NAME} (registry auth failed; cannot compute reference protection)"
+		emit_skip_summary ":warning: Skipped (registry auth failed)"
+		exit 0
+	fi
+
+	referenced_complete=true
+	referenced_digests_text=""
+	ghcr_collect_referenced_digests \
+		"$GITHUB_ORG" \
+		"$PACKAGE_NAME" \
+		"$non_build_versions" \
+		"$registry_token" \
+		referenced_complete \
+		referenced_digests_text
+
+	if [[ "$referenced_complete" != "true" ]]; then
+		log_warning "Skipping prune for ${PACKAGE_NAME} (referenced-digest collection incomplete)"
+		emit_skip_summary ":warning: Skipped (incomplete reference protection)"
+		exit 0
+	fi
+
+	if [[ -n "$referenced_digests_text" ]]; then
+		while IFS= read -r digest; do
+			[[ -n "$digest" ]] && referenced_digests+=("$digest")
+		done <<<"$referenced_digests_text"
+	fi
+	log_info "Collected ${#referenced_digests[@]} referenced digest(s) for protection"
+else
+	log_warning "PROTECT_REFERENCED=false: referenced-digest safety gate disabled"
+fi
+
+if ((${#referenced_digests[@]} > 0)); then
+	refs_json=$(printf '%s\n' "${referenced_digests[@]}" | jq -R . | jq -s .)
+else
+	refs_json='[]'
+fi
+
+# =============================================================================
+# Select prunable staging tags: older than the cutoff, not among the newest
+# KEEP_RECENT, and not referenced by any live release index.
+# =============================================================================
+cutoff_date=$(date -u -v-"${THRESHOLD_DAYS}d" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+	date -u -d "${THRESHOLD_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null ||
+	die "Could not compute cutoff date")
+
+log_info "Cutoff date: $cutoff_date (older than $THRESHOLD_DAYS days); keeping $KEEP_RECENT most recent"
+
+aged_versions=$(echo "$staging_versions" | jq --arg cutoff "$cutoff_date" --argjson keep "$KEEP_RECENT" '
+	.[$keep:] | [ .[] | select(.t != "" and .t < $cutoff) ]
+')
+aged_count=$(echo "$aged_versions" | jq 'length')
+log_info "Found $aged_count staging tag(s) older than the cutoff"
+
+to_delete=$(echo "$aged_versions" | jq --argjson refs "$refs_json" '
+	[ .[] | select(.name as $n | ($refs | index($n) | not)) ]
+')
+protected=$(echo "$aged_versions" | jq --argjson refs "$refs_json" '
+	[ .[] | select(.name as $n | ($refs | index($n))) ]
+')
+delete_count=$(echo "$to_delete" | jq 'length')
+protected_count=$(echo "$protected" | jq 'length')
+
+# Log every staging tag skipped because it is still an index child.
+while IFS=$'\t' read -r version_name tags_csv; do
+	[[ -z "$version_name" ]] && continue
+	log_info "Skipping $version_name ($tags_csv): still referenced by a live release"
+done < <(echo "$protected" | jq -r '.[] | [.name, (.tags | join(","))] | @tsv')
+
+# =============================================================================
+# Delete prunable staging tags
+# =============================================================================
+deleted=0
+failed=0
+
+while IFS=$'\t' read -r version_id version_name tags_csv version_time; do
+	[[ -z "$version_id" ]] && continue
+	if [[ "$DRY_RUN" == "true" ]]; then
+		log_info "[dry-run] Would prune staging version $version_id ($tags_csv, $version_name, updated $version_time)"
+		deleted=$((deleted + 1))
+		continue
+	fi
+
+	if ghcr_delete_version "$version_id"; then
+		log_success "Pruned staging version $version_id ($tags_csv, $version_name)"
+		deleted=$((deleted + 1))
+	else
+		failed=$((failed + 1))
+	fi
+done < <(echo "$to_delete" | jq -r '.[] | [.id, .name, (.tags | join(",")), .t] | @tsv')
+
+# =============================================================================
+# Summary
+# =============================================================================
+if [[ "$DRY_RUN" == "true" ]]; then
+	log_info "Dry run complete: $deleted staging tag(s) would be pruned, $protected_count protected"
+else
+	log_success "Prune complete: $deleted pruned, $protected_count protected, $failed failed"
+fi
+
+add_github_summary "## Prune Build Staging Tags"
+add_github_summary ""
+add_github_summary "| Property | Value |"
+add_github_summary "| -------- | ----- |"
+add_github_summary "| Package | \`${GITHUB_ORG}/${PACKAGE_NAME}\` |"
+add_github_summary "| Total versions | $total_count |"
+add_github_summary "| Build staging tags | $staging_count |"
+add_github_summary "| Older than ${THRESHOLD_DAYS}d (kept ${KEEP_RECENT} newest) | $aged_count |"
+add_github_summary "| Protected (still referenced) | $protected_count |"
+add_github_summary "| Referenced digests scanned | ${#referenced_digests[@]} |"
+
+if [[ "$DRY_RUN" == "true" ]]; then
+	add_github_summary "| Would prune | $deleted |"
+	add_github_summary "| Status | :construction: Dry Run |"
+else
+	add_github_summary "| Pruned | $deleted |"
+	if [[ $failed -gt 0 ]]; then
+		add_github_summary "| Failed | $failed |"
+		add_github_summary "| Status | :warning: Completed with errors |"
+	else
+		add_github_summary "| Status | :white_check_mark: Complete |"
+	fi
+fi
+
+if [[ $failed -gt 0 ]]; then
+	exit 1
+fi

--- a/tests/bats/integration/test_prune_build_staging_tags.bats
+++ b/tests/bats/integration/test_prune_build_staging_tags.bats
@@ -1,0 +1,257 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Integration tests for the build-* staging-tag pruner.
+#          Guards the #433 safety gate: a staging manifest that a live index
+#          still points at must never be deleted.
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+load "../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/maintenance/prune-build-staging-tags.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+	setup_github_env
+	export LIB_DIR
+	export BATS_TEST_TMPDIR
+	export PROJECT_ROOT
+	export SCRIPT
+
+	export PACKAGE_NAME="test-package"
+	export GITHUB_ORG="test-org"
+	export THRESHOLD_DAYS="30"
+	export KEEP_RECENT="0"
+	export PROTECT_REFERENCED="true"
+	export DRY_RUN="false"
+	export GH_TOKEN="test-token"
+}
+
+teardown() {
+	restore_path
+	teardown_github_env
+	teardown_temp_dir
+}
+
+# Mock gh: serve versions JSON for list calls, record DELETEs to a file.
+mock_gh_versions() {
+	local versions_json="$1"
+	local delete_exit="${2:-0}"
+
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+
+	local versions_file="${mock_bin}/.gh_versions"
+	printf '%s' "$versions_json" >"$versions_file"
+	: >"${mock_bin}/.gh_deletes"
+
+	cat >"${mock_bin}/gh" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+	*--method\ DELETE*)
+		printf '%s\n' "\$*" >>"${mock_bin}/.gh_deletes"
+		exit $delete_exit
+		;;
+	*packages/container*) cat '$versions_file';;
+	*) exit 1;;
+esac
+EOF
+	chmod +x "${mock_bin}/gh"
+
+	if [[ ":$PATH:" != *":${mock_bin}:"* ]]; then
+		export PATH="${mock_bin}:$PATH"
+	fi
+}
+
+# A release index tagged v1.0.0 whose single child is sha256:child-referenced.
+mock_registry_release_index() {
+	mock_command_multi "curl" '
+		*ghcr.io/token*) printf "%s" "{\"token\":\"registry-bearer\"}";;
+		*manifests/sha256:release-index*) printf "%s\n200\n" "{\"manifests\":[{\"digest\":\"sha256:child-referenced\"}]}";;
+		*referrers/sha256:release-index*) printf "%s\n200\n" "{\"manifests\":[]}";;
+		*) printf "%s\n404\n" "{}";;
+	'
+}
+
+# =============================================================================
+# Required env var validation
+# =============================================================================
+
+@test "prune-staging: fails when PACKAGE_NAME is not set" {
+	run bash -c 'unset PACKAGE_NAME; bash "$SCRIPT" 2>&1'
+	assert_failure
+	assert_output --partial "PACKAGE_NAME is required"
+}
+
+@test "prune-staging: fails when GITHUB_ORG is not set" {
+	run bash -c 'unset GITHUB_ORG; bash "$SCRIPT" 2>&1'
+	assert_failure
+	assert_output --partial "GITHUB_ORG is required"
+}
+
+@test "prune-staging: fails when THRESHOLD_DAYS is not an integer" {
+	run bash -c 'export THRESHOLD_DAYS=abc; bash "$SCRIPT" 2>&1'
+	assert_failure
+	assert_output --partial "THRESHOLD_DAYS must be a non-negative integer"
+}
+
+# =============================================================================
+# Core behaviour
+# =============================================================================
+
+@test "prune-staging: no-op when package has no build-* staging tags" {
+	mock_gh_versions '[
+		{"id":222,"name":"sha256:release-index","updated_at":"2024-01-01T00:00:00Z","metadata":{"container":{"tags":["v1.0.0"]}}}
+	]'
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "No build-* staging tags to prune"
+}
+
+@test "prune-staging: deletes an old, UNreferenced build-* staging tag" {
+	mock_registry_release_index
+	mock_gh_versions '[
+		{"id":222,"name":"sha256:release-index","updated_at":"2024-01-01T00:00:00Z","metadata":{"container":{"tags":["v1.0.0"]}}},
+		{"id":111,"name":"sha256:staging-old","updated_at":"2020-01-01T00:00:00Z","metadata":{"container":{"tags":["build-100-linux-amd64"]}}}
+	]'
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Pruned staging version 111"
+
+	run cat "${BATS_TEST_TMPDIR}/bin/.gh_deletes"
+	assert_output --partial "versions/111"
+}
+
+@test "prune-staging: SKIPS a staging tag whose digest is still an index child (#433 guard)" {
+	mock_registry_release_index
+	# The staging version's digest IS the release index's child digest.
+	mock_gh_versions '[
+		{"id":222,"name":"sha256:release-index","updated_at":"2024-01-01T00:00:00Z","metadata":{"container":{"tags":["v1.0.0"]}}},
+		{"id":333,"name":"sha256:child-referenced","updated_at":"2020-01-01T00:00:00Z","metadata":{"container":{"tags":["build-100-linux-amd64"]}}}
+	]'
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "still referenced by a live release"
+	refute_output --partial "Pruned staging version"
+
+	run cat "${BATS_TEST_TMPDIR}/bin/.gh_deletes"
+	refute_output --partial "versions/333"
+}
+
+@test "prune-staging: mixed set prunes only the unreferenced staging tag" {
+	mock_registry_release_index
+	mock_gh_versions '[
+		{"id":222,"name":"sha256:release-index","updated_at":"2024-01-01T00:00:00Z","metadata":{"container":{"tags":["v1.0.0"]}}},
+		{"id":333,"name":"sha256:child-referenced","updated_at":"2020-01-01T00:00:00Z","metadata":{"container":{"tags":["build-100-linux-arm64"]}}},
+		{"id":111,"name":"sha256:staging-old","updated_at":"2020-01-01T00:00:00Z","metadata":{"container":{"tags":["build-100-linux-amd64"]}}}
+	]'
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Pruned staging version 111"
+	assert_output --partial "still referenced by a live release"
+
+	run cat "${BATS_TEST_TMPDIR}/bin/.gh_deletes"
+	assert_output --partial "versions/111"
+	refute_output --partial "versions/333"
+}
+
+# =============================================================================
+# Age and keep-recent guards
+# =============================================================================
+
+@test "prune-staging: keeps staging tags newer than THRESHOLD_DAYS" {
+	local recent
+	recent=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	mock_registry_release_index
+	mock_gh_versions "[
+		{\"id\":222,\"name\":\"sha256:release-index\",\"updated_at\":\"2024-01-01T00:00:00Z\",\"metadata\":{\"container\":{\"tags\":[\"v1.0.0\"]}}},
+		{\"id\":111,\"name\":\"sha256:staging-new\",\"updated_at\":\"${recent}\",\"metadata\":{\"container\":{\"tags\":[\"build-999-linux-amd64\"]}}}
+	]"
+
+	run bash "$SCRIPT"
+	assert_success
+	refute_output --partial "Pruned staging version 111"
+}
+
+@test "prune-staging: KEEP_RECENT protects the newest staging tags regardless of age" {
+	export KEEP_RECENT="1"
+	mock_registry_release_index
+	# Two aged, unreferenced staging tags; the newest is kept.
+	mock_gh_versions '[
+		{"id":222,"name":"sha256:release-index","updated_at":"2024-01-01T00:00:00Z","metadata":{"container":{"tags":["v1.0.0"]}}},
+		{"id":111,"name":"sha256:staging-older","updated_at":"2020-01-01T00:00:00Z","metadata":{"container":{"tags":["build-100-linux-amd64"]}}},
+		{"id":112,"name":"sha256:staging-newer","updated_at":"2021-01-01T00:00:00Z","metadata":{"container":{"tags":["build-200-linux-amd64"]}}}
+	]'
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Pruned staging version 111"
+	refute_output --partial "Pruned staging version 112"
+}
+
+# =============================================================================
+# Fail-closed safety
+# =============================================================================
+
+@test "prune-staging: skips all deletion when referenced-digest collection is incomplete" {
+	# Manifest fetch returns a server error -> collection incomplete -> fail closed.
+	mock_command_multi "curl" '
+		*ghcr.io/token*) printf "%s" "{\"token\":\"registry-bearer\"}";;
+		*manifests/sha256:release-index*) printf "%s\n500\n" "error";;
+		*referrers/sha256:release-index*) printf "%s\n200\n" "{\"manifests\":[]}";;
+		*) printf "%s\n404\n" "{}";;
+	'
+	mock_gh_versions '[
+		{"id":222,"name":"sha256:release-index","updated_at":"2024-01-01T00:00:00Z","metadata":{"container":{"tags":["v1.0.0"]}}},
+		{"id":111,"name":"sha256:staging-old","updated_at":"2020-01-01T00:00:00Z","metadata":{"container":{"tags":["build-100-linux-amd64"]}}}
+	]'
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "incomplete"
+	refute_output --partial "Pruned staging version"
+
+	run cat "${BATS_TEST_TMPDIR}/bin/.gh_deletes"
+	refute_output --partial "versions/111"
+}
+
+@test "prune-staging: skips prune when registry auth fails" {
+	mock_command_multi "curl" '
+		*ghcr.io/token*) exit 22;;
+		*) exit 1;;
+	'
+	mock_gh_versions '[
+		{"id":222,"name":"sha256:release-index","updated_at":"2024-01-01T00:00:00Z","metadata":{"container":{"tags":["v1.0.0"]}}},
+		{"id":111,"name":"sha256:staging-old","updated_at":"2020-01-01T00:00:00Z","metadata":{"container":{"tags":["build-100-linux-amd64"]}}}
+	]'
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "registry auth failed"
+	refute_output --partial "Pruned staging version"
+}
+
+# =============================================================================
+# Dry-run
+# =============================================================================
+
+@test "prune-staging: dry-run reports but does not delete" {
+	export DRY_RUN="true"
+	mock_registry_release_index
+	mock_gh_versions '[
+		{"id":222,"name":"sha256:release-index","updated_at":"2024-01-01T00:00:00Z","metadata":{"container":{"tags":["v1.0.0"]}}},
+		{"id":111,"name":"sha256:staging-old","updated_at":"2020-01-01T00:00:00Z","metadata":{"container":{"tags":["build-100-linux-amd64"]}}}
+	]'
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "[dry-run] Would prune staging version 111"
+
+	run cat "${BATS_TEST_TMPDIR}/bin/.gh_deletes"
+	refute_output --partial "versions/111"
+}

--- a/tests/bats/integration/test_reusable_prune_build_staging_tags.bats
+++ b/tests/bats/integration/test_reusable_prune_build_staging_tags.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for the prune-build-staging-tags workflows
+
+load "../../helpers/common"
+
+REUSABLE="${PROJECT_ROOT}/.github/workflows/reusable-prune-build-staging-tags.yml"
+DISPATCHER="${PROJECT_ROOT}/.github/workflows/prune-build-staging-tags.yml"
+
+@test "reusable-prune: threshold-days defaults to 30" {
+	run awk '/^      threshold-days:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$REUSABLE"
+	assert_success
+	assert_output --partial "default: 30"
+}
+
+@test "reusable-prune: dry-run defaults to true (safe by default)" {
+	run awk '/^      dry-run:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$REUSABLE"
+	assert_success
+	assert_output --partial "default: true"
+}
+
+@test "reusable-prune: protect-referenced defaults to true (#433 safety gate)" {
+	run awk '/^      protect-referenced:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$REUSABLE"
+	assert_success
+	assert_output --partial "default: true"
+}
+
+@test "reusable-prune: egress preset defaults to docker (needs ghcr.io registry)" {
+	run awk '/^      egress-preset:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$REUSABLE"
+	assert_success
+	assert_output --partial 'default: "docker"'
+}
+
+@test "reusable-prune: passes threshold, keep-recent, protection, and dry-run env vars" {
+	run awk '
+		/- name: Prune build/ { step = 1 }
+		step && /THRESHOLD_DAYS:/ { threshold = 1 }
+		step && /KEEP_RECENT:/ { keep = 1 }
+		step && /PROTECT_REFERENCED:/ { protect = 1 }
+		step && /DRY_RUN:/ { dry = 1 }
+		END { exit !(threshold && keep && protect && dry) }
+	' "$REUSABLE"
+	assert_success
+}
+
+@test "reusable-prune: runs the dedicated pruner script (no inline shell logic)" {
+	run grep -q "scripts/ci/maintenance/prune-build-staging-tags.sh" "$REUSABLE"
+	assert_success
+}
+
+@test "reusable-prune: requires packages:write for the prune job" {
+	run awk '/^  prune-staging:$/{show=1} show&&/packages: write/{found=1} END{exit !found}' \
+		"$REUSABLE"
+	assert_success
+}
+
+@test "dispatcher-prune: scheduled runs stay in dry-run mode" {
+	run grep -qE "dry-run: \\$\\{\\{ github.event_name != 'workflow_dispatch'" "$DISPATCHER"
+	assert_success
+}
+
+@test "dispatcher-prune: calls the reusable prune workflow" {
+	run grep -q "uses: ./.github/workflows/reusable-prune-build-staging-tags.yml" "$DISPATCHER"
+	assert_success
+}

--- a/tests/bats/unit/lib/ghcr/test_tags.bats
+++ b/tests/bats/unit/lib/ghcr/test_tags.bats
@@ -65,6 +65,66 @@ teardown() {
 	assert_failure
 }
 
+# =============================================================================
+# ghcr_is_build_staging_only_tagged
+# =============================================================================
+
+@test "ghcr_is_build_staging_only_tagged: accepts build-<run_id>-<slug> tags" {
+	run bash -c '
+		source "$LIB_DIR/ghcr/tags.sh"
+		ghcr_is_build_staging_only_tagged "[\"build-123-linux-amd64\"]"
+	'
+	assert_success
+}
+
+@test "ghcr_is_build_staging_only_tagged: accepts multi-segment platform slugs" {
+	run bash -c '
+		source "$LIB_DIR/ghcr/tags.sh"
+		ghcr_is_build_staging_only_tagged "[\"build-42-linux-arm-v7\"]"
+	'
+	assert_success
+}
+
+@test "ghcr_is_build_staging_only_tagged: rejects release tags" {
+	run bash -c '
+		source "$LIB_DIR/ghcr/tags.sh"
+		ghcr_is_build_staging_only_tagged "[\"v1.0.0\",\"latest\"]"
+	'
+	assert_failure
+}
+
+@test "ghcr_is_build_staging_only_tagged: rejects a version mixing build and release tags" {
+	run bash -c '
+		source "$LIB_DIR/ghcr/tags.sh"
+		ghcr_is_build_staging_only_tagged "[\"build-123-linux-amd64\",\"latest\"]"
+	'
+	assert_failure
+}
+
+@test "ghcr_is_build_staging_only_tagged: rejects non-numeric run id" {
+	run bash -c '
+		source "$LIB_DIR/ghcr/tags.sh"
+		ghcr_is_build_staging_only_tagged "[\"build-main-linux-amd64\"]"
+	'
+	assert_failure
+}
+
+@test "ghcr_is_build_staging_only_tagged: rejects ephemeral build-cache tags" {
+	run bash -c '
+		source "$LIB_DIR/ghcr/tags.sh"
+		ghcr_is_build_staging_only_tagged "[\"pr-42\"]"
+	'
+	assert_failure
+}
+
+@test "ghcr_is_build_staging_only_tagged: rejects empty tag list" {
+	run bash -c '
+		source "$LIB_DIR/ghcr/tags.sh"
+		ghcr_is_build_staging_only_tagged "[]"
+	'
+	assert_failure
+}
+
 @test "ghcr/tags.sh: second source is a no-op when already loaded" {
 	run bash -c '
 		source "$LIB_DIR/ghcr/tags.sh"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Adds a safe periodic pruner for the per-platform `build-<run_id>-<slug>` Docker staging tags that the multi-arch publish now retains (they are the merged release index's own children — deleting them blindly caused the #433 dangling-index incident). The pruner deletes a staging tag only when **both** hold:

- the tag is older than `threshold-days` (default 30, minus the `keep-recent` newest), **and**
- its manifest digest is **not** referenced by any current tagged, non-`build-*` image index in the package.

The referenced-digest set is collected from every live release index (child manifests, subjects, and cosign/SLSA referrers via the registry v2 API). When that collection is incomplete for any reason, the entire prune is skipped (fail-closed), so a transient registry error can never orphan a live multi-arch index. Dry-run is the default everywhere; scheduled runs never delete — deletion requires an explicit `workflow_dispatch` with `dry-run` disabled.

New pieces:

- `scripts/ci/maintenance/prune-build-staging-tags.sh` — the pruner (reuses `lib/ghcr/registry.sh` referenced-digest machinery)
- `ghcr_is_build_staging_only_tagged` in `scripts/ci/lib/ghcr/tags.sh` — versions mixing `build-*` with any release tag are never treated as staging
- `.github/workflows/reusable-prune-build-staging-tags.yml` — reusable workflow (no inline shell)
- `.github/workflows/prune-build-staging-tags.yml` — weekly scheduled dispatcher (dry-run on the scheduled path)
- BATS: pruner deletes an old unreferenced staging tag; **skips** a staging tag whose digest is still an index child (#433 regression guard); fail-closed on incomplete collection/auth failure; age, `keep-recent`, and dry-run guards; workflow contract tests

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #435
- Relates to #433
- Relates to #434

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a safe periodic pruner for `build-<run_id>-<slug>` Docker staging tags that the multi-arch publish retains as children of released image indexes — deleting them blindly caused the #433 dangling-index incident. The pruner is fail-closed: it only deletes a staging tag when its manifest digest is absent from the referenced-digest set collected from every live release index, and it skips the entire run if that collection is incomplete for any reason.

- **New pruner script** (`scripts/ci/maintenance/prune-build-staging-tags.sh`) implements the two-gate check (age + unreferenced), with macOS/Linux date portability, org/user API fallback, and a GitHub Step Summary.
- **New helper** `ghcr_is_build_staging_only_tagged` in `tags.sh` ensures versions carrying any release tag alongside `build-*` tags are never mistaken for staging-only manifests.
- **New workflows** wire a weekly scheduled dispatcher (always dry-run) and a reusable workflow with safe defaults (`dry-run: true`, `protect-referenced: true`), backed by BATS tests covering the #433 regression guard, fail-closed scenarios, age/keep-recent guards, and workflow contract invariants.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge — the fail-closed design means a registry error or missing credentials skips all deletions rather than proceeding blindly, so the worst realistic outcome of a misconfiguration is a no-op run, not a dangling index.

The core safety gate (referenced-digest collection + completeness check) is correctly implemented and well tested. The four comments are all robustness/observability issues: a duplicated regex that could drift between the jq filter and tags.sh, missing GH_TOKEN startup validation that produces a misleading auth-failed message, an err variable overwrite that hides the more relevant org-API error, and silent error suppression in version fetching. None of these affect the deletion safety guarantee, but they would make diagnosing a real failure harder.

scripts/ci/maintenance/prune-build-staging-tags.sh warrants a second look for the four observability/robustness issues noted; all other files look clean.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/ci/maintenance/prune-build-staging-tags.sh | New pruner script — core safety logic (fail-closed, referenced-digest gate) is sound, but has four style/robustness issues: duplicated regex from tags.sh, missing GH_TOKEN startup validation, error overwrite in ghcr_delete_version, and silent error suppression in ghcr_fetch_versions. |
| scripts/ci/lib/ghcr/tags.sh | Adds ghcr_is_build_staging_only_tagged — clean implementation with correct guard against mixed build+release tags and empty-list rejection; pattern and export look correct. |
| .github/workflows/reusable-prune-build-staging-tags.yml | Reusable workflow wiring is correct — safe defaults (dry-run, protect-referenced), proper job-level permissions, no inline shell logic, and pinned action SHA. |
| .github/workflows/prune-build-staging-tags.yml | Dispatcher workflow correctly enforces dry-run on the scheduled path and grants packages:write only at the job level; concurrency guard prevents parallel prune runs. |
| tests/bats/integration/test_prune_build_staging_tags.bats | Good integration test coverage: #433 regression guard, mixed-set pruning, age/keep-recent guards, fail-closed on auth failure and incomplete collection, and dry-run verification. |
| tests/bats/integration/test_reusable_prune_build_staging_tags.bats | Contract tests correctly verify default values, env var forwarding, no inline shell logic, and that scheduled runs stay in dry-run mode. |
| tests/bats/unit/lib/ghcr/test_tags.bats | Unit tests for ghcr_is_build_staging_only_tagged cover all the important boundary cases: mixed tags, empty list, non-numeric run ID, and ephemeral cache tags. |
| docs/reusable-workflows.md | Documentation addition is accurate, mirrors the actual defaults, and includes a working caller example with the correct dry-run guard expression. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Start prune-build-staging-tags.sh] --> B[Fetch all package versions]
    B --> C{Any build-* staging tags?}
    C -- No --> D[Exit: nothing to prune]
    C -- Yes --> E{PROTECT_REFERENCED == true?}
    E -- No --> H[refs_json = empty array]
    E -- Yes --> F[Exchange GHCR registry bearer token]
    F -->|auth fails| G[SKIP: registry auth failed]
    F -->|ok| I[ghcr_collect_referenced_digests]
    I -->|incomplete| J[SKIP: incomplete protection]
    I -->|complete| K[refs_json = collected digests]
    K --> H
    H --> L[Compute cutoff date]
    L --> M[Filter: older than cutoff, skip KEEP_RECENT newest]
    M --> N{Digest in refs_json?}
    N -- Yes --> O[Protected: skip]
    N -- No --> P{DRY_RUN == true?}
    P -- Yes --> Q[Log would-prune]
    P -- No --> R[DELETE version via gh api]
    R --> S{Failures?}
    S -- Yes --> T[exit 1]
    S -- No --> U[Exit 0: complete]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Start prune-build-staging-tags.sh] --> B[Fetch all package versions]
    B --> C{Any build-* staging tags?}
    C -- No --> D[Exit: nothing to prune]
    C -- Yes --> E{PROTECT_REFERENCED == true?}
    E -- No --> H[refs_json = empty array]
    E -- Yes --> F[Exchange GHCR registry bearer token]
    F -->|auth fails| G[SKIP: registry auth failed]
    F -->|ok| I[ghcr_collect_referenced_digests]
    I -->|incomplete| J[SKIP: incomplete protection]
    I -->|complete| K[refs_json = collected digests]
    K --> H
    H --> L[Compute cutoff date]
    L --> M[Filter: older than cutoff, skip KEEP_RECENT newest]
    M --> N{Digest in refs_json?}
    N -- Yes --> O[Protected: skip]
    N -- No --> P{DRY_RUN == true?}
    P -- Yes --> Q[Log would-prune]
    P -- No --> R[DELETE version via gh api]
    R --> S{Failures?}
    S -- Yes --> T[exit 1]
    S -- No --> U[Exit 0: complete]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `scripts/ci/maintenance/prune-build-staging-tags.sh`, line 367-373 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/909e465f2ae08358104a63fbfdca35e0c472779a/scripts/ci/maintenance/prune-build-staging-tags.sh#L367-L373)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Pattern duplication with `tags.sh`**

   `BUILD_STAGING_FILTER` embeds the regex `^build-[0-9]+-[a-zA-Z0-9._-]+$` inline in a jq snippet, but the exact same pattern is already defined as `_GHCR_BUILD_STAGING_TAG_PATTERN` in `tags.sh` (which is sourced a few lines above). If the pattern is ever refined in one place — for example to tighten the slug character set — the jq filter here would silently diverge, causing the two classification paths to disagree on which versions are staging candidates. Consider exporting the pattern from `tags.sh` and injecting it via `jq --arg pattern "$_GHCR_BUILD_STAGING_TAG_PATTERN"`, the same way `ghcr_is_build_staging_only_tagged` does.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%0ALine%3A%20367-373%0A%0AComment%3A%0A**Pattern%20duplication%20with%20%60tags.sh%60**%0A%0A%60BUILD_STAGING_FILTER%60%20embeds%20the%20regex%20%60%5Ebuild-%5B0-9%5D%2B-%5Ba-zA-Z0-9._-%5D%2B%24%60%20inline%20in%20a%20jq%20snippet%2C%20but%20the%20exact%20same%20pattern%20is%20already%20defined%20as%20%60_GHCR_BUILD_STAGING_TAG_PATTERN%60%20in%20%60tags.sh%60%20%28which%20is%20sourced%20a%20few%20lines%20above%29.%20If%20the%20pattern%20is%20ever%20refined%20in%20one%20place%20%E2%80%94%20for%20example%20to%20tighten%20the%20slug%20character%20set%20%E2%80%94%20the%20jq%20filter%20here%20would%20silently%20diverge%2C%20causing%20the%20two%20classification%20paths%20to%20disagree%20on%20which%20versions%20are%20staging%20candidates.%20Consider%20exporting%20the%20pattern%20from%20%60tags.sh%60%20and%20injecting%20it%20via%20%60jq%20--arg%20pattern%20%22%24_GHCR_BUILD_STAGING_TAG_PATTERN%22%60%2C%20the%20same%20way%20%60ghcr_is_build_staging_only_tagged%60%20does.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=448&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%0ALine%3A%20367-373%0A%0AComment%3A%0A**Pattern%20duplication%20with%20%60tags.sh%60**%0A%0A%60BUILD_STAGING_FILTER%60%20embeds%20the%20regex%20%60%5Ebuild-%5B0-9%5D%2B-%5Ba-zA-Z0-9._-%5D%2B%24%60%20inline%20in%20a%20jq%20snippet%2C%20but%20the%20exact%20same%20pattern%20is%20already%20defined%20as%20%60_GHCR_BUILD_STAGING_TAG_PATTERN%60%20in%20%60tags.sh%60%20%28which%20is%20sourced%20a%20few%20lines%20above%29.%20If%20the%20pattern%20is%20ever%20refined%20in%20one%20place%20%E2%80%94%20for%20example%20to%20tighten%20the%20slug%20character%20set%20%E2%80%94%20the%20jq%20filter%20here%20would%20silently%20diverge%2C%20causing%20the%20two%20classification%20paths%20to%20disagree%20on%20which%20versions%20are%20staging%20candidates.%20Consider%20exporting%20the%20pattern%20from%20%60tags.sh%60%20and%20injecting%20it%20via%20%60jq%20--arg%20pattern%20%22%24_GHCR_BUILD_STAGING_TAG_PATTERN%22%60%2C%20the%20same%20way%20%60ghcr_is_build_staging_only_tagged%60%20does.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=448&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22chore%2F435-prune-build-staging-tags%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2F435-prune-build-staging-tags%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%0ALine%3A%20367-373%0A%0AComment%3A%0A**Pattern%20duplication%20with%20%60tags.sh%60**%0A%0A%60BUILD_STAGING_FILTER%60%20embeds%20the%20regex%20%60%5Ebuild-%5B0-9%5D%2B-%5Ba-zA-Z0-9._-%5D%2B%24%60%20inline%20in%20a%20jq%20snippet%2C%20but%20the%20exact%20same%20pattern%20is%20already%20defined%20as%20%60_GHCR_BUILD_STAGING_TAG_PATTERN%60%20in%20%60tags.sh%60%20%28which%20is%20sourced%20a%20few%20lines%20above%29.%20If%20the%20pattern%20is%20ever%20refined%20in%20one%20place%20%E2%80%94%20for%20example%20to%20tighten%20the%20slug%20character%20set%20%E2%80%94%20the%20jq%20filter%20here%20would%20silently%20diverge%2C%20causing%20the%20two%20classification%20paths%20to%20disagree%20on%20which%20versions%20are%20staging%20candidates.%20Consider%20exporting%20the%20pattern%20from%20%60tags.sh%60%20and%20injecting%20it%20via%20%60jq%20--arg%20pattern%20%22%24_GHCR_BUILD_STAGING_TAG_PATTERN%22%60%2C%20the%20same%20way%20%60ghcr_is_build_staging_only_tagged%60%20does.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=448&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>


2. `scripts/ci/maintenance/prune-build-staging-tags.sh`, line 337-342 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/909e465f2ae08358104a63fbfdca35e0c472779a/scripts/ci/maintenance/prune-build-staging-tags.sh#L337-L342)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`GH_TOKEN` missing startup validation**

   Every other required variable (`PACKAGE_NAME`, `GITHUB_ORG`) uses the `:?` expansion to fail fast with a clear message, but `GH_TOKEN` is not validated. When the token is absent: the `gh api` calls in `ghcr_fetch_versions` silently suppress their errors (`2>/dev/null`) before failing, and the registry exchange uses `"${GH_TOKEN:-}"` which causes `${3:?github token required}` to fire inside the function's subshell, surfacing as "registry auth failed; cannot compute reference protection" — which looks like a transient registry problem rather than a misconfigured secret. Adding `: "${GH_TOKEN:?GH_TOKEN is required}"` alongside the existing guards makes the failure immediate and unambiguous.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%0ALine%3A%20337-342%0A%0AComment%3A%0A**%60GH_TOKEN%60%20missing%20startup%20validation**%0A%0AEvery%20other%20required%20variable%20%28%60PACKAGE_NAME%60%2C%20%60GITHUB_ORG%60%29%20uses%20the%20%60%3A%3F%60%20expansion%20to%20fail%20fast%20with%20a%20clear%20message%2C%20but%20%60GH_TOKEN%60%20is%20not%20validated.%20When%20the%20token%20is%20absent%3A%20the%20%60gh%20api%60%20calls%20in%20%60ghcr_fetch_versions%60%20silently%20suppress%20their%20errors%20%28%602%3E%2Fdev%2Fnull%60%29%20before%20failing%2C%20and%20the%20registry%20exchange%20uses%20%60%22%24%7BGH_TOKEN%3A-%7D%22%60%20which%20causes%20%60%24%7B3%3A%3Fgithub%20token%20required%7D%60%20to%20fire%20inside%20the%20function's%20subshell%2C%20surfacing%20as%20%22registry%20auth%20failed%3B%20cannot%20compute%20reference%20protection%22%20%E2%80%94%20which%20looks%20like%20a%20transient%20registry%20problem%20rather%20than%20a%20misconfigured%20secret.%20Adding%20%60%3A%20%22%24%7BGH_TOKEN%3A%3FGH_TOKEN%20is%20required%7D%22%60%20alongside%20the%20existing%20guards%20makes%20the%20failure%20immediate%20and%20unambiguous.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=448&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%0ALine%3A%20337-342%0A%0AComment%3A%0A**%60GH_TOKEN%60%20missing%20startup%20validation**%0A%0AEvery%20other%20required%20variable%20%28%60PACKAGE_NAME%60%2C%20%60GITHUB_ORG%60%29%20uses%20the%20%60%3A%3F%60%20expansion%20to%20fail%20fast%20with%20a%20clear%20message%2C%20but%20%60GH_TOKEN%60%20is%20not%20validated.%20When%20the%20token%20is%20absent%3A%20the%20%60gh%20api%60%20calls%20in%20%60ghcr_fetch_versions%60%20silently%20suppress%20their%20errors%20%28%602%3E%2Fdev%2Fnull%60%29%20before%20failing%2C%20and%20the%20registry%20exchange%20uses%20%60%22%24%7BGH_TOKEN%3A-%7D%22%60%20which%20causes%20%60%24%7B3%3A%3Fgithub%20token%20required%7D%60%20to%20fire%20inside%20the%20function's%20subshell%2C%20surfacing%20as%20%22registry%20auth%20failed%3B%20cannot%20compute%20reference%20protection%22%20%E2%80%94%20which%20looks%20like%20a%20transient%20registry%20problem%20rather%20than%20a%20misconfigured%20secret.%20Adding%20%60%3A%20%22%24%7BGH_TOKEN%3A%3FGH_TOKEN%20is%20required%7D%22%60%20alongside%20the%20existing%20guards%20makes%20the%20failure%20immediate%20and%20unambiguous.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=448&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22chore%2F435-prune-build-staging-tags%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2F435-prune-build-staging-tags%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%0ALine%3A%20337-342%0A%0AComment%3A%0A**%60GH_TOKEN%60%20missing%20startup%20validation**%0A%0AEvery%20other%20required%20variable%20%28%60PACKAGE_NAME%60%2C%20%60GITHUB_ORG%60%29%20uses%20the%20%60%3A%3F%60%20expansion%20to%20fail%20fast%20with%20a%20clear%20message%2C%20but%20%60GH_TOKEN%60%20is%20not%20validated.%20When%20the%20token%20is%20absent%3A%20the%20%60gh%20api%60%20calls%20in%20%60ghcr_fetch_versions%60%20silently%20suppress%20their%20errors%20%28%602%3E%2Fdev%2Fnull%60%29%20before%20failing%2C%20and%20the%20registry%20exchange%20uses%20%60%22%24%7BGH_TOKEN%3A-%7D%22%60%20which%20causes%20%60%24%7B3%3A%3Fgithub%20token%20required%7D%60%20to%20fire%20inside%20the%20function's%20subshell%2C%20surfacing%20as%20%22registry%20auth%20failed%3B%20cannot%20compute%20reference%20protection%22%20%E2%80%94%20which%20looks%20like%20a%20transient%20registry%20problem%20rather%20than%20a%20misconfigured%20secret.%20Adding%20%60%3A%20%22%24%7BGH_TOKEN%3A%3FGH_TOKEN%20is%20required%7D%22%60%20alongside%20the%20existing%20guards%20makes%20the%20failure%20immediate%20and%20unambiguous.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=448&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>


3. `scripts/ci/maintenance/prune-build-staging-tags.sh`, line 391-406 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/909e465f2ae08358104a63fbfdca35e0c472779a/scripts/ci/maintenance/prune-build-staging-tags.sh#L391-L406)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`err` is overwritten before the error log**

   `err` is assigned by the user-API `DELETE` attempt (line 398–403), so when `log_error` fires on line 405 it always shows the user-endpoint error, discarding whatever the org endpoint returned. If the package lives under an org and the org call fails with a meaningful status (e.g. `403 Forbidden: requires admin scope`), that information is lost and the operator sees only a likely-irrelevant `404 Not Found` from the user endpoint instead. Capture each attempt into its own variable and prefer the org error in the final message.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%0ALine%3A%20391-406%0A%0AComment%3A%0A**%60err%60%20is%20overwritten%20before%20the%20error%20log**%0A%0A%60err%60%20is%20assigned%20by%20the%20user-API%20%60DELETE%60%20attempt%20%28line%20398%E2%80%93403%29%2C%20so%20when%20%60log_error%60%20fires%20on%20line%20405%20it%20always%20shows%20the%20user-endpoint%20error%2C%20discarding%20whatever%20the%20org%20endpoint%20returned.%20If%20the%20package%20lives%20under%20an%20org%20and%20the%20org%20call%20fails%20with%20a%20meaningful%20status%20%28e.g.%20%60403%20Forbidden%3A%20requires%20admin%20scope%60%29%2C%20that%20information%20is%20lost%20and%20the%20operator%20sees%20only%20a%20likely-irrelevant%20%60404%20Not%20Found%60%20from%20the%20user%20endpoint%20instead.%20Capture%20each%20attempt%20into%20its%20own%20variable%20and%20prefer%20the%20org%20error%20in%20the%20final%20message.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=448&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%0ALine%3A%20391-406%0A%0AComment%3A%0A**%60err%60%20is%20overwritten%20before%20the%20error%20log**%0A%0A%60err%60%20is%20assigned%20by%20the%20user-API%20%60DELETE%60%20attempt%20%28line%20398%E2%80%93403%29%2C%20so%20when%20%60log_error%60%20fires%20on%20line%20405%20it%20always%20shows%20the%20user-endpoint%20error%2C%20discarding%20whatever%20the%20org%20endpoint%20returned.%20If%20the%20package%20lives%20under%20an%20org%20and%20the%20org%20call%20fails%20with%20a%20meaningful%20status%20%28e.g.%20%60403%20Forbidden%3A%20requires%20admin%20scope%60%29%2C%20that%20information%20is%20lost%20and%20the%20operator%20sees%20only%20a%20likely-irrelevant%20%60404%20Not%20Found%60%20from%20the%20user%20endpoint%20instead.%20Capture%20each%20attempt%20into%20its%20own%20variable%20and%20prefer%20the%20org%20error%20in%20the%20final%20message.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=448&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22chore%2F435-prune-build-staging-tags%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2F435-prune-build-staging-tags%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%0ALine%3A%20391-406%0A%0AComment%3A%0A**%60err%60%20is%20overwritten%20before%20the%20error%20log**%0A%0A%60err%60%20is%20assigned%20by%20the%20user-API%20%60DELETE%60%20attempt%20%28line%20398%E2%80%93403%29%2C%20so%20when%20%60log_error%60%20fires%20on%20line%20405%20it%20always%20shows%20the%20user-endpoint%20error%2C%20discarding%20whatever%20the%20org%20endpoint%20returned.%20If%20the%20package%20lives%20under%20an%20org%20and%20the%20org%20call%20fails%20with%20a%20meaningful%20status%20%28e.g.%20%60403%20Forbidden%3A%20requires%20admin%20scope%60%29%2C%20that%20information%20is%20lost%20and%20the%20operator%20sees%20only%20a%20likely-irrelevant%20%60404%20Not%20Found%60%20from%20the%20user%20endpoint%20instead.%20Capture%20each%20attempt%20into%20its%20own%20variable%20and%20prefer%20the%20org%20error%20in%20the%20final%20message.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=448&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>


4. `scripts/ci/maintenance/prune-build-staging-tags.sh`, line 376-383 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/909e465f2ae08358104a63fbfdca35e0c472779a/scripts/ci/maintenance/prune-build-staging-tags.sh#L376-L383)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Silent error suppression in `ghcr_fetch_versions`**

   Both `gh api` calls use `2>/dev/null`, which swallows all diagnostic output including auth errors, rate-limit messages, and network failures. When both paths fail, the operator sees only `"Failed to fetch package versions"` with no indication of *why*. Since the versions fetch is the first real I/O operation, surfacing the underlying `gh` error here would save significant debugging time. Consider capturing stderr into a variable and including it in the `die` message, or removing `2>/dev/null` and letting the error propagate naturally.

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%0ALine%3A%20376-383%0A%0AComment%3A%0A**Silent%20error%20suppression%20in%20%60ghcr_fetch_versions%60**%0A%0ABoth%20%60gh%20api%60%20calls%20use%20%602%3E%2Fdev%2Fnull%60%2C%20which%20swallows%20all%20diagnostic%20output%20including%20auth%20errors%2C%20rate-limit%20messages%2C%20and%20network%20failures.%20When%20both%20paths%20fail%2C%20the%20operator%20sees%20only%20%60%22Failed%20to%20fetch%20package%20versions%22%60%20with%20no%20indication%20of%20*why*.%20Since%20the%20versions%20fetch%20is%20the%20first%20real%20I%2FO%20operation%2C%20surfacing%20the%20underlying%20%60gh%60%20error%20here%20would%20save%20significant%20debugging%20time.%20Consider%20capturing%20stderr%20into%20a%20variable%20and%20including%20it%20in%20the%20%60die%60%20message%2C%20or%20removing%20%602%3E%2Fdev%2Fnull%60%20and%20letting%20the%20error%20propagate%20naturally.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=448&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%0ALine%3A%20376-383%0A%0AComment%3A%0A**Silent%20error%20suppression%20in%20%60ghcr_fetch_versions%60**%0A%0ABoth%20%60gh%20api%60%20calls%20use%20%602%3E%2Fdev%2Fnull%60%2C%20which%20swallows%20all%20diagnostic%20output%20including%20auth%20errors%2C%20rate-limit%20messages%2C%20and%20network%20failures.%20When%20both%20paths%20fail%2C%20the%20operator%20sees%20only%20%60%22Failed%20to%20fetch%20package%20versions%22%60%20with%20no%20indication%20of%20*why*.%20Since%20the%20versions%20fetch%20is%20the%20first%20real%20I%2FO%20operation%2C%20surfacing%20the%20underlying%20%60gh%60%20error%20here%20would%20save%20significant%20debugging%20time.%20Consider%20capturing%20stderr%20into%20a%20variable%20and%20including%20it%20in%20the%20%60die%60%20message%2C%20or%20removing%20%602%3E%2Fdev%2Fnull%60%20and%20letting%20the%20error%20propagate%20naturally.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=448&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22chore%2F435-prune-build-staging-tags%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2F435-prune-build-staging-tags%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%0ALine%3A%20376-383%0A%0AComment%3A%0A**Silent%20error%20suppression%20in%20%60ghcr_fetch_versions%60**%0A%0ABoth%20%60gh%20api%60%20calls%20use%20%602%3E%2Fdev%2Fnull%60%2C%20which%20swallows%20all%20diagnostic%20output%20including%20auth%20errors%2C%20rate-limit%20messages%2C%20and%20network%20failures.%20When%20both%20paths%20fail%2C%20the%20operator%20sees%20only%20%60%22Failed%20to%20fetch%20package%20versions%22%60%20with%20no%20indication%20of%20*why*.%20Since%20the%20versions%20fetch%20is%20the%20first%20real%20I%2FO%20operation%2C%20surfacing%20the%20underlying%20%60gh%60%20error%20here%20would%20save%20significant%20debugging%20time.%20Consider%20capturing%20stderr%20into%20a%20variable%20and%20including%20it%20in%20the%20%60die%60%20message%2C%20or%20removing%20%602%3E%2Fdev%2Fnull%60%20and%20letting%20the%20error%20propagate%20naturally.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=448&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Ascripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%3A367-373%0A**Pattern%20duplication%20with%20%60tags.sh%60**%0A%0A%60BUILD_STAGING_FILTER%60%20embeds%20the%20regex%20%60%5Ebuild-%5B0-9%5D%2B-%5Ba-zA-Z0-9._-%5D%2B%24%60%20inline%20in%20a%20jq%20snippet%2C%20but%20the%20exact%20same%20pattern%20is%20already%20defined%20as%20%60_GHCR_BUILD_STAGING_TAG_PATTERN%60%20in%20%60tags.sh%60%20%28which%20is%20sourced%20a%20few%20lines%20above%29.%20If%20the%20pattern%20is%20ever%20refined%20in%20one%20place%20%E2%80%94%20for%20example%20to%20tighten%20the%20slug%20character%20set%20%E2%80%94%20the%20jq%20filter%20here%20would%20silently%20diverge%2C%20causing%20the%20two%20classification%20paths%20to%20disagree%20on%20which%20versions%20are%20staging%20candidates.%20Consider%20exporting%20the%20pattern%20from%20%60tags.sh%60%20and%20injecting%20it%20via%20%60jq%20--arg%20pattern%20%22%24_GHCR_BUILD_STAGING_TAG_PATTERN%22%60%2C%20the%20same%20way%20%60ghcr_is_build_staging_only_tagged%60%20does.%0A%0A%23%23%23%20Issue%202%20of%204%0Ascripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%3A337-342%0A**%60GH_TOKEN%60%20missing%20startup%20validation**%0A%0AEvery%20other%20required%20variable%20%28%60PACKAGE_NAME%60%2C%20%60GITHUB_ORG%60%29%20uses%20the%20%60%3A%3F%60%20expansion%20to%20fail%20fast%20with%20a%20clear%20message%2C%20but%20%60GH_TOKEN%60%20is%20not%20validated.%20When%20the%20token%20is%20absent%3A%20the%20%60gh%20api%60%20calls%20in%20%60ghcr_fetch_versions%60%20silently%20suppress%20their%20errors%20%28%602%3E%2Fdev%2Fnull%60%29%20before%20failing%2C%20and%20the%20registry%20exchange%20uses%20%60%22%24%7BGH_TOKEN%3A-%7D%22%60%20which%20causes%20%60%24%7B3%3A%3Fgithub%20token%20required%7D%60%20to%20fire%20inside%20the%20function's%20subshell%2C%20surfacing%20as%20%22registry%20auth%20failed%3B%20cannot%20compute%20reference%20protection%22%20%E2%80%94%20which%20looks%20like%20a%20transient%20registry%20problem%20rather%20than%20a%20misconfigured%20secret.%20Adding%20%60%3A%20%22%24%7BGH_TOKEN%3A%3FGH_TOKEN%20is%20required%7D%22%60%20alongside%20the%20existing%20guards%20makes%20the%20failure%20immediate%20and%20unambiguous.%0A%0A%23%23%23%20Issue%203%20of%204%0Ascripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%3A391-406%0A**%60err%60%20is%20overwritten%20before%20the%20error%20log**%0A%0A%60err%60%20is%20assigned%20by%20the%20user-API%20%60DELETE%60%20attempt%20%28line%20398%E2%80%93403%29%2C%20so%20when%20%60log_error%60%20fires%20on%20line%20405%20it%20always%20shows%20the%20user-endpoint%20error%2C%20discarding%20whatever%20the%20org%20endpoint%20returned.%20If%20the%20package%20lives%20under%20an%20org%20and%20the%20org%20call%20fails%20with%20a%20meaningful%20status%20%28e.g.%20%60403%20Forbidden%3A%20requires%20admin%20scope%60%29%2C%20that%20information%20is%20lost%20and%20the%20operator%20sees%20only%20a%20likely-irrelevant%20%60404%20Not%20Found%60%20from%20the%20user%20endpoint%20instead.%20Capture%20each%20attempt%20into%20its%20own%20variable%20and%20prefer%20the%20org%20error%20in%20the%20final%20message.%0A%0A%23%23%23%20Issue%204%20of%204%0Ascripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%3A376-383%0A**Silent%20error%20suppression%20in%20%60ghcr_fetch_versions%60**%0A%0ABoth%20%60gh%20api%60%20calls%20use%20%602%3E%2Fdev%2Fnull%60%2C%20which%20swallows%20all%20diagnostic%20output%20including%20auth%20errors%2C%20rate-limit%20messages%2C%20and%20network%20failures.%20When%20both%20paths%20fail%2C%20the%20operator%20sees%20only%20%60%22Failed%20to%20fetch%20package%20versions%22%60%20with%20no%20indication%20of%20*why*.%20Since%20the%20versions%20fetch%20is%20the%20first%20real%20I%2FO%20operation%2C%20surfacing%20the%20underlying%20%60gh%60%20error%20here%20would%20save%20significant%20debugging%20time.%20Consider%20capturing%20stderr%20into%20a%20variable%20and%20including%20it%20in%20the%20%60die%60%20message%2C%20or%20removing%20%602%3E%2Fdev%2Fnull%60%20and%20letting%20the%20error%20propagate%20naturally.%0A%0A&pr=448&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Ascripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%3A367-373%0A**Pattern%20duplication%20with%20%60tags.sh%60**%0A%0A%60BUILD_STAGING_FILTER%60%20embeds%20the%20regex%20%60%5Ebuild-%5B0-9%5D%2B-%5Ba-zA-Z0-9._-%5D%2B%24%60%20inline%20in%20a%20jq%20snippet%2C%20but%20the%20exact%20same%20pattern%20is%20already%20defined%20as%20%60_GHCR_BUILD_STAGING_TAG_PATTERN%60%20in%20%60tags.sh%60%20%28which%20is%20sourced%20a%20few%20lines%20above%29.%20If%20the%20pattern%20is%20ever%20refined%20in%20one%20place%20%E2%80%94%20for%20example%20to%20tighten%20the%20slug%20character%20set%20%E2%80%94%20the%20jq%20filter%20here%20would%20silently%20diverge%2C%20causing%20the%20two%20classification%20paths%20to%20disagree%20on%20which%20versions%20are%20staging%20candidates.%20Consider%20exporting%20the%20pattern%20from%20%60tags.sh%60%20and%20injecting%20it%20via%20%60jq%20--arg%20pattern%20%22%24_GHCR_BUILD_STAGING_TAG_PATTERN%22%60%2C%20the%20same%20way%20%60ghcr_is_build_staging_only_tagged%60%20does.%0A%0A%23%23%23%20Issue%202%20of%204%0Ascripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%3A337-342%0A**%60GH_TOKEN%60%20missing%20startup%20validation**%0A%0AEvery%20other%20required%20variable%20%28%60PACKAGE_NAME%60%2C%20%60GITHUB_ORG%60%29%20uses%20the%20%60%3A%3F%60%20expansion%20to%20fail%20fast%20with%20a%20clear%20message%2C%20but%20%60GH_TOKEN%60%20is%20not%20validated.%20When%20the%20token%20is%20absent%3A%20the%20%60gh%20api%60%20calls%20in%20%60ghcr_fetch_versions%60%20silently%20suppress%20their%20errors%20%28%602%3E%2Fdev%2Fnull%60%29%20before%20failing%2C%20and%20the%20registry%20exchange%20uses%20%60%22%24%7BGH_TOKEN%3A-%7D%22%60%20which%20causes%20%60%24%7B3%3A%3Fgithub%20token%20required%7D%60%20to%20fire%20inside%20the%20function's%20subshell%2C%20surfacing%20as%20%22registry%20auth%20failed%3B%20cannot%20compute%20reference%20protection%22%20%E2%80%94%20which%20looks%20like%20a%20transient%20registry%20problem%20rather%20than%20a%20misconfigured%20secret.%20Adding%20%60%3A%20%22%24%7BGH_TOKEN%3A%3FGH_TOKEN%20is%20required%7D%22%60%20alongside%20the%20existing%20guards%20makes%20the%20failure%20immediate%20and%20unambiguous.%0A%0A%23%23%23%20Issue%203%20of%204%0Ascripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%3A391-406%0A**%60err%60%20is%20overwritten%20before%20the%20error%20log**%0A%0A%60err%60%20is%20assigned%20by%20the%20user-API%20%60DELETE%60%20attempt%20%28line%20398%E2%80%93403%29%2C%20so%20when%20%60log_error%60%20fires%20on%20line%20405%20it%20always%20shows%20the%20user-endpoint%20error%2C%20discarding%20whatever%20the%20org%20endpoint%20returned.%20If%20the%20package%20lives%20under%20an%20org%20and%20the%20org%20call%20fails%20with%20a%20meaningful%20status%20%28e.g.%20%60403%20Forbidden%3A%20requires%20admin%20scope%60%29%2C%20that%20information%20is%20lost%20and%20the%20operator%20sees%20only%20a%20likely-irrelevant%20%60404%20Not%20Found%60%20from%20the%20user%20endpoint%20instead.%20Capture%20each%20attempt%20into%20its%20own%20variable%20and%20prefer%20the%20org%20error%20in%20the%20final%20message.%0A%0A%23%23%23%20Issue%204%20of%204%0Ascripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%3A376-383%0A**Silent%20error%20suppression%20in%20%60ghcr_fetch_versions%60**%0A%0ABoth%20%60gh%20api%60%20calls%20use%20%602%3E%2Fdev%2Fnull%60%2C%20which%20swallows%20all%20diagnostic%20output%20including%20auth%20errors%2C%20rate-limit%20messages%2C%20and%20network%20failures.%20When%20both%20paths%20fail%2C%20the%20operator%20sees%20only%20%60%22Failed%20to%20fetch%20package%20versions%22%60%20with%20no%20indication%20of%20*why*.%20Since%20the%20versions%20fetch%20is%20the%20first%20real%20I%2FO%20operation%2C%20surfacing%20the%20underlying%20%60gh%60%20error%20here%20would%20save%20significant%20debugging%20time.%20Consider%20capturing%20stderr%20into%20a%20variable%20and%20including%20it%20in%20the%20%60die%60%20message%2C%20or%20removing%20%602%3E%2Fdev%2Fnull%60%20and%20letting%20the%20error%20propagate%20naturally.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=448&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22chore%2F435-prune-build-staging-tags%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2F435-prune-build-staging-tags%22.%0A%0AFix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Ascripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%3A367-373%0A**Pattern%20duplication%20with%20%60tags.sh%60**%0A%0A%60BUILD_STAGING_FILTER%60%20embeds%20the%20regex%20%60%5Ebuild-%5B0-9%5D%2B-%5Ba-zA-Z0-9._-%5D%2B%24%60%20inline%20in%20a%20jq%20snippet%2C%20but%20the%20exact%20same%20pattern%20is%20already%20defined%20as%20%60_GHCR_BUILD_STAGING_TAG_PATTERN%60%20in%20%60tags.sh%60%20%28which%20is%20sourced%20a%20few%20lines%20above%29.%20If%20the%20pattern%20is%20ever%20refined%20in%20one%20place%20%E2%80%94%20for%20example%20to%20tighten%20the%20slug%20character%20set%20%E2%80%94%20the%20jq%20filter%20here%20would%20silently%20diverge%2C%20causing%20the%20two%20classification%20paths%20to%20disagree%20on%20which%20versions%20are%20staging%20candidates.%20Consider%20exporting%20the%20pattern%20from%20%60tags.sh%60%20and%20injecting%20it%20via%20%60jq%20--arg%20pattern%20%22%24_GHCR_BUILD_STAGING_TAG_PATTERN%22%60%2C%20the%20same%20way%20%60ghcr_is_build_staging_only_tagged%60%20does.%0A%0A%23%23%23%20Issue%202%20of%204%0Ascripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%3A337-342%0A**%60GH_TOKEN%60%20missing%20startup%20validation**%0A%0AEvery%20other%20required%20variable%20%28%60PACKAGE_NAME%60%2C%20%60GITHUB_ORG%60%29%20uses%20the%20%60%3A%3F%60%20expansion%20to%20fail%20fast%20with%20a%20clear%20message%2C%20but%20%60GH_TOKEN%60%20is%20not%20validated.%20When%20the%20token%20is%20absent%3A%20the%20%60gh%20api%60%20calls%20in%20%60ghcr_fetch_versions%60%20silently%20suppress%20their%20errors%20%28%602%3E%2Fdev%2Fnull%60%29%20before%20failing%2C%20and%20the%20registry%20exchange%20uses%20%60%22%24%7BGH_TOKEN%3A-%7D%22%60%20which%20causes%20%60%24%7B3%3A%3Fgithub%20token%20required%7D%60%20to%20fire%20inside%20the%20function's%20subshell%2C%20surfacing%20as%20%22registry%20auth%20failed%3B%20cannot%20compute%20reference%20protection%22%20%E2%80%94%20which%20looks%20like%20a%20transient%20registry%20problem%20rather%20than%20a%20misconfigured%20secret.%20Adding%20%60%3A%20%22%24%7BGH_TOKEN%3A%3FGH_TOKEN%20is%20required%7D%22%60%20alongside%20the%20existing%20guards%20makes%20the%20failure%20immediate%20and%20unambiguous.%0A%0A%23%23%23%20Issue%203%20of%204%0Ascripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%3A391-406%0A**%60err%60%20is%20overwritten%20before%20the%20error%20log**%0A%0A%60err%60%20is%20assigned%20by%20the%20user-API%20%60DELETE%60%20attempt%20%28line%20398%E2%80%93403%29%2C%20so%20when%20%60log_error%60%20fires%20on%20line%20405%20it%20always%20shows%20the%20user-endpoint%20error%2C%20discarding%20whatever%20the%20org%20endpoint%20returned.%20If%20the%20package%20lives%20under%20an%20org%20and%20the%20org%20call%20fails%20with%20a%20meaningful%20status%20%28e.g.%20%60403%20Forbidden%3A%20requires%20admin%20scope%60%29%2C%20that%20information%20is%20lost%20and%20the%20operator%20sees%20only%20a%20likely-irrelevant%20%60404%20Not%20Found%60%20from%20the%20user%20endpoint%20instead.%20Capture%20each%20attempt%20into%20its%20own%20variable%20and%20prefer%20the%20org%20error%20in%20the%20final%20message.%0A%0A%23%23%23%20Issue%204%20of%204%0Ascripts%2Fci%2Fmaintenance%2Fprune-build-staging-tags.sh%3A376-383%0A**Silent%20error%20suppression%20in%20%60ghcr_fetch_versions%60**%0A%0ABoth%20%60gh%20api%60%20calls%20use%20%602%3E%2Fdev%2Fnull%60%2C%20which%20swallows%20all%20diagnostic%20output%20including%20auth%20errors%2C%20rate-limit%20messages%2C%20and%20network%20failures.%20When%20both%20paths%20fail%2C%20the%20operator%20sees%20only%20%60%22Failed%20to%20fetch%20package%20versions%22%60%20with%20no%20indication%20of%20*why*.%20Since%20the%20versions%20fetch%20is%20the%20first%20real%20I%2FO%20operation%2C%20surfacing%20the%20underlying%20%60gh%60%20error%20here%20would%20save%20significant%20debugging%20time.%20Consider%20capturing%20stderr%20into%20a%20variable%20and%20including%20it%20in%20the%20%60die%60%20message%2C%20or%20removing%20%602%3E%2Fdev%2Fnull%60%20and%20letting%20the%20error%20propagate%20naturally.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=448&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["docs(workflows): document reusable prune..."](https://github.com/lgtm-hq/lgtm-ci/commit/909e465f2ae08358104a63fbfdca35e0c472779a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42791916)</sub>

<!-- /greptile_comment -->