### PR TITLE
feat(file-breakdown): add category-based classification with distribution bar

### DIFF
--- a/.github/workflows/reusable-publish-file-breakdown.yml
+++ b/.github/workflows/reusable-publish-file-breakdown.yml
@@ -55,6 +55,13 @@ on:
         required: false
         type: string
         default: "github-minimal"
+      config-path:
+        description: >-
+          Path to category config file relative to repo root
+          (default: .github/file-breakdown.yml)
+        required: false
+        type: string
+        default: ""
       runner-image:
         description: "GitHub-hosted runner image label"
         required: false
@@ -141,6 +148,7 @@ jobs:
           PR_FILES_JSON: pr-files.json
           MAX_ROWS: ${{ inputs.max-rows }}
           COMMENT_OUTPUT: file-breakdown.md
+          FILE_BREAKDOWN_CONFIG: ${{ inputs.config-path }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_SERVER_URL: ${{ github.server_url }}

--- a/scripts/ci/actions/generate-file-breakdown.sh
+++ b/scripts/ci/actions/generate-file-breakdown.sh
@@ -42,7 +42,9 @@ if not isinstance(data, dict) or "categories" not in data:
 cats = []
 for name, patterns in data["categories"].items():
     if isinstance(patterns, list):
-        cats.append({"name": name, "patterns": [str(p) for p in patterns]})
+        # yaml.safe_load may yield bool/int/None keys (true:, 123:, null:);
+        # coerce so jq gsub and markdown rendering always see strings.
+        cats.append({"name": str(name), "patterns": [str(p) for p in patterns]})
 json.dump(cats, sys.stdout)
 ' <"$config_path" 2>/dev/null || true
 }

--- a/scripts/ci/actions/generate-file-breakdown.sh
+++ b/scripts/ci/actions/generate-file-breakdown.sh
@@ -9,9 +9,64 @@
 #     Required env: PR_FILES_JSON (input path)
 #     Optional env: COMMENT_OUTPUT (write to file; stdout when unset),
 #       MAX_ROWS (detail rows cap, default 50),
+#       FILE_BREAKDOWN_CONFIG (category config path; default .github/file-breakdown.yml),
 #       GITHUB_RUN_ID, GITHUB_REPOSITORY, GITHUB_SERVER_URL (build link)
 
 set -euo pipefail
+
+# Default category definitions for file classification.
+# Order matters: first match wins. "Implementation" is the catch-all (must be last).
+DEFAULT_CATEGORIES='[
+  {"name":"CI-CD","patterns":["^\\.github/","^\\.gitlab-ci","^\\.circleci/","^Jenkinsfile$","^\\.travis\\.yml$"]},
+  {"name":"Tests","patterns":["(^|/)tests?/","(^|/)__tests__/","(^|/)spec/","(^|/)test_[^/]+$","_test\\.[^/]+$","\\.test\\.[^/]+$","_spec\\.[^/]+$","\\.spec\\.[^/]+$","(^|/)conftest\\.py$"]},
+  {"name":"Docs","patterns":["\\.md$","\\.rst$","\\.txt$","^docs?/","^LICENSE","^CHANGELOG","^CONTRIBUTING","^AUTHORS"]},
+  {"name":"Images","patterns":["\\.png$","\\.jpe?g$","\\.gif$","\\.svg$","\\.ico$","\\.webp$","\\.bmp$"]},
+  {"name":"Config","patterns":["\\.ya?ml$","\\.toml$","\\.ini$","\\.cfg$","\\.conf$","\\.json$","(^|/)\\.env","(^|/)Makefile$","(^|/)Dockerfile","(^|/)\\.editorconfig$","(^|/)\\.gitignore$","\\.lock$"]},
+  {"name":"Implementation","patterns":["."]}
+]'
+
+# Parse an optional YAML category config and print a JSON array.
+# Prints nothing when the file is absent or unparseable.
+load_category_config() {
+	local config_path="${FILE_BREAKDOWN_CONFIG:-.github/file-breakdown.yml}"
+	[[ -f "$config_path" ]] || return 0
+	python3 -c '
+import json, sys
+try:
+    import yaml
+except ImportError:
+    sys.exit(0)
+data = yaml.safe_load(sys.stdin)
+if not isinstance(data, dict) or "categories" not in data:
+    sys.exit(0)
+cats = []
+for name, patterns in data["categories"].items():
+    if isinstance(patterns, list):
+        cats.append({"name": name, "patterns": [str(p) for p in patterns]})
+json.dump(cats, sys.stdout)
+' <"$config_path" 2>/dev/null || true
+}
+
+# Merge user-defined categories with defaults.  User categories override
+# same-named defaults; new categories are inserted before the catch-all.
+merge_categories() {
+	local user_json="$1"
+	if [[ -z "$user_json" ]]; then
+		printf '%s' "$DEFAULT_CATEGORIES"
+		return
+	fi
+	jq -n --argjson defaults "$DEFAULT_CATEGORIES" --argjson user "$user_json" '
+		($user | map({key: .name, value: .}) | from_entries) as $umap |
+		($defaults | last) as $catchall |
+		($defaults[:-1] | map(
+			if $umap[.name] then $umap[.name] else . end
+		)) as $merged |
+		($user | map(
+			select(.name as $n | $defaults | map(.name) | index($n) | not)
+		)) as $new |
+		$merged + $new + [$catchall]
+	'
+}
 
 # =============================================================================
 # Step: fetch - Retrieve changed files for a PR as a single JSON array
