### PR TITLE
fix(workflows): drop composites from scorecards job for publish allowlist

### DIFF
--- a/.github/workflows/reusable-scorecards.yml
+++ b/.github/workflows/reusable-scorecards.yml
@@ -32,8 +32,8 @@ on:
 
       tooling-ref:
         description: >-
-          Optional — pins egress composites only (no scripts/ci checkout).
-          Defaults to caller workflow SHA.
+          Deprecated no-op — the scorecard job cannot run lgtm-ci composites
+          (scorecard-action publish allowlist, #518). Kept for caller compat.
         required: false
         type: string
         default: ""
@@ -60,17 +60,18 @@ on:
           api.securityscorecards.dev:443
       allowed-endpoints-mode:
         description: >-
-          replace: non-empty allowed-endpoints overrides egress-preset; append:
-          merges preset with allowed-endpoints (deduped, first-seen wins)
+          Deprecated no-op — the scorecard job cannot run the allowlist
+          resolver composite (scorecard-action publish allowlist, #518).
+          allowed-endpoints is fed to harden-runner verbatim.
         required: false
         type: string
         default: "replace"
 
       egress-preset:
         description: >-
-          Named allowlist when allowed-endpoints is empty and egress-policy is
-          block (github-minimal, github-pages, github-tooling, docker, playwright, pypi,
-          rubygems, npm-publish, quality, sbom, scorecard)
+          Deprecated no-op — preset resolution needs lgtm-ci composites, which
+          the scorecard-action publish allowlist forbids in this job (#518).
+          Override allowed-endpoints instead.
         required: false
         type: string
         default: "scorecard"
@@ -104,30 +105,15 @@ jobs:
         with:
           egress-policy: ${{ inputs.egress-policy }}
           allowed-endpoints: ${{ inputs.allowed-endpoints }}
+      # No local composite steps here: ossf/scorecard-action's publish path
+      # only allows checkout, upload-artifact, upload-sarif, scorecard-action,
+      # and harden-runner in the calling job — any other step fails publish
+      # with "job has unallowed step" (#518). Egress therefore uses the static
+      # allowed-endpoints default directly (no preset resolution).
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - name: Checkout lgtm-ci tooling
-        # yamllint disable-line rule:line-length
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: lgtm-hq/lgtm-ci
-          path: .lgtm-ci-tooling
-          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
-          sparse-checkout: |
-            .github/actions/checkout-and-harden
-          sparse-checkout-cone-mode: true
-          persist-credentials: false
-      - name: Checkout and harden
-        id: egress
-        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
-        with:
-          tooling-ref: ${{ inputs.tooling-ref }}
-          egress-policy: ${{ inputs.egress-policy }}
-          egress-preset: ${{ inputs.egress-preset }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
-          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
       - name: Run OpenSSF Scorecard
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:

--- a/tests/bats/integration/test_reusable_scorecards.bats
+++ b/tests/bats/integration/test_reusable_scorecards.bats
@@ -62,7 +62,17 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-scorecards.yml"
 	assert_success
 }
 
-@test "reusable-scorecards: resolve egress before harden-runner composite" {
-	run egress_tooling_checkout_order_ok "$WORKFLOW" scorecards
+@test "reusable-scorecards: scorecard job uses only publish-allowlisted actions" {
+	# ossf/scorecard-action publish path forbids any step besides checkout,
+	# upload-artifact, upload-sarif, scorecard-action, harden-runner (#518).
+	run awk '
+		/^  scorecards:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  scorecards:/ { in_job = 0 }
+		in_job && /^        uses: / {
+			ok = /uses: (actions\/checkout|actions\/upload-artifact|github\/codeql-action\/upload-sarif|ossf\/scorecard-action|step-security\/harden-runner)@/
+			if (!ok) { print "unallowed: " $0; bad = 1 }
+		}
+		END { exit bad }
+	' "$WORKFLOW"
 	assert_success
 }


### PR DESCRIPTION
## Summary

Fixes #518 — ossf/scorecard-action's publish path enforces an action allowlist for the calling job (checkout, upload-artifact, upload-sarif, scorecard-action, harden-runner). The reusable's `checkout-and-harden` composite steps made every `publish-results: true` run fail with **"job has unallowed step"**, forcing consumers (ai-skills, turbo-themes#530) to disable publishing.

## Changes

- Remove tooling checkout + `checkout-and-harden` from the `scorecards` job; harden-runner enforces the static `allowed-endpoints` default directly (no preset resolution)
- Deprecate `egress-preset`, `allowed-endpoints-mode`, `tooling-ref` as documented no-ops (kept so existing callers don't break)
- Replace the composite-order contract test with an assertion that the job contains only publish-allowlisted actions

## Follow-up (after release)

Flip `publish-results` back to `true` in lgtm-hq/ai-skills and lgtm-hq/turbo-themes callers.

## Testing

- Full bats suite green locally (rust-coverage failure is env-only: cargo-llvm-cov missing)
- lintro clean

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the reusable Scorecards workflow so publishing can run within the Scorecard action allowlist. The main changes are:

- Removes the local checkout-and-harden composite from the Scorecards job.
- Passes the static `allowed-endpoints` input directly to harden-runner.
- Marks the old preset, mode, and tooling inputs as deprecated no-ops.
- Replaces the integration test with a check for publish-allowlisted actions.
</details>

<h3>Confidence Score: 4/5</h3>

This is close, but the endpoint handling should be fixed before merging.

- Existing append-mode callers can still lose the required Scorecard endpoints.
- Under blocked egress, Scorecard publishing can fail even though the caller configuration worked before.
- The new test covers the action allowlist but not this endpoint merge behavior.

.github/workflows/reusable-scorecards.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-scorecards.yml | Removes composite-based endpoint resolution from the Scorecards job and feeds harden-runner from the workflow input directly. |
| tests/bats/integration/test_reusable_scorecards.bats | Changes the integration test to verify that the Scorecards job only uses actions accepted by the publish path. |

</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Freusable-scorecards.yml%3A107%0A**Append%20Mode%20Still%20Breaks**%0A%0AWhen%20an%20existing%20caller%20sets%20%60allowed-endpoints-mode%3A%20append%60%20and%20provides%20only%20its%20extra%20endpoints%2C%20this%20step%20now%20sends%20that%20custom%20list%20directly%20to%20harden-runner.%20The%20required%20Scorecard%20endpoints%20from%20the%20default%20list%20are%20no%20longer%20merged%20in%2C%20so%20%60api.osv.dev%60%2C%20%60api.scorecard.dev%60%2C%20and%20%60api.securityscorecards.dev%60%20can%20be%20blocked%20under%20%60egress-policy%3A%20block%60.%20That%20keeps%20the%20Scorecard%20publish%20path%20failing%20for%20caller%20configurations%20that%20previously%20meant%20%E2%80%9Cuse%20the%20scorecard%20preset%20plus%20my%20endpoints.%E2%80%9D%0A%0A&pr=535&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Freusable-scorecards.yml%3A107%0A**Append%20Mode%20Still%20Breaks**%0A%0AWhen%20an%20existing%20caller%20sets%20%60allowed-endpoints-mode%3A%20append%60%20and%20provides%20only%20its%20extra%20endpoints%2C%20this%20step%20now%20sends%20that%20custom%20list%20directly%20to%20harden-runner.%20The%20required%20Scorecard%20endpoints%20from%20the%20default%20list%20are%20no%20longer%20merged%20in%2C%20so%20%60api.osv.dev%60%2C%20%60api.scorecard.dev%60%2C%20and%20%60api.securityscorecards.dev%60%20can%20be%20blocked%20under%20%60egress-policy%3A%20block%60.%20That%20keeps%20the%20Scorecard%20publish%20path%20failing%20for%20caller%20configurations%20that%20previously%20meant%20%E2%80%9Cuse%20the%20scorecard%20preset%20plus%20my%20endpoints.%E2%80%9D%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=535&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22fix%2Fscorecards-publish-allowlist%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fscorecards-publish-allowlist%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Freusable-scorecards.yml%3A107%0A**Append%20Mode%20Still%20Breaks**%0A%0AWhen%20an%20existing%20caller%20sets%20%60allowed-endpoints-mode%3A%20append%60%20and%20provides%20only%20its%20extra%20endpoints%2C%20this%20step%20now%20sends%20that%20custom%20list%20directly%20to%20harden-runner.%20The%20required%20Scorecard%20endpoints%20from%20the%20default%20list%20are%20no%20longer%20merged%20in%2C%20so%20%60api.osv.dev%60%2C%20%60api.scorecard.dev%60%2C%20and%20%60api.securityscorecards.dev%60%20can%20be%20blocked%20under%20%60egress-policy%3A%20block%60.%20That%20keeps%20the%20Scorecard%20publish%20path%20failing%20for%20caller%20configurations%20that%20previously%20meant%20%E2%80%9Cuse%20the%20scorecard%20preset%20plus%20my%20endpoints.%E2%80%9D%0A%0A&repo=lgtm-hq%2Flgtm-ci&pr=535&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/lgtm-hq/lgtm-ci/commit/f6785ba5815fc60ccb290dc36b6a77554ea83233) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43628466)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->