### PR TITLE
feat(org): add list-rulesets.sh discovery helper

### DIFF
--- a/docs/org-rulesets.md
+++ b/docs/org-rulesets.md
@@ -43,10 +43,13 @@ update this table in the same PR that updates the live ruleset.
 ## Tooling
 
 Operator scripts live under `scripts/ci/org/`. They require org-admin `gh`
-auth and honor `LGTM_ORG` (default `lgtm-hq`). Workflow: export → edit
-locally → dry-run sync → apply.
+auth and honor `LGTM_ORG` (default `lgtm-hq`). Workflow: **discover → export
+→ edit locally → dry-run sync → apply**.
 
 ```bash
+# Discover: list all org rulesets (id, name, enforcement, target repos)
+scripts/ci/org/list-rulesets.sh
+
 # Fetch a live ruleset (read-only; stdout by default, -o for a local file)
 scripts/ci/org/export-ruleset.sh checks-py-lintro 16132640 -o /tmp/ruleset.json
 
@@ -56,6 +59,10 @@ scripts/ci/org/sync-ruleset.sh /tmp/ruleset.json
 # Apply the change to the live org ruleset
 scripts/ci/org/sync-ruleset.sh --apply /tmp/ruleset.json
 ```
+
+`list-rulesets.sh` prints a compact table of ruleset id, name, enforcement
+level, and target repositories — use it to find the id before exporting.
+Pass `-q` to suppress informational log lines.
 
 `sync-ruleset.sh` strips read-only fields (`id`, `node_id`, `source`,
 `created_at`, `_links`, …) before the PUT and is a dry run unless `--apply`

