### PR TITLE
feat(ci): align reusable npm publish with OIDC trusted publishing + Node 24

### DIFF
--- a/.github/actions/harden-runner/lib/egress/presets.sh
+++ b/.github/actions/harden-runner/lib/egress/presets.sh
@@ -113,11 +113,13 @@ egress_preset_endpoints() {
 		;;
 	npm-publish)
 		# npm publish + Sigstore attestation (reusable-publish-npm.yml).
-		# oauth2.sigstore.dev is required for OIDC trusted publishing.
+		# oauth2.sigstore.dev + token.actions.githubusercontent.com are required
+		# for OIDC trusted publishing / provenance token exchange.
 		printf '%s\n' \
 			github.com:443 \
 			api.github.com:443 \
 			actions.githubusercontent.com:443 \
+			token.actions.githubusercontent.com:443 \
 			codeload.github.com:443 \
 			objects.githubusercontent.com:443 \
 			raw.githubusercontent.com:443 \

--- a/.github/actions/harden-runner/lib/egress/presets.sh
+++ b/.github/actions/harden-runner/lib/egress/presets.sh
@@ -113,6 +113,7 @@ egress_preset_endpoints() {
 		;;
 	npm-publish)
 		# npm publish + Sigstore attestation (reusable-publish-npm.yml).
+		# oauth2.sigstore.dev is required for OIDC trusted publishing.
 		printf '%s\n' \
 			github.com:443 \
 			api.github.com:443 \
@@ -123,7 +124,8 @@ egress_preset_endpoints() {
 			registry.npmjs.org:443 \
 			fulcio.sigstore.dev:443 \
 			rekor.sigstore.dev:443 \
-			tuf-repo-cdn.sigstore.dev:443
+			tuf-repo-cdn.sigstore.dev:443 \
+			oauth2.sigstore.dev:443
 		;;
 	quality)
 		# Docker-based lintro chk (py-lintro docker-ci dogfooding lint; py-lintro#939).

--- a/.github/actions/publish-npm/action.yml
+++ b/.github/actions/publish-npm/action.yml
@@ -2,7 +2,9 @@
 # For license details, see the repository root LICENSE file.
 ---
 name: "Publish to npm"
-description: "Build and publish Node.js package to npm with provenance"
+description: >-
+  Build and publish Node.js package to npm via OIDC trusted publishing
+  (optional legacy NODE_AUTH_TOKEN)
 author: "lgtm-hq"
 
 inputs:
@@ -11,7 +13,9 @@ inputs:
     required: false
     default: "latest"
   provenance:
-    description: "Enable npm provenance attestation (requires id-token: write)"
+    description: >-
+      Pass --provenance on publish (explicit intent). Under OIDC trusted
+      publishing provenance is also automatic; keep true unless dry-run.
     required: false
     default: "true"
   access:
@@ -26,6 +30,13 @@ inputs:
     description: "Working directory containing the package"
     required: false
     default: "."
+  npm-token:
+    description: >-
+      Optional legacy npm token (NODE_AUTH_TOKEN). Omit for OIDC trusted
+      publishing. Prefer trusted publishing with Node 24+; never run
+      `npm install -g npm` to self-upgrade.
+    required: false
+    default: ""
 
 outputs:
   published:
@@ -76,6 +87,7 @@ runs:
         DIST_TAG: ${{ inputs.dist-tag }}
         PROVENANCE: ${{ inputs.provenance }}
         ACCESS: ${{ inputs.access }}
+        NODE_AUTH_TOKEN: ${{ inputs.npm-token }}
       run: $SCRIPTS_DIR/ci/actions/publish-npm.sh
 
     - name: Generate summary

--- a/.github/workflows/reusable-publish-npm.yml
+++ b/.github/workflows/reusable-publish-npm.yml
@@ -6,18 +6,21 @@ on:
     inputs:
       node-version:
         description: >-
-          Deprecated no-op: publishing uses the runner's Node runtime. Kept
-          only so existing callers passing it do not break; ignored.
+          Node.js version for publish (default 24). Trusted publishing needs
+          npm ≥ 11.5.1; Node 24 ships a compatible npm. Do not self-upgrade
+          npm with `npm install -g npm`.
         required: false
         type: string
