### PR TITLE
chore(renovate): drop rules superseded by org preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -60,17 +60,6 @@
   ],
   "packageRules": [
     {
-      "description": "Group lintro Docker image + PyPI pin so they update together",
-      "groupName": "lintro",
-      "matchPackageNames": ["ghcr.io/lgtm-hq/py-lintro", "lintro"],
-      "automerge": false
-    },
-    {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["ghcr.io/lgtm-hq/py-lintro"],
-      "pinDigests": true
-    },
-    {
       "description": "Group harden-runner SHA pins so workflow and non-workflow copies update together",
       "groupName": "step-security/harden-runner",
       "matchPackageNames": ["step-security/harden-runner"],


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [x] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

lgtm-hq/.github#25 added a canonical `lintro` group to the org preset and switched it to `config:best-practices` (which includes `docker:pinDigests`). Two repo-level rules are now superseded:

- Remove the `lintro` group rule — inherited from the preset with identical behavior (image + PyPI grouped, no automerge)
- Remove the `pinDigests: true` rule for `ghcr.io/lgtm-hq/py-lintro` — covered by `docker:pinDigests`

The `step-security/harden-runner` group and all custom managers are kept.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed

## Closes

- Closes #507

## Details

Config-only change. `renovate-config-validator --strict` → validated successfully; `uv run lintro chk renovate.json` → no issues.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR trims Renovate rules now covered by the shared org preset. The main changes are:

- Removed the local `lintro` grouping rule.
- Removed the local `py-lintro` Docker digest pinning rule.
- Kept the remaining package rules and custom managers unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed config.
- The removed rules are described as covered by the inherited org preset.
- The local custom managers and unrelated grouping rule remain in place.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| renovate.json | Removes repo-local Renovate package rules for `lintro` grouping and `py-lintro` digest pinning while relying on the org preset. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(renovate): drop rules superseded b..."](https://github.com/lgtm-hq/lgtm-ci/commit/5f42d178c51ea182d0143e759d770d574f618259) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43512978)</sub>

<!-- /greptile_comment -->