### PR TITLE
feat(quality): enforce per-job timeout-minutes with documented exception list

### DIFF
--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -178,6 +178,9 @@ jobs:
   prepare:
     name: Prepare Rust Matrix
     runs-on: ${{ inputs.runner-image }}
+    # Independent short cap: the caller's timeout-minutes bounds the main
+    # test job; this coordinator leg keeps its own fixed cap.
+    timeout-minutes: 10
     if: >-
       !inputs.draft-pr-skip ||
       github.event_name != 'pull_request' ||
@@ -495,6 +498,9 @@ jobs:
         github.event.pull_request.draft == false
       )
     runs-on: ${{ inputs.runner-image }}
+    # Independent short cap: the caller's timeout-minutes bounds the main
+    # test job; this coordinator leg keeps its own fixed cap.
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/reusable-test-e2e-matrix.yml
+++ b/.github/workflows/reusable-test-e2e-matrix.yml
@@ -123,6 +123,9 @@ jobs:
   setup:
     name: Setup Matrix
     runs-on: ${{ inputs.runner-image }}
+    # Independent short cap: the caller's timeout-minutes bounds the main
+    # test job; this coordinator leg keeps its own fixed cap.
+    timeout-minutes: 10
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
 
@@ -266,6 +269,9 @@ jobs:
     needs: test
     if: always() && inputs.upload-report
     runs-on: ${{ inputs.runner-image }}
+    # Independent short cap: the caller's timeout-minutes bounds the main
+    # test job; this coordinator leg keeps its own fixed cap.
+    timeout-minutes: 10
     permissions:
       contents: read
 
@@ -335,6 +341,9 @@ jobs:
     needs: merge
     if: inputs.publish-results && !cancelled()
     runs-on: ${{ inputs.runner-image }}
+    # Independent short cap: the caller's timeout-minutes bounds the main
+    # test job; this coordinator leg keeps its own fixed cap.
+    timeout-minutes: 10
     concurrency:
       group: pages-${{ github.repository }}-${{ github.ref }}
       cancel-in-progress: false

--- a/.github/workflows/reusable-test-node-custom.yml
+++ b/.github/workflows/reusable-test-node-custom.yml
@@ -150,6 +150,9 @@ jobs:
   prepare:
     name: Prepare Node Matrix
     runs-on: ${{ inputs.runner-image }}
+    # Independent short cap: the caller's timeout-minutes bounds the main
+    # test job; this coordinator leg keeps its own fixed cap.
+    timeout-minutes: 10
     if: >-
       !inputs.draft-pr-skip ||
       github.event_name != 'pull_request' ||
@@ -428,6 +431,9 @@ jobs:
         github.event.pull_request.draft == false
       )
     runs-on: ${{ inputs.runner-image }}
+    # Independent short cap: the caller's timeout-minutes bounds the main
+    # test job; this coordinator leg keeps its own fixed cap.
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:
@@ -482,6 +488,9 @@ jobs:
       && inputs.upload-pages-coverage-html
       && inputs.coverage
     runs-on: ${{ inputs.runner-image }}
+    # Independent short cap: the caller's timeout-minutes bounds the main
+    # test job; this coordinator leg keeps its own fixed cap.
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/reusable-test-node.yml
+++ b/.github/workflows/reusable-test-node.yml
@@ -191,6 +191,9 @@ jobs:
   prepare:
     name: Prepare Node Matrix
     runs-on: ${{ inputs.runner-image }}
+    # Independent short cap: the caller's timeout-minutes bounds the main
+    # test job; this coordinator leg keeps its own fixed cap.
+    timeout-minutes: 10
     if: >-
       !inputs.draft-pr-skip ||
       github.event_name != 'pull_request' ||
@@ -565,6 +568,9 @@ jobs:
       && inputs.upload-pages-coverage-html
       && inputs.coverage
     runs-on: ${{ inputs.runner-image }}
