### PR TITLE
test(ci): ratchet BATS coverage for release + docker digest scripts

### DIFF
--- a/scripts/ci/quality/script-test-coverage-allowlist.txt
+++ b/scripts/ci/quality/script-test-coverage-allowlist.txt
@@ -5,14 +5,11 @@ actions/check-coverage-threshold.sh
 actions/collect-coverage.sh
 actions/deploy-pages.sh
 actions/docker/health-check-local.sh
-actions/docker/health-lib.sh
 actions/docker/merge-manifests.sh
 actions/docker/metadata.sh
 actions/docker/push.sh
-actions/docker/record-digest.sh
 actions/docker/resolve-local-health-check-image.sh
 actions/docker/resolve-local-scan-image.sh
-actions/docker/set-output-digest.sh
 actions/docker/setup.sh
 actions/docker/sign-image.sh
 actions/generate-coverage-badge.sh
@@ -34,10 +31,5 @@ actions/setup-package-manager.sh
 actions/setup-python.sh
 actions/setup-ruby.sh
 quality/lint-check.sh
-release/build-rust-binary.sh
-release/remove-tooling-checkout.sh
-release/run-version-update-script.sh
-release/write-release-summary.sh
-release/write-version-pr-summary.sh
 testing/rust/build-workspace.sh
 testing/rust/setup-rust-nextest.sh

--- a/tests/bats/unit/actions/docker/test_health_lib.bats
+++ b/tests/bats/unit/actions/docker/test_health_lib.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/actions/docker/health-lib.sh
+
+load "../../../../helpers/common"
+
+LIB="${PROJECT_ROOT}/scripts/ci/actions/docker/health-lib.sh"
+ACTIONS_LIB="${PROJECT_ROOT}/scripts/ci/lib/actions.sh"
+
+setup() {
+	setup_temp_dir
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "health-lib.sh: parse_duration_seconds accepts Ns form" {
+	run bash -c '
+		source "'"$ACTIONS_LIB"'"
+		source "'"$LIB"'"
+		parse_duration_seconds "45s"
+	'
+	assert_success
+	assert_output "45"
+}
+
+@test "health-lib.sh: parse_duration_seconds accepts bare seconds" {
+	run bash -c '
+		source "'"$ACTIONS_LIB"'"
+		source "'"$LIB"'"
+		parse_duration_seconds "12"
+	'
+	assert_success
+	assert_output "12"
+}
+
+@test "health-lib.sh: parse_duration_seconds defaults to 30s" {
+	run bash -c '
+		source "'"$ACTIONS_LIB"'"
+		source "'"$LIB"'"
+		parse_duration_seconds
+	'
+	assert_success
+	assert_output "30"
+}
+
+@test "health-lib.sh: parse_duration_seconds rejects invalid input" {
+	run bash -c '
+		source "'"$ACTIONS_LIB"'"
+		source "'"$LIB"'"
+		parse_duration_seconds "30x"
+	'
+	assert_failure
+	assert_output --partial "Invalid HEALTH_CHECK_TIMEOUT"
+}
+
+@test "health-lib.sh: can be sourced multiple times" {
+	run bash -c '
+		source "'"$ACTIONS_LIB"'"
+		source "'"$LIB"'"
+		source "'"$LIB"'"
+		parse_duration_seconds "5s"
+	'
+	assert_success
+	assert_output "5"
+}

--- a/tests/bats/unit/actions/docker/test_record_digest.bats
+++ b/tests/bats/unit/actions/docker/test_record_digest.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/actions/docker/record-digest.sh
+
+load "../../../../helpers/common"
+load "../../../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/docker/record-digest.sh"
+VALID_DIGEST="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+@test "record-digest.sh: fails without DIGEST" {
+	run env -u DIGEST DIGEST_FILE="${BATS_TEST_TMPDIR}/d.txt" bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "DIGEST is required"
+}
+
+@test "record-digest.sh: fails without DIGEST_FILE" {
+	run env -u DIGEST_FILE DIGEST="$VALID_DIGEST" bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "DIGEST_FILE is required"
+}
+
+@test "record-digest.sh: rejects invalid digest format" {
+	run env \
+		DIGEST="not-a-digest" \
+		DIGEST_FILE="${BATS_TEST_TMPDIR}/nested/d.txt" \
+		bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "DIGEST is not a valid sha256 digest"
+}
+
+@test "record-digest.sh: writes digest and creates parent dirs" {
+	local out="${BATS_TEST_TMPDIR}/nested/out/digest.txt"
+	run env DIGEST="$VALID_DIGEST" DIGEST_FILE="$out" bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Recorded digest to ${out}"
+	[[ -f "$out" ]]
+	run cat "$out"
+	assert_output "$VALID_DIGEST"
+}