@@ -70,6 +125,9 @@ step_generate() {
 	# cannot push a worst-case long-path PR past the limit and fail publish.
 	local body_byte_budget=60000
 
+	local categories_json
+	categories_json="$(merge_categories "$(load_category_config)")"
+
 	local repo build_url
 	repo="${GITHUB_REPOSITORY:-unknown/unknown}"
 	build_url="${GITHUB_SERVER_URL:-https://github.com}/${repo}/actions/runs/${GITHUB_RUN_ID:-0}"
@@ -100,19 +158,31 @@ EOF
 			'group_by(.status) | map("\(length) \(.[0].status)") | join(", ")' \
 			"$PR_FILES_JSON")
 
-		# Group by top-level directory; files at the repo root group as (root)
+		# Classify files into semantic categories and build summary rows
+		# with a Unicode distribution bar per category.
 		local -a all_group_rows=()
-		mapfile -t all_group_rows < <(jq -r '
-			def esc: gsub("[\r\n]"; " ") | gsub("\\|"; "\\|") | gsub("`"; "");
-			map(. + {
-				group: (if (.filename | test("/"))
-					then (.filename | split("/")[0] + "/")
-					else "(root)" end)
-			})
-			| group_by(.group)
-			| sort_by(-length, .[0].group)
-			| .[]
-			| "| `\(.[0].group | esc)` | \(length) | +\(map(.additions) | add // 0) | -\(map(.deletions) | add // 0) |"
+		mapfile -t all_group_rows < <(jq -r --argjson cats "$categories_json" '
+			def classify:
+				.filename as $f |
+				(first(
+					$cats[] | select(.patterns | any(. as $p | $f | test($p)))
+				).name) // "Other";
+			def bar($pct):
+				(($pct / 5 | round) | if . > 20 then 20 elif . < 0 then 0 else . end) as $blocks |
+				(20 - $blocks) as $eblocks |
+				([range($blocks)] | map("\u2588") | join("")) as $full |
+				([range($eblocks)] | map("\u2591") | join("")) as $empty |
+				"\($full)\($empty) \($pct)%";
+			length as $total |
+			map(. + {category: classify}) |
+			group_by(.category) |
+			sort_by(-(.|length), .[0].category) |
+			.[] |
+			(length) as $count |
+			(map(.additions) | add // 0) as $add |
+			(map(.deletions) | add // 0) as $del |
+			(if $total > 0 then ($count * 100 / $total | floor) else 0 end) as $pct |
+			"| \(.[0].category) | \($count) | +\($add) | -\($del) | \(bar($pct)) |"
 		' "$PR_FILES_JSON")
 		local total_groups=${#all_group_rows[@]}
 
@@ -142,7 +212,7 @@ EOF
 				if ((group_size_forced)); then
 					group_reason="dropped to keep this comment within GitHub's size limit"
 				fi
-				group_rows+=$'\n'"| _${remaining_groups} area(s) ${group_reason}_ | — | — | — |"
+				group_rows+=$'\n'"| _${remaining_groups} category(ies) ${group_reason}_ | — | — | — | — |"
 				group_rows=${group_rows#$'\n'}
 			fi
 			if ((shown > 0)); then
@@ -164,8 +234,8 @@ EOF
 
 **${total_files} file(s) changed** (+${total_add} / -${total_del}) — ${status_line}
 
-| Area | Files | Additions | Deletions |
-| --- | ---: | ---: | ---: |
+| Category | Files | Additions | Deletions | Distribution |
+| --- | ---: | ---: | ---: | --- |
 ${group_rows}
 
 <details>
@@ -206,8 +276,8 @@ EOF
 			shown=$best
 			body="$(assemble_body "$shown" 1 "$shown_groups" 0)"
 			if (($(printf '%s' "$body" | wc -c) > body_byte_budget)); then
-				# With zero detail rows, very many unique top-level groups can still
-				# exceed the budget. Drop area rows as the final shrink target.
+				# With zero detail rows, very many categories can still exceed
+				# the budget. Drop category rows as the final shrink target.
 				lo=0
 				hi=$total_groups
 				best=0

--- a/scripts/ci/actions/generate-file-breakdown.sh
+++ b/scripts/ci/actions/generate-file-breakdown.sh
@@ -55,7 +55,8 @@ merge_categories() {
 		printf '%s' "$DEFAULT_CATEGORIES"
 		return
 	fi
-	jq -n --argjson defaults "$DEFAULT_CATEGORIES" --argjson user "$user_json" '
+	jq -n --argjson defaults "$DEFAULT_CATEGORIES" '
+		input as $user |
 		($user | map({key: .name, value: .}) | from_entries) as $umap |
 		($defaults | last) as $catchall |
 		($defaults[:-1] | map(
@@ -65,7 +66,7 @@ merge_categories() {
 			select(.name as $n | $defaults | map(.name) | index($n) | not)
 		)) as $new |
 		$merged + $new + [$catchall]
-	'
+	' <<<"$user_json"
 }
 
 # =============================================================================
@@ -165,7 +166,7 @@ EOF
 			def classify:
 				.filename as $f |
 				(first(
-					$cats[] | select(.patterns | any(. as $p | $f | test($p)))
+					$cats[] | select(.patterns | any(. as $p | try ($f | test($p)) catch false))
 				).name) // "Other";
 			def bar($pct):
 				(($pct / 5 | round) | if . > 20 then 20 elif . < 0 then 0 else . end) as $blocks |
@@ -182,7 +183,7 @@ EOF
 			(map(.additions) | add // 0) as $add |
 			(map(.deletions) | add // 0) as $del |
 			(if $total > 0 then ($count * 100 / $total | floor) else 0 end) as $pct |
-			"| \(.[0].category) | \($count) | +\($add) | -\($del) | \(bar($pct)) |"
+			"| \(.[0].category | gsub("\\|"; "\\|")) | \($count) | +\($add) | -\($del) | \(bar($pct)) |"
 		' "$PR_FILES_JSON")
 		local total_groups=${#all_group_rows[@]}
 

--- a/scripts/ci/actions/generate-file-breakdown.sh
+++ b/scripts/ci/actions/generate-file-breakdown.sh
@@ -162,7 +162,8 @@ EOF
 		# Classify files into semantic categories and build summary rows
 		# with a Unicode distribution bar per category.
 		local -a all_group_rows=()
-		mapfile -t all_group_rows < <(jq -r --argjson cats "$categories_json" '
+		mapfile -t all_group_rows < <(printf '%s' "$categories_json" | jq -r --slurpfile files "$PR_FILES_JSON" '
+			. as $cats | $files[0] |
 			def classify:
 				.filename as $f |
 				(first(
@@ -184,7 +185,7 @@ EOF
 			(map(.deletions) | add // 0) as $del |
 			(if $total > 0 then ($count * 100 / $total | floor) else 0 end) as $pct |
 			"| \(.[0].category | gsub("\\|"; "\\|")) | \($count) | +\($add) | -\($del) | \(bar($pct)) |"
-		' "$PR_FILES_JSON")
+		')
 		local total_groups=${#all_group_rows[@]}
 
 		# Render each candidate detail row (bounded by the row cap) as a single

--- a/scripts/ci/actions/generate-file-breakdown.sh
+++ b/scripts/ci/actions/generate-file-breakdown.sh
@@ -184,7 +184,7 @@ EOF
 			(map(.additions) | add // 0) as $add |
 			(map(.deletions) | add // 0) as $del |
 			(if $total > 0 then ($count * 100 / $total | floor) else 0 end) as $pct |
-			"| \(.[0].category | gsub("\\|"; "\\|")) | \($count) | +\($add) | -\($del) | \(bar($pct)) |"
+			"| \(.[0].category | gsub("[\\r\\n]"; " ") | gsub("\\|"; "\\|")) | \($count) | +\($add) | -\($del) | \(bar($pct)) |"
 		')
 		local total_groups=${#all_group_rows[@]}
 

--- a/tests/bats/unit/actions/test_generate_file_breakdown.bats
+++ b/tests/bats/unit/actions/test_generate_file_breakdown.bats
@@ -445,6 +445,26 @@ YAML
 	assert_output --partial '| Implementation | 4 |'
 }
 
+@test "generate-file-breakdown: coerces non-string YAML category keys" {
+	python3 -c 'import yaml' 2>/dev/null || skip "python3 yaml module not available"
+
+	# Unquoted true: becomes bool True under yaml.safe_load — must still render.
+	cat >"${BATS_TEST_TMPDIR}/config.yml" <<'YAML'
+categories:
+  true:
+    - "\\.sh$"
+YAML
+
+	write_mixed_fixture "${BATS_TEST_TMPDIR}/files.json"
+	run env \
+		STEP="generate" \
+		PR_FILES_JSON="${BATS_TEST_TMPDIR}/files.json" \
+		FILE_BREAKDOWN_CONFIG="${BATS_TEST_TMPDIR}/config.yml" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial '| True | 2 |'
+}
+
 @test "generate-file-breakdown: falls back to defaults when config is absent" {
 	write_mixed_fixture "${BATS_TEST_TMPDIR}/files.json"
 	run env \

--- a/tests/bats/unit/actions/test_generate_file_breakdown.bats
+++ b/tests/bats/unit/actions/test_generate_file_breakdown.bats
@@ -30,6 +30,20 @@ write_mixed_fixture() {
 EOF
 }
 
+write_all_categories_fixture() {
+	local file="$1"
+	cat >"$file" <<'EOF'
+[
+  {"filename": ".github/workflows/ci.yml", "status": "modified", "additions": 3, "deletions": 1},
+  {"filename": "src/main.py", "status": "modified", "additions": 20, "deletions": 5},
+  {"filename": "tests/test_main.py", "status": "added", "additions": 15, "deletions": 0},
+  {"filename": "README.md", "status": "modified", "additions": 2, "deletions": 1},
+  {"filename": "logo.png", "status": "added", "additions": 0, "deletions": 0},
+  {"filename": "pyproject.toml", "status": "modified", "additions": 1, "deletions": 1}
+]
+EOF
+}
+
 # =============================================================================
 # STEP=generate - validation
 # =============================================================================
@@ -90,16 +104,16 @@ EOF
 	assert_output --partial "PR File Breakdown"
 }
 
-@test "generate-file-breakdown: groups files by top-level directory" {
+@test "generate-file-breakdown: classifies files into semantic categories" {
 	write_mixed_fixture "${BATS_TEST_TMPDIR}/files.json"
 	run env \
 		STEP="generate" \
 		PR_FILES_JSON="${BATS_TEST_TMPDIR}/files.json" \
 		bash "${PROJECT_ROOT}/${SCRIPT}"
 	assert_success
-	assert_output --partial '| `scripts/` | 2 | +40 | -2 |'
-	assert_output --partial '| `docs/` | 1 | +5 | -5 |'
-	assert_output --partial '| `(root)` | 1 | +0 | -40 |'
+	assert_output --partial '| Implementation | 2 | +40 | -2 |'
+	assert_output --partial '| Docs | 2 | +5 | -45 |'
+	refute_output --partial '| `scripts/` |'
 }
 
 @test "generate-file-breakdown: reports totals and status counts" {
@@ -171,14 +185,30 @@ EOF
 	assert_file_contains_literal "${BATS_TEST_TMPDIR}/comment.md" \
 		"dropped to keep this comment within GitHub's size limit"
 	# Fixed sections must survive the truncation.
-	assert_file_contains_literal "${BATS_TEST_TMPDIR}/comment.md" "| Area | Files |"
+	assert_file_contains_literal "${BATS_TEST_TMPDIR}/comment.md" "| Category | Files |"
 	assert_file_contains_literal "${BATS_TEST_TMPDIR}/comment.md" "View full build details"
 }
 
-@test "generate-file-breakdown: byte-caps area rows when details are already hidden" {
+@test "generate-file-breakdown: byte-caps category rows when details are already hidden" {
+	# Requires python3 + PyYAML — config with many categories triggers
+	# the category-row byte-cap path.
+	python3 -c 'import yaml' 2>/dev/null || skip "python3 yaml module not available"
+
+	# Generate config with 5000 unique categories
+	python3 -c '
+import sys
+sys.stdout.write("categories:\n")
+for i in range(5000):
+    name = "service-component-with-a-very-long-unique-category-name-" + str(i)
+    sys.stdout.write("  " + name + ":\n")
+    sys.stdout.write("    - \"^unique-svc-dir-" + str(i) + "/\"\n")
+sys.stdout.write("  Uncategorized:\n")
+sys.stdout.write("    - \".\"\n")
+' >"${BATS_TEST_TMPDIR}/config.yml"
+
 	jq -n '
 		[range(0; 5000) | {
-			filename: ("service-component-with-a-very-long-unique-area-name-\(.)/handler.go"),
+			filename: ("unique-svc-dir-\(.)/handler.go"),
 			status: "modified",
 			additions: 1,
 			deletions: 1
@@ -189,6 +219,7 @@ EOF
 		STEP="generate" \
 		MAX_ROWS="500" \
 		PR_FILES_JSON="${BATS_TEST_TMPDIR}/files.json" \
+		FILE_BREAKDOWN_CONFIG="${BATS_TEST_TMPDIR}/config.yml" \
 		COMMENT_OUTPUT="${BATS_TEST_TMPDIR}/comment.md" \
 		bash "${PROJECT_ROOT}/${SCRIPT}"
 	assert_success
@@ -199,7 +230,7 @@ EOF
 
 	assert_file_contains_literal "${BATS_TEST_TMPDIR}/comment.md" "5000 file(s) changed"
 	assert_file_contains_literal "${BATS_TEST_TMPDIR}/comment.md" \
-		"area(s) dropped to keep this comment within GitHub's size limit"
+		"category(ies) dropped to keep this comment within GitHub's size limit"
 	assert_file_contains_literal "${BATS_TEST_TMPDIR}/comment.md" \
 		"5000 more file(s) not shown (dropped to keep this comment within GitHub's size limit)."
 }
@@ -280,6 +311,164 @@ EOF
 		bash "${PROJECT_ROOT}/${SCRIPT}"
 	assert_success
 	assert_output --partial "<summary>Changed files</summary>"
+}
+
+# =============================================================================
+# STEP=generate - category classification
+# =============================================================================
+
+@test "generate-file-breakdown: classifies all six default categories" {
+	write_all_categories_fixture "${BATS_TEST_TMPDIR}/files.json"
+	run env \
+		STEP="generate" \
+		PR_FILES_JSON="${BATS_TEST_TMPDIR}/files.json" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial '| CI-CD | 1 |'
+	assert_output --partial '| Implementation | 1 |'
+	assert_output --partial '| Tests | 1 |'
+	assert_output --partial '| Docs | 1 |'
+	assert_output --partial '| Images | 1 |'
+	assert_output --partial '| Config | 1 |'
+}
+
+@test "generate-file-breakdown: CI-CD category takes priority over Config for .github files" {
+	cat >"${BATS_TEST_TMPDIR}/files.json" <<'EOF'
+[
+  {"filename": ".github/workflows/ci.yml", "status": "modified", "additions": 1, "deletions": 1},
+  {"filename": "config.yml", "status": "modified", "additions": 2, "deletions": 0}
+]
+EOF
+	run env \
+		STEP="generate" \
+		PR_FILES_JSON="${BATS_TEST_TMPDIR}/files.json" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial '| CI-CD | 1 |'
+	assert_output --partial '| Config | 1 |'
+}
+
+@test "generate-file-breakdown: test patterns match various conventions" {
+	cat >"${BATS_TEST_TMPDIR}/files.json" <<'EOF'
+[
+  {"filename": "tests/test_main.py", "status": "added", "additions": 10, "deletions": 0},
+  {"filename": "src/handler_test.go", "status": "added", "additions": 5, "deletions": 0},
+  {"filename": "app/models.spec.ts", "status": "added", "additions": 8, "deletions": 0},
+  {"filename": "__tests__/Button.test.jsx", "status": "added", "additions": 6, "deletions": 0}
+]
+EOF
+	run env \
+		STEP="generate" \
+		PR_FILES_JSON="${BATS_TEST_TMPDIR}/files.json" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial '| Tests | 4 |'
+	refute_output --partial '| Implementation |'
+}
+
+# =============================================================================
+# STEP=generate - distribution bar
+# =============================================================================
+
+@test "generate-file-breakdown: renders distribution bar per category" {
+	write_mixed_fixture "${BATS_TEST_TMPDIR}/files.json"
+	run env \
+		STEP="generate" \
+		PR_FILES_JSON="${BATS_TEST_TMPDIR}/files.json" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial '| Distribution |'
+	# Both categories have 2/4 files = 50% → 10 full blocks + 10 empty blocks
+	assert_output --partial '██████████░░░░░░░░░░ 50%'
+}
+
+@test "generate-file-breakdown: bar shows 100% for single category" {
+	cat >"${BATS_TEST_TMPDIR}/files.json" <<'EOF'
+[
+  {"filename": "src/a.py", "status": "added", "additions": 10, "deletions": 0},
+  {"filename": "src/b.py", "status": "added", "additions": 5, "deletions": 0}
+]
+EOF
+	run env \
+		STEP="generate" \
+		PR_FILES_JSON="${BATS_TEST_TMPDIR}/files.json" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial '████████████████████ 100%'
+}
+
+# =============================================================================
+# STEP=generate - config override
+# =============================================================================
+
+@test "generate-file-breakdown: extends categories via config file" {
+	python3 -c 'import yaml' 2>/dev/null || skip "python3 yaml module not available"
+
+	cat >"${BATS_TEST_TMPDIR}/config.yml" <<'YAML'
+categories:
+  Shell-Scripts:
+    - "\\.sh$"
+YAML
+
+	write_mixed_fixture "${BATS_TEST_TMPDIR}/files.json"
+	run env \
+		STEP="generate" \
+		PR_FILES_JSON="${BATS_TEST_TMPDIR}/files.json" \
+		FILE_BREAKDOWN_CONFIG="${BATS_TEST_TMPDIR}/config.yml" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	# .sh files now match Shell-Scripts (inserted before catch-all)
+	assert_output --partial '| Shell-Scripts | 2 |'
+	assert_output --partial '| Docs | 2 |'
+	refute_output --partial '| Implementation |'
+}
+
+@test "generate-file-breakdown: overrides default category patterns via config" {
+	python3 -c 'import yaml' 2>/dev/null || skip "python3 yaml module not available"
+
+	# Override Docs to only match .rst files
+	cat >"${BATS_TEST_TMPDIR}/config.yml" <<'YAML'
+categories:
+  Docs:
+    - "\\.rst$"
+YAML
+
+	write_mixed_fixture "${BATS_TEST_TMPDIR}/files.json"
+	run env \
+		STEP="generate" \
+		PR_FILES_JSON="${BATS_TEST_TMPDIR}/files.json" \
+		FILE_BREAKDOWN_CONFIG="${BATS_TEST_TMPDIR}/config.yml" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	# No .rst files → Docs category absent; .md files fall to Implementation
+	refute_output --partial '| Docs |'
+	assert_output --partial '| Implementation | 4 |'
+}
+
+@test "generate-file-breakdown: falls back to defaults when config is absent" {
+	write_mixed_fixture "${BATS_TEST_TMPDIR}/files.json"
+	run env \
+		STEP="generate" \
+		PR_FILES_JSON="${BATS_TEST_TMPDIR}/files.json" \
+		FILE_BREAKDOWN_CONFIG="${BATS_TEST_TMPDIR}/nonexistent.yml" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial '| Implementation | 2 |'
+	assert_output --partial '| Docs | 2 |'
+}
+
+@test "generate-file-breakdown: falls back to defaults on invalid config" {
+	printf 'not: [valid: yaml: {{' >"${BATS_TEST_TMPDIR}/bad.yml"
+
+	write_mixed_fixture "${BATS_TEST_TMPDIR}/files.json"
+	run env \
+		STEP="generate" \
+		PR_FILES_JSON="${BATS_TEST_TMPDIR}/files.json" \
+		FILE_BREAKDOWN_CONFIG="${BATS_TEST_TMPDIR}/bad.yml" \
+		bash "${PROJECT_ROOT}/${SCRIPT}"
+	assert_success
+	assert_output --partial '| Implementation | 2 |'
+	assert_output --partial '| Docs | 2 |'
 }
 
 # =============================================================================


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Replace directory-based file grouping in PR file breakdown comments with semantic
category classification (CI-CD, Tests, Docs, Images, Config, Implementation).
Each category row now includes a Unicode distribution bar showing what percentage
of changed files fall into that category. Consumer repos can optionally override
or extend the default category patterns via `.github/file-breakdown.yml`.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Changes Made

- **`scripts/ci/actions/generate-file-breakdown.sh`**: Add default category
  patterns with priority ordering, `load_category_config()` for YAML config
  parsing, `merge_categories()` for override/extend semantics, jq-based file
  classification, and Unicode distribution bar rendering (█/░, 20-char width)
- **`.github/workflows/reusable-publish-file-breakdown.yml`**: Add `config-path`
  input and wire `FILE_BREAKDOWN_CONFIG` env var to generate step
- **`tests/bats/unit/actions/test_generate_file_breakdown.bats`**: Update
  existing tests for category output, add 12 new tests covering classification
  accuracy, all six categories, CI-CD priority over Config, test pattern
  matching, distribution bar rendering, config override/extend, fallback
  behavior, and byte-cap interaction with many categories

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

The category summary table header changes from `| Area |` to `| Category |` with
an additional `| Distribution |` column. Truncation messages now say
"category(ies)" instead of "area(s)". Consumers that parse the comment body
programmatically may need to update their parsers.

## Closes

- Closes #478

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes the file-breakdown comment from directory grouping to category grouping. The main changes are:

- Default semantic categories for CI, tests, docs, images, config, and implementation files.
- Optional `.github/file-breakdown.yml` support for overriding or extending categories.
- Category distribution bars in the generated Markdown table.
- Workflow wiring for the optional config path.
- Expanded unit tests for classification, rendering, config fallback, and truncation behavior.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/actions/generate-file-breakdown.sh | Adds category loading, merging, classification, Markdown rendering, and distribution bars for file-breakdown output. |
| .github/workflows/reusable-publish-file-breakdown.yml | Adds a reusable workflow input for the optional category config path. |
| tests/bats/unit/actions/test_generate_file_breakdown.bats | Updates file-breakdown tests for category output, config behavior, and size-cap handling. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(file-breakdown): coerce YAML categor..."](https://github.com/lgtm-hq/lgtm-ci/commit/8c106f9e58bc5c108ad0defc09c075b308a45909) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43347848)</sub>

<!-- /greptile_comment -->