+    # Independent short cap: the caller's timeout-minutes bounds the main
+    # test job; this coordinator leg keeps its own fixed cap.
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:
@@ -633,6 +639,9 @@ jobs:
         github.event.pull_request.draft == false
       )
     runs-on: ${{ inputs.runner-image }}
+    # Independent short cap: the caller's timeout-minutes bounds the main
+    # test job; this coordinator leg keeps its own fixed cap.
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:

--- a/.github/workflows/reusable-test-python.yml
+++ b/.github/workflows/reusable-test-python.yml
@@ -156,6 +156,9 @@ jobs:
   prepare:
     name: Prepare Python Matrix
     runs-on: ${{ inputs.runner-image }}
+    # Independent short cap: the caller's timeout-minutes bounds the main
+    # test job; this coordinator leg keeps its own fixed cap.
+    timeout-minutes: 10
     if: >-
       !inputs.draft-pr-skip ||
       github.event_name != 'pull_request' ||
@@ -429,6 +432,9 @@ jobs:
         github.event.pull_request.draft == false
       )
     runs-on: ${{ inputs.runner-image }}
+    # Independent short cap: the caller's timeout-minutes bounds the main
+    # test job; this coordinator leg keeps its own fixed cap.
+    timeout-minutes: 10
     permissions:
       actions: write # upload-artifact/merge re-uploads merged python-coverage (artifact write)
       contents: read

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -106,15 +106,28 @@ caller examples including `runner-map`.
 ### Job timeouts
 
 Every reusable exposes a `timeout-minutes` input (type: number) wired to
-`timeout-minutes:` on its jobs so callers can bound runtime. Defaults are
-sized per workflow (small API wrappers 5–10, builds/tests 15–60; scan-style
-workflows such as CodeQL and Scorecard get larger defaults). Jobs that
-compose another reusable via `uses:` rely on the called workflow's own
+`timeout-minutes:` on its primary job so callers can bound runtime. Defaults
+are sized per workflow (small API wrappers 5–10, builds/tests 15–60;
+scan-style workflows such as CodeQL and Scorecard get larger defaults). Jobs
+that compose another reusable via `uses:` rely on the called workflow's own
 `timeout-minutes` default instead.
 
-There are currently no exceptions; the same
-`scripts/ci/quality/validate-runner-contract.sh` script enforces the input's
-presence and maintains the exception list should one become necessary.
+Beyond the caller-facing input, **every job with `runs-on` must declare a
+`timeout-minutes`** — either wired to `${{ inputs.timeout-minutes }}` (the
+main workload) or a literal cap. Lightweight coordinator legs (matrix
+`prepare`/`setup`, result `aggregate`/`merge`/`publish`, and pages-status
+jobs) and the failure-reporter legs keep an **independent literal cap**
+(`timeout-minutes: 10`): the caller's `timeout-minutes` bounds the main test
+job, and lowering it must not silently uncap — or, for reporters, cancel —
+these short-running legs. Only jobs that hand off to another reusable via
+`uses:` are exempt, because they carry no `runs-on` of their own.
+
+`scripts/ci/quality/validate-runner-contract.sh` enforces both the input's
+presence and the per-job cap. It maintains two exception mechanisms mirroring
+the runner-image exceptions: `TIMEOUT_MINUTES_EXCEPTIONS` (file-level, exempt
+from exposing the input) and `TIMEOUT_PER_JOB_EXCEPTIONS` (job-level, keyed by
+`<file>.yml:<job-id>`, exempt from the per-job cap). Both are currently empty;
+add an entry here with justification before adding one to the script.
 
 #### Egress policy exceptions
 