--- a/tests/bats/unit/actions/docker/test_set_output_digest.bats
+++ b/tests/bats/unit/actions/docker/test_set_output_digest.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/actions/docker/set-output-digest.sh
+
+load "../../../../helpers/common"
+load "../../../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/docker/set-output-digest.sh"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+@test "set-output-digest.sh: fails without DIGEST" {
+	run env -u DIGEST bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "DIGEST is required"
+}
+
+@test "set-output-digest.sh: writes digest to GITHUB_OUTPUT" {
+	local digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	run env DIGEST="$digest" bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Digest: ${digest}"
+	assert_github_output "digest" "$digest"
+}

--- a/tests/bats/unit/release/test_build_rust_binary.bats
+++ b/tests/bats/unit/release/test_build_rust_binary.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/release/build-rust-binary.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/release/build-rust-binary.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+@test "build-rust-binary.sh: fails without TARGET" {
+	run env -u TARGET PACKAGES=cli bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "TARGET and PACKAGES are required"
+}
+
+@test "build-rust-binary.sh: fails without PACKAGES" {
+	run env -u PACKAGES TARGET=x86_64-unknown-linux-gnu bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "TARGET and PACKAGES are required"
+}
+
+@test "build-rust-binary.sh: invokes cargo build for each package" {
+	mock_command_record "cargo"
+
+	run env \
+		TARGET=x86_64-unknown-linux-gnu \
+		PACKAGES='cli, server' \
+		bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Building cli with cargo for target x86_64-unknown-linux-gnu"
+	assert_output --partial "Building server with cargo for target x86_64-unknown-linux-gnu"
+
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_cargo"
+	assert_output --partial "build --release --target x86_64-unknown-linux-gnu -p cli"
+	assert_output --partial "build --release --target x86_64-unknown-linux-gnu -p server"
+}
+
+@test "build-rust-binary.sh: uses cross when USE_CROSS=true" {
+	mock_command_record "cross"
+
+	run env \
+		TARGET=aarch64-unknown-linux-gnu \
+		PACKAGES=cli \
+		USE_CROSS=true \
+		bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Building cli with cross for target aarch64-unknown-linux-gnu"
+
+	run cat "${BATS_TEST_TMPDIR}/mock_calls_cross"
+	assert_output --partial "build --release --target aarch64-unknown-linux-gnu -p cli"
+}

