### PR TITLE
feat(docker): add exact-tags backfill mode to reusable-docker

### DIFF
--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -401,7 +401,7 @@ jobs:
 
       - name: Parse additional tags
         id: extra-tags
-        if: inputs.tags != ''
+        if: inputs.tags != '' && !inputs.exact-tags
         shell: bash
         env:
           STEP: parse-tags
@@ -431,7 +431,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
             type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
             type=raw,value=latest,enable=${{ inputs.version != '' && inputs.tag-latest && !inputs.exact-tags }}
-            ${{ steps.extra-tags.outputs.tags }}
+            ${{ !inputs.exact-tags && steps.extra-tags.outputs.tags || '' }}
           # yamllint enable rule:line-length
 
       - name: Build and push
@@ -1106,7 +1106,7 @@ jobs:
 
       - name: Parse additional tags
         id: extra-tags
-        if: inputs.tags != ''
+        if: inputs.tags != '' && !inputs.exact-tags
         shell: bash
         env:
           STEP: parse-tags
@@ -1136,7 +1136,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
             type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
             type=raw,value=latest,enable=${{ inputs.version != '' && inputs.tag-latest && !inputs.exact-tags }}
-            ${{ steps.extra-tags.outputs.tags }}
+            ${{ !inputs.exact-tags && steps.extra-tags.outputs.tags || '' }}
           # yamllint enable rule:line-length
 
       - name: Create multi-arch manifest

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -60,6 +60,15 @@ on:
         required: false
         type: boolean
         default: true
+      exact-tags:
+        description: >-
+          Publish ONLY the pinned version tag (and its immutable by-digest
+          sha), suppressing major/minor/latest/branch/sha-<ref> floating tags.
+          For historical backfills so republishing an old version never drags
+          shared floating tags backward.
+        required: false
+        type: boolean
+        default: false
       push:
         description: "Push image to registry"
         required: false
@@ -410,15 +419,18 @@ jobs:
           # by the gated raw entry below, so backfills never move latest.
           flavor: |
             latest=false
+          # exact-tags (backfill): suppress every floating tag (sha-<ref>,
+          # branch, pr, major, minor, latest); publish only the pinned version
+          # tag (its immutable by-digest sha is inherent to the pushed image).
           # yamllint disable rule:line-length
           tags: |