--- a/scripts/ci/quality/validate-runner-contract.sh
+++ b/scripts/ci/quality/validate-runner-contract.sh
@@ -39,6 +39,13 @@ RUNNER_PINNING_EXCEPTIONS = {
 # timeout-minutes input requirement. Currently every reusable exposes it.
 TIMEOUT_MINUTES_EXCEPTIONS: set[str] = set()
 
+# Per-job exemptions from the requirement that every runs-on job declares
+# timeout-minutes (literal or input-wired). Entries are "<file>.yml:<job-id>"
+# and MUST be documented in docs/workflow-contract.md "Job timeouts". The
+# 10-min failure-reporter legs are NOT listed here: they satisfy the rule with
+# their own literal cap. Currently no job needs an exemption.
+TIMEOUT_PER_JOB_EXCEPTIONS: set[str] = set()
+
 DOCKER_FILE = "reusable-docker.yml"
 DOCKER_INTERNAL_JOBS = {
     "classify",
@@ -51,25 +58,49 @@ DOCKER_MATRIX_RUNS_ON = {"${{ matrix.runner }}"}
 RUNNER_IMAGE_RUNS_ON = "${{ inputs.runner-image }}"
 
 
-def parse_jobs(content: str) -> dict[str, str]:
-    """Return job id -> runs-on expression for each job in the workflow."""
+def iter_job_blocks(content: str) -> list[tuple[str, str]]:
+    """Return (job id, job body) pairs for each job in the workflow."""
     jobs_match = re.search(r"^jobs:\n", content, re.M)
     if not jobs_match:
-        return {}
+        return []
 
     jobs_section = content[jobs_match.end() :]
+    return [
+        (match.group(1), match.group(2))
+        for match in re.finditer(
+            r"^  ([\w-]+):\n(.*?)(?=^  [\w-]+:\n|\Z)",
+            jobs_section,
+            re.M | re.S,
+        )
+    ]
+
+
+def parse_jobs(content: str) -> dict[str, str]:
+    """Return job id -> runs-on expression for each runs-on job."""
     jobs: dict[str, str] = {}
-    for match in re.finditer(
-        r"^  ([\w-]+):\n(.*?)(?=^  [\w-]+:\n|\Z)",
-        jobs_section,
-        re.M | re.S,
-    ):
-        job_id = match.group(1)
-        block = match.group(2)
+    for job_id, block in iter_job_blocks(content):
         runs_match = re.search(r"^    runs-on: (.+)$", block, re.M)
         if runs_match:
             jobs[job_id] = runs_match.group(1).strip()
     return jobs
+
+
+def jobs_missing_timeout(content: str, rel: str) -> list[str]:
+    """Return runs-on job ids lacking a job-level timeout-minutes.
+
+    A job satisfies the contract with either a literal ``timeout-minutes:``
+    or one wired to ``${{ inputs.timeout-minutes }}``. Jobs listed in
+    TIMEOUT_PER_JOB_EXCEPTIONS are skipped.
+    """
+    missing: list[str] = []
+    for job_id, block in iter_job_blocks(content):
+        if not re.search(r"^    runs-on: ", block, re.M):
+            continue
+        if f"{rel}:{job_id}" in TIMEOUT_PER_JOB_EXCEPTIONS:
+            continue
+        if not re.search(r"^    timeout-minutes:", block, re.M):
+            missing.append(job_id)
+    return missing
 
 
 def has_runner_image_input(content: str) -> bool:
@@ -134,6 +165,11 @@ for workflow in sorted(workflows_dir.glob("reusable-*.yml")):
                 violations.append(
                     f"{rel}: timeout-minutes input is never applied to a job",
                 )
+
+    for job_id in jobs_missing_timeout(content, rel):
+        violations.append(
+            f"{rel}: job {job_id} runs-on without timeout-minutes",
+        )
 
     if rel == DOCKER_FILE:
         if not has_runner_map_input(content):

--- a/tests/bats/integration/test_reusable_runner_contract.bats
+++ b/tests/bats/integration/test_reusable_runner_contract.bats
@@ -211,6 +211,58 @@ YAML
 	assert_output --partial "job aggregate runs-on without timeout-minutes"
 }
 
+@test "validate-runner-contract: honors TIMEOUT_PER_JOB_EXCEPTIONS bypass" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	local validator_copy="${BATS_TEST_TMPDIR}/validate-runner-contract.sh"
+	mkdir -p "${workflows_dir}"
+	cat >"${workflows_dir}/reusable-uncapped-job-bad.yml" <<'YAML'
+---
+name: Uncapped job bad example
+on:
+  workflow_call:
+    inputs:
+      runner-image:
+        type: string
+        default: "ubuntu-24.04"
+      timeout-minutes:
+        type: number
+        default: 10
+jobs:
+  test:
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    steps:
+      - run: echo ok
+  aggregate:
+    runs-on: ${{ inputs.runner-image }}
+    steps:
+      - run: echo aggregate
+YAML
+
+	# Patch a throwaway copy of the validator so the exception key format is
+	# exercised without mutating the repo-owned empty set.
+	cp "${VALIDATOR}" "${validator_copy}"
+	python3 - "${validator_copy}" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+text = path.read_text()
+old = "TIMEOUT_PER_JOB_EXCEPTIONS: set[str] = set()"
+new = (
+    "TIMEOUT_PER_JOB_EXCEPTIONS: set[str] = {\n"
+    '    "reusable-uncapped-job-bad.yml:aggregate",\n'
+    "}"
+)
+if old not in text:
+    raise SystemExit("TIMEOUT_PER_JOB_EXCEPTIONS declaration not found")
+path.write_text(text.replace(old, new, 1))
+PY
+
+	WORKFLOWS_DIR="${workflows_dir}" run "${validator_copy}"
+	assert_success
+}
+
 @test "validate-runner-contract: accepts job with independent literal timeout cap" {
 	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
 	mkdir -p "${workflows_dir}"

--- a/tests/bats/integration/test_reusable_runner_contract.bats
+++ b/tests/bats/integration/test_reusable_runner_contract.bats
@@ -179,6 +179,70 @@ YAML
 	assert_output --partial "timeout-minutes input is never applied to a job"
 }
 
