### PR TITLE
docs(org): register checks-turbo-themes and checks-holy-grail rulesets

### DIFF
--- a/docs/org-rulesets.md
+++ b/docs/org-rulesets.md
@@ -28,17 +28,26 @@ for the caller-side YAML pattern.
 | ------- | --------- | ----- | ----------------- |
 | `checks-py-lintro` | `16132640` | `py-lintro` | `test-suite-coverage / 🧪 Test Suite & Coverage`, `lintro-code-quality / 🛠️ Lintro Code Quality`, `🔐 Security Audit` |
 | `checks-rustume` | `16132643` | `Rustume` | `quality / 🛠️ Lintro Code Quality & Analysis`, `rust-build / 🔨 Build Check`, `rust-coverage / 🦀 Rust Coverage`, `web-coverage / 🌐 Web Coverage`, `🔐 Security Audit` |
+| `checks-turbo-themes` | `16132642` | `turbo-themes` | `Socket Security: Pull Request Alerts`, `♿ E2E Accessibility Tests`, `semantic-title / ✅ Validate Conventional Commits`, `🎭 E2E Tests`, `🏗️ Build & Quality Checks (20)`, `🏗️ Build & Quality Checks (22)`, `sbom / SBOM & Supply Chain`, `📦 Validate Examples`, `quality / 🔍 Code Quality & Linting`, `codeql / 🔍 CodeQL Security Analysis`, `security-audit / 🔐 Security Audit`, `🔥 E2E Smoke Tests` |
+| `checks-holy-grail` | `16132645` | `holy-grail` | `Analyze GitHub Actions`, `Analyze JavaScript/TypeScript`, `Build & Test`, `Check SHA Pinning`, `E2E Tests`, `Socket Security: Pull Request Alerts`, `Validate PR Title`, `quality / Lintro Quality Checks`, `🔐 Security Audit` |
 
 <!-- markdownlint-enable MD013 -->
 
-Both rows follow the prefixed-path pattern: every `uses:` gate context is
-`{caller_job_id} / {job-name}`, and only inline jobs (`🔐 Security Audit`)
-appear unprefixed. Consumer repos must keep caller job ids stable — renaming
-a caller job id changes the reported check path and breaks the ruleset gate
-(checks stay **Expected** while Actions shows green under the new name).
+All rows follow the prefixed-path pattern: every `uses:` gate context is
+`{caller_job_id} / {job-name}`, and only inline jobs (`🔐 Security Audit`,
+holy-grail's hand-rolled workflow jobs) appear unprefixed. Consumer repos
+must keep caller job ids stable — renaming a caller job id changes the
+reported check path and breaks the ruleset gate (checks stay **Expected**
+while Actions shows green under the new name).
 
-When migrating additional rulesets (for example `checks-turbo-themes`),
-update this table in the same PR that updates the live ruleset.
+Never require an **app-generated code-scanning summary check** (for example
+the bare `CodeQL` context from the github-advanced-security app) in a repo
+that uses a merge queue: the app only produces it on `pull_request` commits,
+never merge-group commits, so every queue entry times out and is silently
+ejected (holy-grail, 2026-07-11). Require the workflow-job contexts instead.
+
+When migrating additional rulesets, update this table in the same PR that
+updates the live ruleset.
 
 ## Tooling
 


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [x] docs

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Registers the two org rulesets updated live on 2026-07-11 during the v0.52.3 adoption epic (#510) in `docs/org-rulesets.md`:

- `checks-turbo-themes` (16132642) — new prefixed contexts, updated in lockstep with lgtm-hq/turbo-themes#526
- `checks-holy-grail` (16132645) — app-level `CodeQL` summary context removed (it never reports on merge-group commits and silently ejected every queue entry; the workflow-level `Analyze …` contexts remain the gates)

Also documents the "never require app-generated code-scanning summary checks with a merge queue" rule.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local CI passed

## Closes

- Relates to #510
- Relates to #512

## Details

Docs-only. lintro clean.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the org ruleset documentation. The main changes are:

- Adds `checks-turbo-themes` and its required check contexts.
- Adds `checks-holy-grail` and its required check contexts.
- Clarifies prefixed and unprefixed check naming.
- Documents why app-generated CodeQL summary checks should not gate merge queues.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed documentation.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/org-rulesets.md | Registers two org rulesets and expands guidance for merge-queue-safe required checks. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(org): register checks-turbo-themes ..."](https://github.com/lgtm-hq/lgtm-ci/commit/b985c270c9f91502a2ad0c03c8f048914fb00848) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43529632)</sub>

<!-- /greptile_comment -->