-        default: "22"
+        default: "24"
       dist-tag:
         description: "npm dist-tag (latest, beta, next, etc.)"
         required: false
         type: string
         default: "latest"
       provenance:
-        description: "Enable npm provenance attestation"
+        description: >-
+          Pass --provenance on publish (explicit intent). Under OIDC trusted
+          publishing provenance is also automatic.
         required: false
         type: boolean
         default: true
@@ -79,6 +82,13 @@ on:
         required: false
         type: number
         default: 15
+
+    secrets:
+      npm-token:
+        description: >-
+          Optional legacy npm token (NODE_AUTH_TOKEN). Omit for OIDC trusted
+          publishing (preferred).
+        required: false
 
     outputs:
       published:
@@ -142,6 +152,15 @@ jobs:
             .github/actions/
             scripts/ci/
 
+      - name: Set up Node.js
+        # Node 24 ships npm ≥ 11.5.1 (required for OIDC trusted publishing).
+        # Do not run `npm install -g npm`: in-place self-upgrade corrupts the
+        # toolcache and breaks `npm publish --provenance` (missing sigstore).
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ inputs.node-version }}
+          registry-url: https://registry.npmjs.org
+
       - name: Publish to npm
         id: npm
         uses: ./.lgtm-ci-tooling/.github/actions/publish-npm
@@ -151,6 +170,7 @@ jobs:
           access: ${{ inputs.access }}
           dry-run: ${{ inputs.dry-run }}
           working-directory: ${{ inputs.working-directory }}
+          npm-token: ${{ secrets.npm-token }}
 
       - name: Attest build provenance
         if: inputs.dry-run == false && inputs.provenance

--- a/docs/actions/publishing.md
+++ b/docs/actions/publishing.md
@@ -48,20 +48,27 @@ lgtm-ci composites.
 
 ## publish-npm
 
-Build and publish Node.js packages to npm with provenance attestation.
+Build and publish Node.js packages to npm via **OIDC trusted publishing**
+(preferred) or an optional legacy token.
 
 ```yaml
 - uses: lgtm-hq/lgtm-ci/.github/actions/publish-npm@main
   with:
     dist-tag: "latest" # optional
-    provenance: "true" # optional
+    provenance: "true" # optional; explicit --provenance intent
     access: "public" # optional
     dry-run: "false" # optional, build only
+    # npm-token: ${{ secrets.NPM_TOKEN }}  # legacy only; omit for OIDC
 ```
 
 **Outputs:** `published`, `version`, `package-name`, `tarball`. Requires
