### PR TITLE
fix(release): wrap generated changelog lines to 88 columns

### DIFF
--- a/scripts/ci/lib/release/changelog.sh
+++ b/scripts/ci/lib/release/changelog.sh
@@ -18,7 +18,7 @@ source "$SCRIPT_DIR/analyze.sh"
 # generated CHANGELOG.md lines pass consumer lint without a formatting pass.
 : "${CHANGELOG_LINE_LENGTH:=88}"
 
-# Wrap a single-line markdown list item to <= CHANGELOG_LINE_LENGTH columns.
+# Wrap a markdown list item to <= CHANGELOG_LINE_LENGTH columns.
 #
 # Uses greedy word wrapping with a two-space continuation indent, producing
 # output byte-identical to prettier's `proseWrap: always` and accepted by
@@ -32,8 +32,9 @@ wrap_changelog_line() {
 	local width="${CHANGELOG_LINE_LENGTH:-88}"
 	local indent="  "
 
+	local flattened="${line//$'\n'/ }"
 	local -a words=()
-	read -ra words <<<"$line"
+	read -ra words <<<"$flattened"
 
 	local out="" current="" word
 	for word in "${words[@]}"; do

--- a/scripts/ci/lib/release/changelog.sh
+++ b/scripts/ci/lib/release/changelog.sh
@@ -13,6 +13,43 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
 # shellcheck source=./analyze.sh
 source "$SCRIPT_DIR/analyze.sh"
 
+# Column budget for wrapping generated changelog list items. Defaults to the
+# strictest consumer gate (markdownlint MD013 / prettier printWidth = 88) so
+# generated CHANGELOG.md lines pass consumer lint without a formatting pass.
+: "${CHANGELOG_LINE_LENGTH:=88}"
+
+# Wrap a single-line markdown list item to <= CHANGELOG_LINE_LENGTH columns.
+#
+# Uses greedy word wrapping with a two-space continuation indent, producing
+# output byte-identical to prettier's `proseWrap: always` and accepted by
+# markdownlint MD013. Words break only on existing whitespace; a single token
+# longer than the limit (e.g. a URL or SHA) overflows onto its own line, which
+# MD013 tolerates rather than being split.
+#
+# Usage: wrap_changelog_line "- **scope**: long description (abc1234)"
+wrap_changelog_line() {
+	local line="${1:-}"
+	local width="${CHANGELOG_LINE_LENGTH:-88}"
+	local indent="  "
+
+	local -a words=()
+	read -ra words <<<"$line"
+
+	local out="" current="" word
+	for word in "${words[@]}"; do
+		if [[ -z "$current" ]]; then
+			current="$word"
+		elif ((${#current} + 1 + ${#word} <= width)); then
+			current+=" $word"
+		else
+			out+="${current}"$'\n'
+			current="${indent}${word}"
+		fi
+	done
+
+	printf '%s' "${out}${current}"
+}
+
 # Format a single commit entry for changelog
 # Usage: format_commit_entry "abc1234" "feat" "auth" "add login" "full"
 format_commit_entry() {
@@ -23,29 +60,32 @@ format_commit_entry() {
 	local format="${5:-full}"
 
 	local short_sha="${sha:0:7}"
+	local entry
 
 	case "$format" in
 	full)
 		if [[ -n "$scope" ]]; then
-			echo "- **${scope}**: ${description} (${short_sha})"
+			entry="- **${scope}**: ${description} (${short_sha})"
 		else
-			echo "- ${description} (${short_sha})"
+			entry="- ${description} (${short_sha})"
 		fi
 		;;
 	simple)
-		echo "- ${description}"
+		entry="- ${description}"
 		;;
 	with-type)
 		if [[ -n "$scope" ]]; then
-			echo "- ${type}(${scope}): ${description}"
+			entry="- ${type}(${scope}): ${description}"
 		else
-			echo "- ${type}: ${description}"
+			entry="- ${type}: ${description}"
 		fi
 		;;
 	*)
-		echo "- ${description} (${short_sha})"
+		entry="- ${description} (${short_sha})"
 		;;
 	esac
+
+	wrap_changelog_line "$entry"
 }
 
 # Generate changelog section from commits

--- a/tests/bats/unit/lib/release/test_changelog.bats
+++ b/tests/bats/unit/lib/release/test_changelog.bats
@@ -62,6 +62,101 @@ teardown() {
 }
 
 # =============================================================================
+# Line-wrapping tests (issue #417)
+# =============================================================================
+
+# Longest line in the given multi-line text
+_max_line_length() {
+	awk '{ if (length($0) > m) m = length($0) } END { print m + 0 }'
+}
+
+@test "wrap_changelog_line: short line is returned unchanged" {
+	run bash -c 'source "$LIB_DIR/release/changelog.sh" && wrap_changelog_line "- short entry (abc1234)"'
+	assert_success
+	assert_output "- short entry (abc1234)"
+}
+
+@test "wrap_changelog_line: long line wraps to <= 88 columns" {
+	local long="- **release**: add source-ref and tag-latest inputs for historical backfill of previously unreleased Docker multi-arch images (abc1234)"
+	run bash -c "source \"\$LIB_DIR/release/changelog.sh\" && wrap_changelog_line '$long'"
+	assert_success
+	local max
+	max=$(printf '%s\n' "$output" | _max_line_length)
+	[ "$max" -le 88 ]
+}
+
+@test "wrap_changelog_line: continuation lines use two-space indent" {
+	local long="- **release**: add source-ref and tag-latest inputs for historical backfill of previously unreleased Docker multi-arch images (abc1234)"
+	run bash -c "source \"\$LIB_DIR/release/changelog.sh\" && wrap_changelog_line '$long'"
+	assert_success
+	# First line keeps the list marker; the continuation is indented two spaces
+	assert_line --index 0 "- **release**: add source-ref and tag-latest inputs for historical backfill of"
+	assert_line --index 1 "  previously unreleased Docker multi-arch images (abc1234)"
+}
+
+@test "wrap_changelog_line: unbreakable long token overflows onto its own line" {
+	local url="https://example.com/really/long/path/that/keeps/going/and/going/and/going/way/past/eighty/eight/columns/xyz"
+	run bash -c "source \"\$LIB_DIR/release/changelog.sh\" && wrap_changelog_line '- **deps**: ${url} (ccc3333)'"
+	assert_success
+	# The token is not split; it appears intact on its own indented line
+	assert_output --partial "  ${url}"
+}
+
+@test "wrap_changelog_line: wrapping is idempotent for already-short input" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog.sh"
+		first=$(wrap_changelog_line "- short entry (abc1234)")
+		second=$(wrap_changelog_line "$first")
+		[ "$first" = "$second" ] && echo ok'
+	assert_success
+	assert_output "ok"
+}
+
+@test "wrap_changelog_line: honors CHANGELOG_LINE_LENGTH override" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog.sh"
+		CHANGELOG_LINE_LENGTH=40 wrap_changelog_line "- one two three four five six seven eight nine ten"'
+	assert_success
+	local max
+	max=$(printf '%s\n' "$output" | _max_line_length)
+	[ "$max" -le 40 ]
+}
+
+@test "format_commit_entry: long full entry wraps to <= 88 columns" {
+	local desc="add source-ref and tag-latest inputs for historical backfill of previously unreleased Docker multi-arch images"
+	run bash -c "source \"\$LIB_DIR/release/changelog.sh\" && format_commit_entry 'abc1234567' 'feat' 'release' '$desc' 'full'"
+	assert_success
+	local max
+	max=$(printf '%s\n' "$output" | _max_line_length)
+	[ "$max" -le 88 ]
+	assert_output --partial "- **release**:"
+	assert_output --partial "(abc1234)"
+}
+
+@test "generate_changelog: all emitted lines are <= 88 columns for long titles" {
+	tag_mock_repo "v1.0.0"
+	add_commit "feat(release): add source-ref and tag-latest inputs for historical backfill of previously unreleased Docker multi-arch images"
+	add_commit "fix: resolve a crash that happened when the configuration file contained a deeply nested structure with many keys"
+
+	run bash -c "cd \"$MOCK_GIT_REPO\" && source \"\$LIB_DIR/release/changelog.sh\" && generate_changelog \"v1.0.0\" \"HEAD\" \"1.1.0\""
+	assert_success
+	local max
+	max=$(printf '%s\n' "$output" | _max_line_length)
+	[ "$max" -le 88 ]
+}
+
+@test "generate_changelog: short titles remain on a single line" {
+	tag_mock_repo "v1.0.0"
+	add_commit "feat: add search"
+
+	run bash -c "cd \"$MOCK_GIT_REPO\" && source \"\$LIB_DIR/release/changelog.sh\" && generate_changelog \"v1.0.0\" \"HEAD\" \"1.1.0\""
+	assert_success
+	# Short entry is not wrapped: the whole bullet stays on one line
+	assert_output --partial "- add search"
+	refute_output --partial $'\n  '
+}
+
+# =============================================================================
 # generate_changelog_section tests
 # =============================================================================
 

