### PR TITLE
feat(quality): extend validate-static-job-names to flag any expression-based name with if

### DIFF
--- a/scripts/ci/quality/validate-static-job-names.sh
+++ b/scripts/ci/quality/validate-static-job-names.sh
@@ -15,14 +15,45 @@ if [[ ! -d "${WORKFLOWS_DIR}" ]]; then
 	exit 1
 fi
 
+# Documented exceptions: workflow:job-id pairs intentionally allowed to combine
+# an expression-based name: with a job-level if:. Each entry MUST have team
+# sign-off and a rationale in docs/workflow-contract.md.
+#
+# Draft-PR skip pattern (always runs on non-PR events; callers document the
+# check is not required on drafts):
+#   reusable-test-node.yml:test-vitest
+#   reusable-site-quality.yml:site-build-link
+#   reusable-site-quality.yml:site-test
+#   reusable-test-python.yml:test
+#   reusable-test-node-custom.yml:test
+#   reusable-test-shell.yml:test
+#   reusable-rust-test.yml:test
+#   reusable-test-e2e.yml:test
+#   reusable-test-rust-build.yml:build
+#
+# Event-gated (check is not required so skip does not block merge):
+#   reusable-dependency-review.yml:dependency-review
+#
+# Uses always() — never actually skips; conditional-success gate:
+#   reusable-required-check.yml:gate
+STATIC_JOB_NAME_EXCEPTIONS="${STATIC_JOB_NAME_EXCEPTIONS:-reusable-dependency-review.yml:dependency-review reusable-required-check.yml:gate reusable-test-e2e.yml:test reusable-test-rust-build.yml:build reusable-test-node.yml:test-vitest reusable-site-quality.yml:site-build-link reusable-site-quality.yml:site-test reusable-test-python.yml:test reusable-test-node-custom.yml:test reusable-test-shell.yml:test reusable-rust-test.yml:test}"
+
 violations=0
 
 while IFS= read -r -d '' workflow; do
+	rel_file="${workflow#"${WORKFLOWS_DIR%/}/"}"
 	awk_output="$(