-`id-token: write` and a GitHub-hosted runner for provenance;
-`NODE_AUTH_TOKEN` for authentication.
+`id-token: write` and a GitHub-hosted runner. Use **Node 24+** (npm ≥ 11.5.1)
+for trusted publishing; never run `npm install -g npm`. Under trusted
+publishing provenance is automatic; `provenance: true` still passes
+`--provenance` as explicit intent. Optional `npm-token` input sets
+`NODE_AUTH_TOKEN` for legacy callers. Configure a trusted publisher on
+npmjs.com for the **caller** workflow (allow `npm publish`). See
+[workflows/publishing.md](../workflows/publishing.md#reusable-publish-npmyml).
 
 ## publish-gem
 

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -477,7 +477,19 @@ jobs:
       contents: read
       id-token: write
       attestations: write
+    with:
+      node-version: "24"
+      # Prefer OIDC trusted publishing (no secrets). Optional legacy:
+      # secrets: { npm-token: ${{ secrets.NPM_TOKEN }} }
+```
 
+Configure an npm trusted publisher for the **caller** workflow filename and
+allow the `npm publish` action. Use Node 24 (default); never
+`npm install -g npm`. Full recipe:
+[workflows/publishing.md](workflows/publishing.md#reusable-publish-npmyml).
+
+```yaml
+jobs:
   pypi-build:
     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-build-python-dist.yml@<sha>
     permissions:

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -130,7 +130,7 @@ These reusables intentionally omit `runner-image`:
 | `reusable-scorecards.yml`            | Action-only wrapper                                    |
 | `reusable-semantic-pr-title.yml`     | Action-only wrapper                                    |
 | `reusable-pr-labeler.yml`            | Action-only wrapper                                    |
-| `reusable-publish-npm.yml`           | Hardcoded for npm provenance attestation               |
+| `reusable-publish-npm.yml`           | OIDC trusted publishing + npm provenance; Node 24      |
 | `reusable-publish-gem.yml`           | OIDC publish; runner pin under attestation review      |
 
 <!-- markdownlint-enable MD013 -->
@@ -697,7 +697,7 @@ Use `append` to keep lgtm-ci defaults and add project-specific hosts. Empty
 | `playwright`     | Playwright E2E + browser CDN downloads                               |
 | `pypi`           | PyPI/TestPyPI publish and availability checks                        |
 | `rubygems`       | RubyGems publish                                                     |
-| `npm-publish`    | npm publish + Sigstore attestation                                   |
+| `npm-publish`    | npm OIDC trusted publish + Sigstore (`oauth2.sigstore.dev`)          |
 | `quality`        | Docker `lintro chk` (default on quality lint)                        |
 | `rust-release`   | Rust cross-compile releases (`reusable-build-rust-binaries.yml`)     |
 | `sbom`           | SBOM, Grype scan, Sigstore attestation                               |
@@ -832,6 +832,20 @@ allowed-endpoints: >
 
 See [python-release-publish.md](python-release-publish.md) for trusted
 publishing requirements.
+
+### npm publish (OIDC trusted publishing)
+
+Prefer the preset (canonical list in `scripts/ci/lib/egress/presets.sh`):
+
+```yaml
+egress-policy: block
+egress-preset: npm-publish
+```
+
+Includes `registry.npmjs.org:443`, Sigstore hosts, and
+`oauth2.sigstore.dev:443` for OIDC trusted publishing. Use Node 24 via
+`setup-node`; never `npm install -g npm`. See
+[workflows/publishing.md](workflows/publishing.md#reusable-publish-npmyml).
 
 ### GitHub Release (artifact upload)
 

--- a/docs/workflows/publishing.md
+++ b/docs/workflows/publishing.md
@@ -34,7 +34,8 @@ preset) and uploads them to the release — see
 
 ### reusable-publish-npm.yml
 
-Publish Node.js packages to npm with provenance attestation.
+Publish Node.js packages to npm using **OIDC trusted publishing** (preferred)
+or an optional legacy `npm-token` / `NODE_AUTH_TOKEN`.
 
 ```yaml
 jobs:
@@ -45,21 +46,43 @@ jobs:
       id-token: write
       attestations: write
     with:
-      node-version: "22"
+      node-version: "24"
       dist-tag: "latest"
       provenance: true
       access: "public"
       dry-run: false
 ```
 
-**Inputs:** `node-version` (default '22'), `dist-tag` (default 'latest'),
+#### Trusted publishing recipe
+
+1. On [npmjs.com](https://www.npmjs.com/), add a trusted publisher for the
+   package: GitHub org/user, repository, the **caller** workflow filename
+   (not `reusable-publish-npm.yml`), and allow the `npm publish` action
+   (required for publishers created after 2026-05-20).
+2. Grant `id-token: write` (and `attestations: write` when attesting the
+   tarball). No long-lived npm token is required.
+3. Use **Node 24** (default). Trusted publishing needs npm ≥ 11.5.1; Node 24
+   ships a compatible npm. **Never** run `npm install -g npm` / in-place
+   self-upgrade — it corrupts the Actions toolcache and breaks
+   `npm publish --provenance` (missing sigstore).
+4. Provenance is **automatic** under trusted publishing. The workflow still
+   passes `--provenance` when `provenance: true` as explicit intent.
+5. Egress preset `npm-publish` includes Sigstore OIDC
+   (`oauth2.sigstore.dev:443`). See
+   [workflow-contract.md](../workflow-contract.md#egress-presets).
+
+Legacy token path: pass `secrets.npm-token` (maps to `NODE_AUTH_TOKEN`)
+only for callers that have not migrated to trusted publishing.
+
+**Inputs:** `node-version` (default '24'), `dist-tag` (default 'latest'),
 `provenance` (default true), `access` (default 'public'), `dry-run`
 (default false), `working-directory` (default '.').
 
+**Secrets:** `npm-token` (optional, legacy).
+
 **Outputs:** `published`, `version`, `package-name`, `tarball`. Requires
-`contents: read`, `id-token: write`, `attestations: write`; declares no
-`workflow_call` secrets and must run on GitHub-hosted runners for npm
-provenance.
+`contents: read`, `id-token: write`, `attestations: write`; must run on
+GitHub-hosted runners for npm provenance / trusted publishing.
 
 ### reusable-publish-gem.yml
 

--- a/scripts/ci/actions/publish-npm.sh
+++ b/scripts/ci/actions/publish-npm.sh
@@ -8,7 +8,15 @@
 #   DIST_TAG: npm dist-tag (default: latest)
 #   PROVENANCE: Enable provenance attestation (default: true)
 #   ACCESS: Package access level (default: public)
-#   NODE_AUTH_TOKEN: npm authentication token
+#   NODE_AUTH_TOKEN: Optional legacy npm token. When unset, publish uses
+#     OIDC trusted publishing (requires id-token: write and npm ≥ 11.5.1).
+#
+# Policy:
+#   - Prefer Node 24+ (bundled npm ≥ 11.5.1) for trusted publishing.
+#   - Never run `npm install -g npm` / in-place self-upgrade: it corrupts the
+#     Actions toolcache and breaks `npm publish --provenance` (missing sigstore).
+#   - Under trusted publishing, provenance is automatic; --provenance is still
+#     passed when PROVENANCE=true as explicit intent.
 set -euo pipefail
 
 : "${STEP:?STEP is required}"
@@ -20,6 +28,28 @@ source "$SCRIPT_DIR/../lib/publish.sh"
 
 # Change to working directory
 cd "$WORKING_DIRECTORY"
+
+# Compare dotted numeric versions (major.minor.patch...). Returns 0 if $1 >= $2.
+_npm_version_ge() {
+	local IFS=.
+	# shellcheck disable=SC2206 # intentional word-split on dotted versions
+	local -a left=($1) right=($2)
+	local i max=${#left[@]}
+	if [[ ${#right[@]} -gt $max ]]; then
+		max=${#right[@]}
+	fi
+	for ((i = 0; i < max; i++)); do
+		local l=${left[i]:-0}
+		local r=${right[i]:-0}
+		if ((l > r)); then
+			return 0
+		fi
+		if ((l < r)); then
+			return 1
+		fi
+	done
+	return 0
+}
 
 case "$STEP" in
 validate)
@@ -129,11 +159,30 @@ publish)
 	: "${PROVENANCE:=true}"
 	: "${ACCESS:=public}"
 
+	# Empty NODE_AUTH_TOKEN (e.g. from setup-node registry-url placeholder)
+	# must be cleared so npm initiates OIDC trusted publishing instead of
+	# treating an empty classic token as configured auth.
 	if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then
-		die "NODE_AUTH_TOKEN is required for publishing"
+		unset NODE_AUTH_TOKEN
 	fi
 
-	log_info "Publishing to npm..."
+	local_auth_mode="oidc"
+	if [[ -n "${NODE_AUTH_TOKEN:-}" ]]; then
+		local_auth_mode="token"
+		log_info "Publishing to npm with legacy NODE_AUTH_TOKEN auth..."
+	else
+		log_info "Publishing to npm with OIDC trusted publishing..."
+		log_info "Require Node 24+ (npm ≥ 11.5.1). Do not run: npm install -g npm"
+	fi
+
+	npm_version=$(npm --version)
+
+	if [[ "$local_auth_mode" == "oidc" ]]; then
+		# Trusted publishing requires npm 11.5.1+ (Node 24 recommended).
+		if ! _npm_version_ge "$npm_version" "11.5.1"; then
+			die "OIDC trusted publishing requires npm 11.5.1+ (found: $npm_version). Use Node 24 via setup-node; do not run npm install -g npm."
+		fi
+	fi
 
 	# Build publish command
 	publish_args=(
@@ -142,13 +191,13 @@ publish)
 	)
 
 	if [[ "$PROVENANCE" == "true" ]]; then
-		# npm provenance requires npm 9.5.0+
-		npm_version=$(npm --version)
-		npm_major="${npm_version%%.*}"
-		npm_rest="${npm_version#*.}"
-		npm_minor="${npm_rest%%.*}"
-		if [[ "$npm_major" -lt 9 ]] || { [[ "$npm_major" -eq 9 ]] && [[ "$npm_minor" -lt 5 ]]; }; then
-			die "npm 9.5.0+ required for provenance support (found: $npm_version)"
+		# Token path: provenance needs npm 9.5.0+.
+		# OIDC path: already gated at 11.5.1+ above; provenance is automatic
+		# under trusted publishing, but --provenance remains explicit intent.
+		if [[ "$local_auth_mode" == "token" ]]; then
+			if ! _npm_version_ge "$npm_version" "9.5.0"; then
+				die "npm 9.5.0+ required for provenance support (found: $npm_version)"
+			fi
 		fi
 		publish_args+=("--provenance")
 	fi

--- a/scripts/ci/actions/publish-npm.sh
+++ b/scripts/ci/actions/publish-npm.sh
@@ -51,6 +51,22 @@ _npm_version_ge() {
 	return 0
 }
 
+# Remove setup-node registry _authToken lines so OIDC trusted publishing can run.
+_strip_npmrc_auth_tokens() {
+	local npmrc tmp
+	for npmrc in "${NPM_CONFIG_USERCONFIG:-}" "${HOME}/.npmrc" ".npmrc"; do
+		[[ -n "$npmrc" && -f "$npmrc" ]] || continue
+		if grep -q '_authToken' "$npmrc"; then
+			tmp="$(mktemp)"
+			# Drop authToken entries only; keep registry / always-auth lines.
+			# grep -v exits 1 when every line matched (file becomes empty) — tolerate that.
+			grep -v '_authToken' "$npmrc" >"$tmp" || true
+			mv "$tmp" "$npmrc"
+			log_info "Stripped _authToken from ${npmrc} for OIDC trusted publishing"
+		fi
+	done
+}
+
 case "$STEP" in
 validate)
 	log_info "Validating package.json..."
@@ -171,6 +187,10 @@ publish)
 		local_auth_mode="token"
 		log_info "Publishing to npm with legacy NODE_AUTH_TOKEN auth..."
 	else
+		# setup-node with registry-url writes //registry…/:_authToken=${NODE_AUTH_TOKEN}
+		# into the user npmrc. Leaving that entry with an empty token makes npm
+		# treat token auth as configured and skip OIDC trusted publishing.
+		_strip_npmrc_auth_tokens
 		log_info "Publishing to npm with OIDC trusted publishing..."
 		log_info "Require Node 24+ (npm ≥ 11.5.1). Do not run: npm install -g npm"
 	fi

--- a/scripts/ci/lib/egress/presets.sh
+++ b/scripts/ci/lib/egress/presets.sh
@@ -113,11 +113,13 @@ egress_preset_endpoints() {
 		;;
 	npm-publish)
 		# npm publish + Sigstore attestation (reusable-publish-npm.yml).
-		# oauth2.sigstore.dev is required for OIDC trusted publishing.
+		# oauth2.sigstore.dev + token.actions.githubusercontent.com are required
+		# for OIDC trusted publishing / provenance token exchange.
 		printf '%s\n' \
 			github.com:443 \
 			api.github.com:443 \
 			actions.githubusercontent.com:443 \
+			token.actions.githubusercontent.com:443 \
 			codeload.github.com:443 \
 			objects.githubusercontent.com:443 \
 			raw.githubusercontent.com:443 \

--- a/scripts/ci/lib/egress/presets.sh
+++ b/scripts/ci/lib/egress/presets.sh
@@ -113,6 +113,7 @@ egress_preset_endpoints() {
 		;;
 	npm-publish)
 		# npm publish + Sigstore attestation (reusable-publish-npm.yml).
+		# oauth2.sigstore.dev is required for OIDC trusted publishing.
 		printf '%s\n' \
 			github.com:443 \
 			api.github.com:443 \
@@ -123,7 +124,8 @@ egress_preset_endpoints() {
 			registry.npmjs.org:443 \
 			fulcio.sigstore.dev:443 \
 			rekor.sigstore.dev:443 \
-			tuf-repo-cdn.sigstore.dev:443
+			tuf-repo-cdn.sigstore.dev:443 \
+			oauth2.sigstore.dev:443
 		;;
 	quality)
 		# Docker-based lintro chk (py-lintro docker-ci dogfooding lint; py-lintro#939).

--- a/tests/bats/unit/actions/test_publish_npm.bats
+++ b/tests/bats/unit/actions/test_publish_npm.bats
@@ -110,6 +110,33 @@ EOF
 	assert_output --partial "OIDC trusted publishing"
 }
 
+@test "publish-npm: OIDC strips setup-node _authToken from npmrc" {
+	write_package_json
+	mock_command_multi "npm" '
+		--version) echo "11.5.1";;
+		*) exit 0;;
+	'
+
+	npmrc_dir="${BATS_TEST_TMPDIR}/npmrc-home"
+	mkdir -p "$npmrc_dir"
+	cat >"${npmrc_dir}/.npmrc" <<'EOF'
+registry=https://registry.npmjs.org/
+//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+always-auth=true
+EOF
+
+	STEP="publish" WORKING_DIRECTORY="$PKG_DIR" PROVENANCE="false" \
+		HOME="$npmrc_dir" \
+		run env -u NODE_AUTH_TOKEN bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "OIDC trusted publishing"
+	assert_output --partial "Stripped _authToken"
+	run grep -c '_authToken' "${npmrc_dir}/.npmrc" || true
+	assert_equal 0 "$output"
+	run grep -F 'always-auth=true' "${npmrc_dir}/.npmrc"
+	assert_success
+}
+
 @test "publish-npm: publish runs npm publish without provenance" {
 	write_package_json
 	mock_command_record "npm" ""

--- a/tests/bats/unit/actions/test_publish_npm.bats
+++ b/tests/bats/unit/actions/test_publish_npm.bats
@@ -69,12 +69,45 @@ EOF
 	assert_output --partial "validation failed"
 }
 
