### PR TITLE
docs(org): full ruleset registry after emoji canon rollout

### DIFF
--- a/.github/workflows/reusable-quality-lint.yml
+++ b/.github/workflows/reusable-quality-lint.yml
@@ -8,7 +8,7 @@ on:
         description: "GitHub check run name reported for this job"
         required: false
         type: string
-        default: "Lintro Quality Checks"
+        default: "🛠️ Lintro Code Quality"
       tools:
         description: "Comma-separated lintro --tools list (empty = all tools)"
         required: false

--- a/docs/org-rulesets.md
+++ b/docs/org-rulesets.md
@@ -24,12 +24,31 @@ for the caller-side YAML pattern.
 
 <!-- markdownlint-disable MD013 -->
 
+Shared rulesets (one logical check, uniform context, many repos):
+
 | Ruleset | GitHub id | Repos | Required contexts |
 | ------- | --------- | ----- | ----------------- |
-| `checks-py-lintro` | `16132640` | `py-lintro` | `test-suite-coverage / 🧪 Test Suite & Coverage`, `lintro-code-quality / 🛠️ Lintro Code Quality`, `🔐 Security Audit` |
-| `checks-rustume` | `16132643` | `Rustume` | `quality / 🛠️ Lintro Code Quality & Analysis`, `rust-build / 🔨 Build Check`, `rust-coverage / 🦀 Rust Coverage`, `web-coverage / 🌐 Web Coverage`, `🔐 Security Audit` |
-| `checks-turbo-themes` | `16132642` | `turbo-themes` | `Socket Security: Pull Request Alerts`, `♿ E2E Accessibility Tests`, `semantic-title / ✅ Validate Conventional Commits`, `🎭 E2E Tests`, `🏗️ Build & Quality Checks (20)`, `🏗️ Build & Quality Checks (22)`, `sbom / SBOM & Supply Chain`, `📦 Validate Examples`, `quality / 🔍 Code Quality & Linting`, `codeql / 🔍 CodeQL Security Analysis`, `security-audit / 🔐 Security Audit`, `🔥 E2E Smoke Tests` |
-| `checks-holy-grail` | `16132645` | `holy-grail` | `Analyze GitHub Actions`, `Analyze JavaScript/TypeScript`, `Build & Test`, `Check SHA Pinning`, `E2E Tests`, `Socket Security: Pull Request Alerts`, `Validate PR Title`, `quality / Lintro Quality Checks`, `🔐 Security Audit` |
+| `checks-quality` | `18812462` | all except `py-lintro` | `quality / 🛠️ Lintro Code Quality` (py-lintro gates its dogfood run as `lintro-code-quality / 🛠️ Lintro Code Quality` in its own row) |
+| `checks-socket` | `18809614` | all except `ui-framework` | `Socket Security: Pull Request Alerts` (external app check — name not renamable) |
+
+Per-repo rulesets (stack-specific gates only; canonical emoji names per #514):
+
+| Ruleset | GitHub id | Repos | Required contexts |
+| ------- | --------- | ----- | ----------------- |
+| `checks-ai-skills` | `16132646` | `ai-skills` | `validate / 📚 Validate Skill Structure` |
+| `checks-dot-github` | `16438323` | `.github` | `validate / 🧾 Validate Org Config` |
+| `checks-holy-grail` | `16132645` | `holy-grail` | `codeql / 🔬 CodeQL Analysis`, `semantic-title / 📝 Validate PR Title`, `validate / Validate Action Pinning`, `🎭 E2E Tests`, `🏗️ Build & Test`, `🔐 Security Audit` |
+| `checks-homebrew-tap` | `16438312` | `homebrew-tap` | `shell-tests / 🐚 Shell Tests`, `🍺 Validate Formula` |
+| `checks-lgtm-ci` | `16438310` | `lgtm-ci` | `shell-tests / 🐚 Shell Tests`, `semantic-title / 📝 Validate PR Title`, `validate / 📌 Validate Action Pinning` |
+| `checks-podex` | `16438314` | `podex` | `semantic-title / 📝 Validate PR Title`, `test / Aggregate Python Results` |
+| `checks-py-lintro` | `16132640` | `py-lintro` | `🚦 Test Gate`, `codeql / 🔬 CodeQL Analysis`, `lintro-code-quality / 🛠️ Lintro Code Quality`, `semantic-title / 📝 Validate PR Title`, `test-compat / Aggregate Python Results`, `test-compat / Python Compatibility`, `test-coverage / Aggregate Python Results`, `test-coverage / Python Coverage`, `test-suite-coverage / 🧪 Test Suite & Coverage`, `🐳 Build Docker Images`, `🔐 Security Audit`, `🧪 Docker Integration Tests` |
+| `checks-rustume` | `16132643` | `Rustume` | `codeql / 🔬 CodeQL Analysis`, `semantic-title / 📝 Validate PR Title`, `check-pinning / Validate Action Pinning`, `rust-build / 🔨 Build Check`, `rust-coverage / 🦀 Rust Coverage`, `web-coverage / 🌐 Web Coverage`, `🔐 Security Audit` |
+| `checks-turbo-themes` | `16132642` | `turbo-themes` | `♿ E2E Accessibility Tests`, `semantic-title / 📝 Validate PR Title`, `🎭 E2E Tests`, `🏗️ Build & Quality Checks (20)`, `🏗️ Build & Quality Checks (22)`, `sbom / 📋 SBOM & Supply Chain`, `📦 Validate Examples`, `codeql / 🔬 CodeQL Analysis`, `security-audit / 🔐 Security Audit`, `🔥 E2E Smoke Tests` |
+| `checks-winnow` | `17448561` | `winnow` | `codeql / 🔬 CodeQL Analysis`, `security-audit / 🔐 Security Audit`, `semantic-title / 📝 Validate PR Title`, `test / Aggregate Python Results`, `test / 🧪 Python Compatibility`, `validate / 🧾 Validate Lintro Version` |
+
+There is no `checks-ui-framework` row: the repo's only gate is the shared
+`checks-quality` context. `ui-framework` is not in `checks-socket` because
+the Socket app does not scan it yet.
 
 <!-- markdownlint-enable MD013 -->
 

--- a/examples/ci-node-custom.yml
+++ b/examples/ci-node-custom.yml
@@ -29,7 +29,7 @@ jobs:
       packages: read
     with:
       tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
-      job-name: "Lintro Quality Checks"
+      job-name: "🛠️ Lintro Code Quality"
       egress-policy: block
       egress-preset: quality
 

--- a/examples/ci-node-vitest.yml
+++ b/examples/ci-node-vitest.yml
@@ -29,7 +29,7 @@ jobs:
       packages: read
     with:
       tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
-      job-name: "Lintro Quality Checks"
+      job-name: "🛠️ Lintro Code Quality"
       egress-policy: block
       egress-preset: quality
 

--- a/examples/ci-python.yml
+++ b/examples/ci-python.yml
@@ -30,7 +30,7 @@ jobs:
       packages: read
     with:
       tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
-      job-name: "Lintro Quality Checks"
+      job-name: "🛠️ Lintro Code Quality"
       egress-policy: block
       egress-preset: quality
 

--- a/examples/ci-quality-only.yml
+++ b/examples/ci-quality-only.yml
@@ -30,6 +30,6 @@ jobs:
       packages: read
     with:
       tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
-      job-name: "Lintro Quality Checks"
+      job-name: "🛠️ Lintro Code Quality"
       egress-policy: block
       egress-preset: quality

--- a/examples/ci-rust.yml
+++ b/examples/ci-rust.yml
@@ -30,7 +30,7 @@ jobs:
       packages: read
     with:
       tooling-ref: "4aaefe64763b7841b6d92d94dc47185083d34c9a" # v0.46.0
-      job-name: "Lintro Quality Checks"
+      job-name: "🛠️ Lintro Code Quality"
       egress-policy: block
       # GHCR image pulls resolve layers via pkg-containers.githubusercontent.com;
       # codeload/objects cover tooling checkout and action release downloads.


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Type:
  - [x] docs

## What’s Changing

Registers the complete post-rollout org-ruleset state in `docs/org-rulesets.md`: the two shared rulesets (`checks-quality` 18812462, `checks-socket` 18809614), all 10 per-repo `checks-*` rulesets with their canonical emoji contexts (#514), and the deletion of `checks-ui-framework` (fully covered by the shared quality ruleset).

## Checklist

- [x] Title follows Conventional Commits
- [x] Local CI passed

## Closes

- Relates to #514

## Details

Docs-only; table generated from the live rulesets via the API. lintro clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the organization ruleset registry with additional shared and repository-specific rulesets.
  * Clarified the required GitHub Actions status check contexts, including quality and Socket security checks.
  * Documented exceptions and revised context names for several rulesets, including guidance on current UI framework coverage.

* **Chores / Workflow Updates**
  * Renamed the reusable quality lint job’s display name to **“🛠️ Lintro Code Quality”** across the reusable workflow and example CI workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the org ruleset registry and quality workflow naming.

- Adds shared org rulesets for quality and Socket checks.
- Expands the per-repo ruleset table with canonical required contexts.
- Updates reusable quality workflow naming to `🛠️ Lintro Code Quality`.
- Updates starter CI examples to emit the shared quality check context.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-quality-lint.yml | Updates the reusable workflow default job name to match the shared quality ruleset context. |
| docs/org-rulesets.md | Documents the shared and per-repo rulesets with their required check contexts. |
| examples/ci-node-custom.yml | Updates the example quality job name to the canonical shared context. |
| examples/ci-node-vitest.yml | Updates the example quality job name to the canonical shared context. |
| examples/ci-python.yml | Updates the example quality job name to the canonical shared context. |
| examples/ci-quality-only.yml | Updates the example quality job name to the canonical shared context. |
| examples/ci-rust.yml | Updates the example quality job name to the canonical shared context. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(quality): default job-name emits can..."](https://github.com/lgtm-hq/lgtm-ci/commit/f0fb9a358a28804cde0108877bce1d2a5bf7e8c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43544679)</sub>

<!-- /greptile_comment -->