### PR TITLE
refactor(workflows): migrate reusable-ai-review to checkout-and-harden composite

### DIFF
--- a/.github/workflows/reusable-ai-review.yml
+++ b/.github/workflows/reusable-ai-review.yml
@@ -144,12 +144,13 @@ jobs:
     steps:
       - name: Harden runner
         if: runner.os == 'Linux' || runner.environment == 'self-hosted'
-        # yamllint disable-line rule:line-length
+        # Pinned to SHA for supply chain security
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: ${{ inputs.egress-policy }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
       - name: Checkout repository
+        # Pinned to SHA for supply chain security
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -161,20 +162,21 @@ jobs:
           path: .lgtm-ci-tooling
           ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
           sparse-checkout: |
-            .github/actions/harden-runner
-            .github/actions/resolve-egress-allowlist
-            .github/actions/post-pr-comment
-            scripts/ci/
+            .github/actions/checkout-and-harden
           sparse-checkout-cone-mode: true
           persist-credentials: false
-      - name: Resolve egress allowlist
+      - name: Checkout and harden
         id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/resolve-egress-allowlist
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
         with:
+          tooling-ref: ${{ inputs.tooling-ref }}
           egress-policy: ${{ inputs.egress-policy }}
           egress-preset: ${{ inputs.egress-preset }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
           allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+          sparse-checkout-extra: |
+            .github/actions/post-pr-comment
+            scripts/ci/
       - name: Set up uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Preflight guards


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Migrate `reusable-ai-review.yml` from the legacy resolve-egress-allowlist + harden-runner triplet to the shared `checkout-and-harden` composite action, completing the migration started in PR #411 (#379). The bootstrap sparse-checkout now only materialises the composite directory, and `scripts/ci/` plus `post-pr-comment` are fetched via `sparse-checkout-extra`.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #476

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves the reusable AI review workflow onto the shared checkout-and-harden composite. The main changes are:

- Bootstraps only `.github/actions/checkout-and-harden` from the tooling repository.
- Replaces the standalone egress allowlist action with the shared composite action.
- Passes `post-pr-comment` and `scripts/ci/` through `sparse-checkout-extra` for later workflow steps.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-ai-review.yml | Migrates the workflow to the shared checkout-and-harden composite while preserving the later tooling paths through sparse-checkout-extra. |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(workflows): migrate reusable-ai..."](https://github.com/lgtm-hq/lgtm-ci/commit/d089c6130c4bbd6db08241c497c2f345fbc9ac8a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43340789)</sub>

<!-- /greptile_comment -->