+@test "validate-runner-contract: flags runs-on job without job-level timeout-minutes" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	mkdir -p "${workflows_dir}"
+	cat >"${workflows_dir}/reusable-uncapped-job-bad.yml" <<'YAML'
+---
+name: Uncapped job bad example
+on:
+  workflow_call:
+    inputs:
+      runner-image:
+        type: string
+        default: "ubuntu-24.04"
+      timeout-minutes:
+        type: number
+        default: 10
+jobs:
+  test:
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    steps:
+      - run: echo ok
+  aggregate:
+    runs-on: ${{ inputs.runner-image }}
+    steps:
+      - run: echo aggregate
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" run "${VALIDATOR}"
+	assert_failure
+	assert_output --partial "job aggregate runs-on without timeout-minutes"
+}
+
+@test "validate-runner-contract: accepts job with independent literal timeout cap" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	mkdir -p "${workflows_dir}"
+	cat >"${workflows_dir}/reusable-literal-cap-good.yml" <<'YAML'
+---
+name: Literal cap good example
+on:
+  workflow_call:
+    inputs:
+      runner-image:
+        type: string
+        default: "ubuntu-24.04"
+      timeout-minutes:
+        type: number
+        default: 10
+jobs:
+  test:
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    steps:
+      - run: echo ok
+  report-failure:
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: 10
+    steps:
+      - run: echo report
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" run "${VALIDATOR}"
+	assert_success
+}
+
 @test "validate-runner-contract: allows documented action-only exception" {
 	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
 	mkdir -p "${workflows_dir}"


### PR DESCRIPTION
## Summary

Extends `scripts/ci/quality/validate-runner-contract.sh` (follow-up to #393) so that **every job with `runs-on` must declare `timeout-minutes`** — either wired to `${{ inputs.timeout-minutes }}` or a literal cap. A new per-job exception mechanism (`TIMEOUT_PER_JOB_EXCEPTIONS`, keyed by `<file>.yml:<job-id>`) mirrors the existing runner-image exception list; it is currently empty.

Running the extended check surfaced 13 uncapped coordinator legs across 5 test reusables. All are wired with an **independent literal `timeout-minutes: 10`** (matching the failure-reporter convention from #393: the caller's `timeout-minutes` bounds the main test job, and lowering it must not uncap these short legs):

- `reusable-rust-test.yml`: `prepare`, `aggregate`
- `reusable-test-e2e-matrix.yml`: `setup`, `merge`, `publish`
- `reusable-test-node.yml`: `prepare`, `pages-coverage-status`, `aggregate-tests`
- `reusable-test-node-custom.yml`: `prepare`, `aggregate-tests`, `pages-coverage-status`
- `reusable-test-python.yml`: `prepare`, `aggregate`

No exceptions were needed; the existing 10-min failure-reporter legs already satisfy the rule via their own literal caps.

Docs: rewrote the "Job timeouts" section of `docs/workflow-contract.md` to document the per-job rule, the coordinator-leg literal-cap convention, and both exception mechanisms. Tests: two negative/positive BATS cases per the #393 pattern.

> **Merge order note:** this PR should merge **LAST** among the open backlog PRs — it touches 5 reusable workflow files plus the contract validator, so it has the widest conflict surface. Rebased onto latest `main` (post #444–#452 merges); the extended validator passes against the current workflow set.

**Known local-env test failure (pre-existing, unrelated):** `run-rust-coverage-html: fails when cargo-llvm-cov is missing` fails on this machine on a clean `origin/main` checkout too (`rm: command not found` under the test's restricted `PATH=/usr/local/bin`; macOS `rm` lives in `/bin`). Documented here rather than chased per triage. All other 2758 BATS tests pass.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None for callers. Repo-internal contract tightening: any future reusable adding a `runs-on` job without `timeout-minutes` will fail the runner-contract check unless listed in `TIMEOUT_PER_JOB_EXCEPTIONS` with documentation.

## Closes

- Closes #407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added explicit time limits to several reusable workflow jobs so coordinator and reporting steps finish promptly and don’t run longer than intended.
  * Improved validation to catch jobs that use a runner but don’t define their own timeout.
* **Documentation**
  * Clarified workflow timeout expectations and when shorter job-level caps should be used.
* **Tests**
  * Added coverage for timeout enforcement and approved exception handling in reusable workflow validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the runner-contract validator to enforce that every `runs-on` job in a reusable workflow declares a `timeout-minutes` — either wired to `${{ inputs.timeout-minutes }}` or a fixed literal cap. It adds a per-job exception mechanism (`TIMEOUT_PER_JOB_EXCEPTIONS`) mirroring the existing runner-image exception list, wires it correctly into the validation loop, and backfills the 13 coordinator legs across five reusable workflows with an independent `timeout-minutes: 10`.

- **Validator (`validate-runner-contract.sh`)**: New `iter_job_blocks` helper factors out the shared YAML parse; new `jobs_missing_timeout` function uses it to check every `runs-on` job; the check is inserted before the Docker/pinning-exception `continue` branches so timeout enforcement is universal across all reusable types.
- **BATS tests**: Three new tests cover the negative case (uncapped `aggregate` flagged), the exception-bypass path (key format locked by patching a throwaway copy of the script with a guard), and the positive literal-cap case — following the same pattern as the #393 tests.
- **Workflow files**: Thirteen coordinator legs (`prepare`, `aggregate`, `setup`, `merge`, `publish`, `pages-coverage-status`) across five reusables get `timeout-minutes: 10` with the standard explanatory comment; no exceptions were needed.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the changes are purely additive enforcement with no effect on running workflows, and the validator is confirmed passing against the current workflow set.

The validator logic is correct — `jobs_missing_timeout` uses the same regex infrastructure as `parse_jobs`, the exception key format is tested end-to-end, and the three new BATS tests cover the negative, bypass, and positive paths. The 13 coordinator-leg additions are mechanical and consistent. No existing behavior is removed or altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/quality/validate-runner-contract.sh | Adds `iter_job_blocks` helper, `jobs_missing_timeout` function, `TIMEOUT_PER_JOB_EXCEPTIONS` set, and wires the new per-job timeout check into the main loop before Docker/pinning-exception branches — all correct and internally consistent. |
| tests/bats/integration/test_reusable_runner_contract.bats | Three new BATS tests cover: negative (uncapped job flagged), exception bypass (TIMEOUT_PER_JOB_EXCEPTIONS key format exercised via script patching with guard), and positive (literal-cap job accepted). Follows existing pattern from #393. |
| docs/workflow-contract.md | Rewrites the "Job timeouts" section to document the per-job cap rule, coordinator-leg literal-cap convention, and both exception mechanisms; clear and accurate. |
| .github/workflows/reusable-rust-test.yml | Adds `timeout-minutes: 10` with explanatory comment to `prepare` and `aggregate` coordinator legs; correct placement and indentation for the validator regex. |
| .github/workflows/reusable-test-e2e-matrix.yml | Adds `timeout-minutes: 10` to `setup`, `merge`, and `publish` coordinator legs; `publish` retains its `concurrency` group and the cap is appropriate for a pages-publish step. |
| .github/workflows/reusable-test-node.yml | Adds `timeout-minutes: 10` to `prepare`, `pages-coverage-status`, and `aggregate-tests` coordinator legs; changes are mechanical and correct. |
| .github/workflows/reusable-test-node-custom.yml | Adds `timeout-minutes: 10` to `prepare`, `aggregate-tests`, and `pages-coverage-status` coordinator legs; mirrors the `reusable-test-node.yml` pattern exactly. |
| .github/workflows/reusable-test-python.yml | Adds `timeout-minutes: 10` to `prepare` and `aggregate` coordinator legs; correct and consistent with the other reusable workflow changes. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[For each reusable-*.yml] --> B{In TIMEOUT_MINUTES_EXCEPTIONS?}
    B -- No --> C[Check: timeout-minutes input present & type:number]
    B -- Yes --> D
    C --> D[Check: input applied to at least one job]
    D --> E[jobs_missing_timeout: iter all job blocks]
    E --> F{job has runs-on?}
    F -- No --> G[Skip — uses: job, no runner]
    F -- Yes --> H{key in TIMEOUT_PER_JOB_EXCEPTIONS?}
    H -- Yes --> I[Skip — documented exception]
    H -- No --> J{job block contains timeout-minutes:?}
    J -- Yes --> K[Passes]
    J -- No --> L[Violation: job X runs-on without timeout-minutes]
    K --> M{rel == DOCKER_FILE?}
    L --> M
    M -- Yes --> N[Docker-specific runner checks]
    M -- No --> O{rel in RUNNER_PINNING_EXCEPTIONS?}
    O -- Yes --> P[Skip runner-image checks]
    O -- No --> Q[runner-image wiring and default checks]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[For each reusable-*.yml] --> B{In TIMEOUT_MINUTES_EXCEPTIONS?}
    B -- No --> C[Check: timeout-minutes input present & type:number]
    B -- Yes --> D
    C --> D[Check: input applied to at least one job]
    D --> E[jobs_missing_timeout: iter all job blocks]
    E --> F{job has runs-on?}
    F -- No --> G[Skip — uses: job, no runner]
    F -- Yes --> H{key in TIMEOUT_PER_JOB_EXCEPTIONS?}
    H -- Yes --> I[Skip — documented exception]
    H -- No --> J{job block contains timeout-minutes:?}
    J -- Yes --> K[Passes]
    J -- No --> L[Violation: job X runs-on without timeout-minutes]
    K --> M{rel == DOCKER_FILE?}
    L --> M
    M -- Yes --> N[Docker-specific runner checks]
    M -- No --> O{rel in RUNNER_PINNING_EXCEPTIONS?}
    O -- Yes --> P[Skip runner-image checks]
    O -- No --> Q[runner-image wiring and default checks]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(quality): cover TIMEOUT\_PER\_JOB\_EXC..."](https://github.com/lgtm-hq/lgtm-ci/commit/753d83ea0402c7b9228da1ca4e694ac75efd6c9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43001712)</sub>

<!-- /greptile_comment -->