### PR TITLE
refactor(actions): wrap dorny/paths-filter in detect-changes

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -13,9 +13,9 @@ Full documentation lives in [docs/actions/](../../docs/actions/README.md):
   `egress-audit`, `validate-runner-policy`, `validate-action-pinning`,
   `generate-sbom`, `scan-vulnerabilities`, `attest-build`,
   `verify-attestation`, `sign-artifact`, `verify-signature`
-- [Testing and quality](../../docs/actions/testing.md) — `detect-changes`,
-  `run-quality`, `run-tests`, `run-pytest`, `run-vitest`,
-  `run-playwright`, `merge-playwright-reports`
+- [Testing and quality](../../docs/actions/testing.md) — `detect-changes`
+  (dorny/paths-filter wrapper, fail-open), `run-quality`, `run-tests`,
+  `run-pytest`, `run-vitest`, `run-playwright`, `merge-playwright-reports`
 - [Coverage](../../docs/actions/coverage.md) — `collect-coverage`,
   `check-coverage-threshold`, `generate-coverage-badge`,
   `publish-test-results`

--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -5,16 +5,18 @@ name: "Detect Changes"
 description: >-
   Map changed paths to named filters so conditional jobs always run and
   early-exit green when their paths didn't change (required-check-safe
-  replacement for on.<event>.paths). Resolves the diff range from
-  pull_request, merge_group, and push contexts.
+  replacement for on.<event>.paths). Thin SHA-pinned wrapper around
+  dorny/paths-filter with fail-open when the diff base is missing or
+  unresolvable. Resolves the diff range from pull_request, merge_group,
+  and push contexts.
 author: "lgtm-hq"
 
 inputs:
   filters:
     description: >-
-      One filter per line: `name=pattern [pattern...]`. Patterns are
-      bash-style globs matched against full repo-relative paths; `*`
-      crosses directory separators.
+      Dorny YAML filters (inline document or path to a filters file).
+      Example: `frontend:\n  - 'packages/frontend/**'`. Legacy
+      `name=glob …` line format is not accepted; see docs/actions/testing.md.
     required: true
   base:
     description: >-
@@ -23,17 +25,19 @@ inputs:
     required: false
     default: ""
   head:
-    description: "Head SHA override (default: event head or HEAD)"
+    description: >-
+      Head SHA override passed to dorny as `ref` (default: event head or
+      github.sha). Ignored by dorny on pull_request events.
     required: false
     default: ""
 
 outputs:
   changes:
     description: 'JSON object mapping each filter name to true/false'
-    value: ${{ steps.detect.outputs.changes }}
+    value: ${{ steps.result.outputs.changes }}
   any-changed:
     description: "Whether any filter matched"
-    value: ${{ steps.detect.outputs.any-changed }}
+    value: ${{ steps.result.outputs.any-changed }}
 
 runs:
   using: "composite"
@@ -44,15 +48,37 @@ runs:
         SCRIPTS_DIR="$(cd "${GITHUB_ACTION_PATH}/../../../scripts" && pwd)"
         echo "SCRIPTS_DIR=${SCRIPTS_DIR}" >> "$GITHUB_ENV"
 
-    - name: Detect changed paths
-      id: detect
+    - name: Resolve fail-open and filter names
+      id: resolve
       shell: bash
       env:
+        STEP: resolve
         FILTERS: ${{ inputs.filters }}
