### PR TITLE
fix(pages): delete stale same-run Pages artifacts before upload

### DIFF
--- a/.github/actions/deploy-pages/action.yml
+++ b/.github/actions/deploy-pages/action.yml
@@ -50,6 +50,15 @@ runs:
         SOURCE_PATH: ${{ inputs.source-path }}
       run: $SCRIPTS_DIR/ci/actions/deploy-pages.sh
 
+    - name: Delete stale Pages artifacts from prior run attempts
+      # Self-heal `gh run rerun --failed`: remove any same-run github-pages
+      # artifact so deploy-pages sees exactly one at deploy time (#415).
+      shell: bash
+      env:
+        ARTIFACT_NAME: ${{ inputs.artifact-name }}
+        GH_TOKEN: ${{ github.token }}
+      run: $SCRIPTS_DIR/ci/actions/delete-run-pages-artifacts.sh
+
     - name: Upload Pages artifact
       id: upload
       # Pinned to SHA for supply chain security

--- a/.github/actions/publish-test-results/action.yml
+++ b/.github/actions/publish-test-results/action.yml
@@ -62,6 +62,15 @@ runs:
     - name: Configure GitHub Pages
       uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
+    - name: Delete stale Pages artifacts from prior run attempts
+      # Self-heal `gh run rerun --failed`: remove any same-run github-pages
+      # artifact so deploy-pages sees exactly one at deploy time (#415).
+      shell: bash
+      env:
+        ARTIFACT_NAME: github-pages
+        GH_TOKEN: ${{ github.token }}
+      run: bash "$GITHUB_ACTION_PATH/../../../scripts/ci/actions/delete-run-pages-artifacts.sh"
+
     - name: Upload GitHub Pages artifact
       uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       with:

--- a/.github/workflows/reusable-coverage.yml
+++ b/.github/workflows/reusable-coverage.yml
@@ -222,6 +222,7 @@ jobs:
       contents: read
       pages: write
       id-token: write
+      actions: write # delete stale same-run Pages artifacts on rerun (#415)
 
     outputs:
       pages-url: ${{ steps.publish.outputs.pages-url }}

--- a/.github/workflows/reusable-deploy-site-with-reports.yml
+++ b/.github/workflows/reusable-deploy-site-with-reports.yml
@@ -165,7 +165,8 @@ jobs:
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
       contents: read
-      actions: read # resolve and download workflow artifacts for bundling
+      # write (not read) so delete-run-pages-artifacts.sh can self-heal reruns (#415)
+      actions: write # resolve/download workflow artifacts for bundling + prune stale Pages artifacts
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/reusable-test-e2e-matrix.yml
+++ b/.github/workflows/reusable-test-e2e-matrix.yml
@@ -345,6 +345,7 @@ jobs:
       contents: read
       pages: write
       id-token: write
+      actions: write # delete stale same-run Pages artifacts on rerun (#415)
 
     outputs:
       pages-url: ${{ steps.publish.outputs.pages-url }}

--- a/.github/workflows/reusable-test-node-publish.yml
+++ b/.github/workflows/reusable-test-node-publish.yml
@@ -92,6 +92,7 @@ jobs:
       contents: read
       pages: write
       id-token: write
+      actions: write # delete stale same-run Pages artifacts on rerun (#415)
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/reusable-test-python-publish.yml
+++ b/.github/workflows/reusable-test-python-publish.yml
@@ -87,6 +87,7 @@ jobs:
       contents: read
       pages: write
       id-token: write
+      actions: write # delete stale same-run Pages artifacts on rerun (#415)
 
     steps:
       - name: Checkout repository

--- a/docs/pages-publishing.md
+++ b/docs/pages-publishing.md
@@ -73,7 +73,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
-  actions: read # required to download workflow artifacts
+  actions: write # download workflow artifacts + prune stale same-run Pages artifacts on rerun
 
 jobs:
   deploy:
