### PR TITLE
feat(sbom)!: default fail-on-severity to critical in reusable-sbom

### DIFF
--- a/.github/workflows/reusable-sbom.yml
+++ b/.github/workflows/reusable-sbom.yml
@@ -25,10 +25,12 @@ on:
         type: boolean
         default: true
       fail-on-severity:
-        description: "Fail on vulnerability severity: critical, high, medium, low, none"
+        description: >-
+          Fail on vulnerability severity: critical, high, medium, low, none.
+          Empty string disables the gate (advisory-only).
         required: false
         type: string
-        default: ""
+        default: "critical"
       upload-sarif:
         description: "Upload vulnerability SARIF to GitHub Security"
         required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **workflows**: **BREAKING** — `reusable-sbom.yml` now defaults
+  `fail-on-severity` to `critical` instead of `""` (#480). Consumers that relied
+  on advisory-only scans (generate + scan without failing the job) must opt out
+  explicitly with `fail-on-severity: ""` (or `none`). Coordinate consumer repos
+  before adopting a release that includes this change.
+
 ### Deprecated
 
 ### Removed

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -814,6 +814,37 @@ receives full SBOM and provenance attestations.
 
 All inputs are opt-in; existing callers keep current behavior without changes.
 
+### SBOM (`reusable-sbom.yml`)
+
+Generates an SBOM with Syft, optionally scans it with Grype, and can create a
+Sigstore attestation. Used by release layouts such as
+[python-release-publish.md](python-release-publish.md).
+
+| Input                  | Default      | Description                                      |
+| ---------------------- | ------------ | ------------------------------------------------ |
+| `scan-vulnerabilities` | `true`       | Run Grype against the generated SBOM             |
+| `fail-on-severity`     | `"critical"` | Fail when findings meet this severity or higher  |
+| `upload-sarif`         | `false`      | Upload Grype SARIF to GitHub Security            |
+| `create-attestation`   | `false`      | Create a Sigstore attestation for the SBOM       |
+| `egress-preset`        | `sbom`       | Harden-runner allowlist preset (workflow-contract) |
+
+**Breaking (#480):** `fail-on-severity` previously defaulted to `""` (advisory
+only). Callers that must keep advisory-only behavior should pass
+`fail-on-severity: ""` or `none`.
+
+```yaml
+sbom:
+  uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@<sha>
+  permissions:
+    contents: read
+    security-events: write
+    id-token: write
+    attestations: write
+  with:
+    # default fail-on-severity is critical; opt out for advisory-only:
+    # fail-on-severity: ""
+```
+
 ## PR Automation And Security
 
 ### Semantic PR title

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -885,6 +885,18 @@ egress-preset: sbom
 Covers GitHub, Anchore (Syft/Grype), Sigstore attestation hosts. Canonical list:
 `scripts/ci/lib/egress/presets.sh` (preset name `sbom`).
 
+`reusable-sbom.yml` defaults `fail-on-severity` to `critical` (breaking as of
+issue #480). The Grype gate fails the job when findings meet or exceed that
+threshold. Callers that need the previous advisory-only posture must pass
+`fail-on-severity: ""` (or `none`):
+
+```yaml
+sbom:
+  uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@<sha>
+  with:
+    fail-on-severity: "" # advisory-only; default is critical
+```
+
 ## Action pinning policy
 
 Org repos must pin GitHub Actions to **commit SHAs only** and add a trailing

--- a/docs/workflows/deployment.md
+++ b/docs/workflows/deployment.md
@@ -107,7 +107,12 @@ job). Manifest schema and `workflow_run` caller patterns:
 
 ## Supply chain
 
-`reusable-sbom.yml` generates an SBOM with Cosign signing.
+`reusable-sbom.yml` generates an SBOM (Syft), optionally scans it with Grype, and
+can create a Sigstore attestation. `fail-on-severity` defaults to `critical` —
+the job fails when Grype finds vulnerabilities at that severity or higher. Opt
+out of the gate with `fail-on-severity: ""` (or `none`) for advisory-only scans.
+See [workflow-contract.md](../workflow-contract.md#sbom--attestation) and
+[reusable-workflows.md](../reusable-workflows.md#sbom-reusable-sbomyml).
 
 ### Rust release binaries
 

--- a/tests/bats/integration/test_reusable_sbom.bats
+++ b/tests/bats/integration/test_reusable_sbom.bats
@@ -31,6 +31,7 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-sbom.yml"
 	run awk '
 		/^  sbom:/ { in_job = 1; scan = 0 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  sbom:/ { in_job = 0; scan = 0 }
+		in_job && scan && /^[[:space:]]+- name:/ { scan = 0 }
 		in_job && /- name: Scan vulnerabilities/ { scan = 1 }
 		in_job && scan && /fail-on: \$\{\{ inputs\.fail-on-severity \}\}/ { found = 1; exit }
 		END { exit !found }
@@ -42,6 +43,7 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-sbom.yml"
 	run awk '
 		/^  sbom:/ { in_job = 1; scan = 0 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  sbom:/ { in_job = 0; scan = 0 }
+		in_job && scan && /^[[:space:]]+- name:/ { scan = 0 }
 		in_job && /- name: Scan vulnerabilities/ { scan = 1 }
 		in_job && scan && /if: inputs\.scan-vulnerabilities/ { found = 1; exit }
 		END { exit !found }

--- a/tests/bats/integration/test_reusable_sbom.bats
+++ b/tests/bats/integration/test_reusable_sbom.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-sbom workflow inputs and scan wiring (#480)
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-sbom.yml"
+
+@test "reusable-sbom: fail-on-severity defaults to critical" {
+	run awk '/^      fail-on-severity:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: "critical"'
+}
+
+@test "reusable-sbom: scan-vulnerabilities defaults to true" {
+	run awk '/^      scan-vulnerabilities:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: true'
+}
+
+@test "reusable-sbom: egress-preset defaults to sbom" {
+	run awk '/^      egress-preset:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: "sbom"'
+}
+
+@test "reusable-sbom: scan step passes fail-on from fail-on-severity input" {
+	run awk '
+		/^  sbom:/ { in_job = 1; scan = 0 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  sbom:/ { in_job = 0; scan = 0 }
+		in_job && /- name: Scan vulnerabilities/ { scan = 1 }
+		in_job && scan && /fail-on: \$\{\{ inputs\.fail-on-severity \}\}/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-sbom: scan step is gated on scan-vulnerabilities" {
+	run awk '
+		/^  sbom:/ { in_job = 1; scan = 0 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  sbom:/ { in_job = 0; scan = 0 }
+		in_job && /- name: Scan vulnerabilities/ { scan = 1 }
+		in_job && scan && /if: inputs\.scan-vulnerabilities/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}


### PR DESCRIPTION
## Summary

Flip `reusable-sbom.yml` `fail-on-severity` default from `""` (advisory-only) to `critical`, completing the deferred half of #366. Consumers that relied on generate+scan without failing the job must opt out explicitly.

**Consumer coordination:** before adopting a release that includes this change, audit callers of `reusable-sbom.yml`. Any workflow that intentionally kept the gate advisory-only must pass `fail-on-severity: ""` (or `none`). Callers that already set an explicit severity are unaffected.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

**Yes.** `reusable-sbom.yml` now defaults `fail-on-severity` to `critical`.

Migration / opt-out:

```yaml
with:
  fail-on-severity: "" # restore advisory-only posture (or use none)
```

Coordinate consumer repos before release so unexpected critical findings do not start failing previously green pipelines.

## Closes

- Closes #480
- Relates to #366

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes the reusable SBOM workflow default gate. The main changes are:

- `fail-on-severity` now defaults to `critical`.
- Documentation explains the breaking default and advisory-only opt-out.
- Bats tests cover the SBOM defaults and scan-step wiring.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-sbom.yml | Changes the SBOM reusable workflow default from advisory-only to failing on critical vulnerabilities. |
| tests/bats/integration/test_reusable_sbom.bats | Adds contract tests for SBOM workflow defaults and scan-step input wiring. |
| docs/reusable-workflows.md | Adds SBOM reusable workflow documentation and opt-out guidance. |
| docs/workflow-contract.md | Documents the new SBOM gate default in the workflow contract. |
| docs/workflows/deployment.md | Updates deployment supply-chain docs for SBOM scanning and attestation behavior. |
| CHANGELOG.md | Records the breaking SBOM workflow default change. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(sbom): scope reusable-sbom scan-ste..."](https://github.com/lgtm-hq/lgtm-ci/commit/e30681a8f3f8564040135d1acbd1762162d85d9c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43410383)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Vulnerability scanning now fails by default when critical-severity issues are detected.
  * Advisory-only scanning remains available by setting the severity threshold to empty or `none`.
  * SBOM generation, vulnerability scanning, and attestation behavior is now more clearly documented.

* **Tests**
  * Added integration coverage for default scanning settings and workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->