### PR TITLE
fix(ci): avoid lychee-action output conflict in link-check

### DIFF
--- a/.github/workflows/reusable-link-check.yml
+++ b/.github/workflows/reusable-link-check.yml
@@ -166,6 +166,8 @@ jobs:
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: ${{ steps.args.outputs.args }}
+          # lychee-action v2.9+ errors if --output is also in args.
+          output: lychee-report.md
           token: ${{ github.token }}
           fail: ${{ inputs.fail-on-error }}
       - name: Upload link report

--- a/scripts/ci/actions/build-lychee-args.sh
+++ b/scripts/ci/actions/build-lychee-args.sh
@@ -75,10 +75,10 @@ build_targets() {
 	done
 }
 
+# --output is set via lychee-action `output:` input (v2.9+ rejects both).
 args=(
 	"--no-progress"
 	"--format" "markdown"
-	"--output" "lychee-report.md"
 	"--timeout" "$TIMEOUT"
 	"--max-retries" "3"
 	"--accept" "200..=204"


### PR DESCRIPTION
## Summary
- Remove `--output` from `build-lychee-args.sh` and set `output: lychee-report.md` on `reusable-link-check` so lychee-action v2.9+ no longer errors with duplicate output configuration.
- Unblocks consumers (e.g. ai-skills Link Check) once egress allowlists include `release-assets.githubusercontent.com`.

## Test plan
- [ ] Unit bats for `prepare-lychee-action-args` still pass
- [ ] Link Check on a consumer PR reaches Lychee run (no `'output' is set in args...` error)
- [ ] Report artifact path remains `lychee-report.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link-check workflow compatibility with newer Lychee action versions.
  * Ensured link-check reports are generated consistently using the configured report filename.
  * Prevented failures caused by duplicate report-output configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the reusable link-check workflow to avoid duplicate Lychee output configuration.

- Sets the Lychee action `output` input to `lychee-report.md`.
- Removes the matching `--output lychee-report.md` CLI argument from the generated args.
- Keeps the report artifact path unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-link-check.yml | Adds the Lychee action output path while preserving the existing report upload path. |
| scripts/ci/actions/build-lychee-args.sh | Removes the duplicate Lychee CLI output flag from the generated argument list. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/lychee-acti..."](https://github.com/lgtm-hq/lgtm-ci/commit/1f95700c62b87544bb322cef35a36263cecafe0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43623012)</sub>

<!-- /greptile_comment -->