-		awk -v file="${workflow#"${WORKFLOWS_DIR%/}/"}" '
+		awk -v file="${rel_file}" -v exceptions="${STATIC_JOB_NAME_EXCEPTIONS}" '
+		BEGIN {
+			n = split(exceptions, arr, " ")
+			for (i = 1; i <= n; i++) {
+				if (arr[i] != "") exempt[arr[i]] = 1
+			}
+		}
 		function flush_job() {
-			if (in_job && has_if && name ~ /\$\{\{|format\(/) {
-				if (name ~ /matrix\./ || name ~ /format\(/ || name ~ /&&.*\|\|/) {
+			if (in_job && has_if && name ~ /\$\{\{/) {
+				key = file ":" job_id
+				if (!(key in exempt)) {
 					printf("%s:%d: job %s uses dynamic job.name with if:\n  %s\n", file, name_line, job_id, name)
 					violations++
 				}

--- a/scripts/ci/quality/validate-static-job-names.sh
+++ b/scripts/ci/quality/validate-static-job-names.sh
@@ -36,7 +36,7 @@ fi
 #
 # Uses always() — never actually skips; conditional-success gate:
 #   reusable-required-check.yml:gate
-STATIC_JOB_NAME_EXCEPTIONS="${STATIC_JOB_NAME_EXCEPTIONS:-reusable-dependency-review.yml:dependency-review reusable-required-check.yml:gate reusable-test-e2e.yml:test reusable-test-rust-build.yml:build reusable-test-node.yml:test-vitest reusable-site-quality.yml:site-build-link reusable-site-quality.yml:site-test reusable-test-python.yml:test reusable-test-node-custom.yml:test reusable-test-shell.yml:test reusable-rust-test.yml:test}"
+STATIC_JOB_NAME_EXCEPTIONS="${STATIC_JOB_NAME_EXCEPTIONS-reusable-dependency-review.yml:dependency-review reusable-required-check.yml:gate reusable-test-e2e.yml:test reusable-test-rust-build.yml:build reusable-test-node.yml:test-vitest reusable-site-quality.yml:site-build-link reusable-site-quality.yml:site-test reusable-test-python.yml:test reusable-test-node-custom.yml:test reusable-test-shell.yml:test reusable-rust-test.yml:test}"
 
 violations=0
 

--- a/tests/bats/integration/test_reusable_static_job_names.bats
+++ b/tests/bats/integration/test_reusable_static_job_names.bats
@@ -130,3 +130,85 @@ YAML
 	' "$workflow"
 	assert_success
 }
+
+@test "validate-static-job-names: flags inputs-based name with job-level event skip (#429 shape)" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	mkdir -p "${workflows_dir}"
+	cat >"${workflows_dir}/reusable-inputs-skip-bad.yml" <<'YAML'
+---
+name: Inputs-based name with event skip
+on:
+  workflow_call:
+    inputs:
+      job-name:
+        type: string
+        default: My check
+      run-on-push:
+        type: boolean
+        default: true
+jobs:
+  check:
+    name: ${{ inputs.job-name }}
+    if: ${{ inputs.run-on-push }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" STATIC_JOB_NAME_EXCEPTIONS="" run "${VALIDATOR}"
+	assert_failure
+	assert_output --partial "dynamic job.name"
+}
+
+@test "validate-static-job-names: static name with job-level if passes" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	mkdir -p "${workflows_dir}"
+	cat >"${workflows_dir}/reusable-static-if-good.yml" <<'YAML'
+---
+name: Static name with conditional
+on:
+  workflow_call:
+    inputs:
+      enabled:
+        type: boolean
+        default: true
+jobs:
+  lint:
+    name: Lint checks
+    if: ${{ inputs.enabled }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" STATIC_JOB_NAME_EXCEPTIONS="" run "${VALIDATOR}"
+	assert_success
+	assert_output --partial "OK:"
+}
+
+@test "validate-static-job-names: exception mechanism skips documented jobs" {
+	local workflows_dir="${BATS_TEST_TMPDIR}/.github/workflows"
+	mkdir -p "${workflows_dir}"
+	cat >"${workflows_dir}/reusable-excepted.yml" <<'YAML'
+---
+name: Excepted workflow
+on:
+  workflow_call:
+    inputs:
+      job-name:
+        type: string
+      enabled:
+        type: boolean
+jobs:
+  my-job:
+    name: ${{ inputs.job-name }}
+    if: ${{ inputs.enabled }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+YAML
+
+	WORKFLOWS_DIR="${workflows_dir}" STATIC_JOB_NAME_EXCEPTIONS="reusable-excepted.yml:my-job" run "${VALIDATOR}"
+	assert_success
+	assert_output --partial "OK:"
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Extend `validate-static-job-names.sh` to flag ANY job combining a job-level `if:` with an expression-based `name:` (containing `${{}}`), not just `matrix.`/`format()`/ternary patterns. This prevents the #429 failure class (unreportable required checks when a dynamic-name job is skipped) from being reintroduced in any reusable workflow.

Adds a documented `STATIC_JOB_NAME_EXCEPTIONS` mechanism (space-delimited `workflow:job-id` pairs, overridable via env var) consistent with the other contract validators. Existing legitimate jobs are grandfathered with rationale comments.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #479

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends the static job-name validator for reusable workflows. The main changes are:

- Flags any expression-based job `name:` combined with a job-level `if:`.
- Adds a documented exception list for grandfathered workflow jobs.
- Lets callers override exceptions, including an empty value for strict audits.
- Adds integration tests for dynamic names, static names, and explicit exceptions.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/quality/validate-static-job-names.sh | Broadens dynamic job-name detection and honors empty exception overrides. |
| tests/bats/integration/test_reusable_static_job_names.bats | Adds integration coverage for strict audits and explicit exception handling. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(quality): use ${VAR-default} to pres..."](https://github.com/lgtm-hq/lgtm-ci/commit/8d46f37cdb2bf34d88730f7f7d81fafd00ed40e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43345989)</sub>

<!-- /greptile_comment -->