### PR TITLE
fix(egress): add release-assets CDN to github-tooling preset

### DIFF
--- a/.github/actions/harden-runner/lib/egress/presets.sh
+++ b/.github/actions/harden-runner/lib/egress/presets.sh
@@ -26,12 +26,16 @@ egress_preset_endpoints() {
 			pipelines.actions.githubusercontent.com:443
 		;;
 	github-tooling)
+		# release-assets.githubusercontent.com: GitHub release-asset CDN — actions
+		# that download release binaries (e.g. codeql-action CLI bundle) redirect
+		# here; absent it, toolcache misses fail under block policy (#517).
 		printf '%s\n' \
 			github.com:443 \
 			api.github.com:443 \
 			codeload.github.com:443 \
 			objects.githubusercontent.com:443 \
 			raw.githubusercontent.com:443 \
+			release-assets.githubusercontent.com:443 \
 			uploads.github.com:443 \
 			pipelines.actions.githubusercontent.com:443
 		;;
@@ -202,7 +206,6 @@ egress_preset_endpoints() {
 		# Direct osv-scanner binary install + scan (reusable-vuln-suppression-check).
 		egress_preset_endpoints github-tooling
 		printf '%s\n' \
-			release-assets.githubusercontent.com:443 \
 			api.osv.dev:443 \
 			api.deps.dev:443
 		;;
@@ -213,7 +216,6 @@ egress_preset_endpoints() {
 		# from it — its omission previously broke py-lintro's dogfood workflow).
 		egress_preset_endpoints github-tooling
 		printf '%s\n' \
-			release-assets.githubusercontent.com:443 \
 			pypi.org:443 \
 			files.pythonhosted.org:443 \
 			astral.sh:443 \

--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -59,6 +59,7 @@ on:
           codeload.github.com:443
           objects.githubusercontent.com:443
           raw.githubusercontent.com:443
+          release-assets.githubusercontent.com:443
           uploads.github.com:443
           pipelines.actions.githubusercontent.com:443
       allowed-endpoints-mode:

--- a/.github/workflows/reusable-link-check.yml
+++ b/.github/workflows/reusable-link-check.yml
@@ -68,6 +68,7 @@ on:
           codeload.github.com:443
           objects.githubusercontent.com:443
           raw.githubusercontent.com:443
+          release-assets.githubusercontent.com:443
           uploads.github.com:443
           pipelines.actions.githubusercontent.com:443
       allowed-endpoints-mode:

--- a/.github/workflows/reusable-site-quality.yml
+++ b/.github/workflows/reusable-site-quality.yml
@@ -184,6 +184,7 @@ on:
           codeload.github.com:443
           objects.githubusercontent.com:443
           raw.githubusercontent.com:443
+          release-assets.githubusercontent.com:443
           uploads.github.com:443
           pipelines.actions.githubusercontent.com:443
       allowed-endpoints-mode:

--- a/scripts/ci/lib/egress/presets.sh
+++ b/scripts/ci/lib/egress/presets.sh
@@ -26,12 +26,16 @@ egress_preset_endpoints() {
 			pipelines.actions.githubusercontent.com:443
 		;;
 	github-tooling)
+		# release-assets.githubusercontent.com: GitHub release-asset CDN — actions
+		# that download release binaries (e.g. codeql-action CLI bundle) redirect
+		# here; absent it, toolcache misses fail under block policy (#517).
 		printf '%s\n' \
 			github.com:443 \
 			api.github.com:443 \
 			codeload.github.com:443 \
 			objects.githubusercontent.com:443 \
 			raw.githubusercontent.com:443 \
+			release-assets.githubusercontent.com:443 \
 			uploads.github.com:443 \
 			pipelines.actions.githubusercontent.com:443
 		;;
@@ -202,7 +206,6 @@ egress_preset_endpoints() {
 		# Direct osv-scanner binary install + scan (reusable-vuln-suppression-check).
 		egress_preset_endpoints github-tooling
 		printf '%s\n' \
-			release-assets.githubusercontent.com:443 \
 			api.osv.dev:443 \
 			api.deps.dev:443
 		;;
@@ -213,7 +216,6 @@ egress_preset_endpoints() {
 		# from it — its omission previously broke py-lintro's dogfood workflow).
 		egress_preset_endpoints github-tooling
 		printf '%s\n' \
-			release-assets.githubusercontent.com:443 \
 			pypi.org:443 \
 			files.pythonhosted.org:443 \
 			astral.sh:443 \

--- a/tests/bats/unit/lib/egress/test_presets.bats
+++ b/tests/bats/unit/lib/egress/test_presets.bats
@@ -23,6 +23,12 @@ PRESETS="${PROJECT_ROOT}/scripts/ci/lib/egress/presets.sh"
 	assert_output --partial 'uploads.github.com:443'
 }
 
+@test "egress preset github-tooling includes release-assets CDN for release-binary downloads" {
+	run bash -c "source '$PRESETS' && egress_preset_endpoints github-tooling"
+	assert_success
+	assert_output --partial 'release-assets.githubusercontent.com:443'
+}
+
 @test "egress preset github-pages includes OIDC and release asset hosts" {
 	run bash -c "source '$PRESETS' && egress_preset_endpoints github-pages"
 	assert_success


### PR DESCRIPTION
## Summary

Fixes #517 — codeql-action's v2.26.0 CLI bundle downloads redirect to `release-assets.githubusercontent.com`, absent from the `github-tooling` preset and `reusable-codeql.yml`'s default `allowed-endpoints`. harden-runner block policy failed every toolcache-miss run (all merge_group/push runs) org-wide.

## Changes

- Add `release-assets.githubusercontent.com:443` to the `github-tooling` preset (canonical lib + synced harden-runner bundle); drop now-redundant entries from `osv-scanner` and `ai-review` presets
- Add it to inline default `allowed-endpoints` of `reusable-codeql.yml`, `reusable-link-check.yml`, `reusable-site-quality.yml` (lychee-action and setup-bun also download GitHub release binaries)
- New bats test asserting release-assets in github-tooling

## Not in scope

Item 2 of #517 (resolve caller `allowed-endpoints` before the enforcing pre-hook so append mode works as named) — tracked with #512.

## Testing

- Full bats suite green locally (rust-coverage test failure is env-only: cargo-llvm-cov missing)
- `validate-harden-runner-bundle.sh` passes
- lintro clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secure network access for release asset downloads, including toolcache and release binaries.
  * Updated default endpoint allowlists across reusable workflows to support GitHub release assets.

* **Tests**
  * Added coverage verifying that release asset endpoints are included in the GitHub tooling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the egress allowlists used by GitHub tooling downloads.

- Adds `release-assets.githubusercontent.com:443` to the shared `github-tooling` preset.
- Keeps the bundled harden-runner preset copy in sync.
- Removes duplicate inherited entries from `osv-scanner` and `ai-review` presets.
- Adds the same endpoint to reusable workflow defaults for CodeQL, link checking, and site quality.
- Adds a Bats test for the `github-tooling` preset.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/harden-runner/lib/egress/presets.sh | Adds the release-assets CDN to the bundled `github-tooling` preset and keeps inherited child presets working. |
| scripts/ci/lib/egress/presets.sh | Adds the release-assets CDN to the canonical `github-tooling` preset and removes duplicate child-preset entries. |
| .github/workflows/reusable-codeql.yml | Adds the release-assets CDN to the default CodeQL workflow endpoint list. |
| .github/workflows/reusable-link-check.yml | Adds the release-assets CDN to the default link-check workflow endpoint list. |
| .github/workflows/reusable-site-quality.yml | Adds the release-assets CDN to the default site-quality workflow endpoint list. |
| tests/bats/unit/lib/egress/test_presets.bats | Adds test coverage for the release-assets CDN in `github-tooling`. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/lgtm-hq/lgtm-ci/commit/cde25d9108a26a4f2f3311e8530178319755988d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43626992)</sub>

<!-- /greptile_comment -->