### PR TITLE
fix(ci): grant contents:write for SBOM release asset upload

### DIFF
--- a/.github/workflows/reusable-sbom.yml
+++ b/.github/workflows/reusable-sbom.yml
@@ -131,7 +131,9 @@ jobs:
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
-      contents: read
+      # write: attach CycloneDX SBOM to the GitHub Release asset list
+      # (anchore/sbom-action defaults upload-release-assets on release events)
+      contents: write
       security-events: write
       id-token: write
       attestations: write


### PR DESCRIPTION
## Summary

- Grant `contents: write` on `reusable-sbom.yml` so release-event runs can attach the CycloneDX file to the GitHub Release
- Callers that only grant `contents: read` cannot raise this; the reusable must request write

## Context

ai-skills (and likely other consumers) fail SBOM on every release with:
`Resource not accessible by integration` at "Attaching SBOMs to release".

## Test plan

- [ ] Merge + release lgtm-ci
- [ ] Repin ai-skills caller and re-run Release: SBOM on a tag

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR broadens the reusable SBOM workflow permission so release uploads can succeed. The main change is:

- `contents` permission changes from `read` to `write` for the SBOM job.
- Comments explain that the write scope is for CycloneDX release asset uploads.
</details>

<h3>Confidence Score: 4/5</h3>

The release upload path should work, but the write token is broader than the release-only operation that needs it.

- The permission change is small and targets the reported GitHub Release asset upload failure.
- The workflow grants the write token to all job steps and all reusable invocations.
- A narrower release-only path would reduce exposure for normal SBOM runs.

.github/workflows/reusable-sbom.yml

<details open><summary><h3>Security Review</h3></summary>

The SBOM job now grants a repository write token to every reusable workflow invocation, not only release asset upload runs.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-sbom.yml | The job-level `contents` permission now grants write access for all SBOM workflow runs. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Freusable-sbom.yml%3A134%0A**Write%20Token%20Covers%20All%20Runs**%0A%0AWhen%20a%20caller%20uses%20this%20reusable%20workflow%20for%20a%20normal%20SBOM%20or%20tag-push%20run%2C%20the%20whole%20job%20now%20receives%20%60contents%3A%20write%60%20even%20though%20only%20release%20asset%20upload%20needs%20it.%20That%20exposes%20every%20unconditional%20step%20in%20the%20job%2C%20including%20the%20SBOM%20action%20path%2C%20to%20a%20repository%20write%20token%20and%20lets%20release-asset%20behavior%20run%20outside%20the%20intended%20release-event%20case.%0A%0A&pr=505&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Freusable-sbom.yml%3A134%0A**Write%20Token%20Covers%20All%20Runs**%0A%0AWhen%20a%20caller%20uses%20this%20reusable%20workflow%20for%20a%20normal%20SBOM%20or%20tag-push%20run%2C%20the%20whole%20job%20now%20receives%20%60contents%3A%20write%60%20even%20though%20only%20release%20asset%20upload%20needs%20it.%20That%20exposes%20every%20unconditional%20step%20in%20the%20job%2C%20including%20the%20SBOM%20action%20path%2C%20to%20a%20repository%20write%20token%20and%20lets%20release-asset%20behavior%20run%20outside%20the%20intended%20release-event%20case.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=505&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22fix%2Fsbom-contents-write%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsbom-contents-write%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Freusable-sbom.yml%3A134%0A**Write%20Token%20Covers%20All%20Runs**%0A%0AWhen%20a%20caller%20uses%20this%20reusable%20workflow%20for%20a%20normal%20SBOM%20or%20tag-push%20run%2C%20the%20whole%20job%20now%20receives%20%60contents%3A%20write%60%20even%20though%20only%20release%20asset%20upload%20needs%20it.%20That%20exposes%20every%20unconditional%20step%20in%20the%20job%2C%20including%20the%20SBOM%20action%20path%2C%20to%20a%20repository%20write%20token%20and%20lets%20release-asset%20behavior%20run%20outside%20the%20intended%20release-event%20case.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=505&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): grant contents:write for SBOM r..."](https://github.com/lgtm-hq/lgtm-ci/commit/518d537683bfb662d2c3f183516d090ace98ec62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43498406)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->