-@test "publish-npm: publish fails without NODE_AUTH_TOKEN" {
+@test "publish-npm: publish uses OIDC when NODE_AUTH_TOKEN unset" {
 	write_package_json
+	mock_command_multi "npm" '
+		--version) echo "11.5.1";;
+		*) exit 0;;
+	'
 
-	STEP="publish" WORKING_DIRECTORY="$PKG_DIR" run bash "${PROJECT_ROOT}/${SCRIPT}"
+	STEP="publish" WORKING_DIRECTORY="$PKG_DIR" PROVENANCE="false" \
+		run env -u NODE_AUTH_TOKEN bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "OIDC trusted publishing"
+	assert_output --partial "Published successfully"
+}
+
+@test "publish-npm: OIDC publish rejects npm below 11.5.1" {
+	write_package_json
+	mock_command_multi "npm" '
+		--version) echo "10.9.2";;
+		*) exit 0;;
+	'
+
+	STEP="publish" WORKING_DIRECTORY="$PKG_DIR" \
+		run env -u NODE_AUTH_TOKEN bash "${PROJECT_ROOT}/${SCRIPT}"
 	assert_failure
-	assert_output --partial "NODE_AUTH_TOKEN is required"
+	assert_output --partial "OIDC trusted publishing requires npm 11.5.1+"
+}
+
+@test "publish-npm: empty NODE_AUTH_TOKEN uses OIDC path" {
+	write_package_json
+	mock_command_multi "npm" '
+		--version) echo "11.6.0";;
+		*) exit 0;;
+	'
+
+	STEP="publish" WORKING_DIRECTORY="$PKG_DIR" NODE_AUTH_TOKEN="" \
+		PROVENANCE="false" \
+		run bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "OIDC trusted publishing"
 }
 
 @test "publish-npm: publish runs npm publish without provenance" {
@@ -85,6 +118,7 @@ EOF
 		PROVENANCE="false" DIST_TAG="next" ACCESS="restricted" \
 		run bash "${PROJECT_ROOT}/${SCRIPT}"
 	assert_success
+	assert_output --partial "legacy NODE_AUTH_TOKEN"
 	assert_output --partial "Published successfully"
 
 	grep -qF -- "publish --tag next --access restricted" "${BATS_TEST_TMPDIR}/mock_calls_npm"
@@ -104,6 +138,21 @@ EOF
 	assert_success
 	assert_output --partial "npm publish"
 	assert_output --partial "provenance"
+}
+
+@test "publish-npm: OIDC publish adds --provenance as explicit intent" {
+	write_package_json
+	: >"${BATS_TEST_TMPDIR}/mock_calls_npm"
+	mock_command_multi "npm" '
+		--version) echo "11.5.1";;
+		*) echo "$*" >> "'"${BATS_TEST_TMPDIR}"'/mock_calls_npm"; exit 0;;
+	'
+
+	STEP="publish" WORKING_DIRECTORY="$PKG_DIR" PROVENANCE="true" \
+		run env -u NODE_AUTH_TOKEN bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial "OIDC trusted publishing"
+	grep -qF -- "--provenance" "${BATS_TEST_TMPDIR}/mock_calls_npm"
 }
 
 @test "publish-npm: publish rejects provenance on old npm" {

--- a/tests/bats/unit/lib/egress/test_presets.bats
+++ b/tests/bats/unit/lib/egress/test_presets.bats
@@ -86,6 +86,7 @@ PRESETS="${PROJECT_ROOT}/scripts/ci/lib/egress/presets.sh"
 	assert_output --partial 'raw.githubusercontent.com:443'
 	assert_output --partial 'registry.npmjs.org:443'
 	assert_output --partial 'fulcio.sigstore.dev:443'
+	assert_output --partial 'oauth2.sigstore.dev:443'
 }
 
 @test "egress preset scorecard includes Scorecard API hosts" {

--- a/tests/bats/unit/lib/egress/test_presets.bats
+++ b/tests/bats/unit/lib/egress/test_presets.bats
@@ -83,6 +83,7 @@ PRESETS="${PROJECT_ROOT}/scripts/ci/lib/egress/presets.sh"
 	run bash -c "source '$PRESETS' && egress_preset_endpoints npm-publish"
 	assert_success
 	assert_output --partial 'actions.githubusercontent.com:443'
+	assert_output --partial 'token.actions.githubusercontent.com:443'
 	assert_output --partial 'raw.githubusercontent.com:443'
 	assert_output --partial 'registry.npmjs.org:443'
 	assert_output --partial 'fulcio.sigstore.dev:443'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Align `reusable-publish-npm` / `publish-npm` with npm OIDC trusted publishing and Node 24 so consumers no longer need long-lived `NODE_AUTH_TOKEN` or unsafe `npm install -g npm` workarounds. Adds `oauth2.sigstore.dev:443` to the `npm-publish` egress preset and documents the trusted-publishing recipe.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. Legacy `npm-token` / `NODE_AUTH_TOKEN` remains optional. `node-version` is restored as a real input (default `24`); callers still passing it are no longer ignored.

## Closes

- Closes #456

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates npm publishing to use OIDC trusted publishing with Node 24. The main changes are:

- Adds optional legacy npm token support.
- Restores `node-version` as an active publish workflow input.
- Adds setup-node before publishing.
- Removes generated npm auth token entries for tokenless publishing.
- Adds the GitHub OIDC and Sigstore OAuth hosts to the npm publish egress preset.
- Updates publishing docs and unit tests.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/actions/publish-npm.sh | Adds OIDC publishing behavior, npm version checks, and npm auth token cleanup for tokenless publish runs. |
| scripts/ci/lib/egress/presets.sh | Adds the GitHub OIDC and Sigstore OAuth endpoints to the canonical npm publish preset. |
| .github/actions/harden-runner/lib/egress/presets.sh | Keeps the bundled npm publish egress preset in sync with the canonical preset. |
| .github/workflows/reusable-publish-npm.yml | Sets up Node 24 for publishing and passes the optional npm token secret into the publish action. |
| .github/actions/publish-npm/action.yml | Adds the optional `npm-token` input and maps it to `NODE_AUTH_TOKEN` for legacy token publishing. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ci): sync harden-runner bundle with ..."](https://github.com/lgtm-hq/lgtm-ci/commit/5717cfc876044b5f0247ff0ac1c1ea98ef19f79d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43227626)</sub>

<!-- /greptile_comment -->