--- a/tests/bats/unit/release/test_remove_tooling_checkout.bats
+++ b/tests/bats/unit/release/test_remove_tooling_checkout.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/release/remove-tooling-checkout.sh
+
+load "../../../helpers/common"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/release/remove-tooling-checkout.sh"
+
+setup() {
+	setup_temp_dir
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "remove-tooling-checkout.sh: fails without GITHUB_WORKSPACE" {
+	run env -u GITHUB_WORKSPACE bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "GITHUB_WORKSPACE is required"
+}
+
+@test "remove-tooling-checkout.sh: fails when workspace directory missing" {
+	run env GITHUB_WORKSPACE="${BATS_TEST_TMPDIR}/missing-ws" bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "GITHUB_WORKSPACE does not exist"
+}
+
+@test "remove-tooling-checkout.sh: removes .lgtm-ci-tooling directory" {
+	local ws="${BATS_TEST_TMPDIR}/ws"
+	mkdir -p "${ws}/.lgtm-ci-tooling/scripts"
+	echo keep >"${ws}/README.md"
+	echo tooling >"${ws}/.lgtm-ci-tooling/scripts/x.sh"
+
+	run env GITHUB_WORKSPACE="$ws" bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Removed temporary lgtm-ci tooling checkout"
+	[[ ! -e "${ws}/.lgtm-ci-tooling" ]]
+	[[ -f "${ws}/README.md" ]]
+}
+
+@test "remove-tooling-checkout.sh: succeeds when tooling dir already absent" {
+	local ws="${BATS_TEST_TMPDIR}/ws-empty"
+	mkdir -p "$ws"
+
+	run env GITHUB_WORKSPACE="$ws" bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Removed temporary lgtm-ci tooling checkout"
+}

--- a/tests/bats/unit/release/test_run_version_update_script.bats
+++ b/tests/bats/unit/release/test_run_version_update_script.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/release/run-version-update-script.sh
+
+load "../../../helpers/common"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/release/run-version-update-script.sh"
+
+setup() {
+	setup_temp_dir
+}
+
+teardown() {
+	teardown_temp_dir
+}
+
+@test "run-version-update-script.sh: fails without SCRIPT_PATH" {
+	run env -u SCRIPT_PATH NEXT_VERSION=1.0.0 bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "SCRIPT_PATH is required"
+}
+
+@test "run-version-update-script.sh: fails without NEXT_VERSION" {
+	run env -u NEXT_VERSION SCRIPT_PATH=/bin/true bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "NEXT_VERSION is required"
+}
+
+@test "run-version-update-script.sh: executes SCRIPT_PATH" {
+	local updater="${BATS_TEST_TMPDIR}/updater.sh"
+	cat >"$updater" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'updated-to=%s\n' "${NEXT_VERSION}"
+EOF
+	chmod +x "$updater"
+
+	run env SCRIPT_PATH="$updater" NEXT_VERSION=9.9.9 bash "$SCRIPT"
+	assert_success
+	assert_output --partial "updated-to=9.9.9"
+}
+
+@test "run-version-update-script.sh: propagates updater failure" {
+	local updater="${BATS_TEST_TMPDIR}/fail.sh"
+	cat >"$updater" <<'EOF'
+#!/usr/bin/env bash
+echo boom >&2
+exit 7
+EOF
+	chmod +x "$updater"
+
+	run env SCRIPT_PATH="$updater" NEXT_VERSION=1.0.0 bash "$SCRIPT"
+	assert_failure
+	assert_equal "$status" 7
+	assert_output --partial "boom"
+}

--- a/tests/bats/unit/release/test_write_release_summary.bats
+++ b/tests/bats/unit/release/test_write_release_summary.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/release/write-release-summary.sh
+
+load "../../../helpers/common"
+load "../../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/release/write-release-summary.sh"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+@test "write-release-summary.sh: fails without VERSION" {
+	run env -u VERSION bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "VERSION is required"
+}
+
+@test "write-release-summary.sh: dry-run writes version and bump preview" {
+	run env \
+		SUMMARY_TYPE=dry-run \
+		VERSION=1.2.3 \
+		TAG_PREFIX=v \
+		BUMP_TYPE=minor \
+		CHANGELOG='### Added\n- feature' \
+		bash "$SCRIPT"
+	assert_success
+	run cat "$GITHUB_STEP_SUMMARY"
+	assert_output --partial "## Dry Run Summary"
+	assert_output --partial "**Version:** 1.2.3"
+	assert_output --partial "**Tag:** v1.2.3"
+	assert_output --partial "**Bump type:** minor"
+	assert_output --partial "### Changelog Preview"
+}
+
+@test "write-release-summary.sh: release with URL writes Release Created" {
+	run env \
+		SUMMARY_TYPE=release \
+		VERSION=2.0.0 \
+		TAG_NAME=v2.0.0 \
+		RELEASE_URL=https://github.com/org/repo/releases/tag/v2.0.0 \
+		bash "$SCRIPT"
+	assert_success
+	run cat "$GITHUB_STEP_SUMMARY"
+	assert_output --partial "## Release Created"
+	assert_output --partial "**Version:** 2.0.0"
+	assert_output --partial "**Tag:** v2.0.0"
+	assert_output --partial "**Release:** https://github.com/org/repo/releases/tag/v2.0.0"
+}
+
+@test "write-release-summary.sh: release without URL writes Release Tag Created" {
+	run env \
+		SUMMARY_TYPE=release \
+		VERSION=2.0.0 \
+		TAG_NAME=v2.0.0 \
+		RELEASE_URL= \
+		bash "$SCRIPT"
+	assert_success
+	run cat "$GITHUB_STEP_SUMMARY"
+	assert_output --partial "## Release Tag Created"
+	refute_output --partial "**Release:**"
+}
+
+@test "write-release-summary.sh: rejects unknown SUMMARY_TYPE" {
+	run env SUMMARY_TYPE=bogus VERSION=1.0.0 bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "Unknown summary type: bogus"
+}

--- a/tests/bats/unit/release/test_write_version_pr_summary.bats
+++ b/tests/bats/unit/release/test_write_version_pr_summary.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/release/write-version-pr-summary.sh
+
+load "../../../helpers/common"
+load "../../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/release/write-version-pr-summary.sh"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+@test "write-version-pr-summary.sh: skips when last commit is a release" {
+	run env IS_RELEASE=true bash "$SCRIPT"
+	assert_success
+	run cat "$GITHUB_STEP_SUMMARY"
+	assert_output --partial "## Version PR Summary"
+	assert_output --partial "Skipped: last commit is a release commit"
+}
+
+@test "write-version-pr-summary.sh: skips when version PR already exists" {
+	run env IS_RELEASE=false PR_EXISTS=true bash "$SCRIPT"
+	assert_success
+	run cat "$GITHUB_STEP_SUMMARY"
+	assert_output --partial "Skipped: version PR already exists"
+}
+
+@test "write-version-pr-summary.sh: skips when no releasable commits" {
+	run env IS_RELEASE=false PR_EXISTS=false RELEASE_NEEDED=false bash "$SCRIPT"
+	assert_success
+	run cat "$GITHUB_STEP_SUMMARY"
+	assert_output --partial "Skipped: no releasable commits found"
+}
+
+@test "write-version-pr-summary.sh: writes created PR details" {
+	run env \
+		IS_RELEASE=false \
+		PR_EXISTS=false \
+		RELEASE_NEEDED=true \
+		NEXT_VERSION=1.4.0 \
+		BUMP_TYPE=minor \
+		PR_URL=https://github.com/org/repo/pull/99 \
+		PR_OP=created \
+		ECOSYSTEMS=python,npm \
+		bash "$SCRIPT"
+	assert_success
+	run cat "$GITHUB_STEP_SUMMARY"
+	assert_output --partial "**Version:** 1.4.0"
+	assert_output --partial "**Bump type:** minor"
+	assert_output --partial "**PR:** https://github.com/org/repo/pull/99"
+	assert_output --partial "**Operation:** created"
+	assert_output --partial "**Ecosystems:** python,npm"
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Continue the script-to-BATS coverage ratchet (#477 / #370) with a release-critical + docker digest tranche. Adds unit tests for 8 previously allowlisted entrypoints and shrinks `script-test-coverage-allowlist.txt` from 40 → 32 entries.

Covered in this tranche:
- `release/write-release-summary.sh`
- `release/write-version-pr-summary.sh`
- `release/remove-tooling-checkout.sh`
- `release/run-version-update-script.sh`
- `release/build-rust-binary.sh`
- `actions/docker/set-output-digest.sh`
- `actions/docker/record-digest.sh`
- `actions/docker/health-lib.sh`

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [ ] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Relates to #477 (tranche; remaining allowlist entries stay open)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds BATS coverage for release and Docker helper scripts. The main changes are:

- New unit tests for Docker health and digest scripts.
- New unit tests for release summary, version update, cleanup, and Rust build scripts.
- Removed the newly covered scripts from the script coverage allowlist.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The allowlist removals match newly added BATS files that reference the covered script basenames.
- The tests follow existing helper and environment patterns for these shell scripts.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/quality/script-test-coverage-allowlist.txt | Removes entries for scripts that now have BATS coverage. |
| tests/bats/unit/actions/docker/test_health_lib.bats | Adds tests for Docker health duration parsing and repeated sourcing. |
| tests/bats/unit/actions/docker/test_record_digest.bats | Adds tests for digest input validation and digest file writing. |
| tests/bats/unit/actions/docker/test_set_output_digest.bats | Adds tests for digest output handling through GitHub output files. |
| tests/bats/unit/release/test_build_rust_binary.bats | Adds tests for required Rust build inputs and cargo or cross invocation. |
| tests/bats/unit/release/test_remove_tooling_checkout.bats | Adds tests for workspace validation and tooling checkout removal. |
| tests/bats/unit/release/test_run_version_update_script.bats | Adds tests for version update script execution and failure propagation. |
| tests/bats/unit/release/test_write_release_summary.bats | Adds tests for dry-run and release GitHub step summaries. |
| tests/bats/unit/release/test_write_version_pr_summary.bats | Adds tests for version PR summary skip paths and created PR details. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test(ci): ratchet BATS coverage for rele..."](https://github.com/lgtm-hq/lgtm-ci/commit/21d222b1c2e6d04c6da2c5598ef7f22cfac1b564) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43425333)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for Docker workflow helpers, including input validation, digest handling, and output generation.
  * Added release workflow coverage for binary builds, tooling cleanup, version updates, and release summary generation.
  * Added checks for release-summary skip conditions and generated pull request details.
* **Chores**
  * Updated quality checks to remove now-tested scripts from the coverage allowlist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->