-            type=sha,prefix=sha-
-            type=ref,event=branch
-            type=ref,event=pr
+            type=sha,prefix=sha-,enable=${{ !inputs.exact-tags }}
+            type=ref,event=branch,enable=${{ !inputs.exact-tags }}
+            type=ref,event=pr,enable=${{ !inputs.exact-tags }}
             type=semver,pattern={{version}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
-            type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
-            type=raw,value=latest,enable=${{ inputs.version != '' && inputs.tag-latest }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
+            type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
+            type=raw,value=latest,enable=${{ inputs.version != '' && inputs.tag-latest && !inputs.exact-tags }}
             ${{ steps.extra-tags.outputs.tags }}
           # yamllint enable rule:line-length
 
@@ -679,15 +691,18 @@ jobs:
           # by the gated raw entry below, so backfills never move latest.
           flavor: |
             latest=false
+          # exact-tags (backfill): suppress every floating tag (sha-<ref>,
+          # branch, pr, major, minor, latest); publish only the pinned version
+          # tag (its immutable by-digest sha is inherent to the pushed image).
           # yamllint disable rule:line-length
           tags: |
-            type=sha,prefix=sha-
-            type=ref,event=branch
-            type=ref,event=pr
+            type=sha,prefix=sha-,enable=${{ !inputs.exact-tags }}
+            type=ref,event=branch,enable=${{ !inputs.exact-tags }}
+            type=ref,event=pr,enable=${{ !inputs.exact-tags }}
             type=semver,pattern={{version}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
-            type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
-            type=raw,value=latest,enable=${{ inputs.version != '' && inputs.tag-latest }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
+            type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
+            type=raw,value=latest,enable=${{ inputs.version != '' && inputs.tag-latest && !inputs.exact-tags }}
           # yamllint enable rule:line-length
 
       - name: Build and push (${{ matrix.platform }})
@@ -1109,15 +1124,18 @@ jobs:
           # by the gated raw entry below, so backfills never move latest.
           flavor: |
             latest=false
+          # exact-tags (backfill): suppress every floating tag (sha-<ref>,
+          # branch, pr, major, minor, latest); publish only the pinned version
+          # tag (its immutable by-digest sha is inherent to the pushed image).
           # yamllint disable rule:line-length
           tags: |
-            type=sha,prefix=sha-
-            type=ref,event=branch
-            type=ref,event=pr
+            type=sha,prefix=sha-,enable=${{ !inputs.exact-tags }}
+            type=ref,event=branch,enable=${{ !inputs.exact-tags }}
+            type=ref,event=pr,enable=${{ !inputs.exact-tags }}
             type=semver,pattern={{version}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
-            type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
-            type=raw,value=latest,enable=${{ inputs.version != '' && inputs.tag-latest }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
+            type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
+            type=raw,value=latest,enable=${{ inputs.version != '' && inputs.tag-latest && !inputs.exact-tags }}
             ${{ steps.extra-tags.outputs.tags }}
           # yamllint enable rule:line-length
 

--- a/tests/bats/integration/test_reusable_docker_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_workflow.bats
@@ -235,3 +235,13 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
 		"$WORKFLOW"
 	assert_failure
 }
+
+@test "reusable-docker: exact-tags ignores additional tags" {
+	local parse_steps gated_extra_tags extra_tag_blocks
+	extra_tag_blocks=$(grep -cF -- "- name: Parse additional tags" "$WORKFLOW")
+	parse_steps=$(grep -cF "if: inputs.tags != '' && !inputs.exact-tags" "$WORKFLOW")
+	gated_extra_tags=$(grep -cF "\${{ !inputs.exact-tags && steps.extra-tags.outputs.tags || '' }}" "$WORKFLOW")
+	[ "$parse_steps" -eq "$extra_tag_blocks" ]
+	[ "$gated_extra_tags" -eq "$extra_tag_blocks" ]
+	[ "$extra_tag_blocks" -ge 2 ]
+}

--- a/tests/bats/integration/test_reusable_docker_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_workflow.bats
@@ -175,7 +175,7 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
 	# block silently dropping the gate fails the test.
 	local raw gated
 	raw=$(grep -cF 'type=raw,value=latest' "$WORKFLOW")
-	gated=$(grep -cF "type=raw,value=latest,enable=\${{ inputs.version != '' && inputs.tag-latest }}" "$WORKFLOW")
+	gated=$(grep -cF "type=raw,value=latest,enable=\${{ inputs.version != '' && inputs.tag-latest && !inputs.exact-tags }}" "$WORKFLOW")
 	[ "$raw" -eq "$gated" ]
 	[ "$gated" -ge 2 ]
 	# No ungated raw-latest remains.
@@ -187,4 +187,51 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
 	metablocks=$(grep -c 'uses: docker/metadata-action@' "$WORKFLOW")
 	flavor=$(grep -c 'latest=false' "$WORKFLOW")
 	[ "$flavor" -eq "$metablocks" ]
+}
+
+@test "reusable-docker: exposes exact-tags backfill input" {
+	run grep -E '^      exact-tags:$' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker: exact-tags suppresses sha/branch/pr tags in every metadata block" {
+	# Backfill mode must drop the mutable ref/sha floating tags from every
+	# metadata-action block (build, build-per-platform, merge). Each entry must
+	# carry the exact-tags gate exactly once per block.
+	local blocks count entry
+	blocks=$(grep -c 'uses: docker/metadata-action@' "$WORKFLOW")
+	[ "$blocks" -ge 3 ]
+	for entry in 'type=sha,prefix=sha-' 'type=ref,event=branch' 'type=ref,event=pr'; do
+		count=$(grep -cF "${entry},enable=\${{ !inputs.exact-tags }}" "$WORKFLOW")
+		[ "$count" -eq "$blocks" ]
+	done
+}
+
+@test "reusable-docker: exact-tags suppresses semver major and minor tags in every metadata block" {
+	local blocks major minor
+	blocks=$(grep -c 'uses: docker/metadata-action@' "$WORKFLOW")
+	major=$(grep -cF \
+		"type=semver,pattern={{major}},value=\${{ inputs.version }},enable=\${{ inputs.version != '' && !inputs.exact-tags }}" \
+		"$WORKFLOW")
+	minor=$(grep -cF \
+		"type=semver,pattern={{major}}.{{minor}},value=\${{ inputs.version }},enable=\${{ inputs.version != '' && !inputs.exact-tags }}" \
+		"$WORKFLOW")
+	[ "$major" -eq "$blocks" ]
+	[ "$minor" -eq "$blocks" ]
+}
+
+@test "reusable-docker: exact-tags keeps the pinned version tag in every metadata block" {
+	# The version tag is the one tag a backfill must still publish; its enable
+	# gate stays on version presence only, never on exact-tags.
+	local blocks version
+	blocks=$(grep -c 'uses: docker/metadata-action@' "$WORKFLOW")
+	version=$(grep -cF \
+		"type=semver,pattern={{version}},value=\${{ inputs.version }},enable=\${{ inputs.version != '' }}" \
+		"$WORKFLOW")
+	[ "$version" -eq "$blocks" ]
+	# The version entry must not gain an exact-tags gate.
+	run grep -F \
+		"type=semver,pattern={{version}},value=\${{ inputs.version }},enable=\${{ inputs.version != '' && !inputs.exact-tags }}" \
+		"$WORKFLOW"
+	assert_failure
 }


### PR DESCRIPTION
## Summary

Adds an `exact-tags` boolean input to `reusable-docker.yml` for historical backfills. When true, every floating tag — `sha-<ref>`, branch, PR, semver `MAJOR`/`MAJOR.MINOR`, and `latest` — is suppressed in all three `docker/metadata-action` blocks (single-platform `build`, `build-per-platform`, and `merge`), so a backfill with `source-ref` + `version` publishes ONLY the pinned version tag (plus its immutable by-digest sha). This removes the manual `docker buildx imagetools create` repair step that was needed after backfills dragged `:latest`/`:0`/`:MINOR`/`:main` backward.

- Defaults to `false` — existing behavior is unchanged.
- The pinned version entry stays gated on version presence only (`enable=${{ inputs.version != '' }}`), never on `exact-tags`.
- `flavor: latest=false` already applies to every metadata block (from #438), so no per-platform auto-`latest` can slip past `tag-latest`/`exact-tags`; the raw `latest` entry now additionally gates on `!inputs.exact-tags`.
- Per-platform pushes use only run-scoped staging tags (`build-<run_id>-<slug>`), so no floating tag can escape from the split path.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Changes Made

- `.github/workflows/reusable-docker.yml`
  - New `exact-tags` input (boolean, default `false`) documented for historical backfills.
  - All three metadata-action `tags:` blocks gain `enable=${{ !inputs.exact-tags }}` on `type=sha`, `type=ref,event=branch`, `type=ref,event=pr`, and `&& !inputs.exact-tags` on semver major/minor and raw `latest` entries.
- `tests/bats/integration/test_reusable_docker_workflow.bats`
  - Updated raw-latest gate assertion to the new `tag-latest && !exact-tags` expression.
  - New tests: `exact-tags` input exposure; sha/branch/pr suppression counted across every metadata block; semver major/minor suppression counted across every block; pinned version tag kept ungated by `exact-tags`.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Testing

- `uv run lintro chk`: 0 issues, 0 affected files (actionlint, yamllint, shellcheck, etc. all pass).
- Full bats suite (`bats --recursive tests/bats`): 2702/2703 pass, including all 25 reusable-docker wiring tests. The single failure (`run-rust-coverage-html: fails when cargo-llvm-cov is missing`) is pre-existing and environment-specific (macOS: `rm` not in `/usr/local/bin` under the test's restricted PATH); the files involved are byte-identical to `origin/main`.

## Breaking Changes

None. `exact-tags` defaults to `false`; current tag behavior is unchanged for all existing consumers.

## Closes

- Closes #440
- Relates to #437
- Relates to #438

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an `exact-tags` boolean input (default `false`) to `reusable-docker.yml` for historical backfill scenarios, suppressing all floating tags so republishing an old version cannot drag shared tags like `:latest`, `:0`, or `:main` backward.

- All three `docker/metadata-action` blocks (`build`, `build-per-platform`, `merge`) gain `enable=${{ !inputs.exact-tags }}` on `sha`, `branch`, and `pr` tag types, and `&& !inputs.exact-tags` guards on semver `major`/`minor` and raw `latest` entries; the pinned `{{version}}` tag is intentionally left ungated.
- The `Parse additional tags` step and its inline expression in the `tags:` block are both gated on `!inputs.exact-tags`, closing the extra-tags bypass raised in a prior review.
- Five new BATS tests assert suppression counts across every metadata block, verify the pinned-version entry is never gated by `exact-tags`, and check both halves of the extra-tags guard.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — existing behavior is unchanged (default false), all three metadata blocks are consistently updated, and the extra-tags bypass concern from a prior review is now properly addressed.

The change is purely additive with a safe default. Logic across all three metadata blocks is symmetric and backed by count-equality BATS assertions that would catch any accidental omission. The only edge case (using exact-tags=true without version) produces an empty tag list, which is a misconfiguration rather than a default-path defect.

No files require special attention; the one edge case worth a follow-up is the zero-tags scenario when exact-tags is true but version is not supplied.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-docker.yml | Adds `exact-tags` boolean input that gates all floating tags (sha/branch/pr/major/minor/latest/extra-tags) across all three metadata-action blocks; pinned version tag is intentionally left ungated. The extra-tags concern from a prior review has been properly addressed by gating both the parse step and the inline expression. |
| tests/bats/integration/test_reusable_docker_workflow.bats | Adds five new BATS tests covering input exposure, sha/branch/pr suppression across all metadata blocks, semver major/minor suppression, pinned-version preservation (with a negative assertion), and extra-tags gating. Updates the raw-latest gate assertion to include the new `!inputs.exact-tags` condition. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller triggers reusable-docker.yml] --> B{exact-tags input}
    B -- false/default --> C[Parse additional tags runs if tags set]
    B -- true/backfill --> D[Parse additional tags SKIPPED]
    C --> E[Extract metadata]
    D --> E
    E --> F{Tag type}
    F --> G[sha/branch/pr\nenable=!exact-tags]
    F --> J[semver version\nenable=version!='']
    F --> K[semver major/minor\nenable=version!='' AND !exact-tags]
    F --> M[raw latest\nenable=version!='' AND tag-latest AND !exact-tags]
    F --> N[extra-tags\n!exact-tags AND tags-output OR '']
    G --> O{exact-tags?}
    K --> O
    M --> O
    O -- false --> P[Tag emitted]
    O -- true --> Q[Tag suppressed]
    J --> R[Always emitted when version set]
    N --> S{exact-tags?}
    S -- false --> T[Caller extra tags emitted]
    S -- true --> U[Empty - no extra tags]
    P --> V[Image pushed with floating tags]
    R --> V
    T --> V
    Q --> W[Tag absent from pushed image]
    U --> W
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Caller triggers reusable-docker.yml] --> B{exact-tags input}
    B -- false/default --> C[Parse additional tags runs if tags set]
    B -- true/backfill --> D[Parse additional tags SKIPPED]
    C --> E[Extract metadata]
    D --> E
    E --> F{Tag type}
    F --> G[sha/branch/pr\nenable=!exact-tags]
    F --> J[semver version\nenable=version!='']
    F --> K[semver major/minor\nenable=version!='' AND !exact-tags]
    F --> M[raw latest\nenable=version!='' AND tag-latest AND !exact-tags]
    F --> N[extra-tags\n!exact-tags AND tags-output OR '']
    G --> O{exact-tags?}
    K --> O
    M --> O
    O -- false --> P[Tag emitted]
    O -- true --> Q[Tag suppressed]
    J --> R[Always emitted when version set]
    N --> S{exact-tags?}
    S -- false --> T[Caller extra tags emitted]
    S -- true --> U[Empty - no extra tags]
    P --> V[Image pushed with floating tags]
    R --> V
    T --> V
    Q --> W[Tag absent from pushed image]
    U --> W
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(docker): honor exact-tags for extra ..."](https://github.com/lgtm-hq/lgtm-ci/commit/1ac8c61318795b0e3c6ff3c51e82245100786280) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42791920)</sub>

<!-- /greptile_comment -->