### PR TITLE
fix(workflows): always run lintro-version check on PRs

### DIFF
--- a/.github/workflows/validate-lintro-version.yml
+++ b/.github/workflows/validate-lintro-version.yml
@@ -4,17 +4,12 @@
 name: Quality Check - Lintro Version Sync
 
 'on':
+  # No pull_request path filter: "validate / Validate Lintro Version" is a
+  # required check, and a path-filtered required check never reports on PRs
+  # that miss the filter, deadlocking them at merge-queue entry (see
+  # validate-action-pinning.yml for the same pattern).
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - 'pyproject.toml'
-      - '.github/workflows/reusable-quality-lint.yml'
-      - '.github/workflows/reusable-validate-lintro-version.yml'
-      - '.github/workflows/validate-lintro-version.yml'
-      - '.github/actions/run-quality/action.yml'
-      - 'scripts/ci/quality/check-lintro-tooling-bootstrap.sh'
-      - 'scripts/ci/quality/resolve-lintro-image.sh'
-      - 'scripts/ci/quality/validate-lintro-version.sh'
   merge_group:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary

`validate / Validate Lintro Version` is a required status check, but its `pull_request` trigger was path-filtered — PRs not touching the filtered paths never receive the check and sit permanently `BLOCKED` at merge-queue entry. #534 and #535 are deadlocked by this right now.

Same trap as the documented pattern in `validate-action-pinning.yml` (and py-lintro#1196 for CodeQL): a path-filtered required check deadlocks non-matching PRs.

## Changes

- Drop the `pull_request` path filter so the check always runs and reports (~1–2 min; the quality job pulls the same lintro image anyway)
- `push` (main) path filter unchanged; `merge_group` already unfiltered

## Testing

- version-drift workflow bats tests pass
- lintro clean

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes the Lintro version workflow report on every pull request. The main changes are:

- Removed the `pull_request` path filter from `.github/workflows/validate-lintro-version.yml`.
- Kept the existing filtered `push` behavior for `main`.
- Added a comment explaining why required checks should not be path-filtered on PRs.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/validate-lintro-version.yml | The workflow now runs for all pull requests while preserving the existing push path filter. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workflows): always run lintro-versio..."](https://github.com/lgtm-hq/lgtm-ci/commit/978d3d2473a6bbd186f19034c061737fce84e40b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43633606)</sub>

<!-- /greptile_comment -->