--- a/scripts/ci/org/list-rulesets.sh
+++ b/scripts/ci/org/list-rulesets.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: List org rulesets as a compact discovery table (read-only)
+#
+# Usage:
+#   list-rulesets.sh [-q]
+#
+# Options:
+#   -q  Quiet: print the table only (no informational log lines)
+#
+# Environment variables:
+#   LGTM_ORG - GitHub organization (default: lgtm-hq)
+#
+# Requires org-admin `gh` auth. Prints a table of ruleset id, name,
+# enforcement level, and target repositories to stdout. Use this as
+# the discovery step before export → edit → sync (see docs/org-rulesets.md).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/log.sh
+source "$SCRIPT_DIR/../lib/log.sh"
+
+QUIET="false"
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	-q | --quiet)
+		QUIET="true"
+		shift
+		;;
+	-h | --help)
+		echo "Usage: $(basename "$0") [-q]" >&2
+		exit 0
+		;;
+	*)
+		log_error "Unknown argument: $1"
+		echo "Usage: $(basename "$0") [-q]" >&2
+		exit 2
+		;;
+	esac
+done
+
+for tool in gh jq; do
+	if ! command -v "$tool" >/dev/null 2>&1; then
+		log_error "Required tool not found: ${tool}"
+		exit 1
+	fi
+done
+
+LGTM_ORG="${LGTM_ORG:-lgtm-hq}"
+readonly ENDPOINT="orgs/${LGTM_ORG}/rulesets"
+
+if [[ "$QUIET" != "true" ]]; then
+	log_info "Fetching rulesets for ${LGTM_ORG}"
+fi
+
+if ! payload="$(gh api "$ENDPOINT")"; then
+	log_error "Failed to fetch ${ENDPOINT} (check gh auth and org permissions)"
+	exit 1
+fi
+
+if ! jq -e 'type == "array"' <<<"$payload" >/dev/null 2>&1; then
+	log_error "Unexpected response: expected a JSON array"
+	exit 1
+fi
+
+count="$(jq 'length' <<<"$payload")"
+if [[ "$count" -eq 0 ]]; then
+	if [[ "$QUIET" != "true" ]]; then
+		log_info "No rulesets found for ${LGTM_ORG}"
+	fi
+	exit 0
+fi
+
+jq -r '
+  ["ID","NAME","ENFORCEMENT","REPOS"],
+  ["--","----","-----------","-----"],
+  (.[] |
+    [
+      (.id | tostring),
+      .name,
+      .enforcement,
+      ((.conditions.repository_name.include // []) | join(", "))
+    ]
+  )
+  | @tsv
+' <<<"$payload" | column -t -s $'\t'
+
+if [[ "$QUIET" != "true" ]]; then
+	log_info "${count} ruleset(s) found"
+fi

--- a/scripts/ci/org/list-rulesets.sh
+++ b/scripts/ci/org/list-rulesets.sh
@@ -40,7 +40,7 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
-for tool in gh jq; do
+for tool in gh jq column; do
 	if ! command -v "$tool" >/dev/null 2>&1; then
 		log_error "Required tool not found: ${tool}"
 		exit 1
@@ -54,7 +54,7 @@ if [[ "$QUIET" != "true" ]]; then
 	log_info "Fetching rulesets for ${LGTM_ORG}"
 fi
 
-if ! payload="$(gh api "$ENDPOINT")"; then
+if ! payload="$(gh api --paginate "${ENDPOINT}?per_page=100" | jq -s 'add // []')"; then
 	log_error "Failed to fetch ${ENDPOINT} (check gh auth and org permissions)"
 	exit 1
 fi

--- a/tests/bats/unit/org/test_list_rulesets.bats
+++ b/tests/bats/unit/org/test_list_rulesets.bats
@@ -52,7 +52,7 @@ mock_gh_with_fixture() {
 	run bash "$SCRIPT" -q
 	assert_success
 	run cat "${BATS_TEST_TMPDIR}/mock_calls_gh"
-	assert_output --partial "api orgs/lgtm-hq/rulesets"
+	assert_output --partial "api --paginate orgs/lgtm-hq/rulesets?per_page=100"
 }
 
 @test "list-rulesets: LGTM_ORG overrides the organization" {
@@ -60,7 +60,7 @@ mock_gh_with_fixture() {
 	LGTM_ORG="other-org" run bash "$SCRIPT" -q
 	assert_success
 	run cat "${BATS_TEST_TMPDIR}/mock_calls_gh"
-	assert_output --partial "api orgs/other-org/rulesets"
+	assert_output --partial "api --paginate orgs/other-org/rulesets?per_page=100"
 }
 
 @test "list-rulesets: logs info when not quiet" {

--- a/tests/bats/unit/org/test_list_rulesets.bats
+++ b/tests/bats/unit/org/test_list_rulesets.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/org/list-rulesets.sh (mocked gh, no live API)
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+
+FIXTURE_RELATIVE="json/org_rulesets_list.json"
+
+setup() {
+	setup_temp_dir
+	save_path
+	export SCRIPT="${PROJECT_ROOT}/scripts/ci/org/list-rulesets.sh"
+	export FIXTURE="${FIXTURES_DIR}/${FIXTURE_RELATIVE}"
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+mock_gh_with_fixture() {
+	mock_command_record "gh" "$(cat "$FIXTURE")"
+}
+
+@test "list-rulesets: prints table with id, name, enforcement, and repos" {
+	mock_gh_with_fixture
+	run bash "$SCRIPT" -q
+	assert_success
+	assert_output --partial "16132640"
+	assert_output --partial "checks-py-lintro"
+	assert_output --partial "active"
+	assert_output --partial "py-lintro"
+	assert_output --partial "16132643"
+	assert_output --partial "checks-rustume"
+	assert_output --partial "evaluate"
+	assert_output --partial "Rustume"
+}
+
+@test "list-rulesets: table has header row" {
+	mock_gh_with_fixture
+	run bash "$SCRIPT" -q
+	assert_success
+	assert_output --partial "ID"
+	assert_output --partial "NAME"
+	assert_output --partial "ENFORCEMENT"
+	assert_output --partial "REPOS"
+}
+
+@test "list-rulesets: calls gh api with correct endpoint" {
+	mock_gh_with_fixture
+	run bash "$SCRIPT" -q
+	assert_success
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_output --partial "api orgs/lgtm-hq/rulesets"
+}
+
+@test "list-rulesets: LGTM_ORG overrides the organization" {
+	mock_gh_with_fixture
+	LGTM_ORG="other-org" run bash "$SCRIPT" -q
+	assert_success
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_gh"
+	assert_output --partial "api orgs/other-org/rulesets"
+}
+
+@test "list-rulesets: logs info when not quiet" {
+	mock_gh_with_fixture
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Fetching rulesets"
+	assert_output --partial "2 ruleset(s) found"
+}
+
+@test "list-rulesets: -q suppresses info log lines" {
+	mock_gh_with_fixture
+	run bash "$SCRIPT" -q
+	assert_success
+	refute_output --partial "Fetching rulesets"
+	refute_output --partial "ruleset(s) found"
+}
+
+@test "list-rulesets: handles empty ruleset array" {
+	mock_command_record "gh" "[]"
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "No rulesets found"
+}
+
+@test "list-rulesets: fails when gh api errors" {
+	mock_command "gh" "" 1
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "Failed to fetch"
+}
+
+@test "list-rulesets: fails on unexpected non-array response" {
+	mock_command "gh" '{"error":"bad"}'
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "expected a JSON array"
+}
+
+@test "list-rulesets: fails on unknown argument" {
+	run bash "$SCRIPT" --bogus
+	assert_failure
+	assert_output --partial "Unknown argument"
+}

--- a/tests/fixtures/json/org_rulesets_list.json
+++ b/tests/fixtures/json/org_rulesets_list.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": 16132640,
+    "name": "checks-py-lintro",
+    "target": "branch",
+    "source_type": "Organization",
+    "source": "lgtm-hq",
+    "enforcement": "active",
+    "node_id": "RRS_lADOLEx45M8AAAABJg",
+    "conditions": {
+      "ref_name": {
+        "exclude": [],
+        "include": ["~DEFAULT_BRANCH"]
+      },
+      "repository_name": {
+        "exclude": [],
+        "include": ["py-lintro"],
+        "protected": false
+      }
+    }
+  },
+  {
+    "id": 16132643,
+    "name": "checks-rustume",
+    "target": "branch",
+    "source_type": "Organization",
+    "source": "lgtm-hq",
+    "enforcement": "evaluate",
+    "node_id": "RRS_lADOLEx45M8AAAABJh",
+    "conditions": {
+      "ref_name": {
+        "exclude": [],
+        "include": ["~DEFAULT_BRANCH"]
+      },
+      "repository_name": {
+        "exclude": [],
+        "include": ["Rustume"],
+        "protected": false
+      }
+    }
+  }
+]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Add `scripts/ci/org/list-rulesets.sh` — a discovery helper that prints a
compact table of org ruleset id, name, enforcement level, and target
repositories via `gh api /orgs/{org}/rulesets`. This rounds off the tooling
gap from #301 (PR #404) by completing the documented discover → export →
edit → sync operator workflow.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Changes Made

- Add `scripts/ci/org/list-rulesets.sh` with `-q`/`--quiet` flag and
  `LGTM_ORG` env var support, following the style of the existing
  `export-ruleset.sh` and `sync-ruleset.sh` scripts
- Add 10 BATS unit tests with mocked `gh` in
  `tests/bats/unit/org/test_list_rulesets.bats`
- Add test fixture `tests/fixtures/json/org_rulesets_list.json`
- Update `docs/org-rulesets.md` to document `list-rulesets.sh` as the
  discovery step in the operator workflow

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Quality Checks

- [x] `uv run lintro chk` — zero issues (all 27 tools pass)
- [x] `make test` — all new tests pass (2806/2807 total; 1 pre-existing
  failure in `run-rust-coverage-html` unrelated to this change)

## Breaking Changes

None

## Closes

- Closes #483

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an org ruleset discovery helper and documents it in the operator workflow.

- New `list-rulesets.sh` script for listing org ruleset IDs, names, enforcement, and repositories.
- Pagination and required tool checks for the discovery path.
- BATS tests and a JSON fixture for the new helper.
- Documentation updates for the discover → export → edit → sync workflow.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/org/list-rulesets.sh | Adds the ruleset listing helper with pagination, JSON validation, table output, quiet mode, and required tool checks. |
| tests/bats/unit/org/test_list_rulesets.bats | Adds unit tests for output, endpoint selection, org override, logging behavior, empty results, and error handling. |
| docs/org-rulesets.md | Documents the discovery step in the org ruleset operator workflow. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(org): update assertions for paginat..."](https://github.com/lgtm-hq/lgtm-ci/commit/d77f01cc4b271552f69c854eef5aa35263a65d4d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43346616)</sub>

<!-- /greptile_comment -->