### PR TITLE
fix(ci): address unresolved bot review feedback from PRs #385, #391, #423

### DIFF
--- a/.github/workflows/reusable-validate-action-pinning.yml
+++ b/.github/workflows/reusable-validate-action-pinning.yml
@@ -3,6 +3,14 @@ name: Reusable Validate Action Pinning
 
 on:
   workflow_call:
+    secrets:
+      gh-token:
+        description: >-
+          GitHub token forwarded to the composite action for verify-tags /
+          audit-transitive API resolution (e.g. a PAT able to resolve private
+          or cross-org actions). Optional — falls back to GH_TOKEN env var,
+          then the workflow token.
+        required: false
     inputs:
       fail-on-error:
         description: "Fail if non-pinned actions are found"
@@ -140,3 +148,4 @@ jobs:
           scan-paths: ${{ inputs.scan-paths }}
           verify-tags: ${{ inputs.verify-tags }}
           audit-transitive: ${{ inputs.audit-transitive }}
+          gh-token: ${{ secrets.gh-token }}

--- a/examples/ci-docker.yml
+++ b/examples/ci-docker.yml
@@ -33,7 +33,7 @@ jobs:
     with:
       tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
       file: Dockerfile
-      push: ${{ github.event_name != 'pull_request' }}
+      push: ${{ github.event_name == 'push' }}
       # Split per-platform validation on PRs without QEMU overhead
       validate-on-pr: ${{ github.event_name == 'pull_request' }}
       # Native arm64 runner instead of QEMU (contract: "Runner pinning")

--- a/examples/ci-rust.yml
+++ b/examples/ci-rust.yml
@@ -83,6 +83,7 @@ jobs:
         objects.githubusercontent.com:443
         github-releases.githubusercontent.com:443
         static.rust-lang.org:443
+        sh.rustup.rs:443
         crates.io:443
         static.crates.io:443
         index.crates.io:443

--- a/tests/bats/integration/test_version_drift_workflows.bats
+++ b/tests/bats/integration/test_version_drift_workflows.bats
@@ -22,6 +22,15 @@ load "../../helpers/common"
 	assert_success
 }
 
+@test "reusable-validate-action-pinning: accepts gh-token secret and forwards to action" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-validate-action-pinning.yml"
+
+	run grep -F 'gh-token:' "$workflow"
+	assert_success
+	run grep -F 'gh-token: ${{ secrets.gh-token }}' "$workflow"
+	assert_success
+}
+
 @test "validate-action-pinning action: wires GH_TOKEN for verify-tags API resolution" {
 	local action="${PROJECT_ROOT}/.github/actions/validate-action-pinning/action.yml"
 


### PR DESCRIPTION
## Summary

Address three unresolved P1 review findings from PRs #385, #391, and #423:

1. **Token passthrough** — the reusable validate-action-pinning workflow now accepts an optional `gh-token` secret and forwards it to the composite action, enabling callers to supply a stronger PAT/App token for private/cross-org action lookups.
2. **Rustup egress** — the `examples/ci-rust.yml` build job's allowed-endpoints now includes `sh.rustup.rs:443` (matching the coverage job) so rustup bootstrap succeeds under `egress-policy: block`.
3. **Merge-queue publish** — the `examples/ci-docker.yml` push condition is now `github.event_name == 'push'` (instead of `!= 'pull_request'`) so merge-queue validation no longer publishes images for temporary queue SHAs.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #474

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes several CI workflow edge cases.

- Adds optional token passthrough for the reusable action-pinning workflow.
- Restricts Docker image publishing to push events.
- Adds the missing rustup bootstrap endpoint to the Rust example allowlist.
- Adds a Bats check for the new token forwarding wiring.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-validate-action-pinning.yml | Adds an optional `gh-token` secret and forwards it to the composite action input. |
| examples/ci-docker.yml | Changes Docker publishing so merge queue events validate without pushing images. |
| examples/ci-rust.yml | Adds `sh.rustup.rs:443` to the blocked-egress Rust build allowlist. |
| tests/bats/integration/test_version_drift_workflows.bats | Adds coverage for the reusable workflow token forwarding strings. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): address unresolved bot review f..."](https://github.com/lgtm-hq/lgtm-ci/commit/8cfb68b71f04533e696623af9557c766b3a0c3f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43343692)</sub>

<!-- /greptile_comment -->