### PR TITLE
feat(ci): wire main-failure-notifier into ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,15 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+
+  notify-failure:
+    needs: [quality, shell-tests]
+    if: failure() && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/reusable-main-failure-notifier.yml
+    with:
+      workflow-key: ci
+      tooling-ref: ${{ github.sha }}
+    permissions:
+      actions: read
+      contents: read
+      issues: write

--- a/tests/bats/integration/test_ci_main_failure_notifier.bats
+++ b/tests/bats/integration/test_ci_main_failure_notifier.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for the main-failure-notifier caller in ci.yml
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/ci.yml"
+
+@test "ci.yml: defines notify-failure job" {
+	run grep -F "notify-failure:" "$WORKFLOW"
+	assert_success
+}
+
+@test "ci.yml: notify-failure depends on main jobs" {
+	run grep -F "needs: [quality, shell-tests]" "$WORKFLOW"
+	assert_success
+}
+
+@test "ci.yml: notify-failure gates on failure and main branch" {
+	run grep -F "failure()" "$WORKFLOW"
+	assert_success
+	run grep -F "github.ref == 'refs/heads/main'" "$WORKFLOW"
+	assert_success
+}
+
+@test "ci.yml: notify-failure calls reusable-main-failure-notifier" {
+	run grep -F "reusable-main-failure-notifier.yml" "$WORKFLOW"
+	assert_success
+}
+
+@test "ci.yml: notify-failure passes workflow-key" {
+	run grep -F "workflow-key: ci" "$WORKFLOW"
+	assert_success
+}
+
+@test "ci.yml: notify-failure grants minimal required permissions" {
+	run awk '
+		/notify-failure:/ { in_job = 1; in_perms = 0 }
+		in_job && /^  [A-Za-z_][A-Za-z0-9_-]*:/ && $0 !~ /notify-failure:/ {
+			in_job = 0
+			in_perms = 0
+		}
+		in_job && /permissions:/ { in_perms = 1 }
+		in_perms && /actions: read/ { found_actions = 1 }
+		in_perms && /contents: read/ { found_contents = 1 }
+		in_perms && /issues: write/ { found_issues = 1 }
+		END { exit !(found_actions && found_contents && found_issues) }
+	' "$WORKFLOW"
+	assert_success
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Wire `reusable-main-failure-notifier.yml` into `ci.yml` so that silent
main-branch failures (quality, shell tests) surface as deduplicated
GitHub issues. This was the missing adoption step after PR #426 shipped
the reusable notifier mechanism (#424).

The `notify-failure` job runs after `quality` and `shell-tests`, gated
on `failure() && github.ref == 'refs/heads/main'`, with minimal
permissions (`actions: read`, `contents: read`, `issues: write`).

`registry-health-check.yml` already has its own `open-issue-on-failure`
mechanism and does not need the notifier.

## Type of Change

- [x] CI/CD improvement

## Changes Made

- Added `notify-failure` job to `.github/workflows/ci.yml` calling
  `reusable-main-failure-notifier.yml` with `workflow-key: ci`
- Added BATS contract tests validating the caller shape, `needs` graph,
  `if` condition, workflow-key, and permissions

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #475

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR wires the main failure notifier into the CI workflow. The main changes are:

- Adds a `notify-failure` job after `quality` and `shell-tests`.
- Gates notification on failed `main` branch runs.
- Adds BATS contract tests for the caller shape, needs graph, condition, inputs, and permissions.
</details>

<h3>Confidence Score: 4/5</h3>

The CI notification path can fail before creating the main-branch failure issue.

- The new caller passes the workflow run SHA as the tooling checkout ref.
- The reusable notifier checks out a separate tooling repository at that ref.
- A missing ref stops the notifier before the issue creation step.

.github/workflows/ci.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds the `notify-failure` reusable workflow caller, with a tooling ref that can point at the wrong repository. |
| tests/bats/integration/test_ci_main_failure_notifier.bats | Adds BATS contract coverage for the new CI notifier wiring. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fci.yml%3A68%0A**Tooling%20Ref%20Targets%20Wrong%20Repository**%0A%0AWhen%20CI%20fails%20on%20%60main%60%2C%20the%20reusable%20notifier%20checks%20out%20the%20hard-coded%20%60lgtm-hq%2Flgtm-ci%60%20tooling%20repository%20at%20%60tooling-ref%60.%20This%20caller%20passes%20%60%24%7B%7B%20github.sha%20%7D%7D%60%2C%20which%20is%20the%20run%20commit%20for%20this%20workflow%2C%20so%20the%20checkout%20can%20target%20a%20ref%20that%20is%20not%20present%20in%20the%20tooling%20repository%20and%20the%20notifier%20fails%20before%20it%20opens%20the%20failure%20issue.%0A%0A&pr=489&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fci.yml%3A68%0A**Tooling%20Ref%20Targets%20Wrong%20Repository**%0A%0AWhen%20CI%20fails%20on%20%60main%60%2C%20the%20reusable%20notifier%20checks%20out%20the%20hard-coded%20%60lgtm-hq%2Flgtm-ci%60%20tooling%20repository%20at%20%60tooling-ref%60.%20This%20caller%20passes%20%60%24%7B%7B%20github.sha%20%7D%7D%60%2C%20which%20is%20the%20run%20commit%20for%20this%20workflow%2C%20so%20the%20checkout%20can%20target%20a%20ref%20that%20is%20not%20present%20in%20the%20tooling%20repository%20and%20the%20notifier%20fails%20before%20it%20opens%20the%20failure%20issue.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=489&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22feat%2F475-wire-main-failure-notifier%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2F475-wire-main-failure-notifier%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fci.yml%3A68%0A**Tooling%20Ref%20Targets%20Wrong%20Repository**%0A%0AWhen%20CI%20fails%20on%20%60main%60%2C%20the%20reusable%20notifier%20checks%20out%20the%20hard-coded%20%60lgtm-hq%2Flgtm-ci%60%20tooling%20repository%20at%20%60tooling-ref%60.%20This%20caller%20passes%20%60%24%7B%7B%20github.sha%20%7D%7D%60%2C%20which%20is%20the%20run%20commit%20for%20this%20workflow%2C%20so%20the%20checkout%20can%20target%20a%20ref%20that%20is%20not%20present%20in%20the%20tooling%20repository%20and%20the%20notifier%20fails%20before%20it%20opens%20the%20failure%20issue.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=489&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(ci): wire main-failure-notifier int..."](https://github.com/lgtm-hq/lgtm-ci/commit/46d326290db9a881039be95f2f69b271555c5715) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43346550)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->