### PR TITLE
chore(deps): track harden-runner SHA pins outside workflows via Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,26 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\s*\\n\\s*default: \"(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\""
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Track pinned step-security/harden-runner SHAs outside workflows",
+      "managerFilePatterns": [
+        "/^scripts/ci/actions/validate-harden-runner-action-ref\\.sh$/",
+        "/^tests/bats/integration/test_harden_runner_action_ref\\.bats$/",
+        "/^tests/bats/integration/test_reusable_tooling_sparse_checkout\\.bats$/",
+        "/^docs/actions/security\\.md$/",
+        "/^docs/actions/README\\.md$/",
+        "/^docs/workflow-contract\\.md$/"
+      ],
+      "matchStrings": [
+        "step-security/harden-runner@(?<currentDigest>[a-f0-9]{40}) # v(?<currentValue>\\d+\\.\\d+\\.\\d+)",
+        "HARDEN_SHA='(?<currentDigest>[a-f0-9]{40})' # v(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "step-security/harden-runner",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ],
   "packageRules": [
@@ -48,6 +68,12 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["ghcr.io/lgtm-hq/py-lintro"],
       "pinDigests": true
+    },
+    {
+      "description": "Group harden-runner SHA pins so workflow and non-workflow copies update together",
+      "groupName": "step-security/harden-runner",
+      "matchPackageNames": ["step-security/harden-runner"],
+      "automerge": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -45,7 +45,8 @@
         "/^tests/bats/integration/test_reusable_tooling_sparse_checkout\\.bats$/",
         "/^docs/actions/security\\.md$/",
         "/^docs/actions/README\\.md$/",
-        "/^docs/workflow-contract\\.md$/"
+        "/^docs/workflow-contract\\.md$/",
+        "/^examples/publish-python-release\\.yml$/"
       ],
       "matchStrings": [
         "step-security/harden-runner@(?<currentDigest>[a-f0-9]{40}) # v(?<currentValue>\\d+\\.\\d+\\.\\d+)",

--- a/scripts/ci/actions/validate-harden-runner-action-ref.sh
+++ b/scripts/ci/actions/validate-harden-runner-action-ref.sh
@@ -14,7 +14,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 # dir containing only reusable-*.yml is safe.
 WORKFLOWS_DIR="${WORKFLOWS_DIR:-$REPO_ROOT/.github/workflows}"
 
-HARDEN_SHA='bf7454d06d71f1098171f2acdf0cd4708d7b5920'
+HARDEN_SHA='bf7454d06d71f1098171f2acdf0cd4708d7b5920' # v2.20.0
 STEP_SECURITY_HARDEN_RE="^[[:space:]]+uses:[[:space:]]+step-security/harden-runner@${HARDEN_SHA}([[:space:]]+#.*)?[[:space:]]*$"
 TOOLING_RESOLVE_RE='^[[:space:]]+uses:[[:space:]]+\./\.lgtm-ci-tooling/\.github/actions/resolve-egress-allowlist[[:space:]]*$'
 TOOLING_HARDEN_RE='^[[:space:]]+uses:[[:space:]]+\./\.lgtm-ci-tooling/\.github/actions/harden-runner[[:space:]]*$'

--- a/tests/bats/integration/test_harden_runner_sha_pins.bats
+++ b/tests/bats/integration/test_harden_runner_sha_pins.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Guard that validator HARDEN_SHA matches the canonical workflow pin
+
+load "../../helpers/common"
+
+VALIDATOR="${PROJECT_ROOT}/scripts/ci/actions/validate-harden-runner-action-ref.sh"
+CANONICAL_WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-validate.yml"
+
+@test "harden-runner SHA: validator HARDEN_SHA matches canonical reusable-validate.yml pin" {
+	local validator_sha workflow_sha
+	validator_sha="$(
+		sed -nE "s/^HARDEN_SHA='([a-f0-9]{40})'.*/\1/p" "$VALIDATOR" | head -1
+	)"
+	workflow_sha="$(
+		sed -nE 's/.*step-security\/harden-runner@([a-f0-9]{40}).*/\1/p' \
+			"$CANONICAL_WORKFLOW" | head -1
+	)"
+	[[ -n "$validator_sha" ]]
+	[[ -n "$workflow_sha" ]]
+	if [[ "$validator_sha" != "$workflow_sha" ]]; then
+		echo "HARDEN_SHA drift: validator=${validator_sha} workflow=${workflow_sha}" >&2
+		return 1
+	fi
+}


### PR DESCRIPTION
## Summary

Renovate already bumps `step-security/harden-runner` SHAs in workflows but missed the validator constant, BATS fixtures, and docs. Add custom regex managers for those copies and a pin-equality BATS guard so drift fails closed.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally (new BATS + lintro)
- [x] I have updated documentation if needed (Renovate covers existing doc pins)
- [x] Shell scripts pass `shellcheck` (via lintro)
- [x] YAML files pass `yamllint` (via lintro)
- [x] Python code passes `ruff` and `black` (via lintro)

## Breaking Changes

None

## Closes

- Closes #482

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR keeps harden-runner SHA pins in sync outside workflow files. The main changes are:

- Adds a Renovate regex manager for non-workflow harden-runner pins.
- Includes the example release workflow in the managed file list.
- Adds version metadata to the validator harden-runner SHA.
- Adds a BATS guard for validator and workflow SHA drift.
- Groups harden-runner Renovate updates together.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| renovate.json | Adds Renovate coverage for harden-runner SHA pins outside workflow files. |
| scripts/ci/actions/validate-harden-runner-action-ref.sh | Adds version metadata to the validator harden-runner SHA. |
| tests/bats/integration/test_harden_runner_sha_pins.bats | Adds a BATS check that compares the validator SHA with the canonical workflow pin. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(deps): include example workflow in h..."](https://github.com/lgtm-hq/lgtm-ci/commit/03f1513c4e577d89c5159ef63f4ba5e99476d13a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43387688)</sub>

<!-- /greptile_comment -->