+        EVENT_NAME: ${{ github.event_name }}
         # yamllint disable rule:line-length
         BASE_SHA: ${{ inputs.base || github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
         HEAD_SHA: ${{ inputs.head || github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
         # yamllint enable rule:line-length
+      run: "$SCRIPTS_DIR/ci/actions/detect-changes.sh"
+
+    - name: Filter changed paths
+      id: filter
+      if: steps.resolve.outputs.fail-open != 'true'
+      # Pinned to SHA for supply chain security (dorny/paths-filter v4.0.2)
+      uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+      with:
+        filters: ${{ inputs.filters }}
+        base: ${{ steps.resolve.outputs.base }}
+        ref: ${{ steps.resolve.outputs.ref }}
+
+    - name: Map filter outputs
+      id: result
+      shell: bash
+      env:
+        STEP: map
+        FAIL_OPEN: ${{ steps.resolve.outputs.fail-open }}
+        FILTER_NAMES: ${{ steps.resolve.outputs.filter-names }}
+        DORNY_CHANGES: ${{ steps.filter.outputs.changes }}
       run: "$SCRIPTS_DIR/ci/actions/detect-changes.sh"
 
 branding:

--- a/docs/actions/README.md
+++ b/docs/actions/README.md
@@ -29,7 +29,7 @@ want a drop-in job without wiring these composites by hand.
 | `verify-attestation` | [security](security.md#verify-attestation) | Attestation verification |
 | `sign-artifact` | [security](security.md#sign-artifact) | Artifact signing (Cosign) |
 | `verify-signature` | [security](security.md#verify-signature) | Signature verification |
-| `detect-changes` | [testing](testing.md#detect-changes) | Path-filter change detection (required-check-safe) |
+| `detect-changes` | [testing](testing.md#detect-changes) | dorny/paths-filter wrapper (required-check-safe, fail-open) |
 | `run-quality` | [testing](testing.md#run-quality) | Lintro via full py-lintro Docker image |
 | `run-tests` | [testing](testing.md#run-tests) | Generic test runner (auto-detect) |
 | `run-pytest` | [testing](testing.md#run-pytest) | Pytest execution |

--- a/docs/actions/testing.md
+++ b/docs/actions/testing.md
@@ -8,8 +8,15 @@ per-language test workflows, see [workflows/testing.md](../workflows/testing.md)
 Maps changed paths to named filters so conditional jobs **always run and
 early-exit green** when their paths didn't change — the required-check-safe
 replacement for `on.<event>.paths` filters, which deadlock required checks.
-Resolves the diff range from `pull_request`, `merge_group`, and `push`
-contexts; an unresolvable base fails open (all filters report changed).
+
+Thin SHA-pinned wrapper around
+[`dorny/paths-filter`](https://github.com/dorny/paths-filter) (v4.0.2+), which
+resolves `pull_request`, `merge_group`, and `push` diffs (including merge-queue
+`base`/`ref` defaults). The wrapper keeps the org contract: public outputs stay
+`changes` (JSON name→bool) + `any-changed`, and an empty or unresolvable base
+**fails open** (all filters true, logged) so required checks run full jobs
+instead of silently early-exiting. Checkout with `fetch-depth: 0` so dorny's git
+mode has history.
 
 ```yaml
 jobs:
@@ -25,9 +32,19 @@ jobs:
         id: detect
         with:
           filters: |
-            examples=examples/* packages/*
-            docs=docs/* *.md
+            examples:
+              - 'examples/**'
+              - 'packages/**'
+            docs:
+              - 'docs/**'
+              - '*.md'
 ```
+
+**Filters:** dorny-native YAML (inline or path to a filters file). Picomatch
+globs — use `**` to cross directories. Legacy `name=glob …` line format from the
+pre-dorny action is rejected; migrate to the YAML shape above (e.g.
+`examples=examples/* packages/*` → `examples:` with `- 'examples/**'` /
+`- 'packages/**'`).
 
 **Outputs:** `changes` (JSON object of filter name → boolean), `any-changed`.
 Keep the downstream job name static — it is the required check's identity.

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -1207,13 +1207,15 @@ Instead, drop the `paths:` filter, always run the workflow (including on
    `fromJSON(needs.changes.outputs.changes).<filter>`, running a cheap
    "skipped" step (~seconds) when the filter didn't match.
 
-The action resolves the diff base from `pull_request`
-(`event.pull_request.base.sha`), `merge_group` (`event.merge_group.base_sha`),
-and `push` (`event.before`); when no base is resolvable it **fails open** and
-reports every filter as changed, so a required check runs its full job rather
-than silently early-exiting. See `.github/actions/README.md`
-("detect-changes") for a complete caller example, and homebrew-tap's
-`validate-homebrew-formula.yml` for the pattern's prior art.
+`detect-changes` is a thin SHA-pinned wrapper around `dorny/paths-filter`
+(v4.0.2+), which supports `merge_group` natively. The wrapper resolves the
+diff base from `pull_request` (`event.pull_request.base.sha`), `merge_group`
+(`event.merge_group.base_sha`), and `push` (`event.before`); when no base is
+resolvable it **fails open** and reports every filter as changed, so a
+required check runs its full job rather than silently early-exiting. Filters
+are dorny YAML (see [detect-changes](actions/testing.md#detect-changes)).
+Prior art for the caller pattern: homebrew-tap's
+`validate-homebrew-formula.yml`.
 
 Callers need `pull-requests: write` when `post-failure-comment` is enabled
 (default). With `post-failure-comment: false`, `pull-requests: read` suffices.

--- a/scripts/ci/actions/detect-changes.sh
+++ b/scripts/ci/actions/detect-changes.sh
@@ -20,7 +20,7 @@
 #   EVENT_NAME      github.event_name (resolve). PR events skip git reachability
 #                   checks because dorny uses the Pulls API.
 #   FAIL_OPEN       "true"/"false" (map).
-#   FILTER_NAMES    Space-separated filter names (map).
+#   FILTER_NAMES    Newline-separated filter names (map).
 #   DORNY_CHANGES   Dorny `changes` JSON array of matched names (map; optional).
 
 set -euo pipefail
@@ -218,7 +218,9 @@ resolve_step() {
 
 	{
 		echo "fail-open=${fail_open}"
-		echo "filter-names=${names[*]}"
+		echo "filter-names<<EOF"
+		printf '%s\n' "${names[@]}"
+		echo "EOF"
 		echo "base=${base_sha}"
 		echo "ref=${head_sha}"
 	} >>"$GITHUB_OUTPUT"
@@ -229,8 +231,12 @@ map_step() {
 	FAIL_OPEN="${FAIL_OPEN:-false}"
 
 	local -a names=()
-	# shellcheck disable=SC2206
-	names=($FILTER_NAMES)
+	local name
+	# Newline-separated so dorny keys with spaces survive the handoff.
+	while IFS= read -r name || [[ -n "$name" ]]; do
+		[[ -z "$name" ]] && continue
+		names+=("$name")
+	done <<<"$FILTER_NAMES"
 
 	if [[ "$FAIL_OPEN" == "true" ]]; then
 		echo "detect-changes: fail-open active; reporting all filters true" >&2

--- a/scripts/ci/actions/detect-changes.sh
+++ b/scripts/ci/actions/detect-changes.sh
@@ -71,8 +71,9 @@ write_changes_outputs() {
 
 load_filters_text() {
 	local filters="$1"
-	# Reject legacy `name=glob …` before dorny-style path detection: a
-	# single-line value without ':' would otherwise be treated as a file path.
+	# Pass legacy `name=glob …` through unchanged so extract_filter_names can
+	# detect and reject it with a migration hint. Without this early-return a
+	# single-line value without ':' would be treated as a file path below.
 	if [[ "$filters" != *$'\n'* && "$filters" == *=* && "$filters" != *:* ]]; then
 		printf '%s' "$filters"
 		return 0
@@ -149,6 +150,10 @@ extract_filter_names() {
 base_is_resolvable() {
 	local base="$1"
 	[[ -n "$base" ]] || return 1
+	# GitHub uses the null SHA as event.before on the first push of a branch.
+	# Dorny handles that case natively (compare to default branch / list all
+	# files as added); treat it as resolvable so we do not fail-open and skip
+	# dorny.
 	[[ "$base" == "$NULL_SHA" ]] && return 0
 	git cat-file -e "${base}^{commit}" 2>/dev/null
 }

--- a/scripts/ci/actions/detect-changes.sh
+++ b/scripts/ci/actions/detect-changes.sh
@@ -89,6 +89,26 @@ load_filters_text() {
 	printf '%s' "$filters"
 }
 
+# Match a top-level dorny YAML filter key on an unindented line.
+# Supports unquoted names (letters/digits/_/-/.) and single-/double-quoted
+# names (e.g. "api/v2", 'frontend.app').
+parse_top_level_filter_key() {
+	local line="$1"
+	if [[ "$line" =~ ^\"([^\"]+)\":([[:space:]]|$) ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"
+		return 0
+	fi
+	if [[ "$line" =~ ^\'([^\']+)\':([[:space:]]|$) ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"
+		return 0
+	fi
+	if [[ "$line" =~ ^([A-Za-z0-9_][A-Za-z0-9_.-]*):([[:space:]]|$) ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"
+		return 0
+	fi
+	return 1
+}
+
 looks_like_legacy_line_format() {
 	local filters="$1"
 	local line trimmed
@@ -102,7 +122,7 @@ looks_like_legacy_line_format() {
 			saw_legacy=1
 			continue
 		fi
-		if [[ "$line" =~ ^[A-Za-z0-9_-]+:([[:space:]]|$) ]]; then
+		if parse_top_level_filter_key "$line" >/dev/null; then
 			saw_yaml_key=1
 		fi
 	done <<<"$filters"
@@ -127,9 +147,9 @@ extract_filter_names() {
 	while IFS= read -r line || [[ -n "$line" ]]; do
 		trimmed="${line#"${line%%[![:space:]]*}"}"
 		[[ -z "$trimmed" || "$trimmed" == \#* ]] && continue
-		# Top-level dorny filter keys are unindented `name:` entries.
-		if [[ "$line" =~ ^([A-Za-z0-9_-]+):([[:space:]]|$) ]]; then
-			name="${BASH_REMATCH[1]}"
+		# Top-level dorny filter keys are unindented `name:` entries
+		# (unquoted with ._- or quoted for special characters).
+		if name="$(parse_top_level_filter_key "$line")"; then
 			names+=("$name")
 			continue
 		fi

--- a/scripts/ci/actions/detect-changes.sh
+++ b/scripts/ci/actions/detect-changes.sh
@@ -1,117 +1,228 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
-# Purpose: Map changed paths to named filters so conditional jobs can
-# early-exit green instead of being skipped by on.<event>.paths (which
-# deadlocks required checks: a check that never reports blocks the PR and
-# times out merge-queue entries).
-#
-# Writes to GITHUB_OUTPUT:
-#   changes        JSON object mapping each filter name to "true"/"false"
+# Purpose: Helper for the detect-changes composite action. Resolves fail-open
+# when the diff base is empty/unresolvable, extracts dorny filter names, and
+# maps dorny/paths-filter outputs onto the public contract:
+#   changes        JSON object mapping each filter name to true/false
 #   any-changed    "true" if any filter matched
 #
+# Glob matching is owned by dorny/paths-filter; this script does not reimplement
+# a path-filter engine.
+#
 # Environment:
-#   GITHUB_OUTPUT        Required. File to append outputs to.
-#   FILTERS              Required. One filter per line: `name=pattern [pattern...]`.
-#                        Patterns are bash-style globs matched against full
-#                        repo-relative paths; `*` crosses directory separators
-#                        (so `docs/*` and `docs/**` are equivalent).
-#   BASE_SHA             Base commit for the diff. Empty -> fail open (all
-#                        filters report true) so required checks stay safe.
-#   HEAD_SHA             Head commit for the diff (default: HEAD).
-#   CHANGED_FILES        Optional test seam: newline-separated file list used
-#                        instead of computing a git diff.
+#   GITHUB_OUTPUT   Required. File to append outputs to.
+#   STEP            Required. One of: resolve, map.
+#   FILTERS         Required for resolve. Dorny YAML filters (or path to a
+#                   filters file). Legacy `name=glob …` lines are rejected with
+#                   a migration hint.
+#   BASE_SHA        Base commit for the diff (resolve). Empty -> fail open.
+#   HEAD_SHA        Head commit / dorny `ref` (resolve; default HEAD).
+#   EVENT_NAME      github.event_name (resolve). PR events skip git reachability
+#                   checks because dorny uses the Pulls API.
+#   FAIL_OPEN       "true"/"false" (map).
+#   FILTER_NAMES    Space-separated filter names (map).
+#   DORNY_CHANGES   Dorny `changes` JSON array of matched names (map; optional).
 
 set -euo pipefail
 
 : "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
-: "${FILTERS:?FILTERS is required}"
+: "${STEP:?STEP is required}"
 
-BASE_SHA="${BASE_SHA:-}"
-HEAD_SHA="${HEAD_SHA:-HEAD}"
+NULL_SHA="0000000000000000000000000000000000000000"
 
-# Resolve the changed-file list. No base ref (push without before-SHA, manual
-# dispatch, shallow history) -> fail open: report every filter as changed so
-# a required check runs its full job rather than silently early-exiting.
-fail_open=0
-if [[ -n "${CHANGED_FILES+x}" ]]; then
-	# Test seam: set-but-empty means "no files changed".
-	changed="$CHANGED_FILES"
-elif [[ -z "$BASE_SHA" ]]; then
-	echo "detect-changes: BASE_SHA is empty; failing open (all filters true)" >&2
-	fail_open=1
-	changed=""
-elif ! changed="$(git -c core.quotePath=false diff --name-only "${BASE_SHA}...${HEAD_SHA}" 2>/dev/null)"; then
-	# Unreachable base (shallow clone, force-push): fail open, same rationale.
-	echo "detect-changes: cannot diff ${BASE_SHA}...${HEAD_SHA}; failing open (all filters true)" >&2
-	fail_open=1
-	changed=""
-fi
+write_changes_outputs() {
+	local -a names=("$@")
+	local fail_open="${FAIL_OPEN:-false}"
+	local dorny_changes="${DORNY_CHANGES:-}"
+	local json="{"
+	local any="false"
+	local first=1
+	local name result
 
-matches_any_pattern() {
-	local file="$1"
-	shift
-	local pattern
-	for pattern in "$@"; do
-		# shellcheck disable=SC2254
-		case "$file" in
-		$pattern) return 0 ;;
-		esac
+	if [[ "$fail_open" != "true" && -z "$dorny_changes" ]]; then
+		dorny_changes="[]"
+	fi
+
+	for name in "${names[@]}"; do
+		result="false"
+		if [[ "$fail_open" == "true" ]]; then
+			result="true"
+		elif [[ "$dorny_changes" == *"\"${name}\""* ]]; then
+			result="true"
+		fi
+		[[ "$result" == "true" ]] && any="true"
+
+		[[ "$first" -eq 0 ]] && json+=","
+		json+="\"${name}\":${result}"
+		first=0
 	done
-	return 1
+	json+="}"
+
+	if [[ "$first" -eq 1 ]]; then
+		echo "detect-changes: FILTERS contained no filter names" >&2
+		exit 1
+	fi
+
+	{
+		echo "changes=${json}"
+		echo "any-changed=${any}"
+	} >>"$GITHUB_OUTPUT"
 }
 
-json="{"
-any="false"
-first=1
-while IFS= read -r line; do
-	# Skip blanks and comments (allowing leading whitespace).
-	trimmed="${line#"${line%%[![:space:]]*}"}"
-	[[ -z "$trimmed" || "$trimmed" == \#* ]] && continue
-	line="$trimmed"
-	if [[ "$line" != *=* ]]; then
-		echo "detect-changes: invalid filter line (expected name=patterns): $line" >&2
-		exit 1
+load_filters_text() {
+	local filters="$1"
+	# Reject legacy `name=glob …` before dorny-style path detection: a
+	# single-line value without ':' would otherwise be treated as a file path.
+	if [[ "$filters" != *$'\n'* && "$filters" == *=* && "$filters" != *:* ]]; then
+		printf '%s' "$filters"
+		return 0
 	fi
-	name="${line%%=*}"
-	name="${name// /}"
-	read -r -a patterns <<<"${line#*=}"
-	if [[ -z "$name" || "${#patterns[@]}" -eq 0 ]]; then
-		echo "detect-changes: invalid filter line (empty name or patterns): $line" >&2
-		exit 1
+	# Dorny treats a single-line value without ':' as a config file path.
+	if [[ "$filters" != *$'\n'* && "$filters" != *:* ]]; then
+		if [[ ! -f "$filters" ]]; then
+			echo "detect-changes: filters file not found: $filters" >&2
+			exit 1
+		fi
+		filters="$(cat "$filters")"
 	fi
-	# Names become JSON keys verbatim; restrict to characters that need no
-	# escaping so the output can never be malformed JSON.
-	if [[ ! "$name" =~ ^[A-Za-z0-9_-]+$ ]]; then
-		echo "detect-changes: invalid filter name (allowed: [A-Za-z0-9_-]): $name" >&2
+	printf '%s' "$filters"
+}
+
+looks_like_legacy_line_format() {
+	local filters="$1"
+	local line trimmed
+	local saw_legacy=0
+	local saw_yaml_key=0
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		trimmed="${line#"${line%%[![:space:]]*}"}"
+		[[ -z "$trimmed" || "$trimmed" == \#* ]] && continue
+		if [[ "$trimmed" =~ ^[A-Za-z0-9_-]+= ]]; then
+			saw_legacy=1
+			continue
+		fi
+		if [[ "$line" =~ ^[A-Za-z0-9_-]+:([[:space:]]|$) ]]; then
+			saw_yaml_key=1
+		fi
+	done <<<"$filters"
+
+	[[ "$saw_legacy" -eq 1 && "$saw_yaml_key" -eq 0 ]]
+}
+
+extract_filter_names() {
+	local filters="$1"
+	local line trimmed name
+	local -a names=()
+
+	if looks_like_legacy_line_format "$filters"; then
+		echo "detect-changes: legacy line format (name=glob …) is no longer supported" >&2
+		echo "detect-changes: migrate to dorny YAML filters, e.g.:" >&2
+		echo "detect-changes:   frontend:" >&2
+		echo "detect-changes:     - 'packages/frontend/**'" >&2
+		echo "detect-changes: See docs/actions/testing.md (detect-changes)." >&2
 		exit 1
 	fi
 
-	result="false"
-	if [[ "$fail_open" -eq 1 ]]; then
-		result="true"
-	else
-		while IFS= read -r file; do
-			[[ -z "$file" ]] && continue
-			if matches_any_pattern "$file" "${patterns[@]}"; then
-				result="true"
-				break
-			fi
-		done <<<"$changed"
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		trimmed="${line#"${line%%[![:space:]]*}"}"
+		[[ -z "$trimmed" || "$trimmed" == \#* ]] && continue
+		# Top-level dorny filter keys are unindented `name:` entries.
+		if [[ "$line" =~ ^([A-Za-z0-9_-]+):([[:space:]]|$) ]]; then
+			name="${BASH_REMATCH[1]}"
+			names+=("$name")
+			continue
+		fi
+		if [[ "$line" =~ ^[^[:space:]#].*= ]]; then
+			echo "detect-changes: unexpected filter line (expected dorny YAML): $line" >&2
+			exit 1
+		fi
+	done <<<"$filters"
+
+	if [[ "${#names[@]}" -eq 0 ]]; then
+		echo "detect-changes: FILTERS contained no filter names" >&2
+		exit 1
 	fi
-	[[ "$result" == "true" ]] && any="true"
 
-	[[ "$first" -eq 0 ]] && json+=","
-	json+="\"${name}\":${result}"
-	first=0
-done <<<"$FILTERS"
-json+="}"
+	printf '%s\n' "${names[@]}"
+}
 
-if [[ "$first" -eq 1 ]]; then
-	echo "detect-changes: FILTERS contained no filter lines" >&2
+base_is_resolvable() {
+	local base="$1"
+	[[ -n "$base" ]] || return 1
+	[[ "$base" == "$NULL_SHA" ]] && return 0
+	git cat-file -e "${base}^{commit}" 2>/dev/null
+}
+
+resolve_step() {
+	: "${FILTERS:?FILTERS is required}"
+
+	local filters_text names_text
+	filters_text="$(load_filters_text "$FILTERS")"
+	# Command substitution (not process substitution) so extract failures exit.
+	names_text="$(extract_filter_names "$filters_text")" || exit $?
+
+	local -a names=()
+	local name
+	while IFS= read -r name; do
+		[[ -z "$name" ]] && continue
+		names+=("$name")
+	done <<<"$names_text"
+
+	if [[ "${#names[@]}" -eq 0 ]]; then
+		echo "detect-changes: FILTERS contained no filter names" >&2
+		exit 1
+	fi
+
+	local base_sha="${BASE_SHA:-}"
+	local head_sha="${HEAD_SHA:-HEAD}"
+	local event_name="${EVENT_NAME:-}"
+	local fail_open="false"
+
+	if [[ -z "$base_sha" ]]; then
+		echo "detect-changes: BASE_SHA is empty; failing open (all filters true)" >&2
+		fail_open="true"
+	elif [[ "$event_name" != pull_request && "$event_name" != pull_request_target &&
+		"$event_name" != pull_request_review && "$event_name" != pull_request_review_comment ]]; then
+		# Dorny uses git for merge_group/push/other; unreachable base must not
+		# fail the required check closed. PR events use the Pulls API instead.
+		if ! base_is_resolvable "$base_sha"; then
+			echo "detect-changes: cannot resolve base ${base_sha}; failing open (all filters true)" >&2
+			fail_open="true"
+		fi
+	fi
+
+	{
+		echo "fail-open=${fail_open}"
+		echo "filter-names=${names[*]}"
+		echo "base=${base_sha}"
+		echo "ref=${head_sha}"
+	} >>"$GITHUB_OUTPUT"
+}
+
+map_step() {
+	: "${FILTER_NAMES:?FILTER_NAMES is required}"
+	FAIL_OPEN="${FAIL_OPEN:-false}"
+
+	local -a names=()
+	# shellcheck disable=SC2206
+	names=($FILTER_NAMES)
+
+	if [[ "$FAIL_OPEN" == "true" ]]; then
+		echo "detect-changes: fail-open active; reporting all filters true" >&2
+	fi
+
+	write_changes_outputs "${names[@]}"
+}
+
+case "$STEP" in
+resolve)
+	resolve_step
+	;;
+map)
+	map_step
+	;;
+*)
+	echo "detect-changes: unknown STEP '${STEP}' (expected resolve or map)" >&2
 	exit 1
-fi
-
-{
-	echo "changes=${json}"
-	echo "any-changed=${any}"
-} >>"$GITHUB_OUTPUT"
+	;;
+esac

--- a/tests/bats/unit/actions/test_detect_changes.bats
+++ b/tests/bats/unit/actions/test_detect_changes.bats
@@ -92,6 +92,19 @@ run_detect() {
 	assert_output "true"
 }
 
+@test "detect-changes: resolve null before-SHA stays closed for dorny first-push" {
+	# GitHub sends the null SHA as event.before on the first push of a branch.
+	# Dorny handles that natively; the wrapper must not fail-open and skip it.
+	run_detect STEP=resolve FILTERS="$YAML_FILTERS" \
+		BASE_SHA="0000000000000000000000000000000000000000" \
+		EVENT_NAME=push
+	assert_success
+	run get_github_output "fail-open"
+	assert_output "false"
+	run get_github_output "base"
+	assert_output "0000000000000000000000000000000000000000"
+}
+
 @test "detect-changes: resolve skips git reachability check on pull_request" {
 	run_detect STEP=resolve FILTERS="$YAML_FILTERS" \
 		BASE_SHA="0000000000000000000000000000000000000001" \

--- a/tests/bats/unit/actions/test_detect_changes.bats
+++ b/tests/bats/unit/actions/test_detect_changes.bats
@@ -31,7 +31,7 @@ run_detect() {
 }
 
 @test "detect-changes: fails without FILTERS on resolve" {
-	run_detect STEP=resolve
+	run env -u FILTERS STEP=resolve bash "${PROJECT_ROOT}/${SCRIPT}"
 	assert_failure
 	assert_output --partial "FILTERS is required"
 }
@@ -151,7 +151,8 @@ run_detect() {
 }
 
 @test "detect-changes: map treats missing DORNY_CHANGES as empty array" {
-	run_detect STEP=map FAIL_OPEN=false FILTER_NAMES="tests"
+	run env -u DORNY_CHANGES STEP=map FAIL_OPEN=false FILTER_NAMES="tests" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
 	assert_success
 	run get_github_output "changes"
 	assert_output '{"tests":false}'

--- a/tests/bats/unit/actions/test_detect_changes.bats
+++ b/tests/bats/unit/actions/test_detect_changes.bats
@@ -173,6 +173,26 @@ run_detect() {
 	assert_output "false"
 }
 
+
+@test "detect-changes: resolve extracts dotted and quoted YAML filter names" {
+	local filters=$'frontend.app:\n  - \'packages/frontend/**\'\n"api/v2":\n  - \'packages/api/**\'\n\'docs-site\':\n  - \'docs/**\''
+	run_detect STEP=resolve FILTERS="$filters" BASE_SHA="abc123" HEAD_SHA="def456" \
+		EVENT_NAME=pull_request
+	assert_success
+	run get_github_output "filter-names"
+	assert_output "frontend.app api/v2 docs-site"
+}
+
+@test "detect-changes: map preserves dotted filter names in changes JSON" {
+	run_detect STEP=map FAIL_OPEN=false FILTER_NAMES="frontend.app api/v2" \
+		DORNY_CHANGES='["frontend.app"]'
+	assert_success
+	run get_github_output "changes"
+	assert_output '{"frontend.app":true,"api/v2":false}'
+	run get_github_output "any-changed"
+	assert_output "true"
+}
+
 @test "detect-changes: script is executable (action invokes it directly)" {
 	# The composite action runs "$SCRIPTS_DIR/ci/actions/detect-changes.sh"
 	# with no bash prefix, so a missing execute bit fails at runtime (126).

--- a/tests/bats/unit/actions/test_detect_changes.bats
+++ b/tests/bats/unit/actions/test_detect_changes.bats
@@ -54,7 +54,7 @@ run_detect() {
 		EVENT_NAME=pull_request
 	assert_success
 	run get_github_output "filter-names"
-	assert_output "tests docs"
+	assert_output $'tests\ndocs'
 	run get_github_output "fail-open"
 	assert_output "false"
 	run get_github_output "base"
@@ -70,7 +70,7 @@ run_detect() {
 	run get_github_output "fail-open"
 	assert_output "true"
 	run get_github_output "filter-names"
-	assert_output "tests docs"
+	assert_output $'tests\ndocs'
 }
 
 @test "detect-changes: resolve unreachable base fails open on push" {
@@ -134,7 +134,7 @@ run_detect() {
 }
 
 @test "detect-changes: map fail-open reports all filters true" {
-	run_detect STEP=map FAIL_OPEN=true FILTER_NAMES="tests docs"
+	run_detect STEP=map FAIL_OPEN=true FILTER_NAMES=$'tests\ndocs'
 	assert_success
 	assert_output --partial "fail-open active"
 	run get_github_output "changes"
@@ -144,7 +144,7 @@ run_detect() {
 }
 
 @test "detect-changes: map converts dorny changes array to object" {
-	run_detect STEP=map FAIL_OPEN=false FILTER_NAMES="tests docs" \
+	run_detect STEP=map FAIL_OPEN=false FILTER_NAMES=$'tests\ndocs' \
 		DORNY_CHANGES='["tests"]'
 	assert_success
 	run get_github_output "changes"
@@ -154,7 +154,7 @@ run_detect() {
 }
 
 @test "detect-changes: map with no dorny matches reports all false" {
-	run_detect STEP=map FAIL_OPEN=false FILTER_NAMES="tests docs" \
+	run_detect STEP=map FAIL_OPEN=false FILTER_NAMES=$'tests\ndocs' \
 		DORNY_CHANGES='[]'
 	assert_success
 	run get_github_output "changes"
@@ -180,17 +180,33 @@ run_detect() {
 		EVENT_NAME=pull_request
 	assert_success
 	run get_github_output "filter-names"
-	assert_output "frontend.app api/v2 docs-site"
+	assert_output $'frontend.app\napi/v2\ndocs-site'
 }
 
 @test "detect-changes: map preserves dotted filter names in changes JSON" {
-	run_detect STEP=map FAIL_OPEN=false FILTER_NAMES="frontend.app api/v2" \
+	run_detect STEP=map FAIL_OPEN=false FILTER_NAMES=$'frontend.app\napi/v2' \
 		DORNY_CHANGES='["frontend.app"]'
 	assert_success
 	run get_github_output "changes"
 	assert_output '{"frontend.app":true,"api/v2":false}'
 	run get_github_output "any-changed"
 	assert_output "true"
+}
+
+
+@test "detect-changes: resolve and map preserve filter names with spaces" {
+	local filters=$'"frontend app":\n  - \'packages/frontend/**\'\ndocs:\n  - \'docs/**\''
+	run_detect STEP=resolve FILTERS="$filters" BASE_SHA="abc123" HEAD_SHA="def456" \
+		EVENT_NAME=pull_request
+	assert_success
+	run get_github_output "filter-names"
+	assert_output $'frontend app\ndocs'
+
+	run_detect STEP=map FAIL_OPEN=false FILTER_NAMES=$'frontend app\ndocs' \
+		DORNY_CHANGES='["frontend app"]'
+	assert_success
+	run get_github_output "changes"
+	assert_output '{"frontend app":true,"docs":false}'
 }
 
 @test "detect-changes: script is executable (action invokes it directly)" {

--- a/tests/bats/unit/actions/test_detect_changes.bats
+++ b/tests/bats/unit/actions/test_detect_changes.bats
@@ -1,12 +1,14 @@
 #!/usr/bin/env bats
 # SPDX-License-Identifier: MIT
-# Purpose: Tests for scripts/ci/actions/detect-changes.sh
+# Purpose: Tests for scripts/ci/actions/detect-changes.sh (dorny wrapper helpers)
 
 load "../../../helpers/common"
 load "../../../helpers/mocks"
 load "../../../helpers/github_env"
 
 SCRIPT="scripts/ci/actions/detect-changes.sh"
+
+YAML_FILTERS=$'tests:\n  - \'tests/**\'\ndocs:\n  - \'docs/**\'\n  - \'*.md\''
 
 setup() {
 	setup_temp_dir
@@ -22,102 +24,56 @@ run_detect() {
 	run env "$@" bash "${PROJECT_ROOT}/${SCRIPT}"
 }
 
-@test "detect-changes: fails without FILTERS" {
-	run env -u FILTERS bash "${PROJECT_ROOT}/${SCRIPT}"
+@test "detect-changes: fails without STEP" {
+	run env -u STEP FILTERS="$YAML_FILTERS" bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_failure
+	assert_output --partial "STEP is required"
+}
+
+@test "detect-changes: fails without FILTERS on resolve" {
+	run_detect STEP=resolve
 	assert_failure
 	assert_output --partial "FILTERS is required"
 }
 
-@test "detect-changes: fails on invalid filter line" {
-	run_detect FILTERS="no-equals-sign" CHANGED_FILES="a.txt"
+@test "detect-changes: resolve rejects legacy line format" {
+	run_detect STEP=resolve FILTERS="tests=tests/* src/*" BASE_SHA="abc"
 	assert_failure
-	assert_output --partial "invalid filter line"
+	assert_output --partial "legacy line format"
+	assert_output --partial "dorny YAML"
 }
 
-@test "detect-changes: fails on JSON-unsafe filter name" {
-	run_detect FILTERS='bad"name=tests/*' CHANGED_FILES="a.txt"
+@test "detect-changes: resolve fails on empty filter list" {
+	run_detect STEP=resolve FILTERS=$'\n  \n' BASE_SHA="abc"
 	assert_failure
-	assert_output --partial "invalid filter name"
+	assert_output --partial "no filter names"
 }
 
-@test "detect-changes: fails on empty filter list" {
-	run_detect FILTERS=$'\n  \n' CHANGED_FILES="a.txt"
-	assert_failure
-	assert_output --partial "no filter lines"
-}
-
-@test "detect-changes: matching filter reports true" {
-	run_detect \
-		FILTERS="tests=tests/* src/*" \
-		CHANGED_FILES=$'tests/unit/a_test.rs'
+@test "detect-changes: resolve extracts YAML filter names" {
+	run_detect STEP=resolve FILTERS="$YAML_FILTERS" BASE_SHA="abc123" HEAD_SHA="def456" \
+		EVENT_NAME=pull_request
 	assert_success
-	run get_github_output "changes"
-	assert_output '{"tests":true}'
-	run get_github_output "any-changed"
-	assert_output "true"
-}
-
-@test "detect-changes: non-matching filter reports false" {
-	run_detect \
-		FILTERS="tests=tests/* src/*" \
-		CHANGED_FILES=$'docs/readme.md'
-	assert_success
-	run get_github_output "changes"
-	assert_output '{"tests":false}'
-	run get_github_output "any-changed"
+	run get_github_output "filter-names"
+	assert_output "tests docs"
+	run get_github_output "fail-open"
 	assert_output "false"
+	run get_github_output "base"
+	assert_output "abc123"
+	run get_github_output "ref"
+	assert_output "def456"
 }
 
-@test "detect-changes: multiple filters evaluated independently" {
-	run_detect \
-		FILTERS=$'tests=tests/* src/*\ndocs=docs/* *.md' \
-		CHANGED_FILES=$'docs/guide.md\nsrc/main.rs'
+@test "detect-changes: resolve empty base fails open" {
+	run_detect STEP=resolve FILTERS="$YAML_FILTERS" BASE_SHA="" EVENT_NAME=push
 	assert_success
-	run get_github_output "changes"
-	assert_output '{"tests":true,"docs":true}'
-}
-
-@test "detect-changes: glob star crosses directory separators" {
-	run_detect \
-		FILTERS="examples=examples/*" \
-		CHANGED_FILES=$'examples/react/src/App.tsx'
-	assert_success
-	run get_github_output "changes"
-	assert_output '{"examples":true}'
-}
-
-@test "detect-changes: comments and blank filter lines are ignored" {
-	run_detect \
-		FILTERS=$'# tests below\n  # indented comment\n\ntests=tests/*' \
-		CHANGED_FILES=$'tests/a.rs'
-	assert_success
-	run get_github_output "changes"
-	assert_output '{"tests":true}'
-}
-
-@test "detect-changes: set-but-empty CHANGED_FILES means no changes" {
-	run_detect \
-		FILTERS=$'tests=tests/*\ndocs=docs/*' \
-		CHANGED_FILES=""
-	assert_success
-	run get_github_output "changes"
-	assert_output '{"tests":false,"docs":false}'
-	run get_github_output "any-changed"
-	assert_output "false"
-}
-
-@test "detect-changes: empty base fails open (all filters true)" {
-	run_detect \
-		FILTERS=$'tests=tests/*\ndocs=docs/*' \
-		BASE_SHA=""
-	assert_success
-	run get_github_output "changes"
-	assert_output '{"tests":true,"docs":true}'
-	run get_github_output "any-changed"
+	assert_output --partial "BASE_SHA is empty; failing open"
+	run get_github_output "fail-open"
 	assert_output "true"
+	run get_github_output "filter-names"
+	assert_output "tests docs"
 }
 
-@test "detect-changes: unreachable base fails open" {
+@test "detect-changes: resolve unreachable base fails open on push" {
 	cd "$BATS_TEST_TMPDIR"
 	git init -q repo
 	cd repo
@@ -125,15 +81,27 @@ run_detect() {
 	git config user.name "Test"
 	git commit -q --allow-empty -m init
 	run env \
-		FILTERS="tests=tests/*" \
+		STEP=resolve \
+		FILTERS="$YAML_FILTERS" \
 		BASE_SHA="0000000000000000000000000000000000000001" \
+		EVENT_NAME=push \
 		bash "${PROJECT_ROOT}/${SCRIPT}"
 	assert_success
-	run get_github_output "changes"
-	assert_output '{"tests":true}'
+	assert_output --partial "cannot resolve base"
+	run get_github_output "fail-open"
+	assert_output "true"
 }
 
-@test "detect-changes: computes diff from git when no seam provided" {
+@test "detect-changes: resolve skips git reachability check on pull_request" {
+	run_detect STEP=resolve FILTERS="$YAML_FILTERS" \
+		BASE_SHA="0000000000000000000000000000000000000001" \
+		EVENT_NAME=pull_request
+	assert_success
+	run get_github_output "fail-open"
+	assert_output "false"
+}
+
+@test "detect-changes: resolve reachable base stays closed on push" {
 	cd "$BATS_TEST_TMPDIR"
 	git init -q repo
 	cd repo
@@ -141,17 +109,54 @@ run_detect() {
 	git config user.name "Test"
 	git commit -q --allow-empty -m init
 	base="$(git rev-parse HEAD)"
-	mkdir -p tests
-	echo "x" >tests/a.rs
-	git add tests/a.rs
-	git commit -q -m "add test"
 	run env \
-		FILTERS=$'tests=tests/*\ndocs=docs/*' \
+		STEP=resolve \
+		FILTERS="$YAML_FILTERS" \
 		BASE_SHA="$base" \
+		EVENT_NAME=push \
 		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	run get_github_output "fail-open"
+	assert_output "false"
+}
+
+@test "detect-changes: map fail-open reports all filters true" {
+	run_detect STEP=map FAIL_OPEN=true FILTER_NAMES="tests docs"
+	assert_success
+	assert_output --partial "fail-open active"
+	run get_github_output "changes"
+	assert_output '{"tests":true,"docs":true}'
+	run get_github_output "any-changed"
+	assert_output "true"
+}
+
+@test "detect-changes: map converts dorny changes array to object" {
+	run_detect STEP=map FAIL_OPEN=false FILTER_NAMES="tests docs" \
+		DORNY_CHANGES='["tests"]'
 	assert_success
 	run get_github_output "changes"
 	assert_output '{"tests":true,"docs":false}'
+	run get_github_output "any-changed"
+	assert_output "true"
+}
+
+@test "detect-changes: map with no dorny matches reports all false" {
+	run_detect STEP=map FAIL_OPEN=false FILTER_NAMES="tests docs" \
+		DORNY_CHANGES='[]'
+	assert_success
+	run get_github_output "changes"
+	assert_output '{"tests":false,"docs":false}'
+	run get_github_output "any-changed"
+	assert_output "false"
+}
+
+@test "detect-changes: map treats missing DORNY_CHANGES as empty array" {
+	run_detect STEP=map FAIL_OPEN=false FILTER_NAMES="tests"
+	assert_success
+	run get_github_output "changes"
+	assert_output '{"tests":false}'
+	run get_github_output "any-changed"
+	assert_output "false"
 }
 
 @test "detect-changes: script is executable (action invokes it directly)" {


### PR DESCRIPTION
## Summary

Replace the bespoke `detect-changes` glob engine with a thin SHA-pinned wrapper around `dorny/paths-filter` v4.0.2 while preserving the required-check-safe public contract (`changes` JSON name→bool, `any-changed`, fail-open on empty/unresolvable base).

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [x] CI/CD improvement

## Changes Made

- `.github/actions/detect-changes/action.yml` — invoke `dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706` (# v4.0.2); resolve/map helper steps around it
- `scripts/ci/actions/detect-changes.sh` — shrink to fail-open + filter-name extract + dorny output mapping (no glob engine)
- `tests/bats/unit/actions/test_detect_changes.bats` — retarget to wrapper helpers (fail-open, output shape, legacy rejection, null before-SHA)
- Docs: dorny YAML filters, legacy line-format migration, correct outdated “dorny lacks merge_group” rationale

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

Filter input is now dorny-native YAML (inline or filters file). Legacy `name=glob …` line format is rejected with a migration hint. Example:

```yaml
# before
filters: |
  examples=examples/* packages/*

# after
filters: |
  examples:
    - 'examples/**'
    - 'packages/**'
```

Public outputs (`changes`, `any-changed`) and fail-open policy are unchanged.

## Closes

- Closes #466
- Relates to #36
- Relates to #421
- Relates to #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved change detection across pull requests, merge queues, and pushes.
  * Added support for native YAML filter definitions and base/head SHA overrides.
  * Change detection now fails open when the comparison base cannot be resolved, helping required checks continue running.
  * Preserved `changes` and `any-changed` outputs with improved handling of filter results.

* **Documentation**
  * Updated action documentation with configuration guidance, migration notes, and checkout requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes `detect-changes` into a wrapper around `dorny/paths-filter`. The main changes are:

- Adds resolve, filter, and output-mapping steps to the composite action.
- Replaces the local glob engine with dorny output mapping.
- Keeps the existing `changes` and `any-changed` outputs.
- Updates tests and docs for dorny-native YAML filters.
</details>

<h3>Confidence Score: 4/5</h3>

This is close, but the filter-name mapping should be fixed before merging.

- The wrapper path now preserves simple dotted, quoted, slash, and space-containing filter names.
- Escaped quoted YAML keys can still be accepted by dorny but dropped from the public `changes` output.
- That can make downstream workflow gates skip jobs even though the filter matched.

scripts/ci/actions/detect-changes.sh

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/detect-changes/action.yml | Splits the composite action into helper resolution, dorny filtering, and result mapping. |
| scripts/ci/actions/detect-changes.sh | Refactors change detection into fail-open handling, filter-name extraction, and dorny result mapping. |
| tests/bats/unit/actions/test_detect_changes.bats | Updates the unit tests for the new wrapper helper behavior and YAML filter format. |
| docs/actions/testing.md | Documents dorny YAML filters, fail-open behavior, and migration from the legacy format. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fdetect-changes.sh%3A101%0A**Escaped%20Keys%20Still%20Break**%0A%0AThis%20still%20parses%20quoted%20YAML%20keys%20as%20raw%20text%20instead%20of%20resolving%20the%20YAML%20scalar%20the%20same%20way%20dorny%20does.%20A%20valid%20filter%20like%20%60'owner''s-docs'%3A%60%20is%20passed%20to%20dorny%20as%20%60owner's-docs%60%2C%20but%20this%20regex%20does%20not%20extract%20that%20key%2C%20so%20the%20later%20%60changes%60%20object%20never%20reports%20it%20even%20when%20dorny%20matches%20it.%20The%20same%20mismatch%20can%20happen%20for%20double-quoted%20keys%20that%20use%20YAML%20escapes.%20Downstream%20workflow%20gates%20can%20then%20receive%20a%20%60changes%60%20object%20that%20is%20missing%20a%20matched%20filter%20and%20skip%20a%20required%20job.%0A%0A&pr=468&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fdetect-changes.sh%3A101%0A**Escaped%20Keys%20Still%20Break**%0A%0AThis%20still%20parses%20quoted%20YAML%20keys%20as%20raw%20text%20instead%20of%20resolving%20the%20YAML%20scalar%20the%20same%20way%20dorny%20does.%20A%20valid%20filter%20like%20%60'owner''s-docs'%3A%60%20is%20passed%20to%20dorny%20as%20%60owner's-docs%60%2C%20but%20this%20regex%20does%20not%20extract%20that%20key%2C%20so%20the%20later%20%60changes%60%20object%20never%20reports%20it%20even%20when%20dorny%20matches%20it.%20The%20same%20mismatch%20can%20happen%20for%20double-quoted%20keys%20that%20use%20YAML%20escapes.%20Downstream%20workflow%20gates%20can%20then%20receive%20a%20%60changes%60%20object%20that%20is%20missing%20a%20matched%20filter%20and%20skip%20a%20required%20job.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=468&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22refactor%2F466-dorny-detect-changes%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22refactor%2F466-dorny-detect-changes%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fci%2Factions%2Fdetect-changes.sh%3A101%0A**Escaped%20Keys%20Still%20Break**%0A%0AThis%20still%20parses%20quoted%20YAML%20keys%20as%20raw%20text%20instead%20of%20resolving%20the%20YAML%20scalar%20the%20same%20way%20dorny%20does.%20A%20valid%20filter%20like%20%60'owner''s-docs'%3A%60%20is%20passed%20to%20dorny%20as%20%60owner's-docs%60%2C%20but%20this%20regex%20does%20not%20extract%20that%20key%2C%20so%20the%20later%20%60changes%60%20object%20never%20reports%20it%20even%20when%20dorny%20matches%20it.%20The%20same%20mismatch%20can%20happen%20for%20double-quoted%20keys%20that%20use%20YAML%20escapes.%20Downstream%20workflow%20gates%20can%20then%20receive%20a%20%60changes%60%20object%20that%20is%20missing%20a%20matched%20filter%20and%20skip%20a%20required%20job.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=468&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["fix(actions): hand off dorny filter name..."](https://github.com/lgtm-hq/lgtm-ci/commit/0e24505c5cc8f6a91d8b72cd531f5fab1a5d67e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43230648)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->