@@ -135,10 +135,17 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  actions: write # delete stale same-run Pages artifacts so reruns self-heal
 ```
 
-Model B build jobs also require `actions: read` on the caller workflow so the
-bundle step can resolve and download artifacts from other workflow runs.
+`actions: write` lets the publish path delete any pre-existing `github-pages`
+artifact on the current run before uploading a fresh one. Without it, re-running
+a failed Pages deploy uploads a second artifact and `actions/deploy-pages`
+hard-fails with "Artifact count is 2", so the run can never self-heal (#415).
+
+Model B build jobs also require `actions: write` on the caller workflow: the
+bundle step reads artifacts from other workflow runs (read) and the upload step
+prunes stale same-run Pages artifacts (write).
 
 Do **not** grant `contents: write` for Pages publish; branch-push deploy is no
 longer used.

--- a/scripts/ci/actions/delete-run-pages-artifacts.sh
+++ b/scripts/ci/actions/delete-run-pages-artifacts.sh
@@ -24,6 +24,7 @@ set -euo pipefail
 : "${ARTIFACT_NAME:=github-pages}"
 : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
 : "${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+: "${GH_TOKEN:?GH_TOKEN is required}"
 : "${DRY_RUN:=false}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"

--- a/scripts/ci/actions/delete-run-pages-artifacts.sh
+++ b/scripts/ci/actions/delete-run-pages-artifacts.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Delete existing same-run Pages artifacts before a fresh upload so
+#          `gh run rerun --failed` self-heals the deploy-pages deadlock (#415).
+#
+# When a Pages deploy fails transiently and the failed job is re-run, the rerun
+# re-executes the artifact upload step and produces a SECOND `github-pages`
+# artifact on the same run. actions/deploy-pages then hard-fails with
+# "Multiple artifacts named ... Artifact count is 2", and every subsequent
+# rerun re-uploads again, so the run can never self-heal. actions/upload-pages-
+# artifact (pinned v5.0.0) has no overwrite semantics, so we delete any
+# pre-existing artifact of the same name on the CURRENT run first, guaranteeing
+# exactly one artifact exists at deploy time.
+#
+# Environment variables:
+#   ARTIFACT_NAME     - Name of the Pages artifact (default: github-pages)
+#   GITHUB_REPOSITORY - owner/repo (provided by GitHub Actions)
+#   GITHUB_RUN_ID     - Current workflow run id (provided by GitHub Actions)
+#   GH_TOKEN          - Token with actions:write scope
+#   DRY_RUN           - Log intended deletions without performing them (default: false)
+
+set -euo pipefail
+
+: "${ARTIFACT_NAME:=github-pages}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${GITHUB_RUN_ID:?GITHUB_RUN_ID is required}"
+: "${DRY_RUN:=false}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/actions.sh
+source "$SCRIPT_DIR/../lib/actions.sh"
+
+# List artifacts scoped to the current run and select ids matching the target
+# name. Paginate defensively in case a run carries many artifacts.
+fetch_matching_artifact_ids() {
+	gh api --paginate \
+		"/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" |
+		jq -r --arg name "$ARTIFACT_NAME" \
+			'.artifacts[]? | select(.name == $name) | .id'
+}
+
+delete_artifact() {
+	local artifact_id="$1"
+	gh api --method DELETE \
+		"/repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}"
+}
+
+main() {
+	local ids
+	if ! ids="$(fetch_matching_artifact_ids)"; then
+		die "Failed to list artifacts for run ${GITHUB_RUN_ID}"
+	fi
+
+	if [[ -z "$ids" ]]; then
+		log_info "No existing '${ARTIFACT_NAME}' artifact on run ${GITHUB_RUN_ID}; nothing to delete"
+		return 0
+	fi
+
+	local deleted=0 failed=0 id
+	while IFS= read -r id; do
+		[[ -z "$id" ]] && continue
+
+		if [[ "$DRY_RUN" == "true" ]]; then
+			log_info "[dry-run] Would delete stale '${ARTIFACT_NAME}' artifact ${id}"
+			deleted=$((deleted + 1))
+			continue
+		fi
+
+		if delete_artifact "$id"; then
+			log_success "Deleted stale '${ARTIFACT_NAME}' artifact ${id}"
+			deleted=$((deleted + 1))
+		else
+			log_error "Failed to delete stale '${ARTIFACT_NAME}' artifact ${id}"
+			failed=$((failed + 1))
+		fi
+	done <<<"$ids"
+
+	log_info "Pages artifact cleanup for run ${GITHUB_RUN_ID}: ${deleted} deleted, ${failed} failed"
+
+	if [[ "$failed" -gt 0 ]]; then
+		die "Failed to delete ${failed} stale '${ARTIFACT_NAME}' artifact(s)"
+	fi
+}
+
+main "$@"

--- a/tests/bats/integration/test_bundle_workflow_artifacts.bats
+++ b/tests/bats/integration/test_bundle_workflow_artifacts.bats
@@ -39,12 +39,14 @@ load "../../helpers/common"
 	assert_success
 }
 
-@test "reusable-deploy-site-with-reports: build job has actions read permission" {
+@test "reusable-deploy-site-with-reports: build job has actions permission" {
+	# actions: write (implies read) so it can both resolve/download workflow
+	# artifacts for bundling and prune stale same-run Pages artifacts (#415).
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-deploy-site-with-reports.yml"
 	run awk '
 		/^  build:/ { in_build = 1 }
 		/^  deploy:/ { in_build = 0 }
-		in_build && /actions: read/ { actions = 1 }
+		in_build && /actions: (read|write)/ { actions = 1 }
 		in_build && /contents: read/ { contents = 1 }
 		END { exit !(actions && contents) }
 	' "$workflow"

--- a/tests/bats/unit/actions/test_delete_run_pages_artifacts.bats
+++ b/tests/bats/unit/actions/test_delete_run_pages_artifacts.bats
@@ -89,6 +89,13 @@ _artifacts() {
 	assert_output --partial "GITHUB_RUN_ID is required"
 }
 
+@test "delete-run-pages-artifacts: fails when GH_TOKEN is unset" {
+	_mock_gh "$(_artifacts)"
+	run bash -c 'unset GH_TOKEN; bash "$SCRIPT" 2>&1'
+	assert_failure
+	assert_output --partial "GH_TOKEN is required"
+}
+
 # =============================================================================
 # Zero pre-existing artifacts
 # =============================================================================

--- a/tests/bats/unit/actions/test_delete_run_pages_artifacts.bats
+++ b/tests/bats/unit/actions/test_delete_run_pages_artifacts.bats
@@ -1,0 +1,189 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/delete-run-pages-artifacts.sh (#415)
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+
+setup() {
+	setup_temp_dir
+	save_path
+	export SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/delete-run-pages-artifacts.sh"
+	export GITHUB_REPOSITORY="lgtm-hq/py-lintro"
+	export GITHUB_RUN_ID="123456789"
+	export GH_TOKEN="test-token"
+	export ARTIFACT_NAME="github-pages"
+	export DELETE_CALLS="${BATS_TEST_TMPDIR}/delete_calls"
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+# Mock gh: list run artifacts from the supplied JSON, record DELETE calls, and
+# exit DELETE with the given code (default 0).
+_mock_gh() {
+	local artifacts_json="$1"
+	local delete_exit="${2:-0}"
+
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+
+	local artifacts_file="${mock_bin}/.artifacts.json"
+	printf '%s' "$artifacts_json" >"$artifacts_file"
+	: >"$DELETE_CALLS"
+
+	cat >"${mock_bin}/gh" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+	*--method\ DELETE*)
+		echo "\$*" >> '${DELETE_CALLS}'
+		exit ${delete_exit}
+		;;
+	*runs/*/artifacts*)
+		cat '${artifacts_file}'
+		;;
+	*)
+		echo "unexpected gh call: \$*" >&2
+		exit 1
+		;;
+esac
+EOF
+	chmod +x "${mock_bin}/gh"
+	export PATH="${mock_bin}:$PATH"
+}
+
+_artifacts() {
+	# Build a {"artifacts":[...]} payload from name:id pairs.
+	local entries=()
+	local pair name id
+	for pair in "$@"; do
+		name="${pair%%:*}"
+		id="${pair##*:}"
+		entries+=("{\"id\": ${id}, \"name\": \"${name}\"}")
+	done
+	local joined
+	joined="$(
+		IFS=,
+		echo "${entries[*]}"
+	)"
+	printf '{"total_count": %d, "artifacts": [%s]}' "$#" "$joined"
+}
+
+# =============================================================================
+# Required env var validation
+# =============================================================================
+
+@test "delete-run-pages-artifacts: fails when GITHUB_REPOSITORY is unset" {
+	_mock_gh "$(_artifacts)"
+	run bash -c 'unset GITHUB_REPOSITORY; bash "$SCRIPT" 2>&1'
+	assert_failure
+	assert_output --partial "GITHUB_REPOSITORY is required"
+}
+
+@test "delete-run-pages-artifacts: fails when GITHUB_RUN_ID is unset" {
+	_mock_gh "$(_artifacts)"
+	run bash -c 'unset GITHUB_RUN_ID; bash "$SCRIPT" 2>&1'
+	assert_failure
+	assert_output --partial "GITHUB_RUN_ID is required"
+}
+
+# =============================================================================
+# Zero pre-existing artifacts
+# =============================================================================
+
+@test "delete-run-pages-artifacts: no artifacts on run is a no-op success" {
+	_mock_gh "$(_artifacts)"
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "nothing to delete"
+	[ ! -s "$DELETE_CALLS" ]
+}
+
+@test "delete-run-pages-artifacts: ignores artifacts with a different name" {
+	_mock_gh "$(_artifacts "python-coverage:11" "sbom:22")"
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "nothing to delete"
+	[ ! -s "$DELETE_CALLS" ]
+}
+
+# =============================================================================
+# One pre-existing artifact
+# =============================================================================
+
+@test "delete-run-pages-artifacts: deletes the single matching artifact" {
+	_mock_gh "$(_artifacts "github-pages:42")"
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Deleted stale 'github-pages' artifact 42"
+	assert_output --partial "1 deleted, 0 failed"
+	run grep -c -- "artifacts/42" "$DELETE_CALLS"
+	assert_output "1"
+}
+
+@test "delete-run-pages-artifacts: leaves differently named artifacts untouched" {
+	_mock_gh "$(_artifacts "github-pages:42" "python-coverage:11")"
+	run bash "$SCRIPT"
+	assert_success
+	run grep -c -- "artifacts/42" "$DELETE_CALLS"
+	assert_output "1"
+	run grep -c -- "artifacts/11" "$DELETE_CALLS"
+	assert_output "0"
+}
+
+# =============================================================================
+# Multiple pre-existing artifacts
+# =============================================================================
+
+@test "delete-run-pages-artifacts: deletes every matching artifact on the run" {
+	_mock_gh "$(_artifacts "github-pages:1" "github-pages:2" "github-pages:3")"
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "3 deleted, 0 failed"
+	local id
+	for id in 1 2 3; do
+		run grep -c -- "artifacts/${id}" "$DELETE_CALLS"
+		assert_output "1"
+	done
+}
+
+# =============================================================================
+# Custom artifact name
+# =============================================================================
+
+@test "delete-run-pages-artifacts: honors a custom ARTIFACT_NAME" {
+	export ARTIFACT_NAME="site"
+	_mock_gh "$(_artifacts "github-pages:9" "site:7")"
+	run bash "$SCRIPT"
+	assert_success
+	run grep -c -- "artifacts/7" "$DELETE_CALLS"
+	assert_output "1"
+	run grep -c -- "artifacts/9" "$DELETE_CALLS"
+	assert_output "0"
+}
+
+# =============================================================================
+# Dry run
+# =============================================================================
+
+@test "delete-run-pages-artifacts: DRY_RUN logs without deleting" {
+	export DRY_RUN="true"
+	_mock_gh "$(_artifacts "github-pages:42")"
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "[dry-run] Would delete stale 'github-pages' artifact 42"
+	[ ! -s "$DELETE_CALLS" ]
+}
+
+# =============================================================================
+# Deletion failure
+# =============================================================================
+
+@test "delete-run-pages-artifacts: fails loudly when a delete call errors" {
+	_mock_gh "$(_artifacts "github-pages:42")" 1
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "Failed to delete"
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Rerunning a failed Pages deploy re-executes the artifact upload step and produces a second `github-pages` artifact on the same run. `actions/deploy-pages` then hard-fails with `Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.`, and every subsequent rerun re-uploads again, so the run can never self-heal (observed 3x on py-lintro main).

The pinned `actions/upload-pages-artifact` v5.0.0 has no overwrite semantics, so this PR adds a dedicated script that deletes any pre-existing same-name artifact on the CURRENT run (`DELETE /repos/{owner}/{repo}/actions/artifacts/{id}`) immediately before upload, in both composites that upload a `github-pages` artifact. `gh run rerun --failed` is now self-healing: exactly one artifact exists at deploy time.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Changes Made

- New `scripts/ci/actions/delete-run-pages-artifacts.sh`: lists artifacts on the current run, deletes those matching `ARTIFACT_NAME` (default `github-pages`); supports `DRY_RUN`, fails loudly on API errors
- `.github/actions/deploy-pages/action.yml`: run the delete script before `upload-pages-artifact`
- `.github/actions/publish-test-results/action.yml`: run the delete script before `upload-pages-artifact` (the py-lintro coverage deploy path from the issue)
- Add `actions: write` to the five reusable-workflow jobs that invoke these composites (`reusable-test-python-publish`, `reusable-test-node-publish`, `reusable-coverage`, `reusable-test-e2e-matrix`, `reusable-deploy-site-with-reports` build job, previously `actions: read`)
- `docs/pages-publishing.md`: document the new `actions: write` caller permission requirement
- BATS: new `tests/bats/unit/actions/test_delete_run_pages_artifacts.bats` (10 tests: zero/one/multiple pre-existing artifacts, custom name, dry-run, env validation, delete-failure propagation, mocked `gh`); update the bundle-workflow-artifacts permission assertion to accept `actions: write`

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

Callers of the five updated reusable workflows must grant `actions: write` in their caller-workflow `permissions` block (previously `actions: read` or none was sufficient for the non-bundling paths). A caller that grants less will fail at workflow-call resolution with a permission-elevation error. `docs/pages-publishing.md` documents the new requirement; consumer repos (e.g. py-lintro) need a one-line permissions bump when they take this change.

## Closes

- Closes #415

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a self-healing blocker: rerunning a failed Pages deploy re-uploads the `github-pages` artifact, causing `actions/deploy-pages` to hard-fail with \"Artifact count is 2\" on every subsequent attempt. The fix adds a dedicated shell script that deletes any same-name artifact on the current run immediately before upload, and bumps the `actions` permission to `write` in the five reusable workflows that invoke the affected composites.

- New `scripts/ci/actions/delete-run-pages-artifacts.sh` lists run artifacts via `gh api --paginate`, filters by name, and deletes matches with loud failure propagation and optional `DRY_RUN` mode; env-var validation (including `GH_TOKEN`) follows the repo's `:?` guard pattern.
- The delete step is inserted in both `deploy-pages` and `publish-test-results` composites, and all five reusable-workflow jobs that call them receive `actions: write`; docs and the integration BATS assertion are updated to match the new permission requirement.
- Ten new BATS unit tests cover zero/one/multiple pre-existing artifacts, custom name, dry-run, required-env validation, and delete-failure propagation.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the fix is narrowly scoped to the rerun deadlock path and does not alter upload or deploy logic.

The core delete script is correctly written: env validation, error propagation, pagination, and idempotent no-op on first runs all behave as expected. The permission upgrade is justified and documented. The two observations are edge-case hardening items that do not affect the primary fix.

No files require special attention; the minor improvement opportunities are isolated to delete-run-pages-artifacts.sh (404 handling) and the BATS unit test file (pagination coverage).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/actions/delete-run-pages-artifacts.sh | New script that lists same-run artifacts by name and deletes matches before upload; solid env-var validation and error handling, but a 404 on delete is treated as a fatal error rather than an idempotent success |
| .github/actions/deploy-pages/action.yml | Adds delete step before upload, wiring inputs.artifact-name and github.token correctly; execution pattern is consistent with other steps in this composite |
| .github/actions/publish-test-results/action.yml | Adds delete step before upload; ARTIFACT_NAME is correctly hardcoded to github-pages matching the upload-pages-artifact default |
| .github/workflows/reusable-coverage.yml | Adds actions: write to the coverage publish job; change is minimal and correctly scoped |
| .github/workflows/reusable-deploy-site-with-reports.yml | Upgrades actions permission from read to write on the build job with a clear comment explaining both purposes |
| .github/workflows/reusable-test-e2e-matrix.yml | Adds actions: write to the publish job; one-line change, correctly justified |
| .github/workflows/reusable-test-node-publish.yml | Adds actions: write to the publish job; consistent with the other four workflow updates |
| .github/workflows/reusable-test-python-publish.yml | Adds actions: write to the publish job; consistent with the other four workflow updates |
| docs/pages-publishing.md | Updates caller permission requirement from read to write and documents the breaking change for consumer repos |
| tests/bats/integration/test_bundle_workflow_artifacts.bats | Updates the permission assertion to accept actions: write via regex, correctly reflecting the real workflow file |
| tests/bats/unit/actions/test_delete_run_pages_artifacts.bats | 10 well-structured BATS tests cover zero/one/multiple artifacts, custom names, dry-run, env validation, and delete failure; missing coverage for the artifact-list API failure path and multi-page pagination |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Job as Rerun Job
    participant Script as delete-run-pages-artifacts.sh
    participant GHAPI as GitHub Actions API
    participant Upload as upload-pages-artifact
    participant Deploy as deploy-pages

    Job->>Script: invoke (ARTIFACT_NAME, GH_TOKEN, RUN_ID)
    Script->>GHAPI: "GET /runs/{run_id}/artifacts --paginate"
    GHAPI-->>Script: artifact list
    alt stale artifact found
        Script->>GHAPI: "DELETE /artifacts/{id}"
        GHAPI-->>Script: 204 No Content
        Script->>Script: log success, increment deleted
    else no matching artifact
        Script->>Script: log nothing to delete
    end
    Script-->>Job: "exit 0 or die if failed > 0"
    Job->>Upload: "upload-pages-artifact (name=github-pages)"
    Upload-->>Job: artifact_id
    Job->>Deploy: deploy-pages (exactly one artifact)
    Deploy-->>Job: page_url
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Job as Rerun Job
    participant Script as delete-run-pages-artifacts.sh
    participant GHAPI as GitHub Actions API
    participant Upload as upload-pages-artifact
    participant Deploy as deploy-pages

    Job->>Script: invoke (ARTIFACT_NAME, GH_TOKEN, RUN_ID)
    Script->>GHAPI: "GET /runs/{run_id}/artifacts --paginate"
    GHAPI-->>Script: artifact list
    alt stale artifact found
        Script->>GHAPI: "DELETE /artifacts/{id}"
        GHAPI-->>Script: 204 No Content
        Script->>Script: log success, increment deleted
    else no matching artifact
        Script->>Script: log nothing to delete
    end
    Script-->>Job: "exit 0 or die if failed > 0"
    Job->>Upload: "upload-pages-artifact (name=github-pages)"
    Upload-->>Job: artifact_id
    Job->>Deploy: deploy-pages (exactly one artifact)
    Deploy-->>Job: page_url
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: require GH\_TOKEN in delete-run-page..."](https://github.com/lgtm-hq/lgtm-ci/commit/013d82f62933c2cc7accffaac090a637b959cfd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42792256)</sub>

<!-- /greptile_comment -->