### PR TITLE
refactor(workflows): split reusable-docker.yml into focused workflows

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -25,7 +25,8 @@ Full documentation lives in [docs/actions/](../../docs/actions/README.md):
 - [Publishing and deployment](../../docs/actions/publishing.md) —
   `build-python-package`, `prepare-pypi-upload`, `publish-npm`,
   `publish-gem`, `trigger-homebrew-update`, `validate-package`,
-  `wait-for-package`, `build-docker`, `docker-login`, `deploy-pages`,
+  `wait-for-package`, `build-docker`, `docker-login`, `docker-auth`,
+  `deploy-pages`,
   `bundle-workflow-artifacts`
 - [Release](../../docs/actions/release.md) — `calculate-version`,
   `generate-changelog`, `create-release-tag`, `create-github-release`

--- a/.github/actions/docker-auth/action.yml
+++ b/.github/actions/docker-auth/action.yml
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: MIT
+# For license details, see the repository root LICENSE file.
+---
+name: "Docker registry auth"
+description: >-
+  Validate the target registry and log in to GHCR or a secondary registry
+  (Docker Hub). Consolidates the validate + login step sequence duplicated
+  across the reusable-docker workflow family. Resolves the shared login
+  helper from the lgtm-ci tooling checkout via GITHUB_ACTION_PATH, so the
+  action works both in-repo and under a cross-repo .lgtm-ci-tooling checkout.
+author: "lgtm-hq"
+
+inputs:
+  registry:
+    description: "Container registry URL (ghcr.io or docker.io)"
+    required: true
+  dockerhub-username:
+    description: "Docker Hub username (required when registry is docker.io)"
+    required: false
+    default: ""
+  dockerhub-token:
+    description: "Docker Hub token (required when registry is docker.io)"
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve scripts directory
+      shell: bash
+      run: |
+        SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
+        echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
+
+    - name: Validate registry
+      shell: bash
+      env:
+        STEP: validate
+        REGISTRY: ${{ inputs.registry }}
+        DOCKERHUB_USERNAME: ${{ inputs.dockerhub-username }}
+        DOCKERHUB_TOKEN: ${{ inputs.dockerhub-token }}
+      run: $SCRIPTS_DIR/ci/actions/docker-login.sh
+
+    - name: Login to GHCR
+      if: inputs.registry == 'ghcr.io'
+      # Pinned to SHA for supply chain security
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Login to Docker Hub
+      if: inputs.registry == 'docker.io'
+      # Pinned to SHA for supply chain security
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-token }}
+
+branding:
+  icon: "lock"
+  color: "blue"

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -503,6 +503,7 @@ jobs:
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
           sparse-checkout-extra: |
+            scripts/ci/
             .github/actions/docker-auth
 
       - name: Docker registry auth

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -474,8 +474,10 @@ jobs:
       needs.build.result == 'success'
     runs-on: ubuntu-24.04
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    # packages: read — pull the pushed image by digest for Trivy.
     permissions:
       contents: read
+      packages: read
       security-events: write
 
     steps:
