### PR TITLE
chore(ci): adopt canonical emoji check names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
   quality:
     uses: ./.github/workflows/reusable-quality-lint.yml
     with:
+      job-name: "🛠️ Lintro Code Quality"
       tooling-ref: ${{ github.sha }}
     permissions:
       contents: read
@@ -36,12 +37,12 @@ jobs:
       pull-requests: write
 
   shell-tests:
-    name: Shell Library Tests
     uses: ./.github/workflows/reusable-test-shell.yml
     permissions:
       contents: read
       pull-requests: write
     with:
+      job-name: "🐚 Shell Tests"
       test-path: tests/bats
       coverage: true
       coverage-threshold: 84

--- a/.github/workflows/reusable-validate-action-pinning.yml
+++ b/.github/workflows/reusable-validate-action-pinning.yml
@@ -12,6 +12,11 @@ on:
           then the workflow token.
         required: false
     inputs:
+      job-name:
+        description: "GitHub check name for the validation job"
+        required: false
+        type: string
+        default: "Validate Action Pinning"
       fail-on-error:
         description: "Fail if non-pinned actions are found"
         required: false
@@ -99,7 +104,7 @@ on:
 
 jobs:
   action-pinning:
-    name: Validate Action Pinning
+    name: ${{ inputs.job-name }}
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -17,6 +17,7 @@ jobs:
   semantic-title:
     uses: ./.github/workflows/reusable-semantic-pr-title.yml
     with:
+      job-name: "📝 Validate PR Title"
       tooling-ref: ${{ github.sha }}
       egress-preset: github-minimal
     permissions:

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -26,6 +26,7 @@ jobs:
   validate:
     uses: ./.github/workflows/reusable-validate-action-pinning.yml
     with:
+      job-name: "📌 Validate Action Pinning"
       fail-on-error: true
       verify-tags: true
       audit-transitive: true


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Adopt the org canonical emoji check-name scheme (lgtm-hq/lgtm-ci#514) for this repo's own CI caller workflows. Only caller `job-name` inputs are renamed; caller job ids are unchanged, so `needs:` wiring and the notifier contract tests are untouched.

`reusable-validate-action-pinning.yml` previously had a hardcoded inner `name:` and no `job-name` input, so it gains an **optional** `job-name` input whose default (`"Validate Action Pinning"`) preserves the existing check context for every external consumer — only this repo's caller opts into the emoji name.

The `shell-tests` caller in `ci.yml` drops its `name: Shell Library Tests` override so the check context uses the canonical caller job id path.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [ ] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [ ] Python code passes `ruff` and `black`

Local validation: `uv run lintro chk` (incl. actionlint) clean; `scripts/ci/quality/validate-static-job-names.sh` OK; workflow-related BATS subset (ci notifier, merge-group, quality-lint, semantic-pr-title, validate-action-pinning, tooling-sparse-checkout, generate-test-summary) all passing.

## Ruleset lockstep

The `checks-lgtm-ci` ruleset must be updated at merge time (coordinator-managed, temporary merge-queue disable per #514 transition plan):

| Old required context | New required context |
| --- | --- |
| `quality / Lintro Quality Checks` | `quality / 🛠️ Lintro Code Quality` |
| `Shell Library Tests / Shell Tests` | `shell-tests / 🐚 Shell Tests` |
| `semantic-title / Semantic PR Title` | `semantic-title / 📝 Validate PR Title` |
| `validate / Validate Action Pinning` | `validate / 📌 Validate Action Pinning` |

## Breaking Changes

None for external consumers: the new `job-name` input on `reusable-validate-action-pinning.yml` defaults to the current name, and no reusable default job-names were changed. This repo's own required-check contexts change per the lockstep table above.

## Related Issues

Closes #515. Part of lgtm-hq/lgtm-ci#514 (epic #510).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates this repository's CI check names to the canonical emoji scheme. The main changes are:

- Adds emoji `job-name` inputs to CI caller workflows.
- Removes the shell test caller `name:` override.
- Adds a backward-compatible `job-name` input to the validate-action-pinning reusable workflow.
- Passes the new validate-action-pinning check name from the local caller.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge once the required-check ruleset is updated in lockstep.

- The reusable workflow keeps the previous default check name for external callers.
- The changed callers pass supported string inputs.
- The only noted risk is the intended check-context rename, which can block required checks if the ruleset update is not applied at the same time.

.github/workflows/validate-action-pinning.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Updates the quality and shell test caller check names without changing job ids or dependencies. |
| .github/workflows/reusable-validate-action-pinning.yml | Adds an optional `job-name` input whose default preserves the old validate action pinning check name. |
| .github/workflows/semantic-pr-title.yml | Passes the canonical emoji PR title check name to the existing reusable workflow. |
| .github/workflows/validate-action-pinning.yml | Passes the new emoji validate action pinning check name from this repository's caller. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fvalidate-action-pinning.yml%3A29%0A**Required%20Check%20Name%20Drift**%0A%0AWhen%20this%20caller%20starts%20reporting%20%60%F0%9F%93%8C%20Validate%20Action%20Pinning%60%2C%20any%20branch%20protection%20or%20ruleset%20still%20requiring%20the%20previous%20%60validate%20%2F%20Validate%20Action%20Pinning%60%20context%20will%20wait%20forever%20even%20though%20the%20workflow%20ran.%20The%20PR%20notes%20that%20the%20ruleset%20update%20happens%20at%20merge%20time%2C%20so%20this%20changed%20line%20can%20block%20every%20PR%20or%20merge-queue%20entry%20if%20the%20ruleset%20is%20not%20updated%20before%20this%20commit%20is%20enforced.%0A%0A&pr=516&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fvalidate-action-pinning.yml%3A29%0A**Required%20Check%20Name%20Drift**%0A%0AWhen%20this%20caller%20starts%20reporting%20%60%F0%9F%93%8C%20Validate%20Action%20Pinning%60%2C%20any%20branch%20protection%20or%20ruleset%20still%20requiring%20the%20previous%20%60validate%20%2F%20Validate%20Action%20Pinning%60%20context%20will%20wait%20forever%20even%20though%20the%20workflow%20ran.%20The%20PR%20notes%20that%20the%20ruleset%20update%20happens%20at%20merge%20time%2C%20so%20this%20changed%20line%20can%20block%20every%20PR%20or%20merge-queue%20entry%20if%20the%20ruleset%20is%20not%20updated%20before%20this%20commit%20is%20enforced.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=516&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22chore%2F515-emoji-check-names%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2F515-emoji-check-names%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Fvalidate-action-pinning.yml%3A29%0A**Required%20Check%20Name%20Drift**%0A%0AWhen%20this%20caller%20starts%20reporting%20%60%F0%9F%93%8C%20Validate%20Action%20Pinning%60%2C%20any%20branch%20protection%20or%20ruleset%20still%20requiring%20the%20previous%20%60validate%20%2F%20Validate%20Action%20Pinning%60%20context%20will%20wait%20forever%20even%20though%20the%20workflow%20ran.%20The%20PR%20notes%20that%20the%20ruleset%20update%20happens%20at%20merge%20time%2C%20so%20this%20changed%20line%20can%20block%20every%20PR%20or%20merge-queue%20entry%20if%20the%20ruleset%20is%20not%20updated%20before%20this%20commit%20is%20enforced.%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=516&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): adopt canonical emoji check n..."](https://github.com/lgtm-hq/lgtm-ci/commit/aa95eeef36af47da5ad2ab56f1e55ddbc5d41e97) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43533033)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->