--- a/tests/bats/unit/lib/release/test_changelog.bats
+++ b/tests/bats/unit/lib/release/test_changelog.bats
@@ -112,6 +112,18 @@ _max_line_length() {
 	assert_output "ok"
 }
 
+@test "wrap_changelog_line: wrapping is idempotent for already-wrapped input" {
+	run bash -c '
+		source "$LIB_DIR/release/changelog.sh"
+		long="- **release**: add source-ref and tag-latest inputs for historical backfill of previously unreleased Docker multi-arch images (abc1234)"
+		first=$(wrap_changelog_line "$long")
+		second=$(wrap_changelog_line "$first")
+		line_count=$(printf "%s\n" "$first" | wc -l | tr -d " ")
+		[ "$line_count" -gt 1 ] && [ "$first" = "$second" ] && echo ok'
+	assert_success
+	assert_output "ok"
+}
+
 @test "wrap_changelog_line: honors CHANGELOG_LINE_LENGTH override" {
 	run bash -c '
 		source "$LIB_DIR/release/changelog.sh"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

The version-PR generation path (`reusable-release-version-pr.yml` ->
`generate-changelog.sh` -> `lib/release/changelog.sh`) emitted one long line per
release note (title + scope + short SHA), routinely exceeding the 88-column
markdownlint MD013 / prettier `printWidth` gates enforced by consumer repos
(observed on py-lintro v0.65.0/v0.65.1). Release PRs failed consumer lint, blocked
auto-merge, and left consumer main lint-red after manual merges.

This PR fixes the generator so output is deterministic and consumers need no
formatting pass:

- New `wrap_changelog_line` helper in `scripts/ci/lib/release/changelog.sh`:
  greedy word wrap at 88 columns with a two-space continuation indent.
- `format_commit_entry` now routes every emitted list item (all formats) through
  the wrapper, so `generate_changelog`, `generate_release_notes`, and both
  consumers (`generate-changelog.sh`, `create-version-pr.sh`) emit wrapped lines.
- Output verified byte-identical to `prettier --write` with the consumer's
  markdown config (`printWidth: 88`, `proseWrap: always`), including the
  unbreakable-token case, and clean under markdownlint MD013
  (`line_length: 88`). Long unbreakable tokens (URLs/SHAs) overflow onto their
  own indented line instead of being split, matching prettier behavior and
  MD013 tolerance.
- Wrapping is idempotent and the budget is overridable via
  `CHANGELOG_LINE_LENGTH` (default 88, the strictest consumer gate).

Reproduction before the fix: a realistic long PR title produced a 135-column
line; after the fix the same entry wraps to 78/58 columns.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Testing

- 9 new BATS tests in `tests/bats/unit/lib/release/test_changelog.bats`:
  long titles wrap to <= 88 columns (unit and end-to-end via
  `generate_changelog`), continuation indent is exactly two spaces, short
  titles are unchanged, unbreakable long tokens overflow intact, wrapping is
  idempotent, and `CHANGELOG_LINE_LENGTH` override is honored.
- Full lint: `uv run lintro chk` passes (27 tools, 0 issues).
- Full BATS suite (2708 tests): 2706 pass. The 2 failures are pre-existing and
  unrelated to this change:
  - `run-rust-coverage-html: fails when cargo-llvm-cov is missing` fails
    identically on a clean `origin/main` checkout (the test strips `PATH` to
    `/usr/local/bin`; `rm` lives in `/bin` on macOS, so the script dies before
    reaching the assertion).
  - `bundle-workflow-artifacts action script: runs end-to-end` is flaky only
    under the full-suite run; it passes consistently in isolation (3/3) and in
    a unit-only sweep with this diff applied.

## Breaking Changes

None. Short entries are byte-for-byte unchanged; only entries longer than
88 columns gain wrapped continuation lines.

## Closes

- Closes #417

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a linting-gate regression where generated CHANGELOG entries exceeded 88 columns (markdownlint MD013 / prettier `printWidth`), causing consumer-repo release PRs to fail lint and block auto-merge. The fix is contained to `scripts/ci/lib/release/changelog.sh` and its BATS test file.

- Adds `wrap_changelog_line`, a greedy word-wrapper with a two-space continuation indent and an 88-column default budget (`CHANGELOG_LINE_LENGTH`), whose output is byte-identical to prettier's `proseWrap: always`.
- Routes every `format_commit_entry` output format through `wrap_changelog_line` via `printf '%s'` (no trailing newline), which is correctly paired with callers that already append an explicit `$'\n'` via command substitution.
- Adds 9 BATS tests covering short lines (unchanged), long lines (wrapping ≤ 88 cols), continuation-indent format, unbreakable-token overflow, idempotency (short and already-wrapped input), `CHANGELOG_LINE_LENGTH` override, and end-to-end `generate_changelog` integration.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to the changelog formatting pipeline and the wrapping logic is correct, including the idempotency guarantee for already-wrapped multi-line input.

The `wrap_changelog_line` implementation correctly flattens embedded newlines into spaces before word-splitting (`local flattened="${line//$'
'/ }"`), making the idempotency property genuine rather than just claimed. The `printf '%s'` (no trailing newline) pairs correctly with the single caller in `generate_changelog_section`, which always appends an explicit `$'
'` via command substitution. All four `format_commit_entry` branches route through the wrapper, so the fix covers every output path. The nine new BATS tests exercise short lines, long lines, continuation indent, unbreakable-token overflow, idempotency for both short and already-wrapped input, the `CHANGELOG_LINE_LENGTH` override, and the end-to-end `generate_changelog` function.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/lib/release/changelog.sh | Adds `wrap_changelog_line` with `flattened` pre-processing for correct idempotency; routes all `format_commit_entry` formats through the wrapper; `printf '%s'` (no trailing newline) is correctly paired with callers that append `$'\n'` explicitly. Logic is sound. |
| tests/bats/unit/lib/release/test_changelog.bats | Adds 9 well-structured BATS tests covering short lines, wrapped lines, continuation indent, unbreakable tokens, idempotency (both short and multi-line cases), CHANGELOG_LINE_LENGTH override, and end-to-end generate_changelog integration. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GC as generate_changelog
    participant GCS as generate_changelog_section
    participant FCE as format_commit_entry
    participant WCL as wrap_changelog_line

    GC->>GCS: commits_data, format
    loop "for each commit (IFS=0x1F)"
        GCS->>FCE: sha, type, scope, description, format
        FCE->>FCE: "build entry string (full/simple/with-type/*)"
        FCE->>WCL: entry string
        WCL->>WCL: flatten newlines to spaces
        WCL->>WCL: read -ra words
        WCL->>WCL: greedy wrap at CHANGELOG_LINE_LENGTH cols
        WCL-->>FCE: printf '%s' wrapped lines
        FCE-->>GCS: wrapped entry (no trailing newline)
        GCS->>GCS: "output += entry + newline"
    end
    GCS-->>GC: echo -n output (section block)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GC as generate_changelog
    participant GCS as generate_changelog_section
    participant FCE as format_commit_entry
    participant WCL as wrap_changelog_line

    GC->>GCS: commits_data, format
    loop "for each commit (IFS=0x1F)"
        GCS->>FCE: sha, type, scope, description, format
        FCE->>FCE: "build entry string (full/simple/with-type/*)"
        FCE->>WCL: entry string
        WCL->>WCL: flatten newlines to spaces
        WCL->>WCL: read -ra words
        WCL->>WCL: greedy wrap at CHANGELOG_LINE_LENGTH cols
        WCL-->>FCE: printf '%s' wrapped lines
        FCE-->>GCS: wrapped entry (no trailing newline)
        GCS->>GCS: "output += entry + newline"
    end
    GCS-->>GC: echo -n output (section block)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: make changelog line wrapping idempo..."](https://github.com/lgtm-hq/lgtm-ci/commit/09732a037d2f4f326e5f9e24c5283febb429248b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42792258)</sub>

<!-- /greptile_comment -->