@@ -500,6 +502,15 @@ jobs:
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+          sparse-checkout-extra: |
+            .github/actions/docker-auth
+
+      - name: Docker registry auth
+        uses: ./.lgtm-ci-tooling/.github/actions/docker-auth
+        with:
+          registry: ${{ inputs.registry }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Run Trivy vulnerability scanner
         # Pinned to SHA for supply chain security

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -1,0 +1,520 @@
+---
+name: Reusable Docker Build (single-platform)
+
+# Focused reusable for the non-split build path: single-platform builds, or
+# multi-platform builds via QEMU when push is disabled. Assembled and called by
+# reusable-docker.yml (the thin orchestrator) when the classify job resolves
+# use-split=false. All shared shell scripts resolve from lgtm-ci via a cross-repo
+# checkout into .lgtm-ci-tooling (same pattern as reusable-docker.yml); no
+# vendored scripts/ci tree is required in the caller repository.
+
+on:
+  workflow_call:
+    inputs:
+      context:
+        description: "Build context path"
+        required: false
+        type: string
+        default: "."
+      file:
+        description: "Path to Dockerfile"
+        required: false
+        type: string
+        default: "Dockerfile"
+      platforms:
+        description: "Target platforms (comma-separated)"
+        required: false
+        type: string
+        default: "linux/amd64,linux/arm64"
+      registry:
+        description: "Container registry URL"
+        required: false
+        type: string
+        default: "ghcr.io"
+      image-name:
+        description: "Image name (default: github.repository)"
+        required: false
+        type: string
+        default: ""
+      tags:
+        description: "Additional tags (comma-separated)"
+        required: false
+        type: string
+        default: ""
+      version:
+        description: "Version for semver tags"
+        required: false
+        type: string
+        default: ""
+      source-ref:
+        description: >-
+          Git ref to check out for the build context (app source), independent
+          of tooling-ref. Empty uses the triggering ref.
+        required: false
+        type: string
+        default: ""
+      tag-latest:
+        description: >-
+          Also apply the 'latest' tag when version is set. Set false for
+          historical backfills so republishing an old version does not move
+          'latest' backward.
+        required: false
+        type: boolean
+        default: true
+      exact-tags:
+        description: >-
+          Publish ONLY the pinned version tag (and its immutable by-digest
+          sha), suppressing major/minor/latest/branch/sha-<ref> floating tags.
+        required: false
+        type: boolean
+        default: false
+      push:
+        description: "Push image to registry"
+        required: false
+        type: boolean
+        default: false
+      provenance:
+        description: "Generate provenance attestation"
+        required: false
+        type: boolean
+        default: true
+      sbom:
+        description: "Generate SBOM attestation"
+        required: false
+        type: boolean
+        default: true
+      scan:
+        description: "Run vulnerability scan"
+        required: false
+        type: boolean
+        default: false
+      build-args:
+        description: "Build arguments (comma-separated key=value)"
+        required: false
+        type: string
+        default: ""
+      target:
+        description: "Docker build target stage (e.g. 'full', 'base')"
+        required: false
+        type: string
+        default: ""
+      health-check-cmd:
+        description: >-
+          Optional command run on the runner against the published localhost
+          port before publish. Requires health-check-port. Skipped when empty.
+        required: false
+        type: string
+        default: ""
+      health-check-port:
+        description: "Container port to publish for the health check."
+        required: false
+        type: string
+        default: ""
+      health-check-timeout:
+        description: "Max wait for health-check-port to accept connections."
+        required: false
+        type: string
+        default: "30s"
+      validate-on-pr:
+        description: >-
+          When true AND push is false, load the image for full validation/scan
+          without pushing.
+        required: false
+        type: boolean
+        default: false
+      scan-exit-code:
+        description: >-
+          Exit code for Trivy when findings match severity filter. "1" fails on
+          CRITICAL/HIGH; "0" is advisory-only SARIF upload.
+        required: false
+        type: string
+        default: "0"
+      cache-registry-ref:
+        description: >-
+          Registry reference for cache fallback (e.g. ghcr.io/org/repo:cache).
+          GHA cache remains primary.
+        required: false
+        type: string
+        default: ""
+      cosign-sign:
+        description: >-
+          Sign the final image manifest with Sigstore Cosign (keyless OIDC).
+          Requires id-token: write. Only runs when push is true.
+        required: false
+        type: boolean
+        default: false
+      no-cache:
+        description: >-
+          Disable build cache entirely. When true, cache-from and cache-to are
+          omitted.
+        required: false
+        type: boolean
+        default: false
+      tooling-ref:
+        # yamllint disable-line rule:line-length
+        description: "Git ref for lgtm-ci tooling checkout. Defaults to the reusable workflow commit."
+        required: false
+        type: string
+        default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "block"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+      egress-preset:
+        description: >-
+          Named allowlist when allowed-endpoints is empty and egress-policy is
+          block.
+        required: false
+        type: string
+        default: "docker"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 60
+
+    outputs:
+      tags:
+        description: "Generated image tags"
+        value: ${{ jobs.build.outputs.tags }}
+      digest:
+        description: "Image digest"
+        value: ${{ jobs.build.outputs.digest }}
+
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: false
+        description: "Docker Hub username (for docker.io registry)"
+      DOCKERHUB_TOKEN:
+        required: false
+        description: "Docker Hub token (for docker.io registry)"
+
+jobs:
+  # Single-platform builds, or multi-platform when push is disabled (QEMU fallback)
+  build:
+    name: Build and Push
+    runs-on: ubuntu-24.04
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      security-events: write
+
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+      digest: ${{ steps.metadata.outputs.digest }}
+
+    steps:
+      - name: Checkout repository
+        # Pinned to SHA for supply chain security
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # source-ref = build-context (app source); tooling-ref stays separate
+          ref: ${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/checkout-and-harden
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Checkout and harden
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+        with:
+          tooling-ref: ${{ inputs.tooling-ref }}
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+          sparse-checkout-extra: |
+            scripts/ci/
+            .github/actions/docker-auth
+      - name: Setup QEMU
+        # Pinned to SHA for supply chain security
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Setup Docker Buildx
+        # Pinned to SHA for supply chain security
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Docker registry auth
+        if: inputs.push
+        uses: ./.lgtm-ci-tooling/.github/actions/docker-auth
+        with:
+          registry: ${{ inputs.registry }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Parse additional tags
+        id: extra-tags
+        if: inputs.tags != '' && !inputs.exact-tags
+        shell: bash
+        env:
+          STEP: parse-tags
+          INPUT_TAGS: ${{ inputs.tags }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Extract metadata
+        id: meta
+        # Pinned to SHA for supply chain security
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: |
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
+          # Disable metadata-action's auto 'latest': the tag is controlled only
+          # by the gated raw entry below, so backfills never move latest.
+          flavor: |
+            latest=false
+          # exact-tags (backfill): suppress every floating tag (sha-<ref>,
+          # branch, pr, major, minor, latest); publish only the pinned version
+          # tag (its immutable by-digest sha is inherent to the pushed image).
+          # yamllint disable rule:line-length
+          tags: |
+            type=sha,prefix=sha-,enable=${{ !inputs.exact-tags }}
+            type=ref,event=branch,enable=${{ !inputs.exact-tags }}
+            type=ref,event=pr,enable=${{ !inputs.exact-tags }}
+            type=semver,pattern={{version}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
+            type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
+            type=raw,value=latest,enable=${{ inputs.version != '' && inputs.tag-latest && !inputs.exact-tags }}
+            ${{ !inputs.exact-tags && steps.extra-tags.outputs.tags || '' }}
+          # yamllint enable rule:line-length
+
+      - name: Build and push
+        id: build
+        # Pinned to SHA for supply chain security
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.file }}
+          platforms: ${{ inputs.platforms }}
+          push: ${{ inputs.push && inputs.health-check-cmd == '' }}
+          load: >-
+            ${{ inputs.health-check-cmd != '' ||
+              (inputs.push == false && (inputs.validate-on-pr || inputs.scan)) }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ inputs.build-args }}
+          target: ${{ inputs.target }}
+          # yamllint disable rule:line-length
+          cache-from: |
+            ${{ inputs.no-cache == false && 'type=gha' || '' }}
+            ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && format('type=registry,ref={0}', inputs.cache-registry-ref) || '' }}
+          cache-to: |
+            ${{ inputs.no-cache == false && 'type=gha,mode=max' || '' }}
+            ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && inputs.push && format('type=registry,ref={0},mode=max', inputs.cache-registry-ref) || '' }}
+          # yamllint enable rule:line-length
+          provenance: ${{ inputs.provenance && inputs.push && inputs.health-check-cmd == '' }}
+          sbom: ${{ inputs.sbom && inputs.push && inputs.health-check-cmd == '' }}
+
+      - name: Resolve local image for health check
+        if: inputs.health-check-cmd != ''
+        id: local-health-check-image
+        shell: bash
+        env:
+          STEP: resolve-local-health-check-image
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Health check
+        if: inputs.health-check-cmd != ''
+        shell: bash
+        env:
+          STEP: health-check-local
+          IMAGE: ${{ steps.local-health-check-image.outputs.image }}
+          HEALTH_CHECK_CMD: ${{ inputs.health-check-cmd }}
+          HEALTH_CHECK_PORT: ${{ inputs.health-check-port }}
+          HEALTH_CHECK_TIMEOUT: ${{ inputs.health-check-timeout }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Install Syft
+        if: inputs.push && inputs.sbom && inputs.health-check-cmd != ''
+        shell: bash
+        env:
+          STEP: install
+        run: .lgtm-ci-tooling/scripts/ci/actions/generate-sbom.sh
+
+      - name: Generate SBOM for attestation
+        if: inputs.push && inputs.sbom && inputs.health-check-cmd != ''
+        shell: bash
+        env:
+          STEP: generate
+          TARGET: ${{ steps.local-health-check-image.outputs.image }}
+          TARGET_TYPE: image
+          FORMAT: spdx-json
+          OUTPUT_FILE: sbom.spdx.json
+        run: .lgtm-ci-tooling/scripts/ci/actions/generate-sbom.sh
+
+      - name: Push image after health check
+        if: inputs.push && inputs.health-check-cmd != ''
+        shell: bash
+        env:
+          STEP: push
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Extract digest
+        id: metadata
+        if: inputs.push || inputs.validate-on-pr
+        shell: bash
+        env:
+          STEP: ${{ inputs.push && inputs.health-check-cmd != '' && 'metadata' || 'set-output-digest' }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          BUILT_TAGS: ${{ steps.meta.outputs.tags }}
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Resolve local image for scan
+        if: inputs.scan && inputs.push == false
+        id: local-scan-image
+        shell: bash
+        env:
+          STEP: resolve-local-scan-image
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Run Trivy vulnerability scanner
+        if: inputs.scan && inputs.push == false
+        # Pinned to SHA for supply chain security
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ steps.local-scan-image.outputs.ref }}
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH"
+          exit-code: ${{ inputs.scan-exit-code }}
+
+      - name: Upload Trivy scan results
+        if: always() && inputs.scan && inputs.push == false
+        # Pinned to SHA for supply chain security
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          sarif_file: "trivy-results.sarif"
+
+      - name: Generate artifact attestation
+        if: inputs.push && inputs.provenance
+        # Pinned to SHA for supply chain security
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
+          subject-digest: ${{ steps.metadata.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate SBOM attestation
+        if: inputs.push && inputs.sbom && inputs.health-check-cmd != ''
+        # Pinned to SHA for supply chain security
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        with:
+          subject-name: ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
+          subject-digest: ${{ steps.metadata.outputs.digest }}
+          sbom-path: sbom.spdx.json
+          push-to-registry: true
+
+      - name: Install Cosign
+        if: inputs.push && inputs.cosign-sign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign image
+        if: inputs.push && inputs.cosign-sign
+        shell: bash
+        env:
+          STEP: sign-image
+          DIGEST: ${{ steps.metadata.outputs.digest }}
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Build summary
+        if: always()
+        shell: bash
+        env:
+          STEP: summary
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+          PLATFORMS: ${{ inputs.platforms }}
+          PUSH: ${{ inputs.push }}
+          DIGEST: ${{ steps.metadata.outputs.digest || '' }}
+          COSIGN_SIGNED: ${{ inputs.cosign-sign && inputs.push }}
+          SCAN_ENABLED: ${{ inputs.scan }}
+          HEALTH_CHECK_ENABLED: ${{ inputs.health-check-cmd != '' }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+  scan:
+    name: Vulnerability Scan
+    needs: build
+    if: >-
+      always() &&
+      inputs.scan &&
+      inputs.push &&
+      needs.build.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/checkout-and-harden
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Checkout and harden
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+        with:
+          tooling-ref: ${{ inputs.tooling-ref }}
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+
+      - name: Run Trivy vulnerability scanner
+        # Pinned to SHA for supply chain security
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: >-
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}@${{
+            needs.build.outputs.digest }}
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH"
+          exit-code: ${{ inputs.scan-exit-code }}
+
+      - name: Upload Trivy scan results
+        # Pinned to SHA for supply chain security
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          sarif_file: "trivy-results.sarif"

--- a/.github/workflows/reusable-docker-multiplatform.yml
+++ b/.github/workflows/reusable-docker-multiplatform.yml
@@ -838,8 +838,10 @@ jobs:
       needs.merge.result == 'success'
     runs-on: ubuntu-24.04
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    # packages: read — pull the merged image by digest for Trivy.
     permissions:
       contents: read
+      packages: read
       security-events: write
 
     steps:
@@ -864,6 +866,15 @@ jobs:
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+          sparse-checkout-extra: |
+            .github/actions/docker-auth
+
+      - name: Docker registry auth
+        uses: ./.lgtm-ci-tooling/.github/actions/docker-auth
+        with:
+          registry: ${{ inputs.registry }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Run Trivy vulnerability scanner
         # Pinned to SHA for supply chain security

--- a/.github/workflows/reusable-docker-multiplatform.yml
+++ b/.github/workflows/reusable-docker-multiplatform.yml
@@ -1,0 +1,884 @@
+---
+name: Reusable Docker Build (multi-platform)
+
+# Focused reusable for the split multi-arch path: per-platform native builds on
+# runner-map runners, optional per-platform smoke-test and health-check gates,
+# manifest merge, published-manifest verification, provenance, and Cosign
+# signing. Assembled and called by reusable-docker.yml (the thin orchestrator)
+# when the classify job resolves use-split=true; the classify matrix is passed
+# in via the `matrix` input. All shared shell scripts resolve from lgtm-ci via a
+# cross-repo checkout into .lgtm-ci-tooling.
+#
+# Staging tag scheme (do not change): each per-platform leg pushes
+# <registry>/<image>:build-<run_id>-<slug>. These are the merged index's child
+# manifests and are intentionally retained; a separate pruner depends on the
+# build-<run_id>-<slug> naming.
+
+on:
+  workflow_call:
+    inputs:
+      matrix:
+        description: >-
+          Per-platform build matrix (JSON array) produced by the classify job
+          in the orchestrator. Each entry carries platform, slug, runner, qemu.
+        required: true
+        type: string
+      context:
+        description: "Build context path"
+        required: false
+        type: string
+        default: "."
+      file:
+        description: "Path to Dockerfile"
+        required: false
+        type: string
+        default: "Dockerfile"
+      platforms:
+        description: "Target platforms (comma-separated, for the summary)"
+        required: false
+        type: string
+        default: "linux/amd64,linux/arm64"
+      registry:
+        description: "Container registry URL"
+        required: false
+        type: string
+        default: "ghcr.io"
+      image-name:
+        description: "Image name (default: github.repository)"
+        required: false
+        type: string
+        default: ""
+      tags:
+        description: "Additional tags (comma-separated)"
+        required: false
+        type: string
+        default: ""
+      version:
+        description: "Version for semver tags"
+        required: false
+        type: string
+        default: ""
+      source-ref:
+        description: >-
+          Git ref to check out for the build context (app source), independent
+          of tooling-ref. Empty uses the triggering ref.
+        required: false
+        type: string
+        default: ""
+      tag-latest:
+        description: >-
+          Also apply the 'latest' tag when version is set. Set false for
+          historical backfills so republishing an old version does not move
+          'latest' backward.
+        required: false
+        type: boolean
+        default: true
+      exact-tags:
+        description: >-
+          Publish ONLY the pinned version tag (and its immutable by-digest
+          sha), suppressing major/minor/latest/branch/sha-<ref> floating tags.
+        required: false
+        type: boolean
+        default: false
+      push:
+        description: "Push image to registry"
+        required: false
+        type: boolean
+        default: false
+      provenance:
+        description: "Generate provenance attestation"
+        required: false
+        type: boolean
+        default: true
+      sbom:
+        description: "Generate SBOM attestation"
+        required: false
+        type: boolean
+        default: true
+      scan:
+        description: "Run vulnerability scan"
+        required: false
+        type: boolean
+        default: false
+      build-args:
+        description: "Build arguments (comma-separated key=value)"
+        required: false
+        type: string
+        default: ""
+      target:
+        description: "Docker build target stage (e.g. 'full', 'base')"
+        required: false
+        type: string
+        default: ""
+      smoke-test:
+        description: >-
+          Shorthand command + args to run inside each per-platform staging
+          image. Word-split; values with spaces need smoke-test-script.
+          Mutually exclusive with smoke-test-script.
+        required: false
+        type: string
+        default: ""
+      smoke-test-script:
+        description: >-
+          Path (relative to checkout root) to a caller-owned smoke-test script.
+          Mutually exclusive with smoke-test.
+        required: false
+        type: string
+        default: ""
+      health-check-cmd:
+        description: >-
+          Optional command run on the runner against each staging image's
+          published localhost port before merge. Requires health-check-port.
+        required: false
+        type: string
+        default: ""
+      health-check-port:
+        description: "Container port to publish for the health check."
+        required: false
+        type: string
+        default: ""
+      health-check-timeout:
+        description: "Max wait for health-check-port to accept connections."
+        required: false
+        type: string
+        default: "30s"
+      validate-on-pr:
+        description: >-
+          When true AND push is false, build per-platform on native runners
+          without pushing staging images (full validation, no QEMU overhead).
+        required: false
+        type: boolean
+        default: false
+      scan-exit-code:
+        description: >-
+          Exit code for Trivy when findings match severity filter. "1" fails on
+          CRITICAL/HIGH; "0" is advisory-only SARIF upload.
+        required: false
+        type: string
+        default: "0"
+      cache-registry-ref:
+        description: >-
+          Registry reference for cache fallback. Per-platform scope is appended
+          automatically (-amd64, -arm64). GHA cache remains primary.
+        required: false
+        type: string
+        default: ""
+      cosign-sign:
+        description: >-
+          Sign the final image manifest with Sigstore Cosign (keyless OIDC).
+          Requires id-token: write. Only runs when push is true.
+        required: false
+        type: boolean
+        default: false
+      no-cache:
+        description: >-
+          Disable build cache entirely. When true, cache-from and cache-to are
+          omitted.
+        required: false
+        type: boolean
+        default: false
+      tooling-ref:
+        # yamllint disable-line rule:line-length
+        description: "Git ref for lgtm-ci tooling checkout. Defaults to the reusable workflow commit."
+        required: false
+        type: string
+        default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "block"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+      egress-preset:
+        description: >-
+          Named allowlist when allowed-endpoints is empty and egress-policy is
+          block.
+        required: false
+        type: string
+        default: "docker"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 60
+
+    outputs:
+      tags:
+        description: "Generated image tags"
+        value: ${{ jobs.merge.outputs.tags }}
+      digest:
+        description: "Image digest"
+        value: ${{ jobs.merge.outputs.digest }}
+
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: false
+        description: "Docker Hub username (for docker.io registry)"
+      DOCKERHUB_TOKEN:
+        required: false
+        description: "Docker Hub token (for docker.io registry)"
+
+jobs:
+  # Per-platform native build leg. One matrix entry per platform; runner and
+  # QEMU config resolved by the orchestrator's classify job.
+  build-per-platform:
+    name: Docker build per platform
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(inputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        # Pinned to SHA for supply chain security
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # source-ref = build-context (app source); tooling-ref stays separate
+          ref: ${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/checkout-and-harden
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Checkout and harden
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+        with:
+          tooling-ref: ${{ inputs.tooling-ref }}
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+          sparse-checkout-extra: |
+            scripts/ci/
+            .github/actions/docker-auth
+      - name: Setup QEMU
+        if: ${{ matrix.qemu }}
+        # Pinned to SHA for supply chain security
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Setup Docker Buildx
+        # Pinned to SHA for supply chain security
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Docker registry auth
+        if: inputs.push
+        uses: ./.lgtm-ci-tooling/.github/actions/docker-auth
+        with:
+          registry: ${{ inputs.registry }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        # Pinned to SHA for supply chain security
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: |
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
+          # Disable metadata-action's auto 'latest': the tag is controlled only
+          # by the gated raw entry below, so backfills never move latest.
+          flavor: |
+            latest=false
+          # exact-tags (backfill): suppress every floating tag (sha-<ref>,
+          # branch, pr, major, minor, latest); publish only the pinned version
+          # tag (its immutable by-digest sha is inherent to the pushed image).
+          # yamllint disable rule:line-length
+          tags: |
+            type=sha,prefix=sha-,enable=${{ !inputs.exact-tags }}
+            type=ref,event=branch,enable=${{ !inputs.exact-tags }}
+            type=ref,event=pr,enable=${{ !inputs.exact-tags }}
+            type=semver,pattern={{version}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
+            type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
+            type=raw,value=latest,enable=${{ inputs.version != '' && inputs.tag-latest && !inputs.exact-tags }}
+          # yamllint enable rule:line-length
+
+      - name: Build and push (${{ matrix.platform }})
+        id: build
+        # Pinned to SHA for supply chain security
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.file }}
+          platforms: ${{ matrix.platform }}
+          push: ${{ inputs.push }}
+          load: >-
+            ${{ inputs.push == false && (inputs.health-check-cmd != '' ||
+              inputs.validate-on-pr || inputs.scan) }}
+          # yamllint disable rule:line-length
+          tags: >-
+            ${{ inputs.push
+              && format('{0}/{1}:build-{2}-{3}', inputs.registry, inputs.image-name || github.repository, github.run_id, matrix.slug)
+              || format('{0}/{1}:validate-{2}', inputs.registry, inputs.image-name || github.repository, matrix.slug) }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ inputs.build-args }}
+          target: ${{ inputs.target }}
+          cache-from: |
+            ${{ inputs.no-cache == false && format('type=gha,scope={0}', matrix.slug) || '' }}
+            ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && format('type=registry,ref={0}-{1}', inputs.cache-registry-ref, matrix.slug) || '' }}
+          cache-to: |
+            ${{ inputs.no-cache == false && format('type=gha,mode=max,scope={0}', matrix.slug) || '' }}
+            ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && inputs.push && format('type=registry,ref={0}-{1},mode=max', inputs.cache-registry-ref, matrix.slug) || '' }}
+          # yamllint enable rule:line-length
+          provenance: false
+          sbom: ${{ inputs.sbom && inputs.push }}
+
+      - name: Record staging digest
+        shell: bash
+        env:
+          STEP: record-digest
+          DIGEST: ${{ steps.build.outputs.digest }}
+          DIGEST_FILE: ${{ runner.temp }}/staging-digest/digest.txt
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Smoke test (${{ matrix.platform }})
+        if: >-
+          inputs.validate-on-pr && inputs.push == false &&
+          (inputs.smoke-test != '' || inputs.smoke-test-script != '')
+        shell: bash
+        env:
+          STEP: smoke-test-local
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE: >-
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:validate-${{
+            matrix.slug }}
+          PLATFORM: ${{ matrix.platform }}
+          SMOKE_TEST: ${{ inputs.smoke-test }}
+          SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Health check (${{ matrix.platform }})
+        if: >-
+          inputs.validate-on-pr && inputs.push == false &&
+          inputs.health-check-cmd != ''
+        shell: bash
+        env:
+          STEP: health-check-local
+          IMAGE: >-
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:validate-${{
+            matrix.slug }}
+          PLATFORM: ${{ matrix.platform }}
+          HEALTH_CHECK_CMD: ${{ inputs.health-check-cmd }}
+          HEALTH_CHECK_PORT: ${{ inputs.health-check-port }}
+          HEALTH_CHECK_TIMEOUT: ${{ inputs.health-check-timeout }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Run Trivy vulnerability scanner (${{ matrix.platform }})
+        if: inputs.scan && inputs.push == false
+        # Pinned to SHA for supply chain security
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: >-
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:validate-${{
+            matrix.slug }}
+          format: "sarif"
+          output: "trivy-results-${{ matrix.slug }}.sarif"
+          severity: "CRITICAL,HIGH"
+          exit-code: ${{ inputs.scan-exit-code }}
+
+      - name: Upload Trivy scan results (${{ matrix.platform }})
+        if: always() && inputs.scan && inputs.push == false
+        # Pinned to SHA for supply chain security
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          sarif_file: "trivy-results-${{ matrix.slug }}.sarif"
+          category: "trivy-${{ matrix.slug }}"
+
+      - name: Upload staging digest
+        if: inputs.push
+        # Pinned to SHA for supply chain security
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: staging-digest-${{ matrix.slug }}
+          path: ${{ runner.temp }}/staging-digest/digest.txt
+          if-no-files-found: error
+          retention-days: 1
+
+  # Optional per-platform smoke test gate (push path only). Runs against each
+  # staging image on its native runner before manifest merge.
+  verify-per-platform:
+    name: Docker verify per platform
+    needs: build-per-platform
+    if: >-
+      inputs.push &&
+      (inputs.smoke-test != '' || inputs.smoke-test-script != '')
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(inputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout repository (for smoke-test-script)
+        # Pinned to SHA for supply chain security
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # source-ref = build-context (app source); tooling-ref stays separate
+          ref: ${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/checkout-and-harden
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Checkout and harden
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+        with:
+          tooling-ref: ${{ inputs.tooling-ref }}
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+          sparse-checkout-extra: |
+            scripts/ci/
+            .github/actions/docker-auth
+      - name: Setup QEMU
+        if: ${{ matrix.qemu }}
+        # Pinned to SHA for supply chain security
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Docker registry auth
+        if: inputs.push
+        uses: ./.lgtm-ci-tooling/.github/actions/docker-auth
+        with:
+          registry: ${{ inputs.registry }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Download staging digest
+        if: inputs.push
+        # Pinned to SHA for supply chain security
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: staging-digest-${{ matrix.slug }}
+          path: ${{ runner.temp }}/staging-digest
+
+      - name: Smoke test (${{ matrix.platform }})
+        shell: bash
+        env:
+          STEP: smoke-test
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+          DIGEST_FILE: ${{ runner.temp }}/staging-digest/digest.txt
+          PLATFORM: ${{ matrix.platform }}
+          SMOKE_TEST: ${{ inputs.smoke-test }}
+          SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+  # Optional per-platform detached-container health check (push path only).
+  # Gates manifest merge on runtime validation of each staging image.
+  health-check-per-platform:
+    name: Docker health check per platform
+    needs: [build-per-platform, verify-per-platform]
+    if: >-
+      always() &&
+      inputs.push &&
+      inputs.health-check-cmd != '' &&
+      needs.build-per-platform.result == 'success' &&
+      (needs.verify-per-platform.result == 'success' ||
+       needs.verify-per-platform.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(inputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    # contents: read — sparse-checkout lgtm-ci tooling scripts for build-docker.sh.
+    # packages: read — pull per-platform staging images by digest before merge.
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/checkout-and-harden
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Checkout and harden
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+        with:
+          tooling-ref: ${{ inputs.tooling-ref }}
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+          sparse-checkout-extra: |
+            scripts/ci/
+            .github/actions/docker-auth
+      - name: Setup QEMU
+        if: ${{ matrix.qemu }}
+        # Pinned to SHA for supply chain security
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Docker registry auth
+        if: inputs.push
+        uses: ./.lgtm-ci-tooling/.github/actions/docker-auth
+        with:
+          registry: ${{ inputs.registry }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Download staging digest
+        if: inputs.push
+        # Pinned to SHA for supply chain security
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: staging-digest-${{ matrix.slug }}
+          path: ${{ runner.temp }}/staging-digest
+
+      - name: Health check (${{ matrix.platform }})
+        shell: bash
+        env:
+          STEP: health-check
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+          DIGEST_FILE: ${{ runner.temp }}/staging-digest/digest.txt
+          PLATFORM: ${{ matrix.platform }}
+          HEALTH_CHECK_CMD: ${{ inputs.health-check-cmd }}
+          HEALTH_CHECK_PORT: ${{ inputs.health-check-port }}
+          HEALTH_CHECK_TIMEOUT: ${{ inputs.health-check-timeout }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+  # Assemble multi-arch manifest from per-platform staging images
+  merge:
+    name: Merge Manifests
+    needs: [build-per-platform, verify-per-platform, health-check-per-platform]
+    if: >-
+      always() &&
+      inputs.push &&
+      needs.build-per-platform.result == 'success' &&
+      (needs.verify-per-platform.result == 'success' ||
+       needs.verify-per-platform.result == 'skipped') &&
+      (needs.health-check-per-platform.result == 'success' ||
+       needs.health-check-per-platform.result == 'skipped')
+    runs-on: ubuntu-24.04
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+      digest: ${{ steps.metadata.outputs.digest }}
+
+    steps:
+      - name: Checkout repository
+        # Pinned to SHA for supply chain security
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # source-ref = build-context (app source); tooling-ref stays separate
+          ref: ${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/checkout-and-harden
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Checkout and harden
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+        with:
+          tooling-ref: ${{ inputs.tooling-ref }}
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+          sparse-checkout-extra: |
+            scripts/ci/
+            .github/actions/docker-auth
+      - name: Setup Docker Buildx
+        # Pinned to SHA for supply chain security
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Docker registry auth
+        uses: ./.lgtm-ci-tooling/.github/actions/docker-auth
+        with:
+          registry: ${{ inputs.registry }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Parse additional tags
+        id: extra-tags
+        if: inputs.tags != '' && !inputs.exact-tags
+        shell: bash
+        env:
+          STEP: parse-tags
+          INPUT_TAGS: ${{ inputs.tags }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Extract metadata
+        id: meta
+        # Pinned to SHA for supply chain security
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: |
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
+          # Disable metadata-action's auto 'latest': the tag is controlled only
+          # by the gated raw entry below, so backfills never move latest.
+          flavor: |
+            latest=false
+          # exact-tags (backfill): suppress every floating tag (sha-<ref>,
+          # branch, pr, major, minor, latest); publish only the pinned version
+          # tag (its immutable by-digest sha is inherent to the pushed image).
+          # yamllint disable rule:line-length
+          tags: |
+            type=sha,prefix=sha-,enable=${{ !inputs.exact-tags }}
+            type=ref,event=branch,enable=${{ !inputs.exact-tags }}
+            type=ref,event=pr,enable=${{ !inputs.exact-tags }}
+            type=semver,pattern={{version}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
+            type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
+            type=raw,value=latest,enable=${{ inputs.version != '' && inputs.tag-latest && !inputs.exact-tags }}
+            ${{ !inputs.exact-tags && steps.extra-tags.outputs.tags || '' }}
+          # yamllint enable rule:line-length
+
+      - name: Create multi-arch manifest
+        shell: bash
+        env:
+          STEP: merge-manifests
+          MATRIX: ${{ inputs.matrix }}
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          TARGET_TAGS: ${{ steps.meta.outputs.tags }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Extract digest
+        id: metadata
+        shell: bash
+        env:
+          STEP: metadata
+          BUILT_TAGS: ${{ steps.meta.outputs.tags }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      # Non-skippable gate: pull the published index back from the registry and
+      # assert every platform child manifest resolves. A dangling index (child
+      # manifests 404) fails the release here instead of publishing as green.
+      - name: Verify published manifest
+        shell: bash
+        env:
+          STEP: verify-published
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+          MATRIX: ${{ inputs.matrix }}
+          TARGET_TAGS: ${{ steps.meta.outputs.tags }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Generate artifact attestation
+        if: inputs.provenance
+        # Pinned to SHA for supply chain security
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
+          subject-digest: ${{ steps.metadata.outputs.digest }}
+          push-to-registry: true
+
+      - name: Install Cosign
+        if: inputs.cosign-sign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign image
+        if: inputs.cosign-sign
+        shell: bash
+        env:
+          STEP: sign-image
+          DIGEST: ${{ steps.metadata.outputs.digest }}
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      # NOTE: per-platform staging images (build-<run_id>-<slug> tags) are the
+      # merged index's child manifests — deleting them by digest orphans the
+      # index (children 404). They are intentionally retained; safe periodic
+      # pruning of stale build-* tags is tracked separately.
+
+      - name: Build summary
+        if: always()
+        shell: bash
+        env:
+          STEP: summary
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+          PLATFORMS: ${{ inputs.platforms }}
+          PUSH: ${{ inputs.push }}
+          DIGEST: ${{ steps.metadata.outputs.digest || '' }}
+          COSIGN_SIGNED: ${{ inputs.cosign-sign && inputs.push }}
+          SCAN_ENABLED: ${{ inputs.scan }}
+          HEALTH_CHECK_ENABLED: ${{ inputs.health-check-cmd != '' }}
+          MATRIX: ${{ inputs.matrix }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+  summary-validate:
+    name: Validation Summary
+    needs: [build-per-platform, verify-per-platform, health-check-per-platform]
+    if: >-
+      always() &&
+      inputs.validate-on-pr &&
+      inputs.push == false
+    runs-on: ubuntu-24.04
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        # Pinned to SHA for supply chain security
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # source-ref = build-context (app source); tooling-ref stays separate
+          ref: ${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/checkout-and-harden
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Checkout and harden
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+        with:
+          tooling-ref: ${{ inputs.tooling-ref }}
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+          sparse-checkout-extra: |
+            scripts/ci/
+
+      - name: Build summary
+        if: always()
+        shell: bash
+        env:
+          STEP: summary
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+          PLATFORMS: ${{ inputs.platforms }}
+          PUSH: ${{ inputs.push }}
+          SCAN_ENABLED: ${{ inputs.scan }}
+          VALIDATE_ON_PR: true
+          HEALTH_CHECK_ENABLED: ${{ inputs.health-check-cmd != '' }}
+          MATRIX: ${{ inputs.matrix }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+  scan:
+    name: Vulnerability Scan
+    needs: merge
+    if: >-
+      always() &&
+      inputs.scan &&
+      inputs.push &&
+      needs.merge.result == 'success'
+    runs-on: ubuntu-24.04
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/checkout-and-harden
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Checkout and harden
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+        with:
+          tooling-ref: ${{ inputs.tooling-ref }}
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+
+      - name: Run Trivy vulnerability scanner
+        # Pinned to SHA for supply chain security
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: >-
+            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}@${{
+            needs.merge.outputs.digest }}
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH"
+          exit-code: ${{ inputs.scan-exit-code }}
+
+      - name: Upload Trivy scan results
+        # Pinned to SHA for supply chain security
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          sarif_file: "trivy-results.sarif"

--- a/.github/workflows/reusable-docker-multiplatform.yml
+++ b/.github/workflows/reusable-docker-multiplatform.yml
@@ -867,6 +867,7 @@ jobs:
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
           sparse-checkout-extra: |
+            scripts/ci/
             .github/actions/docker-auth
 
       - name: Docker registry auth

--- a/.github/workflows/reusable-docker-smoke-test.yml
+++ b/.github/workflows/reusable-docker-smoke-test.yml
@@ -164,6 +164,8 @@ jobs:
             scripts/ci/
             .github/actions/docker-auth
       - name: Setup QEMU
+        # Default runner is amd64; skip QEMU for the native linux/amd64 default.
+        if: ${{ inputs.platform != 'linux/amd64' }}
         # Pinned to SHA for supply chain security
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 

--- a/.github/workflows/reusable-docker-smoke-test.yml
+++ b/.github/workflows/reusable-docker-smoke-test.yml
@@ -1,0 +1,210 @@
+---
+name: Reusable Docker Smoke Test
+
+# Focused, independently callable image-validation reusable: pull a published
+# image by immutable digest and run a smoke test (a bare command inside the
+# image or a caller-owned script) and/or a detached-container health check
+# against it. Shares the same docker/smoke-test.sh and docker/health-check.sh
+# helpers the multi-platform verify gate uses. All shared shell scripts resolve
+# from lgtm-ci via a cross-repo checkout into .lgtm-ci-tooling.
+
+on:
+  workflow_call:
+    inputs:
+      registry:
+        description: "Container registry URL"
+        required: false
+        type: string
+        default: "ghcr.io"
+      image-name:
+        description: "Image name (default: github.repository)"
+        required: false
+        type: string
+        default: ""
+      digest:
+        description: >-
+          Immutable image digest to validate (sha256:...). The image is pulled
+          by digest to avoid TOCTOU against floating tags.
+        required: true
+        type: string
+      platform:
+        description: "Target platform to validate (e.g. linux/amd64)"
+        required: false
+        type: string
+        default: "linux/amd64"
+      smoke-test:
+        description: >-
+          Shorthand command + args run as `docker run --rm --platform <p>
+          <image@digest> <smoke-test>`. Word-split. Mutually exclusive with
+          smoke-test-script.
+        required: false
+        type: string
+        default: ""
+      smoke-test-script:
+        description: >-
+          Path (relative to checkout root) to a caller-owned script executed on
+          the runner with env IMAGE, PLATFORM, REGISTRY. Mutually exclusive with
+          smoke-test.
+        required: false
+        type: string
+        default: ""
+      health-check-cmd:
+        description: >-
+          Optional command run on the runner against the image's published
+          localhost port. Requires health-check-port. Skipped when empty.
+        required: false
+        type: string
+        default: ""
+      health-check-port:
+        description: "Container port to publish for the health check."
+        required: false
+        type: string
+        default: ""
+      health-check-timeout:
+        description: "Max wait for health-check-port to accept connections."
+        required: false
+        type: string
+        default: "30s"
+      source-ref:
+        description: >-
+          Git ref to check out for smoke-test-script resolution, independent of
+          tooling-ref. Empty uses the triggering ref.
+        required: false
+        type: string
+        default: ""
+      runner-image:
+        description: "Runner image for the validation job"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+      tooling-ref:
+        # yamllint disable-line rule:line-length
+        description: "Git ref for lgtm-ci tooling checkout. Defaults to the reusable workflow commit."
+        required: false
+        type: string
+        default: ""
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "block"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: ""
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+      egress-preset:
+        description: >-
+          Named allowlist when allowed-endpoints is empty and egress-policy is
+          block.
+        required: false
+        type: string
+        default: "docker"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 30
+
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: false
+        description: "Docker Hub username (for docker.io registry)"
+      DOCKERHUB_TOKEN:
+        required: false
+        description: "Docker Hub token (for docker.io registry)"
+
+jobs:
+  smoke-test:
+    name: Docker Smoke Test
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout repository (for smoke-test-script)
+        # Pinned to SHA for supply chain security
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # source-ref = build-context (app source); tooling-ref stays separate
+          ref: ${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/checkout-and-harden
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+
+      - name: Checkout and harden
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+        with:
+          tooling-ref: ${{ inputs.tooling-ref }}
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+          sparse-checkout-extra: |
+            scripts/ci/
+            .github/actions/docker-auth
+      - name: Setup QEMU
+        # Pinned to SHA for supply chain security
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Docker registry auth
+        uses: ./.lgtm-ci-tooling/.github/actions/docker-auth
+        with:
+          registry: ${{ inputs.registry }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Record digest
+        shell: bash
+        env:
+          STEP: record-digest
+          DIGEST: ${{ inputs.digest }}
+          DIGEST_FILE: ${{ runner.temp }}/staging-digest/digest.txt
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Smoke test (${{ inputs.platform }})
+        if: inputs.smoke-test != '' || inputs.smoke-test-script != ''
+        shell: bash
+        env:
+          STEP: smoke-test
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+          DIGEST_FILE: ${{ runner.temp }}/staging-digest/digest.txt
+          PLATFORM: ${{ inputs.platform }}
+          SMOKE_TEST: ${{ inputs.smoke-test }}
+          SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
+
+      - name: Health check (${{ inputs.platform }})
+        if: inputs.health-check-cmd != ''
+        shell: bash
+        env:
+          STEP: health-check
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
+          DIGEST_FILE: ${{ runner.temp }}/staging-digest/digest.txt
+          PLATFORM: ${{ inputs.platform }}
+          HEALTH_CHECK_CMD: ${{ inputs.health-check-cmd }}
+          HEALTH_CHECK_PORT: ${{ inputs.health-check-port }}
+          HEALTH_CHECK_TIMEOUT: ${{ inputs.health-check-timeout }}
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -1,9 +1,20 @@
 ---
 name: Reusable Docker Build and Push
 
+# Thin orchestrator kept for backwards compatibility (#381). The classify job
+# resolves the build strategy, then delegates to the focused reusables:
+#   - reusable-docker-build.yml          (use-split=false: single-platform or
+#                                         QEMU multi-platform build+scan)
+#   - reusable-docker-multiplatform.yml  (use-split=true: runner-map matrix,
+#                                         manifest merge, signing)
+# Consumers may keep calling this workflow unchanged, or migrate to the
+# focused reusables directly — see docs/workflow-contract.md (runner-map
+# section) for the migration path. reusable-docker-smoke-test.yml is a
+# standalone image-validation reusable and is not called from here.
+#
 # Caller repos only need to pin this workflow; all shared shell scripts are
 # resolved from lgtm-ci via a cross-repo checkout (same pattern as
-# reusable-release-auto-tag.yml).  No vendored scripts/ci tree is required
+# reusable-release-auto-tag.yml). No vendored scripts/ci tree is required
 # in the caller repository.
 
 on:
@@ -239,10 +250,10 @@ on:
     outputs:
       tags:
         description: "Generated image tags"
-        value: ${{ jobs.build.outputs.tags || jobs.merge.outputs.tags }}
+        value: ${{ jobs.build.outputs.tags || jobs.multiplatform.outputs.tags }}
       digest:
         description: "Image digest"
-        value: ${{ jobs.build.outputs.digest || jobs.merge.outputs.digest }}
+        value: ${{ jobs.build.outputs.digest || jobs.multiplatform.outputs.digest }}
 
     secrets:
       DOCKERHUB_USERNAME:
@@ -314,1023 +325,89 @@ jobs:
           HEALTH_CHECK_TIMEOUT: ${{ inputs.health-check-timeout }}
         run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
 
-  # Single-platform builds, or multi-platform when push is disabled (QEMU fallback)
+  # Single-platform builds, or multi-platform when push is disabled (QEMU
+  # fallback). Delegated to the focused build reusable.
   build:
-    name: Build and Push
+    name: Docker build
     needs: classify
     if: ${{ needs.classify.outputs.use-split == 'false' }}
-    runs-on: ubuntu-24.04
-    timeout-minutes: ${{ inputs.timeout-minutes }}
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-      security-events: write
+    uses: ./.github/workflows/reusable-docker-build.yml
+    with:
+      context: ${{ inputs.context }}
+      file: ${{ inputs.file }}
+      platforms: ${{ inputs.platforms }}
+      registry: ${{ inputs.registry }}
+      image-name: ${{ inputs.image-name }}
+      tags: ${{ inputs.tags }}
+      version: ${{ inputs.version }}
+      source-ref: ${{ inputs.source-ref }}
+      tag-latest: ${{ inputs.tag-latest }}
+      exact-tags: ${{ inputs.exact-tags }}
+      push: ${{ inputs.push }}
+      provenance: ${{ inputs.provenance }}
+      sbom: ${{ inputs.sbom }}
+      scan: ${{ inputs.scan }}
+      build-args: ${{ inputs.build-args }}
+      target: ${{ inputs.target }}
+      health-check-cmd: ${{ inputs.health-check-cmd }}
+      health-check-port: ${{ inputs.health-check-port }}
+      health-check-timeout: ${{ inputs.health-check-timeout }}
+      validate-on-pr: ${{ inputs.validate-on-pr }}
+      scan-exit-code: ${{ inputs.scan-exit-code }}
+      cache-registry-ref: ${{ inputs.cache-registry-ref }}
+      cosign-sign: ${{ inputs.cosign-sign }}
+      no-cache: ${{ inputs.no-cache }}
+      tooling-ref: ${{ inputs.tooling-ref }}
+      egress-policy: ${{ inputs.egress-policy }}
+      allowed-endpoints: ${{ inputs.allowed-endpoints }}
+      allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+      egress-preset: ${{ inputs.egress-preset }}
+      timeout-minutes: ${{ inputs.timeout-minutes }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-      digest: ${{ steps.metadata.outputs.digest }}
-
-    steps:
-      - name: Checkout repository
-        # Pinned to SHA for supply chain security
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # source-ref = build-context (app source); tooling-ref stays separate
-          ref: ${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}
-          persist-credentials: false
-
-      - name: Checkout lgtm-ci tooling
-        # yamllint disable-line rule:line-length
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: |
-            .github/actions/checkout-and-harden
-          sparse-checkout-cone-mode: true
-          persist-credentials: false
-
-      - name: Checkout and harden
-        id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
-        with:
-          tooling-ref: ${{ inputs.tooling-ref }}
-          egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
-          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-          sparse-checkout-extra: |
-            scripts/ci/
-      - name: Setup QEMU
-        # Pinned to SHA for supply chain security
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - name: Setup Docker Buildx
-        # Pinned to SHA for supply chain security
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Validate registry
-        if: inputs.push
-        shell: bash
-        env:
-          STEP: validate
-          REGISTRY: ${{ inputs.registry }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/docker-login.sh
-
-      - name: Login to GHCR
-        if: inputs.push && inputs.registry == 'ghcr.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Login to Docker Hub
-        if: inputs.push && inputs.registry == 'docker.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Parse additional tags
-        id: extra-tags
-        if: inputs.tags != '' && !inputs.exact-tags
-        shell: bash
-        env:
-          STEP: parse-tags
-          INPUT_TAGS: ${{ inputs.tags }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-      - name: Extract metadata
-        id: meta
-        # Pinned to SHA for supply chain security
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: |
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
-          # Disable metadata-action's auto 'latest': the tag is controlled only
-          # by the gated raw entry below, so backfills never move latest.
-          flavor: |
-            latest=false
-          # exact-tags (backfill): suppress every floating tag (sha-<ref>,
-          # branch, pr, major, minor, latest); publish only the pinned version
-          # tag (its immutable by-digest sha is inherent to the pushed image).
-          # yamllint disable rule:line-length
-          tags: |
-            type=sha,prefix=sha-,enable=${{ !inputs.exact-tags }}
-            type=ref,event=branch,enable=${{ !inputs.exact-tags }}
-            type=ref,event=pr,enable=${{ !inputs.exact-tags }}
-            type=semver,pattern={{version}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
-            type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
-            type=raw,value=latest,enable=${{ inputs.version != '' && inputs.tag-latest && !inputs.exact-tags }}
-            ${{ !inputs.exact-tags && steps.extra-tags.outputs.tags || '' }}
-          # yamllint enable rule:line-length
-
-      - name: Build and push
-        id: build
-        # Pinned to SHA for supply chain security
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: ${{ inputs.context }}
-          file: ${{ inputs.file }}
-          platforms: ${{ inputs.platforms }}
-          push: ${{ inputs.push && inputs.health-check-cmd == '' }}
-          load: >-
-            ${{ inputs.health-check-cmd != '' ||
-              (inputs.push == false && (inputs.validate-on-pr || inputs.scan)) }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: ${{ inputs.build-args }}
-          target: ${{ inputs.target }}
-          # yamllint disable rule:line-length
-          cache-from: |
-            ${{ inputs.no-cache == false && 'type=gha' || '' }}
-            ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && format('type=registry,ref={0}', inputs.cache-registry-ref) || '' }}
-          cache-to: |
-            ${{ inputs.no-cache == false && 'type=gha,mode=max' || '' }}
-            ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && inputs.push && format('type=registry,ref={0},mode=max', inputs.cache-registry-ref) || '' }}
-          # yamllint enable rule:line-length
-          provenance: ${{ inputs.provenance && inputs.push && inputs.health-check-cmd == '' }}
-          sbom: ${{ inputs.sbom && inputs.push && inputs.health-check-cmd == '' }}
-
-      - name: Resolve local image for health check
-        if: inputs.health-check-cmd != ''
-        id: local-health-check-image
-        shell: bash
-        env:
-          STEP: resolve-local-health-check-image
-          TAGS: ${{ steps.meta.outputs.tags }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-      - name: Health check
-        if: inputs.health-check-cmd != ''
-        shell: bash
-        env:
-          STEP: health-check-local
-          IMAGE: ${{ steps.local-health-check-image.outputs.image }}
-          HEALTH_CHECK_CMD: ${{ inputs.health-check-cmd }}
-          HEALTH_CHECK_PORT: ${{ inputs.health-check-port }}
-          HEALTH_CHECK_TIMEOUT: ${{ inputs.health-check-timeout }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-      - name: Install Syft
-        if: inputs.push && inputs.sbom && inputs.health-check-cmd != ''
-        shell: bash
-        env:
-          STEP: install
-        run: .lgtm-ci-tooling/scripts/ci/actions/generate-sbom.sh
-
-      - name: Generate SBOM for attestation
-        if: inputs.push && inputs.sbom && inputs.health-check-cmd != ''
-        shell: bash
-        env:
-          STEP: generate
-          TARGET: ${{ steps.local-health-check-image.outputs.image }}
-          TARGET_TYPE: image
-          FORMAT: spdx-json
-          OUTPUT_FILE: sbom.spdx.json
-        run: .lgtm-ci-tooling/scripts/ci/actions/generate-sbom.sh
-
-      - name: Push image after health check
-        if: inputs.push && inputs.health-check-cmd != ''
-        shell: bash
-        env:
-          STEP: push
-          TAGS: ${{ steps.meta.outputs.tags }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-      - name: Extract digest
-        id: metadata
-        if: inputs.push || inputs.validate-on-pr
-        shell: bash
-        env:
-          STEP: ${{ inputs.push && inputs.health-check-cmd != '' && 'metadata' || 'set-output-digest' }}
-          DIGEST: ${{ steps.build.outputs.digest }}
-          BUILT_TAGS: ${{ steps.meta.outputs.tags }}
-          REGISTRY: ${{ inputs.registry }}
-          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-      - name: Resolve local image for scan
-        if: inputs.scan && inputs.push == false
-        id: local-scan-image
-        shell: bash
-        env:
-          STEP: resolve-local-scan-image
-          TAGS: ${{ steps.meta.outputs.tags }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-      - name: Run Trivy vulnerability scanner
-        if: inputs.scan && inputs.push == false
-        # Pinned to SHA for supply chain security
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: ${{ steps.local-scan-image.outputs.ref }}
-          format: "sarif"
-          output: "trivy-results.sarif"
-          severity: "CRITICAL,HIGH"
-          exit-code: ${{ inputs.scan-exit-code }}
-
-      - name: Upload Trivy scan results
-        if: always() && inputs.scan && inputs.push == false
-        # Pinned to SHA for supply chain security
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
-        with:
-          sarif_file: "trivy-results.sarif"
-
-      - name: Generate artifact attestation
-        if: inputs.push && inputs.provenance
-        # Pinned to SHA for supply chain security
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
-        with:
-          subject-name: ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
-          subject-digest: ${{ steps.metadata.outputs.digest }}
-          push-to-registry: true
-
-      - name: Generate SBOM attestation
-        if: inputs.push && inputs.sbom && inputs.health-check-cmd != ''
-        # Pinned to SHA for supply chain security
-        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
-        with:
-          subject-name: ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
-          subject-digest: ${{ steps.metadata.outputs.digest }}
-          sbom-path: sbom.spdx.json
-          push-to-registry: true
-
-      - name: Install Cosign
-        if: inputs.push && inputs.cosign-sign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Sign image
-        if: inputs.push && inputs.cosign-sign
-        shell: bash
-        env:
-          STEP: sign-image
-          DIGEST: ${{ steps.metadata.outputs.digest }}
-          REGISTRY: ${{ inputs.registry }}
-          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-      - name: Build summary
-        if: always()
-        shell: bash
-        env:
-          STEP: summary
-          REGISTRY: ${{ inputs.registry }}
-          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
-          TAGS: ${{ steps.meta.outputs.tags }}
-          PLATFORMS: ${{ inputs.platforms }}
-          PUSH: ${{ inputs.push }}
-          DIGEST: ${{ steps.metadata.outputs.digest || '' }}
-          COSIGN_SIGNED: ${{ inputs.cosign-sign && inputs.push }}
-          SCAN_ENABLED: ${{ inputs.scan }}
-          HEALTH_CHECK_ENABLED: ${{ inputs.health-check-cmd != '' }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-  # Per-platform native build leg (multi-arch split path).
-  # One matrix entry per platform; runner and QEMU config resolved by classify.
-  build-per-platform:
-    name: Docker build per platform
+  # Split per-platform path: runner-map matrix builds, optional smoke-test and
+  # health-check gates, manifest merge + verification, provenance, signing.
+  multiplatform:
+    name: Docker multi-platform
     needs: classify
     if: ${{ needs.classify.outputs.use-split == 'true' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.classify.outputs.matrix) }}
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: ${{ inputs.timeout-minutes }}
-    permissions:
-      contents: read
-      packages: write
-      security-events: write
-
-    steps:
-      - name: Checkout repository
-        # Pinned to SHA for supply chain security
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # source-ref = build-context (app source); tooling-ref stays separate
-          ref: ${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}
-          persist-credentials: false
-
-      - name: Checkout lgtm-ci tooling
-        # yamllint disable-line rule:line-length
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: |
-            .github/actions/checkout-and-harden
-          sparse-checkout-cone-mode: true
-          persist-credentials: false
-
-      - name: Checkout and harden
-        id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
-        with:
-          tooling-ref: ${{ inputs.tooling-ref }}
-          egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
-          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-          sparse-checkout-extra: |
-            scripts/ci/
-      - name: Setup QEMU
-        if: ${{ matrix.qemu }}
-        # Pinned to SHA for supply chain security
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - name: Setup Docker Buildx
-        # Pinned to SHA for supply chain security
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Validate registry
-        if: inputs.push
-        shell: bash
-        env:
-          STEP: validate
-          REGISTRY: ${{ inputs.registry }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/docker-login.sh
-
-      - name: Login to GHCR
-        if: inputs.push && inputs.registry == 'ghcr.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Login to Docker Hub
-        if: inputs.push && inputs.registry == 'docker.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        # Pinned to SHA for supply chain security
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: |
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
-          # Disable metadata-action's auto 'latest': the tag is controlled only
-          # by the gated raw entry below, so backfills never move latest.
-          flavor: |
-            latest=false
-          # exact-tags (backfill): suppress every floating tag (sha-<ref>,
-          # branch, pr, major, minor, latest); publish only the pinned version
-          # tag (its immutable by-digest sha is inherent to the pushed image).
-          # yamllint disable rule:line-length
-          tags: |
-            type=sha,prefix=sha-,enable=${{ !inputs.exact-tags }}
-            type=ref,event=branch,enable=${{ !inputs.exact-tags }}
-            type=ref,event=pr,enable=${{ !inputs.exact-tags }}
-            type=semver,pattern={{version}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
-            type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
-            type=raw,value=latest,enable=${{ inputs.version != '' && inputs.tag-latest && !inputs.exact-tags }}
-          # yamllint enable rule:line-length
-
-      - name: Build and push (${{ matrix.platform }})
-        id: build
-        # Pinned to SHA for supply chain security
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: ${{ inputs.context }}
-          file: ${{ inputs.file }}
-          platforms: ${{ matrix.platform }}
-          push: ${{ inputs.push }}
-          load: >-
-            ${{ inputs.push == false && (inputs.health-check-cmd != '' ||
-              inputs.validate-on-pr || inputs.scan) }}
-          # yamllint disable rule:line-length
-          tags: >-
-            ${{ inputs.push
-              && format('{0}/{1}:build-{2}-{3}', inputs.registry, inputs.image-name || github.repository, github.run_id, matrix.slug)
-              || format('{0}/{1}:validate-{2}', inputs.registry, inputs.image-name || github.repository, matrix.slug) }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: ${{ inputs.build-args }}
-          target: ${{ inputs.target }}
-          cache-from: |
-            ${{ inputs.no-cache == false && format('type=gha,scope={0}', matrix.slug) || '' }}
-            ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && format('type=registry,ref={0}-{1}', inputs.cache-registry-ref, matrix.slug) || '' }}
-          cache-to: |
-            ${{ inputs.no-cache == false && format('type=gha,mode=max,scope={0}', matrix.slug) || '' }}
-            ${{ inputs.no-cache == false && inputs.cache-registry-ref != '' && inputs.push && format('type=registry,ref={0}-{1},mode=max', inputs.cache-registry-ref, matrix.slug) || '' }}
-          # yamllint enable rule:line-length
-          provenance: false
-          sbom: ${{ inputs.sbom && inputs.push }}
-
-      - name: Record staging digest
-        shell: bash
-        env:
-          STEP: record-digest
-          DIGEST: ${{ steps.build.outputs.digest }}
-          DIGEST_FILE: ${{ runner.temp }}/staging-digest/digest.txt
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-      - name: Smoke test (${{ matrix.platform }})
-        if: >-
-          inputs.validate-on-pr && inputs.push == false &&
-          (inputs.smoke-test != '' || inputs.smoke-test-script != '')
-        shell: bash
-        env:
-          STEP: smoke-test-local
-          REGISTRY: ${{ inputs.registry }}
-          IMAGE: >-
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:validate-${{
-            matrix.slug }}
-          PLATFORM: ${{ matrix.platform }}
-          SMOKE_TEST: ${{ inputs.smoke-test }}
-          SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-      - name: Health check (${{ matrix.platform }})
-        if: >-
-          inputs.validate-on-pr && inputs.push == false &&
-          inputs.health-check-cmd != ''
-        shell: bash
-        env:
-          STEP: health-check-local
-          IMAGE: >-
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:validate-${{
-            matrix.slug }}
-          PLATFORM: ${{ matrix.platform }}
-          HEALTH_CHECK_CMD: ${{ inputs.health-check-cmd }}
-          HEALTH_CHECK_PORT: ${{ inputs.health-check-port }}
-          HEALTH_CHECK_TIMEOUT: ${{ inputs.health-check-timeout }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-      - name: Run Trivy vulnerability scanner (${{ matrix.platform }})
-        if: inputs.scan && inputs.push == false
-        # Pinned to SHA for supply chain security
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: >-
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}:validate-${{
-            matrix.slug }}
-          format: "sarif"
-          output: "trivy-results-${{ matrix.slug }}.sarif"
-          severity: "CRITICAL,HIGH"
-          exit-code: ${{ inputs.scan-exit-code }}
-
-      - name: Upload Trivy scan results (${{ matrix.platform }})
-        if: always() && inputs.scan && inputs.push == false
-        # Pinned to SHA for supply chain security
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
-        with:
-          sarif_file: "trivy-results-${{ matrix.slug }}.sarif"
-          category: "trivy-${{ matrix.slug }}"
-
-      - name: Upload staging digest
-        if: inputs.push
-        # Pinned to SHA for supply chain security
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: staging-digest-${{ matrix.slug }}
-          path: ${{ runner.temp }}/staging-digest/digest.txt
-          if-no-files-found: error
-          retention-days: 1
-
-  # Optional per-platform smoke test gate (push path only).
-  # Runs against each staging image on its native runner before manifest
-  # merge. PR validation smoke tests and Trivy scans run inline in
-  # build-per-platform because locally-loaded images are not available
-  # across job boundaries.
-  # Two modes:
-  #   - smoke-test (shorthand): `docker run --rm --platform <p> <image> <cmd>`
-  #   - smoke-test-script: caller-owned script with env IMAGE/PLATFORM/REGISTRY
-  verify-per-platform:
-    name: Docker verify per platform
-    needs: [classify, build-per-platform]
-    if: >-
-      needs.classify.outputs.use-split == 'true' &&
-      inputs.push &&
-      (inputs.smoke-test != '' || inputs.smoke-test-script != '')
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.classify.outputs.matrix) }}
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: ${{ inputs.timeout-minutes }}
-    permissions:
-      contents: read
-      packages: read
-
-    steps:
-      - name: Checkout repository (for smoke-test-script)
-        # Pinned to SHA for supply chain security
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # source-ref = build-context (app source); tooling-ref stays separate
-          ref: ${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}
-          persist-credentials: false
-
-      - name: Checkout lgtm-ci tooling
-        # yamllint disable-line rule:line-length
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: |
-            .github/actions/checkout-and-harden
-          sparse-checkout-cone-mode: true
-          persist-credentials: false
-
-      - name: Checkout and harden
-        id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
-        with:
-          tooling-ref: ${{ inputs.tooling-ref }}
-          egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
-          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-          sparse-checkout-extra: |
-            scripts/ci/
-      - name: Setup QEMU
-        if: ${{ matrix.qemu }}
-        # Pinned to SHA for supply chain security
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - name: Validate registry
-        if: inputs.push
-        shell: bash
-        env:
-          STEP: validate
-          REGISTRY: ${{ inputs.registry }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/docker-login.sh
-
-      - name: Login to GHCR
-        if: inputs.push && inputs.registry == 'ghcr.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Login to Docker Hub
-        if: inputs.push && inputs.registry == 'docker.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Download staging digest
-        if: inputs.push
-        # Pinned to SHA for supply chain security
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: staging-digest-${{ matrix.slug }}
-          path: ${{ runner.temp }}/staging-digest
-
-      - name: Smoke test (${{ matrix.platform }})
-        shell: bash
-        env:
-          STEP: smoke-test
-          REGISTRY: ${{ inputs.registry }}
-          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
-          DIGEST_FILE: ${{ runner.temp }}/staging-digest/digest.txt
-          PLATFORM: ${{ matrix.platform }}
-          SMOKE_TEST: ${{ inputs.smoke-test }}
-          SMOKE_TEST_SCRIPT: ${{ inputs.smoke-test-script }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-  # Optional per-platform detached-container health check (push path only).
-  # Gates manifest merge on runtime validation of each staging image.
-  health-check-per-platform:
-    name: Docker health check per platform
-    needs: [classify, build-per-platform, verify-per-platform]
-    if: >-
-      always() &&
-      needs.classify.outputs.use-split == 'true' &&
-      inputs.push &&
-      inputs.health-check-cmd != '' &&
-      needs.build-per-platform.result == 'success' &&
-      (needs.verify-per-platform.result == 'success' ||
-       needs.verify-per-platform.result == 'skipped')
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.classify.outputs.matrix) }}
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: ${{ inputs.timeout-minutes }}
-    # contents: read — sparse-checkout lgtm-ci tooling scripts for build-docker.sh.
-    # packages: read — pull per-platform staging images by digest before merge.
-    permissions:
-      contents: read
-      packages: read
-
-    steps:
-      - name: Checkout lgtm-ci tooling
-        # yamllint disable-line rule:line-length
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: |
-            .github/actions/checkout-and-harden
-          sparse-checkout-cone-mode: true
-          persist-credentials: false
-
-      - name: Checkout and harden
-        id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
-        with:
-          tooling-ref: ${{ inputs.tooling-ref }}
-          egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
-          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-          sparse-checkout-extra: |
-            scripts/ci/
-      - name: Setup QEMU
-        if: ${{ matrix.qemu }}
-        # Pinned to SHA for supply chain security
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - name: Validate registry
-        if: inputs.push
-        shell: bash
-        env:
-          STEP: validate
-          REGISTRY: ${{ inputs.registry }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/docker-login.sh
-
-      - name: Login to GHCR
-        if: inputs.push && inputs.registry == 'ghcr.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Login to Docker Hub
-        if: inputs.push && inputs.registry == 'docker.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Download staging digest
-        if: inputs.push
-        # Pinned to SHA for supply chain security
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: staging-digest-${{ matrix.slug }}
-          path: ${{ runner.temp }}/staging-digest
-
-      - name: Health check (${{ matrix.platform }})
-        shell: bash
-        env:
-          STEP: health-check
-          REGISTRY: ${{ inputs.registry }}
-          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
-          DIGEST_FILE: ${{ runner.temp }}/staging-digest/digest.txt
-          PLATFORM: ${{ matrix.platform }}
-          HEALTH_CHECK_CMD: ${{ inputs.health-check-cmd }}
-          HEALTH_CHECK_PORT: ${{ inputs.health-check-port }}
-          HEALTH_CHECK_TIMEOUT: ${{ inputs.health-check-timeout }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-  # Assemble multi-arch manifest from per-platform staging images
-  merge:
-    name: Merge Manifests
-    needs: [classify, build-per-platform, verify-per-platform, health-check-per-platform]
-    if: >-
-      always() &&
-      inputs.push &&
-      needs.classify.outputs.use-split == 'true' &&
-      needs.build-per-platform.result == 'success' &&
-      (needs.verify-per-platform.result == 'success' ||
-       needs.verify-per-platform.result == 'skipped') &&
-      (needs.health-check-per-platform.result == 'success' ||
-       needs.health-check-per-platform.result == 'skipped')
-    runs-on: ubuntu-24.04
-    timeout-minutes: ${{ inputs.timeout-minutes }}
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-      digest: ${{ steps.metadata.outputs.digest }}
-
-    steps:
-      - name: Checkout repository
-        # Pinned to SHA for supply chain security
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # source-ref = build-context (app source); tooling-ref stays separate
-          ref: ${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}
-          persist-credentials: false
-
-      - name: Checkout lgtm-ci tooling
-        # yamllint disable-line rule:line-length
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: |
-            .github/actions/checkout-and-harden
-          sparse-checkout-cone-mode: true
-          persist-credentials: false
-
-      - name: Checkout and harden
-        id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
-        with:
-          tooling-ref: ${{ inputs.tooling-ref }}
-          egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
-          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-          sparse-checkout-extra: |
-            scripts/ci/
-      - name: Setup Docker Buildx
-        # Pinned to SHA for supply chain security
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Validate registry
-        shell: bash
-        env:
-          STEP: validate
-          REGISTRY: ${{ inputs.registry }}
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/docker-login.sh
-
-      - name: Login to GHCR
-        if: inputs.registry == 'ghcr.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Login to Docker Hub
-        if: inputs.registry == 'docker.io'
-        # Pinned to SHA for supply chain security
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Parse additional tags
-        id: extra-tags
-        if: inputs.tags != '' && !inputs.exact-tags
-        shell: bash
-        env:
-          STEP: parse-tags
-          INPUT_TAGS: ${{ inputs.tags }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-      - name: Extract metadata
-        id: meta
-        # Pinned to SHA for supply chain security
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: |
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
-          # Disable metadata-action's auto 'latest': the tag is controlled only
-          # by the gated raw entry below, so backfills never move latest.
-          flavor: |
-            latest=false
-          # exact-tags (backfill): suppress every floating tag (sha-<ref>,
-          # branch, pr, major, minor, latest); publish only the pinned version
-          # tag (its immutable by-digest sha is inherent to the pushed image).
-          # yamllint disable rule:line-length
-          tags: |
-            type=sha,prefix=sha-,enable=${{ !inputs.exact-tags }}
-            type=ref,event=branch,enable=${{ !inputs.exact-tags }}
-            type=ref,event=pr,enable=${{ !inputs.exact-tags }}
-            type=semver,pattern={{version}},value=${{ inputs.version }},enable=${{ inputs.version != '' }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
-            type=semver,pattern={{major}},value=${{ inputs.version }},enable=${{ inputs.version != '' && !inputs.exact-tags }}
-            type=raw,value=latest,enable=${{ inputs.version != '' && inputs.tag-latest && !inputs.exact-tags }}
-            ${{ !inputs.exact-tags && steps.extra-tags.outputs.tags || '' }}
-          # yamllint enable rule:line-length
-
-      - name: Create multi-arch manifest
-        shell: bash
-        env:
-          STEP: merge-manifests
-          MATRIX: ${{ needs.classify.outputs.matrix }}
-          REGISTRY: ${{ inputs.registry }}
-          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
-          RUN_ID: ${{ github.run_id }}
-          TARGET_TAGS: ${{ steps.meta.outputs.tags }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-      - name: Extract digest
-        id: metadata
-        shell: bash
-        env:
-          STEP: metadata
-          BUILT_TAGS: ${{ steps.meta.outputs.tags }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-      # Non-skippable gate: pull the published index back from the registry and
-      # assert every platform child manifest resolves. A dangling index (child
-      # manifests 404) fails the release here instead of publishing as green.
-      - name: Verify published manifest
-        shell: bash
-        env:
-          STEP: verify-published
-          REGISTRY: ${{ inputs.registry }}
-          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
-          MATRIX: ${{ needs.classify.outputs.matrix }}
-          TARGET_TAGS: ${{ steps.meta.outputs.tags }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-      - name: Generate artifact attestation
-        if: inputs.provenance
-        # Pinned to SHA for supply chain security
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
-        with:
-          subject-name: ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}
-          subject-digest: ${{ steps.metadata.outputs.digest }}
-          push-to-registry: true
-
-      - name: Install Cosign
-        if: inputs.cosign-sign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Sign image
-        if: inputs.cosign-sign
-        shell: bash
-        env:
-          STEP: sign-image
-          DIGEST: ${{ steps.metadata.outputs.digest }}
-          REGISTRY: ${{ inputs.registry }}
-          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-      # NOTE: per-platform staging images (build-<run_id>-<slug> tags) are the
-      # merged index's child manifests — deleting them by digest orphans the
-      # index (children 404). They are intentionally retained; safe periodic
-      # pruning of stale build-* tags is tracked separately.
-
-      - name: Build summary
-        if: always()
-        shell: bash
-        env:
-          STEP: summary
-          REGISTRY: ${{ inputs.registry }}
-          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
-          TAGS: ${{ steps.meta.outputs.tags }}
-          PLATFORMS: ${{ inputs.platforms }}
-          PUSH: ${{ inputs.push }}
-          DIGEST: ${{ steps.metadata.outputs.digest || '' }}
-          COSIGN_SIGNED: ${{ inputs.cosign-sign && inputs.push }}
-          SCAN_ENABLED: ${{ inputs.scan }}
-          HEALTH_CHECK_ENABLED: ${{ inputs.health-check-cmd != '' }}
-          MATRIX: ${{ needs.classify.outputs.matrix }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-  summary-validate:
-    name: Validation Summary
-    needs: [classify, build-per-platform, verify-per-platform, health-check-per-platform]
-    if: >-
-      always() &&
-      needs.classify.outputs.use-split == 'true' &&
-      inputs.validate-on-pr &&
-      inputs.push == false
-    runs-on: ubuntu-24.04
-    timeout-minutes: ${{ inputs.timeout-minutes }}
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout repository
-        # Pinned to SHA for supply chain security
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # source-ref = build-context (app source); tooling-ref stays separate
-          ref: ${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}
-          persist-credentials: false
-
-      - name: Checkout lgtm-ci tooling
-        # yamllint disable-line rule:line-length
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: |
-            .github/actions/checkout-and-harden
-          sparse-checkout-cone-mode: true
-          persist-credentials: false
-
-      - name: Checkout and harden
-        id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
-        with:
-          tooling-ref: ${{ inputs.tooling-ref }}
-          egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
-          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-          sparse-checkout-extra: |
-            scripts/ci/
-
-      - name: Build summary
-        if: always()
-        shell: bash
-        env:
-          STEP: summary
-          REGISTRY: ${{ inputs.registry }}
-          IMAGE_NAME: ${{ inputs.image-name || github.repository }}
-          PLATFORMS: ${{ inputs.platforms }}
-          PUSH: ${{ inputs.push }}
-          SCAN_ENABLED: ${{ inputs.scan }}
-          VALIDATE_ON_PR: true
-          HEALTH_CHECK_ENABLED: ${{ inputs.health-check-cmd != '' }}
-          MATRIX: ${{ needs.classify.outputs.matrix }}
-        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
-
-  scan:
-    name: Vulnerability Scan
-    needs: [classify, build, merge]
-    if: >-
-      always() &&
-      inputs.scan &&
-      inputs.push &&
-      (
-        (needs.classify.outputs.use-split == 'false' && needs.build.result == 'success') ||
-        (needs.classify.outputs.use-split == 'true' && needs.merge.result == 'success')
-      )
-    runs-on: ubuntu-24.04
-    timeout-minutes: ${{ inputs.timeout-minutes }}
-    permissions:
-      contents: read
-      security-events: write
-
-    steps:
-      - name: Checkout lgtm-ci tooling
-        # yamllint disable-line rule:line-length
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: |
-            .github/actions/checkout-and-harden
-          sparse-checkout-cone-mode: true
-          persist-credentials: false
-
-      - name: Checkout and harden
-        id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
-        with:
-          tooling-ref: ${{ inputs.tooling-ref }}
-          egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
-          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
-
-      - name: Run Trivy vulnerability scanner
-        # Pinned to SHA for supply chain security
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: >-
-            ${{ inputs.registry }}/${{ inputs.image-name || github.repository }}@${{
-            needs.build.outputs.digest || needs.merge.outputs.digest }}
-          format: "sarif"
-          output: "trivy-results.sarif"
-          severity: "CRITICAL,HIGH"
-          exit-code: ${{ inputs.scan-exit-code }}
-
-      - name: Upload Trivy scan results
-        # Pinned to SHA for supply chain security
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
-        with:
-          sarif_file: "trivy-results.sarif"
+    uses: ./.github/workflows/reusable-docker-multiplatform.yml
+    with:
+      matrix: ${{ needs.classify.outputs.matrix }}
+      context: ${{ inputs.context }}
+      file: ${{ inputs.file }}
+      platforms: ${{ inputs.platforms }}
+      registry: ${{ inputs.registry }}
+      image-name: ${{ inputs.image-name }}
+      tags: ${{ inputs.tags }}
+      version: ${{ inputs.version }}
+      source-ref: ${{ inputs.source-ref }}
+      tag-latest: ${{ inputs.tag-latest }}
+      exact-tags: ${{ inputs.exact-tags }}
+      push: ${{ inputs.push }}
+      provenance: ${{ inputs.provenance }}
+      sbom: ${{ inputs.sbom }}
+      scan: ${{ inputs.scan }}
+      build-args: ${{ inputs.build-args }}
+      target: ${{ inputs.target }}
+      smoke-test: ${{ inputs.smoke-test }}
+      smoke-test-script: ${{ inputs.smoke-test-script }}
+      health-check-cmd: ${{ inputs.health-check-cmd }}
+      health-check-port: ${{ inputs.health-check-port }}
+      health-check-timeout: ${{ inputs.health-check-timeout }}
+      validate-on-pr: ${{ inputs.validate-on-pr }}
+      scan-exit-code: ${{ inputs.scan-exit-code }}
+      cache-registry-ref: ${{ inputs.cache-registry-ref }}
+      cosign-sign: ${{ inputs.cosign-sign }}
+      no-cache: ${{ inputs.no-cache }}
+      tooling-ref: ${{ inputs.tooling-ref }}
+      egress-policy: ${{ inputs.egress-policy }}
+      allowed-endpoints: ${{ inputs.allowed-endpoints }}
+      allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+      egress-preset: ${{ inputs.egress-preset }}
+      timeout-minutes: ${{ inputs.timeout-minutes }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/docs/actions/README.md
+++ b/docs/actions/README.md
@@ -54,6 +54,7 @@ want a drop-in job without wiring these composites by hand.
 | `wait-for-package` | [publishing](publishing.md#wait-for-package) | Package availability polling |
 | `build-docker` | [publishing](publishing.md#build-docker) | Docker image building |
 | `docker-login` | [publishing](publishing.md#docker-login) | GHCR/Docker Hub login |
+| `docker-auth` | [publishing](publishing.md#docker-auth) | Registry validate + login for the docker workflow family |
 | `deploy-pages` | [publishing](publishing.md#deploy-pages) | GitHub Pages deployment (OIDC) |
 | `bundle-workflow-artifacts` | [publishing](publishing.md#bundle-workflow-artifacts) | Bundle report artifacts before Pages deploy |
 | `calculate-version` | [release](release.md#calculate-version) | Semantic version calculation |

--- a/docs/actions/publishing.md
+++ b/docs/actions/publishing.md
@@ -157,6 +157,26 @@ Login to GHCR or Docker Hub based on the `registry` input.
 
 Used internally by `build-docker` and `reusable-docker.yml`.
 
+## docker-auth
+
+Validate the target registry, then log in to GHCR or Docker Hub (#381).
+Replaces the validate + login step sequence previously duplicated across
+the reusable-docker workflow family. Designed for the cross-repo
+`.lgtm-ci-tooling` checkout: add `.github/actions/docker-auth` to
+`sparse-checkout-extra` on `checkout-and-harden`, then:
+
+```yaml
+- name: Docker registry auth
+  uses: ./.lgtm-ci-tooling/.github/actions/docker-auth
+  with:
+    registry: ghcr.io # or docker.io
+    dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }} # docker.io only
+    dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }} # docker.io only
+```
+
+Fails fast on unsupported registries or missing Docker Hub credentials.
+GHCR login uses `github.actor` + `github.token` (no extra secrets).
+
 ## deploy-pages
 
 Prepare and upload content for GitHub Pages deployment using OIDC.

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -77,9 +77,45 @@ pin OS reproducibility (for example `ubuntu-24.04`). Defaults are
 Multi-arch Docker builds use `runner-map` instead of `runner-image`. Pass a JSON
 object mapping platform to runner label (for example
 `{"linux/arm64":"ubuntu-24.04-arm"}`). Platforms not in the map default to
-`ubuntu-24.04` with QEMU. Orchestration jobs inside `reusable-docker.yml`
-(`classify`, `merge`, summaries) stay on fixed `ubuntu-24.04` coordinators and
-are not caller-pinnable.
+`ubuntu-24.04` with QEMU. Coordinator jobs inside the Docker workflow family
+(`classify`, `merge`, summaries, scan) stay on fixed `ubuntu-24.04`
+coordinators and are not caller-pinnable.
+
+#### Docker workflow family and migration path
+
+Since #381 `reusable-docker.yml` is a thin orchestrator: its `classify` job
+resolves the build strategy from `platforms`/`push`/`validate-on-pr` and
+`runner-map`, then delegates to the focused reusables. Existing callers keep
+working unchanged.
+
+<!-- markdownlint-disable MD013 -->
+
+| Workflow                            | Responsibility                                                         | `runner-map`?                      |
+| ----------------------------------- | ---------------------------------------------------------------------- | ---------------------------------- |
+| `reusable-docker.yml`               | Orchestrator: classify + delegate (backwards-compatible entry point)   | Yes (resolved by `classify`)       |
+| `reusable-docker-build.yml`         | Single-platform or QEMU multi-platform build + scan (non-split path)   | No (fixed `ubuntu-24.04` + QEMU)   |
+| `reusable-docker-multiplatform.yml` | Per-platform matrix build + smoke/health gates + manifest merge + sign | No (takes classify `matrix` input) |
+| `reusable-docker-smoke-test.yml`    | Standalone validation of a published image by immutable digest         | No (`runner-image` input)          |
+
+<!-- markdownlint-enable MD013 -->
+
+Migration: callers that only ever hit one path can pin the focused reusable
+directly and skip the classify hop — single-platform (or QEMU) consumers call
+`reusable-docker-build.yml`; multi-arch consumers that already know their
+platform split call `reusable-docker-multiplatform.yml` and pass the matrix
+JSON themselves (an array of
+`{"platform": ..., "slug": ..., "runner": ..., "qemu": ...}` entries, the
+same shape `classify` emits). Post-publish image validation is available
+standalone via `reusable-docker-smoke-test.yml`. The staging-tag scheme
+(`build-<run_id>-<slug>` children of the release index) is part of the
+contract and must not change; the GHCR staging pruner depends on it.
+
+Nested job names: when called through the orchestrator, GitHub prefixes check
+names with the delegating job (for example
+`<caller-job> / Docker build / Build and Push` or
+`<caller-job> / Docker multi-platform / Merge Manifests`). Update branch
+protection / merge-queue required checks accordingly when upgrading across
+the #381 split.
 
 #### Runner pinning exceptions
 

--- a/docs/workflows/deployment.md
+++ b/docs/workflows/deployment.md
@@ -7,12 +7,19 @@ maintenance. Full inputs/outputs/examples:
 ## Docker
 
 `reusable-docker.yml` builds and pushes multi-platform images with
-provenance/SBOM attestations and optional Trivy scanning. Callers only pin
-the workflow — no vendored `scripts/ci` tree required; `docker-login` and
-tag-metadata logic are inlined in the workflow. Supports native
-per-platform split builds (`runner-map`) with an optional per-platform
-smoke-test or detached-container health check gating the final manifest
-merge. See [Docker workflow inputs](../reusable-workflows.md#docker-workflow-inputs)
+provenance/SBOM attestations and optional Trivy scanning. Since #381 it is
+a thin orchestrator: a `classify` job resolves the strategy and delegates
+to `reusable-docker-build.yml` (single-platform / QEMU path) or
+`reusable-docker-multiplatform.yml` (runner-map matrix + manifest merge +
+signing); `reusable-docker-smoke-test.yml` validates an already published
+image by digest. Existing callers keep working unchanged — see the
+[migration path](../workflow-contract.md#docker-workflow-family-and-migration-path).
+Callers only pin the workflow — no vendored `scripts/ci` tree required;
+registry logins use the shared `docker-auth` composite resolved from the
+lgtm-ci tooling checkout. Supports native per-platform split builds
+(`runner-map`) with an optional per-platform smoke-test or
+detached-container health check gating the final manifest merge. See
+[Docker workflow inputs](../reusable-workflows.md#docker-workflow-inputs)
 for caller examples (push, PR validation, health checks).
 
 ```yaml
@@ -50,7 +57,8 @@ Docker Hub pushes additionally need `DOCKERHUB_USERNAME` /
 `DOCKERHUB_TOKEN` secrets. Caller repos that previously vendored
 `scripts/ci/actions/build-docker.sh`, `scripts/ci/lib/**`, or
 `docker-login`/`docker-metadata` composites can delete those copies — the
-workflow resolves all tooling from the lgtm-ci checkout.
+workflows resolve all tooling (scripts and the `docker-auth` composite)
+from the lgtm-ci checkout.
 
 ## GitHub Pages
 

--- a/scripts/ci/quality/validate-runner-contract.sh
+++ b/scripts/ci/quality/validate-runner-contract.sh
@@ -39,14 +39,26 @@ RUNNER_PINNING_EXCEPTIONS = {
 # timeout-minutes input requirement. Currently every reusable exposes it.
 TIMEOUT_MINUTES_EXCEPTIONS: set[str] = set()
 
-DOCKER_FILE = "reusable-docker.yml"
-DOCKER_INTERNAL_JOBS = {
-    "classify",
-    "build",
-    "merge",
-    "summary-validate",
-    "scan",
+# Docker family (#381): reusable-docker.yml is the thin orchestrator
+# (classify + nested workflow calls); the focused reusables own the
+# build/merge jobs. Internal coordinator jobs are pinned to ubuntu-24.04
+# and are not caller-pinnable; per-platform matrix jobs use the
+# runner-map-resolved ${{ matrix.runner }} expression.
+DOCKER_FAMILY: dict[str, set[str]] = {
+    "reusable-docker.yml": {"classify"},
+    "reusable-docker-build.yml": {"build", "scan"},
+    "reusable-docker-multiplatform.yml": {
+        "build-per-platform",
+        "verify-per-platform",
+        "health-check-per-platform",
+        "merge",
+        "summary-validate",
+        "scan",
+    },
 }
+# Only the orchestrator exposes runner-map; the multiplatform reusable
+# receives the already-resolved matrix from the classify job.
+DOCKER_RUNNER_MAP_FILES = {"reusable-docker.yml"}
 DOCKER_MATRIX_RUNS_ON = {"${{ matrix.runner }}"}
 RUNNER_IMAGE_RUNS_ON = "${{ inputs.runner-image }}"
 
@@ -135,13 +147,13 @@ for workflow in sorted(workflows_dir.glob("reusable-*.yml")):
                     f"{rel}: timeout-minutes input is never applied to a job",
                 )
 
-    if rel == DOCKER_FILE:
-        if not has_runner_map_input(content):
+    if rel in DOCKER_FAMILY:
+        if rel in DOCKER_RUNNER_MAP_FILES and not has_runner_map_input(content):
             violations.append(f"{rel}: missing runner-map input")
         for job_id, runs_on in jobs.items():
             if runs_on in DOCKER_MATRIX_RUNS_ON:
                 continue
-            if job_id in DOCKER_INTERNAL_JOBS:
+            if job_id in DOCKER_FAMILY[rel]:
                 if runs_on != "ubuntu-24.04":
                     violations.append(
                         f"{rel}: job {job_id} must use ubuntu-24.04 coordinator runner "

--- a/tests/bats/integration/test_reusable_docker_build_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_build_workflow.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-docker-build.yml (single-platform /
+#          QEMU build path split out of reusable-docker.yml, #381)
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker-build.yml"
+
+@test "reusable-docker-build: build job passes target input to build-push-action" {
+	run grep -cE '^[[:space:]]+target: \$\{\{ inputs\.target \}\}$' "$WORKFLOW"
+	assert_success
+	assert_output "1"
+}
+
+@test "reusable-docker-build: build job gates sbom and provenance on push" {
+	run grep -E '^[[:space:]]+provenance: \$\{\{ inputs\.provenance && inputs\.push' "$WORKFLOW"
+	assert_success
+
+	run grep -E '^[[:space:]]+sbom: \$\{\{ inputs\.sbom && inputs\.push' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-build: build job does not pass raw sbom or provenance inputs" {
+	run grep -E '^[[:space:]]+(provenance|sbom): \$\{\{ inputs\.(provenance|sbom) \}\}$' "$WORKFLOW"
+	assert_failure
+}
+
+@test "reusable-docker-build: build job defers push when health-check-cmd is set" {
+	run grep -E 'push: \$\{\{ inputs\.push && inputs\.health-check-cmd ==' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-build: build job publishes only after health check when enabled" {
+	run grep -F 'Push image after health check' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-build: deferred push path generates SBOM attestation" {
+	run grep -F 'Generate SBOM attestation' "$WORKFLOW"
+	assert_success
+	run grep -F 'uses: actions/attest@' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-build: scan job gates on build success, scan and push" {
+	run awk '
+		/^  scan:/ { in_job = 1 }
+		in_job && /inputs\.scan &&/ { saw_scan = 1 }
+		in_job && /inputs\.push &&/ { saw_push = 1 }
+		in_job && /needs\.build\.result == .success./ { saw_result = 1 }
+		END { exit !(saw_scan && saw_push && saw_result) }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-build: scan job scans the built digest" {
+	run grep -F 'needs.build.outputs.digest }}' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-build: registry auth uses the docker-auth composite gated on push" {
+	run awk '
+		/name: Docker registry auth/ { in_step = 1 }
+		in_step && /if: inputs\.push/ { has_if = 1 }
+		in_step && /uses: \.\/\.lgtm-ci-tooling\/\.github\/actions\/docker-auth/ { has_uses = 1 }
+		in_step && /^      - name:/ && !/Docker registry auth/ { in_step = 0 }
+		END { exit !(has_if && has_uses) }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-build: tooling sparse checkout includes docker-auth composite" {
+	run grep -E '^[[:space:]]+\.github/actions/docker-auth$' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_docker_build_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_build_workflow.bats
@@ -64,11 +64,12 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker-build.yml"
 		/^  scan:/ { in_job = 1 }
 		in_job && /^  [a-z]/ { if (!/^  scan:/) in_job = 0 }
 		in_job && /sparse-checkout-extra:/ { saw_extra = 1 }
+		in_job && /scripts\/ci\// { saw_scripts = 1 }
 		in_job && /\.github\/actions\/docker-auth/ { saw_sparse = 1 }
 		in_job && /name: Docker registry auth/ { saw_auth = 1 }
 		in_job && /uses: \.\/\.lgtm-ci-tooling\/\.github\/actions\/docker-auth/ { saw_uses = 1 }
 		in_job && /packages: read/ { saw_packages = 1 }
-		END { exit !(saw_extra && saw_sparse && saw_auth && saw_uses && saw_packages) }
+		END { exit !(saw_extra && saw_scripts && saw_sparse && saw_auth && saw_uses && saw_packages) }
 	' "$WORKFLOW"
 	assert_success
 }

--- a/tests/bats/integration/test_reusable_docker_build_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_build_workflow.bats
@@ -59,6 +59,20 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker-build.yml"
 	assert_success
 }
 
+@test "reusable-docker-build: scan job authenticates before Trivy pull" {
+	run awk '
+		/^  scan:/ { in_job = 1 }
+		in_job && /^  [a-z]/ { if (!/^  scan:/) in_job = 0 }
+		in_job && /sparse-checkout-extra:/ { saw_extra = 1 }
+		in_job && /\.github\/actions\/docker-auth/ { saw_sparse = 1 }
+		in_job && /name: Docker registry auth/ { saw_auth = 1 }
+		in_job && /uses: \.\/\.lgtm-ci-tooling\/\.github\/actions\/docker-auth/ { saw_uses = 1 }
+		in_job && /packages: read/ { saw_packages = 1 }
+		END { exit !(saw_extra && saw_sparse && saw_auth && saw_uses && saw_packages) }
+	' "$WORKFLOW"
+	assert_success
+}
+
 @test "reusable-docker-build: registry auth uses the docker-auth composite gated on push" {
 	run awk '
 		/name: Docker registry auth/ { in_step = 1 }

--- a/tests/bats/integration/test_reusable_docker_multiplatform_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_multiplatform_workflow.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-docker-multiplatform.yml (runner-map
+#          matrix + manifest merge + signing path split out of
+#          reusable-docker.yml, #381)
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker-multiplatform.yml"
+
+@test "reusable-docker-multiplatform: requires the classify matrix input" {
+	run awk '
+		/^      matrix:$/ { in_input = 1 }
+		in_input && /^        required: true$/ { found = 1; exit }
+		in_input && /^      [a-z-]+:$/ && !/^      matrix:$/ { in_input = 0 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-multiplatform: per-platform jobs use static display names" {
+	run grep -F 'name: Docker build per platform' "$WORKFLOW"
+	assert_success
+	run grep -F 'name: Docker verify per platform' "$WORKFLOW"
+	assert_success
+	run grep -F 'name: Docker health check per platform' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-multiplatform: preserves the build-<run_id>-<slug> staging tag scheme" {
+	# The per-platform staging tags are the merged index's child manifests and
+	# a separate pruner depends on this exact naming — do not change it.
+	# yamllint disable-line rule:line-length
+	run grep -F "format('{0}/{1}:build-{2}-{3}', inputs.registry, inputs.image-name || github.repository, github.run_id, matrix.slug)" "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-multiplatform: build-per-platform passes target input to build-push-action" {
+	run grep -cE '^[[:space:]]+target: \$\{\{ inputs\.target \}\}$' "$WORKFLOW"
+	assert_success
+	assert_output "1"
+}
+
+@test "reusable-docker-multiplatform: build-per-platform job gates sbom on push" {
+	run awk '
+		/provenance: false/ { in_split = 1 }
+		in_split && /sbom: \$\{\{ inputs\.sbom && inputs\.push \}\}/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-multiplatform: per-platform build avoids push and load together" {
+	run awk '
+		/name: Build and push \(\$\{\{ matrix\.platform \}\}\)/ { in_step = 1 }
+		in_step && /push: \$\{\{ inputs\.push \}\}/ { saw_push = 1 }
+		in_step && /load:/ { saw_load = 1 }
+		in_step && saw_push && saw_load {
+			if ($0 ~ /inputs\.push == false && \(inputs\.health-check-cmd/) {
+				found = 1
+				exit
+			}
+		}
+		in_step && /^[[:space:]]+- name:/ && !/Build and push/ { in_step = 0 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-multiplatform: merge job gates on health-check-per-platform success" {
+	run grep -F 'needs.health-check-per-platform.result ==' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-multiplatform: health-check-per-platform waits for verify-per-platform" {
+	run awk '
+		/name: Docker health check per platform/ { in_job = 1 }
+		in_job && /needs: \[build-per-platform, verify-per-platform\]/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-multiplatform: merge-manifests runs a non-skippable verify-published gate" {
+	# The published index must be pulled back from the registry and verified;
+	# a dangling index (children 404) must fail the release, not publish green.
+	run grep -F 'STEP: verify-published' "$WORKFLOW"
+	assert_success
+	# Scope to the merge-manifests job: the verify step must live there (the
+	# multi-arch publish path) and carry no if: guard that could skip it.
+	run awk '
+		/^  merge:/ { in_job = 1 }
+		in_job && /^  [a-z].*:$/ && $0 !~ /^  merge:/ { in_job = 0 }
+		in_job && /name: Verify published manifest/ { in_step = 1; found = 1; next }
+		in_step && /^        if:/ { bad = 1; exit }
+		in_step && /^      - name:/ { in_step = 0 }
+		END { exit (bad || !found) }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-multiplatform: does not delete staging manifests (they are index children)" {
+	# Deleting the per-platform staging manifests orphans the merged index
+	# (children 404). The destructive cleanup-staging step must be gone.
+	run grep -F 'STEP: cleanup-staging' "$WORKFLOW"
+	assert_failure
+	run grep -F 'Delete staging manifests' "$WORKFLOW"
+	assert_failure
+}
+
+@test "reusable-docker-multiplatform: staging digest artifacts flow between jobs" {
+	run grep -cF 'name: staging-digest-${{ matrix.slug }}' "$WORKFLOW"
+	assert_success
+	# One upload (build-per-platform) + two downloads (verify, health-check).
+	assert_output "3"
+}
+
+@test "reusable-docker-multiplatform: scan job scans the merged digest" {
+	run grep -F 'needs.merge.outputs.digest }}' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-multiplatform: registry logins use the docker-auth composite" {
+	run grep -cF 'uses: ./.lgtm-ci-tooling/.github/actions/docker-auth' "$WORKFLOW"
+	assert_success
+	# build-per-platform, verify-per-platform, health-check-per-platform, merge.
+	assert_output "4"
+}

--- a/tests/bats/integration/test_reusable_docker_multiplatform_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_multiplatform_workflow.bats
@@ -120,9 +120,23 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker-multiplatform.yml"
 	assert_success
 }
 
+@test "reusable-docker-multiplatform: scan job authenticates before Trivy pull" {
+	run awk '
+		/^  scan:/ { in_job = 1 }
+		in_job && /^  [a-z]/ { if (!/^  scan:/) in_job = 0 }
+		in_job && /sparse-checkout-extra:/ { saw_extra = 1 }
+		in_job && /\.github\/actions\/docker-auth/ { saw_sparse = 1 }
+		in_job && /name: Docker registry auth/ { saw_auth = 1 }
+		in_job && /uses: \.\/\.lgtm-ci-tooling\/\.github\/actions\/docker-auth/ { saw_uses = 1 }
+		in_job && /packages: read/ { saw_packages = 1 }
+		END { exit !(saw_extra && saw_sparse && saw_auth && saw_uses && saw_packages) }
+	' "$WORKFLOW"
+	assert_success
+}
+
 @test "reusable-docker-multiplatform: registry logins use the docker-auth composite" {
 	run grep -cF 'uses: ./.lgtm-ci-tooling/.github/actions/docker-auth' "$WORKFLOW"
 	assert_success
-	# build-per-platform, verify-per-platform, health-check-per-platform, merge.
-	assert_output "4"
+	# build-per-platform, verify-per-platform, health-check-per-platform, merge, scan.
+	assert_output "5"
 }

--- a/tests/bats/integration/test_reusable_docker_multiplatform_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_multiplatform_workflow.bats
@@ -125,11 +125,12 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker-multiplatform.yml"
 		/^  scan:/ { in_job = 1 }
 		in_job && /^  [a-z]/ { if (!/^  scan:/) in_job = 0 }
 		in_job && /sparse-checkout-extra:/ { saw_extra = 1 }
+		in_job && /scripts\/ci\// { saw_scripts = 1 }
 		in_job && /\.github\/actions\/docker-auth/ { saw_sparse = 1 }
 		in_job && /name: Docker registry auth/ { saw_auth = 1 }
 		in_job && /uses: \.\/\.lgtm-ci-tooling\/\.github\/actions\/docker-auth/ { saw_uses = 1 }
 		in_job && /packages: read/ { saw_packages = 1 }
-		END { exit !(saw_extra && saw_sparse && saw_auth && saw_uses && saw_packages) }
+		END { exit !(saw_extra && saw_scripts && saw_sparse && saw_auth && saw_uses && saw_packages) }
 	' "$WORKFLOW"
 	assert_success
 }

--- a/tests/bats/integration/test_reusable_docker_smoke_test_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_smoke_test_workflow.bats
@@ -58,6 +58,17 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker-smoke-test.yml"
 	assert_failure
 }
 
+@test "reusable-docker-smoke-test: QEMU setup skips native linux/amd64" {
+	run awk '
+		/name: Setup QEMU/ { in_step = 1 }
+		in_step && /if: \$\{\{ inputs\.platform != .linux\/amd64. \}\}/ { has_if = 1 }
+		in_step && /uses: docker\/setup-qemu-action@/ { has_uses = 1 }
+		in_step && /^      - name:/ && !/Setup QEMU/ { in_step = 0 }
+		END { exit !(has_if && has_uses) }
+	' "$WORKFLOW"
+	assert_success
+}
+
 @test "reusable-docker-smoke-test: read-only permissions" {
 	run grep -E '^      packages: write$' "$WORKFLOW"
 	assert_failure

--- a/tests/bats/integration/test_reusable_docker_smoke_test_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_smoke_test_workflow.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-docker-smoke-test.yml (standalone image
+#          validation reusable, #381)
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker-smoke-test.yml"
+
+@test "reusable-docker-smoke-test: requires an immutable digest input" {
+	run awk '
+		/^      digest:$/ { in_input = 1 }
+		in_input && /^        required: true$/ { found = 1; exit }
+		in_input && /^      [a-z-]+:$/ && !/^      digest:$/ { in_input = 0 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-smoke-test: exposes smoke-test and health-check inputs" {
+	run grep -E '^      smoke-test:$' "$WORKFLOW"
+	assert_success
+	run grep -E '^      smoke-test-script:$' "$WORKFLOW"
+	assert_success
+	run grep -E '^      health-check-cmd:$' "$WORKFLOW"
+	assert_success
+	run grep -E '^      health-check-port:$' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-smoke-test: exposes runner-image with ubuntu-24.04 default" {
+	run grep -E '^      runner-image:$' "$WORKFLOW"
+	assert_success
+	run grep -F 'runs-on: ${{ inputs.runner-image }}' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-smoke-test: records the digest before validating" {
+	# The digest input is persisted via record-digest (which validates the
+	# sha256 format) and the validation steps pull by that immutable digest.
+	run grep -F 'STEP: record-digest' "$WORKFLOW"
+	assert_success
+	run grep -F 'DIGEST: ${{ inputs.digest }}' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-smoke-test: runs the shared smoke-test and health-check steps" {
+	run grep -F 'STEP: smoke-test' "$WORKFLOW"
+	assert_success
+	run grep -F 'STEP: health-check' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker-smoke-test: registry login uses the docker-auth composite" {
+	run grep -F 'uses: ./.lgtm-ci-tooling/.github/actions/docker-auth' "$WORKFLOW"
+	assert_success
+	run grep -F 'uses: docker/login-action@' "$WORKFLOW"
+	assert_failure
+}
+
+@test "reusable-docker-smoke-test: read-only permissions" {
+	run grep -E '^      packages: write$' "$WORKFLOW"
+	assert_failure
+	run grep -E '^      packages: read$' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/integration/test_reusable_docker_workflow.bats
+++ b/tests/bats/integration/test_reusable_docker_workflow.bats
@@ -1,246 +1,248 @@
 #!/usr/bin/env bats
 # SPDX-License-Identifier: MIT
-# Purpose: Contract tests for reusable-docker workflow attestation gating
+# Purpose: Contract tests for the reusable-docker orchestrator and family-wide
+#          invariants shared by the focused Docker reusables (#381).
 
 load "../../helpers/common"
 
 WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
+BUILD_WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker-build.yml"
+MULTI_WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker-multiplatform.yml"
+SMOKE_WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-docker-smoke-test.yml"
 
-@test "reusable-docker: per-platform jobs use static display names" {
-	run grep -F 'name: Docker build per platform' "$WORKFLOW"
-	assert_success
-	run grep -F 'name: Docker verify per platform' "$WORKFLOW"
-	assert_success
+# Workflows that carry docker/metadata-action blocks after the split.
+_metadata_workflows() {
+	cat "$BUILD_WORKFLOW" "$MULTI_WORKFLOW"
 }
 
-@test "reusable-docker: build job passes target input to build-push-action" {
-	run grep -E '^[[:space:]]+target: \$\{\{ inputs\.target \}\}$' "$WORKFLOW"
-	assert_success
+# Every workflow in the docker family.
+_family_workflows() {
+	cat "$WORKFLOW" "$BUILD_WORKFLOW" "$MULTI_WORKFLOW" "$SMOKE_WORKFLOW"
 }
 
-@test "reusable-docker: build-per-platform job passes target input to build-push-action" {
-	run grep -cE '^[[:space:]]+target: \$\{\{ inputs\.target \}\}$' "$WORKFLOW"
-	assert_success
-	assert_output "2"
-}
-
-@test "reusable-docker: exposes target workflow input" {
-	run grep -E '^[[:space:]]+target:$' "$WORKFLOW"
-	assert_success
-}
-
-@test "reusable-docker: build job gates sbom and provenance on push" {
-	run grep -E '^[[:space:]]+provenance: \$\{\{ inputs\.provenance && inputs\.push' "$WORKFLOW"
-	assert_success
-
-	run grep -E '^[[:space:]]+sbom: \$\{\{ inputs\.sbom && inputs\.push' "$WORKFLOW"
-	assert_success
-}
-
-@test "reusable-docker: build-per-platform job gates sbom on push" {
+@test "reusable-docker: orchestrator delegates use-split=false to reusable-docker-build" {
 	run awk '
-		/provenance: false/ { in_split = 1 }
-		in_split && /sbom: \$\{\{ inputs\.sbom && inputs\.push \}\}/ { found = 1; exit }
-		END { exit !found }
+		/^  build:/ { in_job = 1 }
+		in_job && /if: \$\{\{ needs\.classify\.outputs\.use-split == .false. \}\}/ { has_if = 1 }
+		in_job && /uses: \.\/\.github\/workflows\/reusable-docker-build\.yml/ { has_uses = 1 }
+		/^  multiplatform:/ { in_job = 0 }
+		END { exit !(has_if && has_uses) }
 	' "$WORKFLOW"
 	assert_success
 }
 
-@test "reusable-docker: build job does not pass raw sbom or provenance inputs" {
-	run grep -E '^[[:space:]]+(provenance|sbom): \$\{\{ inputs\.(provenance|sbom) \}\}$' "$WORKFLOW"
+@test "reusable-docker: orchestrator delegates use-split=true to reusable-docker-multiplatform" {
+	run awk '
+		/^  multiplatform:/ { in_job = 1 }
+		in_job && /if: \$\{\{ needs\.classify\.outputs\.use-split == .true. \}\}/ { has_if = 1 }
+		in_job && /uses: \.\/\.github\/workflows\/reusable-docker-multiplatform\.yml/ { has_uses = 1 }
+		in_job && /matrix: \$\{\{ needs\.classify\.outputs\.matrix \}\}/ { has_matrix = 1 }
+		END { exit !(has_if && has_uses && has_matrix) }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker: orchestrator keeps classify job and runner-map input" {
+	run grep -E '^  classify:$' "$WORKFLOW"
+	assert_success
+	run grep -E '^      runner-map:$' "$WORKFLOW"
+	assert_success
+	run grep -F 'STEP: classify' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-docker: orchestrator holds no build or metadata steps of its own" {
+	# The orchestrator is thin: build/metadata/login steps live in the focused
+	# reusables, not here.
+	run grep -F 'uses: docker/metadata-action@' "$WORKFLOW"
+	assert_failure
+	run grep -F 'uses: docker/build-push-action@' "$WORKFLOW"
+	assert_failure
+	run grep -F 'uses: docker/login-action@' "$WORKFLOW"
 	assert_failure
 }
 
-@test "reusable-docker: exposes health-check workflow inputs" {
-	run grep -E '^[[:space:]]+health-check-cmd:$' "$WORKFLOW"
+@test "reusable-docker: orchestrator outputs come from build or multiplatform" {
+	run grep -F 'value: ${{ jobs.build.outputs.tags || jobs.multiplatform.outputs.tags }}' "$WORKFLOW"
 	assert_success
-	run grep -E '^[[:space:]]+health-check-port:$' "$WORKFLOW"
-	assert_success
-	run grep -E '^[[:space:]]+health-check-timeout:$' "$WORKFLOW"
+	run grep -F 'value: ${{ jobs.build.outputs.digest || jobs.multiplatform.outputs.digest }}' "$WORKFLOW"
 	assert_success
 }
 
-@test "reusable-docker: per-platform jobs use static health-check display name" {
-	run grep -F 'name: Docker health check per platform' "$WORKFLOW"
+@test "reusable-docker: orchestrator forwards backfill inputs to both nested calls" {
+	# exact-tags / tag-latest / source-ref must flow through to both focused
+	# reusables so backfill behavior is preserved on either path.
+	local entry count
+	for entry in \
+		'exact-tags: ${{ inputs.exact-tags }}' \
+		'tag-latest: ${{ inputs.tag-latest }}' \
+		'source-ref: ${{ inputs.source-ref }}'; do
+		count=$(grep -cF "$entry" "$WORKFLOW")
+		[ "$count" -eq 2 ]
+	done
+}
+
+@test "reusable-docker: orchestrator forwards secrets to both nested calls" {
+	local count
+	count=$(grep -cF 'DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}' "$WORKFLOW")
+	[ "$count" -eq 2 ]
+	count=$(grep -cF 'DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}' "$WORKFLOW")
+	[ "$count" -eq 2 ]
+}
+
+@test "reusable-docker family: exposes target workflow input" {
+	run grep -E '^      target:$' "$WORKFLOW"
+	assert_success
+	run grep -E '^      target:$' "$BUILD_WORKFLOW"
+	assert_success
+	run grep -E '^      target:$' "$MULTI_WORKFLOW"
 	assert_success
 }
 
-@test "reusable-docker: merge job gates on health-check-per-platform success" {
-	run grep -F 'needs.health-check-per-platform.result ==' "$WORKFLOW"
-	assert_success
+@test "reusable-docker family: exposes health-check workflow inputs" {
+	local wf
+	for wf in "$WORKFLOW" "$BUILD_WORKFLOW" "$MULTI_WORKFLOW" "$SMOKE_WORKFLOW"; do
+		run grep -E '^      health-check-cmd:$' "$wf"
+		assert_success
+		run grep -E '^      health-check-port:$' "$wf"
+		assert_success
+		run grep -E '^      health-check-timeout:$' "$wf"
+		assert_success
+	done
 }
 
-@test "reusable-docker: build job defers push when health-check-cmd is set" {
-	run grep -E 'push: \$\{\{ inputs\.push && inputs\.health-check-cmd ==' "$WORKFLOW"
-	assert_success
+@test "reusable-docker family: exposes source-ref and tag-latest inputs" {
+	local wf
+	for wf in "$WORKFLOW" "$BUILD_WORKFLOW" "$MULTI_WORKFLOW"; do
+		run grep -E '^      source-ref:$' "$wf"
+		assert_success
+		run grep -E '^      tag-latest:$' "$wf"
+		assert_success
+	done
 }
 
-@test "reusable-docker: per-platform build avoids push and load together" {
-	run awk '
-		/name: Build and push \(\$\{\{ matrix\.platform \}\}\)/ { in_step = 1 }
-		in_step && /push: \$\{\{ inputs\.push \}\}/ { saw_push = 1 }
-		in_step && /load:/ { saw_load = 1 }
-		in_step && saw_push && saw_load {
-			if ($0 ~ /inputs\.push == false && \(inputs\.health-check-cmd/) {
-				found = 1
-				exit
-			}
-		}
-		in_step && /^[[:space:]]+- name:/ && !/Build and push/ { in_step = 0 }
-		END { exit !found }
-	' "$WORKFLOW"
-	assert_success
+@test "reusable-docker family: exposes exact-tags backfill input" {
+	local wf
+	for wf in "$WORKFLOW" "$BUILD_WORKFLOW" "$MULTI_WORKFLOW"; do
+		run grep -E '^      exact-tags:$' "$wf"
+		assert_success
+	done
 }
 
-@test "reusable-docker: build job publishes only after health check when enabled" {
-	run grep -F 'Push image after health check' "$WORKFLOW"
-	assert_success
-}
-
-@test "reusable-docker: health-check-per-platform waits for verify-per-platform" {
-	run grep -F 'needs: [classify, build-per-platform, verify-per-platform]' "$WORKFLOW" | grep -c 'health-check-per-platform' || true
-	run awk '
-		/name: Docker health check per platform/ { in_job = 1 }
-		in_job && /needs: \[classify, build-per-platform, verify-per-platform\]/ { found = 1; exit }
-		END { exit !found }
-	' "$WORKFLOW"
-	assert_success
-}
-
-@test "reusable-docker: deferred push path generates SBOM attestation" {
-	run grep -F 'Generate SBOM attestation' "$WORKFLOW"
-	assert_success
-	run grep -F 'uses: actions/attest@' "$WORKFLOW"
-	assert_success
-}
-
-@test "reusable-docker: merge-manifests runs a non-skippable verify-published gate" {
-	# The published index must be pulled back from the registry and verified;
-	# a dangling index (children 404) must fail the release, not publish green.
-	run grep -F 'STEP: verify-published' "$WORKFLOW"
-	assert_success
-	# Scope to the merge-manifests job: the verify step must live there (the
-	# multi-arch publish path) and carry no if: guard that could skip it.
-	run awk '
-		/^  merge:/ { in_job = 1 }
-		in_job && /^  [a-z].*:$/ && $0 !~ /^  merge:/ { in_job = 0 }
-		in_job && /name: Verify published manifest/ { in_step = 1; found = 1; next }
-		in_step && /^        if:/ { bad = 1; exit }
-		in_step && /^      - name:/ { in_step = 0 }
-		END { exit (bad || !found) }
-	' "$WORKFLOW"
-	assert_success
-}
-
-@test "reusable-docker: does not delete staging manifests (they are index children)" {
-	# Deleting the per-platform staging manifests orphans the merged index
-	# (children 404). The destructive cleanup-staging step must be gone.
-	run grep -F 'STEP: cleanup-staging' "$WORKFLOW"
-	assert_failure
-	run grep -F 'Delete staging manifests' "$WORKFLOW"
-	assert_failure
-}
-
-@test "reusable-docker: exposes source-ref and tag-latest inputs" {
-	run grep -E '^      source-ref:$' "$WORKFLOW"
-	assert_success
-	run grep -E '^      tag-latest:$' "$WORKFLOW"
-	assert_success
-}
-
-@test "reusable-docker: app-source checkouts honor source-ref" {
+@test "reusable-docker family: app-source checkouts honor source-ref" {
 	# Every app-source 'Checkout repository' uses source-ref (build context);
-	# the count must match the number of app-source checkout steps.
-	local checkouts refs
-	checkouts=$(grep -cE '^      - name: Checkout repository' "$WORKFLOW")
-	refs=$(grep -cF "ref: \${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}" "$WORKFLOW")
-	[ "$checkouts" -eq "$refs" ]
-	[ "$refs" -ge 6 ]
+	# the count must match the number of app-source checkout steps, per file.
+	local wf checkouts refs total=0
+	for wf in "$WORKFLOW" "$BUILD_WORKFLOW" "$MULTI_WORKFLOW" "$SMOKE_WORKFLOW"; do
+		checkouts=$(grep -cE '^      - name: Checkout repository' "$wf" || true)
+		refs=$(grep -cF "ref: \${{ inputs.source-ref != '' && inputs.source-ref || github.sha }}" "$wf" || true)
+		[ "$checkouts" -eq "$refs" ]
+		total=$((total + refs))
+	done
+	[ "$total" -ge 6 ]
 }
 
-@test "reusable-docker: tooling checkout stays on tooling-ref, not source-ref" {
+@test "reusable-docker family: tooling checkout stays on tooling-ref, not source-ref" {
 	# The lgtm-ci tooling checkout must not be repointed by source-ref.
-	run awk '
-		/name: Checkout lgtm-ci tooling/ { in_tool = 1 }
-		in_tool && /inputs\.source-ref/ { bad = 1; exit }
-		in_tool && /^      - name:/ && !/Checkout lgtm-ci tooling/ { in_tool = 0 }
-		END { exit bad }
-	' "$WORKFLOW"
+	run bash -c '
+		cat "$0" "$1" "$2" "$3" | awk "
+			/name: Checkout lgtm-ci tooling/ { in_tool = 1 }
+			in_tool && /inputs\.source-ref/ { bad = 1; exit }
+			in_tool && /^      - name:/ && !/Checkout lgtm-ci tooling/ { in_tool = 0 }
+			END { exit bad }
+		"
+	' "$WORKFLOW" "$BUILD_WORKFLOW" "$MULTI_WORKFLOW" "$SMOKE_WORKFLOW"
 	assert_success
 }
 
-@test "reusable-docker: tag-latest gates the raw latest tag in every metadata block" {
+@test "reusable-docker family: tag-latest gates the raw latest tag in every metadata block" {
 	# Every metadata-action block that emits raw-latest must gate it on
 	# tag-latest — assert the gated count equals the raw-latest count so a
 	# block silently dropping the gate fails the test.
 	local raw gated
-	raw=$(grep -cF 'type=raw,value=latest' "$WORKFLOW")
-	gated=$(grep -cF "type=raw,value=latest,enable=\${{ inputs.version != '' && inputs.tag-latest && !inputs.exact-tags }}" "$WORKFLOW")
+	raw=$(_metadata_workflows | grep -cF 'type=raw,value=latest')
+	gated=$(_metadata_workflows | grep -cF "type=raw,value=latest,enable=\${{ inputs.version != '' && inputs.tag-latest && !inputs.exact-tags }}")
 	[ "$raw" -eq "$gated" ]
 	[ "$gated" -ge 2 ]
 	# No ungated raw-latest remains.
-	run grep -E "type=raw,value=latest,enable=\\\$\{\{ inputs.version != '' \}\}" "$WORKFLOW"
+	run bash -c "cat \"\$0\" \"\$1\" | grep -E \"type=raw,value=latest,enable=\\\\\\\$\\{\\{ inputs.version != '' \\}\\}\"" \
+		"$BUILD_WORKFLOW" "$MULTI_WORKFLOW"
 	assert_failure
 	# metadata-action's auto-latest is disabled in every block, so latest is
 	# controlled solely by the gated raw entry (backfills never move latest).
 	local metablocks flavor
-	metablocks=$(grep -c 'uses: docker/metadata-action@' "$WORKFLOW")
-	flavor=$(grep -c 'latest=false' "$WORKFLOW")
+	metablocks=$(_metadata_workflows | grep -c 'uses: docker/metadata-action@')
+	flavor=$(_metadata_workflows | grep -c 'latest=false')
 	[ "$flavor" -eq "$metablocks" ]
 }
 
-@test "reusable-docker: exposes exact-tags backfill input" {
-	run grep -E '^      exact-tags:$' "$WORKFLOW"
-	assert_success
-}
-
-@test "reusable-docker: exact-tags suppresses sha/branch/pr tags in every metadata block" {
+@test "reusable-docker family: exact-tags suppresses sha/branch/pr tags in every metadata block" {
 	# Backfill mode must drop the mutable ref/sha floating tags from every
 	# metadata-action block (build, build-per-platform, merge). Each entry must
 	# carry the exact-tags gate exactly once per block.
 	local blocks count entry
-	blocks=$(grep -c 'uses: docker/metadata-action@' "$WORKFLOW")
+	blocks=$(_metadata_workflows | grep -c 'uses: docker/metadata-action@')
 	[ "$blocks" -ge 3 ]
 	for entry in 'type=sha,prefix=sha-' 'type=ref,event=branch' 'type=ref,event=pr'; do
-		count=$(grep -cF "${entry},enable=\${{ !inputs.exact-tags }}" "$WORKFLOW")
+		count=$(_metadata_workflows | grep -cF "${entry},enable=\${{ !inputs.exact-tags }}")
 		[ "$count" -eq "$blocks" ]
 	done
 }
 
-@test "reusable-docker: exact-tags suppresses semver major and minor tags in every metadata block" {
+@test "reusable-docker family: exact-tags suppresses semver major and minor tags in every metadata block" {
 	local blocks major minor
-	blocks=$(grep -c 'uses: docker/metadata-action@' "$WORKFLOW")
-	major=$(grep -cF \
-		"type=semver,pattern={{major}},value=\${{ inputs.version }},enable=\${{ inputs.version != '' && !inputs.exact-tags }}" \
-		"$WORKFLOW")
-	minor=$(grep -cF \
-		"type=semver,pattern={{major}}.{{minor}},value=\${{ inputs.version }},enable=\${{ inputs.version != '' && !inputs.exact-tags }}" \
-		"$WORKFLOW")
+	blocks=$(_metadata_workflows | grep -c 'uses: docker/metadata-action@')
+	major=$(_metadata_workflows | grep -cF \
+		"type=semver,pattern={{major}},value=\${{ inputs.version }},enable=\${{ inputs.version != '' && !inputs.exact-tags }}")
+	minor=$(_metadata_workflows | grep -cF \
+		"type=semver,pattern={{major}}.{{minor}},value=\${{ inputs.version }},enable=\${{ inputs.version != '' && !inputs.exact-tags }}")
 	[ "$major" -eq "$blocks" ]
 	[ "$minor" -eq "$blocks" ]
 }
 
-@test "reusable-docker: exact-tags keeps the pinned version tag in every metadata block" {
+@test "reusable-docker family: exact-tags keeps the pinned version tag in every metadata block" {
 	# The version tag is the one tag a backfill must still publish; its enable
 	# gate stays on version presence only, never on exact-tags.
-	local blocks version
-	blocks=$(grep -c 'uses: docker/metadata-action@' "$WORKFLOW")
-	version=$(grep -cF \
-		"type=semver,pattern={{version}},value=\${{ inputs.version }},enable=\${{ inputs.version != '' }}" \
-		"$WORKFLOW")
+	local blocks version gated
+	blocks=$(_metadata_workflows | grep -c 'uses: docker/metadata-action@')
+	version=$(_metadata_workflows | grep -cF \
+		"type=semver,pattern={{version}},value=\${{ inputs.version }},enable=\${{ inputs.version != '' }}")
 	[ "$version" -eq "$blocks" ]
 	# The version entry must not gain an exact-tags gate.
-	run grep -F \
-		"type=semver,pattern={{version}},value=\${{ inputs.version }},enable=\${{ inputs.version != '' && !inputs.exact-tags }}" \
-		"$WORKFLOW"
-	assert_failure
+	gated=$(_metadata_workflows | grep -cF \
+		"type=semver,pattern={{version}},value=\${{ inputs.version }},enable=\${{ inputs.version != '' && !inputs.exact-tags }}" || true)
+	[ "$gated" -eq 0 ]
 }
 
-@test "reusable-docker: exact-tags ignores additional tags" {
+@test "reusable-docker family: does not delete staging manifests (they are index children)" {
+	# Deleting the per-platform staging manifests orphans the merged index
+	# (children 404). The destructive cleanup-staging step must be gone.
+	local hits
+	hits=$(_family_workflows | grep -cF 'STEP: cleanup-staging' || true)
+	[ "$hits" -eq 0 ]
+	hits=$(_family_workflows | grep -cF 'Delete staging manifests' || true)
+	[ "$hits" -eq 0 ]
+}
+
+@test "reusable-docker family: registry logins go through the docker-auth composite" {
+	# The focused reusables must use the shared docker-auth composite instead
+	# of duplicated inline validate+login step sequences.
+	local wf
+	for wf in "$BUILD_WORKFLOW" "$MULTI_WORKFLOW" "$SMOKE_WORKFLOW"; do
+		run grep -F 'uses: ./.lgtm-ci-tooling/.github/actions/docker-auth' "$wf"
+		assert_success
+		run grep -F 'uses: docker/login-action@' "$wf"
+		assert_failure
+	done
+}
+
+@test "reusable-docker family: exact-tags ignores additional tags" {
+	# Every Parse-additional-tags step (build job, merge job) must be gated on
+	# exact-tags and every metadata block must gate the extra-tags expansion.
 	local parse_steps gated_extra_tags extra_tag_blocks
-	extra_tag_blocks=$(grep -cF -- "- name: Parse additional tags" "$WORKFLOW")
-	parse_steps=$(grep -cF "if: inputs.tags != '' && !inputs.exact-tags" "$WORKFLOW")
-	gated_extra_tags=$(grep -cF "\${{ !inputs.exact-tags && steps.extra-tags.outputs.tags || '' }}" "$WORKFLOW")
+	extra_tag_blocks=$(_metadata_workflows | grep -cF -- "- name: Parse additional tags")
+	parse_steps=$(_metadata_workflows | grep -cF "if: inputs.tags != '' && !inputs.exact-tags")
+	gated_extra_tags=$(_metadata_workflows | grep -cF "\${{ !inputs.exact-tags && steps.extra-tags.outputs.tags || '' }}")
 	[ "$parse_steps" -eq "$extra_tag_blocks" ]
 	[ "$gated_extra_tags" -eq "$extra_tag_blocks" ]
 	[ "$extra_tag_blocks" -ge 2 ]

--- a/tests/bats/integration/test_reusable_runner_contract.bats
+++ b/tests/bats/integration/test_reusable_runner_contract.bats
@@ -192,6 +192,9 @@ YAML
 	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
 	mkdir -p "${workflows_dir}"
 	cp "${PROJECT_ROOT}/.github/workflows/reusable-docker.yml" "${workflows_dir}/"
+	cp "${PROJECT_ROOT}/.github/workflows/reusable-docker-build.yml" "${workflows_dir}/"
+	cp "${PROJECT_ROOT}/.github/workflows/reusable-docker-multiplatform.yml" "${workflows_dir}/"
+	cp "${PROJECT_ROOT}/.github/workflows/reusable-docker-smoke-test.yml" "${workflows_dir}/"
 
 	WORKFLOWS_DIR="${workflows_dir}" run "${VALIDATOR}"
 	assert_success

--- a/tests/bats/integration/test_reusable_static_job_names.bats
+++ b/tests/bats/integration/test_reusable_static_job_names.bats
@@ -111,7 +111,7 @@ YAML
 }
 
 @test "reusable-docker: per-platform jobs use static names" {
-	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-docker.yml"
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-docker-multiplatform.yml"
 	run grep -F 'name: Docker build per platform' "$workflow"
 	assert_success
 	run grep -F 'name: Docker verify per platform' "$workflow"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Splits the 1,336-line `reusable-docker.yml` into focused reusable workflows per #381. `reusable-docker.yml` stays as a thin backwards-compatible orchestrator: its `classify` job resolves the build strategy and delegates via nested workflow calls, so existing callers keep working unchanged.

New layout:

| Workflow | Responsibility |
| --- | --- |
| `reusable-docker.yml` | Thin orchestrator: `classify` + delegate (backwards-compatible entry point) |
| `reusable-docker-build.yml` | Single-platform or QEMU multi-platform build + scan (non-split path) |
| `reusable-docker-multiplatform.yml` | runner-map per-platform matrix, smoke/health gates, manifest merge, verify-published gate, provenance, Cosign signing |
| `reusable-docker-smoke-test.yml` | Standalone validation of a published image by immutable digest |

A new `.github/actions/docker-auth` composite replaces the registry validate + GHCR/Docker Hub login step sequence that was duplicated across five jobs.

Behavior preserved end to end:

- `exact-tags` backfill mode from #449, including the extra-tags suppression and every per-metadata-block gate (`sha`/`branch`/`pr`/`major`/`minor`/`latest` suppressed; pinned version tag kept)
- `tag-latest` gating and `source-ref` checkout for historical backfills
- The `build-<run_id>-<slug>` staging tag scheme (child manifests of the release index) is untouched — the GHCR staging pruner (#448) depends on it, and a contract test now locks the format
- Non-skippable `verify-published` gate; no staging-manifest deletion

Note: when called through the orchestrator, GitHub prefixes check names with the delegating job (e.g. `docker / Docker multi-platform / Merge Manifests`). Consumers with branch-protection/merge-queue required checks on the old names should update them when bumping their pin; documented in the migration notes.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] CI/CD improvement

## Changes Made

- Add `reusable-docker-build.yml`, `reusable-docker-multiplatform.yml`, `reusable-docker-smoke-test.yml`
- Rewrite `reusable-docker.yml` as a thin orchestrator (classify + nested `uses:` delegation, same inputs/outputs/secrets contract)
- Add `.github/actions/docker-auth` composite (registry validate + login, resolved via `GITHUB_ACTION_PATH` so it works under `.lgtm-ci-tooling`)
- Teach `validate-runner-contract.sh` the docker family coordinator jobs
- Rework docker BATS contracts: family-wide invariants in `test_reusable_docker_workflow.bats` plus new per-workflow suites for each focused reusable
- Document the family table, migration path, and matrix input shape in `docs/workflow-contract.md`; update `docs/workflows/deployment.md` and the actions docs for `docker-auth`

## Closes

- Closes #381

## Testing

- Full BATS suite: 2,780 pass / 1 fail — the failure is the pre-existing local-environment `run-rust-coverage-html: fails when cargo-llvm-cov is missing` (test pins `PATH=/usr/local/bin`; reproduces on files untouched by this PR)
- Docker family suites, runner-contract, static-job-names, sparse-checkout suites all green
- `actionlint` clean on all workflows

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None for callers of `reusable-docker.yml` (inputs, outputs, secrets, and tag behavior unchanged). Check names gain a nesting prefix — consumers with required checks pinned to the old job names must update them when bumping their workflow pin.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR splits the 1,336-line `reusable-docker.yml` into four focused components: a thin orchestrator, `reusable-docker-build.yml` (non-split path), `reusable-docker-multiplatform.yml` (runner-map matrix path), and `reusable-docker-smoke-test.yml` (standalone image validation), plus a new `.github/actions/docker-auth` composite that eliminates the registry-validate + login duplication that previously existed across five jobs.

- **Backwards compatibility preserved**: the orchestrator's `classify` job resolves the build strategy and delegates via nested `uses:` calls, so all existing callers keep working with the same inputs, outputs, and secrets contract; only check names gain a nesting prefix.
- **Previously flagged auth gaps addressed**: both scan jobs (in `reusable-docker-build.yml` and `reusable-docker-multiplatform.yml`) now sparse-checkout `docker-auth`, authenticate before Trivy pulls from the registry, and declare `packages: read`; the smoke-test QEMU install is now gated on `platform != linux/amd64`.
- **Contract coverage**: per-workflow BATS suites lock the staging-tag scheme (`build-<run_id>-<slug>`), the 5 docker-auth call sites in the multiplatform workflow, the non-skippable `verify-published` gate, and the `DOCKER_FAMILY` runner-contract exemptions.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a structural refactor with no behavioral changes; all previously identified auth and QEMU gaps are resolved in the current head SHA.

The orchestrator correctly forwards every input, output, and secret to both nested workflow calls. All registry auth sites in scan jobs are present and correctly structured with the docker-auth composite. The QEMU guard in the smoke-test workflow matches the pattern used in the multiplatform workflow. The runner-contract validator and BATS suite cover the new structure comprehensively, and the PR author reports 2,780/2,781 BATS tests passing with the single failure being a pre-existing unrelated test.

No files require special attention — the three new workflow files and the docker-auth composite are all well-structured and consistent with each other.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-docker.yml | Rewritten as a thin orchestrator: classify job + two nested workflow calls; backwards-compatible inputs/outputs/secrets contract preserved |
| .github/workflows/reusable-docker-build.yml | New focused reusable for the non-split path; scan job correctly authenticates via docker-auth composite and requests packages:read before Trivy pull |
| .github/workflows/reusable-docker-multiplatform.yml | New focused reusable for the split path; all five auth sites (build-per-platform, verify, health-check, merge, scan) correctly use docker-auth composite |
| .github/workflows/reusable-docker-smoke-test.yml | Standalone smoke-test reusable; QEMU install now gated on platform != linux/amd64; always authenticates before pulling image by digest |
| .github/actions/docker-auth/action.yml | New composite action consolidating registry validate + login; uses GITHUB_ACTION_PATH-relative script resolution to work both in-repo and cross-repo |
| scripts/ci/quality/validate-runner-contract.sh | DOCKER_FAMILY dict updated to include all three focused docker reusables; smoke-test correctly omitted (uses runner-image input path) |
| tests/bats/integration/test_reusable_docker_multiplatform_workflow.bats | New per-workflow suite; asserts 5 docker-auth uses, staging digest artifact count (3), scan auth, and verify-published gate is non-skippable |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Caller["Caller workflow\n(any consumer repo)"]
    Orch["reusable-docker.yml\n(thin orchestrator)"]
    Classify["classify job\n(resolves use-split + matrix)"]
    Build["reusable-docker-build.yml\nuse-split=false path"]
    BuildJob["build job\n(single-platform / QEMU)"]
    ScanBuild["scan job\n(Trivy on pushed digest)"]
    Multi["reusable-docker-multiplatform.yml\nuse-split=true path"]
    BPP["build-per-platform\n(matrix x native runner)"]
    VPP["verify-per-platform\n(smoke-test gate)"]
    HCP["health-check-per-platform\n(detached-container gate)"]
    Merge["merge job\n(manifest merge + verify-published)"]
    ScanMulti["scan job\n(Trivy on merged digest)"]
    SumVal["summary-validate\n(PR validation summary)"]
    Smoke["reusable-docker-smoke-test.yml\n(standalone, not called from orchestrator)"]
    Auth[".github/actions/docker-auth\n(composite: validate + login)"]

    Caller -->|"workflow_call"| Orch
    Orch --> Classify
    Classify -->|"use-split=false"| Build
    Classify -->|"use-split=true"| Multi

    Build --> BuildJob
    Build --> ScanBuild
    BuildJob -.->|"if push"| Auth
    ScanBuild -.->|"always"| Auth

    Multi --> BPP
    BPP -->|"if push && smoke-test"| VPP
    VPP -->|"if push && health-check-cmd"| HCP
    HCP --> Merge
    VPP --> Merge
    Merge --> ScanMulti
    BPP -->|"if validate-on-pr"| SumVal

    BPP -.->|"if push"| Auth
    VPP -.->|"if push"| Auth
    HCP -.->|"if push"| Auth
    Merge -.->|"always"| Auth
    ScanMulti -.->|"always"| Auth

    Caller -->|"direct call (optional)"| Smoke
    Smoke -.->|"always"| Auth

    style Auth fill:#f9f,stroke:#333
    style Orch fill:#bbf,stroke:#333
    style Smoke fill:#bfb,stroke:#333
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    Caller["Caller workflow\n(any consumer repo)"]
    Orch["reusable-docker.yml\n(thin orchestrator)"]
    Classify["classify job\n(resolves use-split + matrix)"]
    Build["reusable-docker-build.yml\nuse-split=false path"]
    BuildJob["build job\n(single-platform / QEMU)"]
    ScanBuild["scan job\n(Trivy on pushed digest)"]
    Multi["reusable-docker-multiplatform.yml\nuse-split=true path"]
    BPP["build-per-platform\n(matrix x native runner)"]
    VPP["verify-per-platform\n(smoke-test gate)"]
    HCP["health-check-per-platform\n(detached-container gate)"]
    Merge["merge job\n(manifest merge + verify-published)"]
    ScanMulti["scan job\n(Trivy on merged digest)"]
    SumVal["summary-validate\n(PR validation summary)"]
    Smoke["reusable-docker-smoke-test.yml\n(standalone, not called from orchestrator)"]
    Auth[".github/actions/docker-auth\n(composite: validate + login)"]

    Caller -->|"workflow_call"| Orch
    Orch --> Classify
    Classify -->|"use-split=false"| Build
    Classify -->|"use-split=true"| Multi

    Build --> BuildJob
    Build --> ScanBuild
    BuildJob -.->|"if push"| Auth
    ScanBuild -.->|"always"| Auth

    Multi --> BPP
    BPP -->|"if push && smoke-test"| VPP
    VPP -->|"if push && health-check-cmd"| HCP
    HCP --> Merge
    VPP --> Merge
    Merge --> ScanMulti
    BPP -->|"if validate-on-pr"| SumVal

    BPP -.->|"if push"| Auth
    VPP -.->|"if push"| Auth
    HCP -.->|"if push"| Auth
    Merge -.->|"always"| Auth
    ScanMulti -.->|"always"| Auth

    Caller -->|"direct call (optional)"| Smoke
    Smoke -.->|"always"| Auth

    style Auth fill:#f9f,stroke:#333
    style Orch fill:#bbf,stroke:#333
    style Smoke fill:#bfb,stroke:#333
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["merge: integrate main into docker workfl..."](https://github.com/lgtm-hq/lgtm-ci/commit/77068be5e944afaf43a31dc233d79443b2fb2053) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43005287)</sub>

<!-- /greptile_comment -->