### PR TITLE
docs(org): registry reflects 📌 pinning canon for Rustume and holy-grail

### DIFF
--- a/docs/org-rulesets.md
+++ b/docs/org-rulesets.md
@@ -37,12 +37,12 @@ Per-repo rulesets (stack-specific gates only; canonical emoji names per #514):
 | ------- | --------- | ----- | ----------------- |
 | `checks-ai-skills` | `16132646` | `ai-skills` | `validate / 📚 Validate Skill Structure` |
 | `checks-dot-github` | `16438323` | `.github` | `validate / 🧾 Validate Org Config` |
-| `checks-holy-grail` | `16132645` | `holy-grail` | `codeql / 🔬 CodeQL Analysis`, `semantic-title / 📝 Validate PR Title`, `validate / Validate Action Pinning`, `🎭 E2E Tests`, `🏗️ Build & Test`, `🔐 Security Audit` |
+| `checks-holy-grail` | `16132645` | `holy-grail` | `codeql / 🔬 CodeQL Analysis`, `semantic-title / 📝 Validate PR Title`, `validate / 📌 Validate Action Pinning`, `🎭 E2E Tests`, `🏗️ Build & Test`, `🔐 Security Audit` |
 | `checks-homebrew-tap` | `16438312` | `homebrew-tap` | `shell-tests / 🐚 Shell Tests`, `🍺 Validate Formula` |
 | `checks-lgtm-ci` | `16438310` | `lgtm-ci` | `shell-tests / 🐚 Shell Tests`, `semantic-title / 📝 Validate PR Title`, `validate / 📌 Validate Action Pinning` |
 | `checks-podex` | `16438314` | `podex` | `semantic-title / 📝 Validate PR Title`, `test / Aggregate Python Results` |
 | `checks-py-lintro` | `16132640` | `py-lintro` | `🚦 Test Gate`, `codeql / 🔬 CodeQL Analysis`, `lintro-code-quality / 🛠️ Lintro Code Quality`, `semantic-title / 📝 Validate PR Title`, `test-compat / Aggregate Python Results`, `test-compat / Python Compatibility`, `test-coverage / Aggregate Python Results`, `test-coverage / Python Coverage`, `test-suite-coverage / 🧪 Test Suite & Coverage`, `🐳 Build Docker Images`, `🔐 Security Audit`, `🧪 Docker Integration Tests` |
-| `checks-rustume` | `16132643` | `Rustume` | `codeql / 🔬 CodeQL Analysis`, `semantic-title / 📝 Validate PR Title`, `check-pinning / Validate Action Pinning`, `rust-build / 🔨 Build Check`, `rust-coverage / 🦀 Rust Coverage`, `web-coverage / 🌐 Web Coverage`, `🔐 Security Audit` |
+| `checks-rustume` | `16132643` | `Rustume` | `codeql / 🔬 CodeQL Analysis`, `semantic-title / 📝 Validate PR Title`, `validate / 📌 Validate Action Pinning`, `rust-build / 🔨 Build Check`, `rust-coverage / 🦀 Rust Coverage`, `web-coverage / 🌐 Web Coverage`, `🔐 Security Audit` |
 | `checks-turbo-themes` | `16132642` | `turbo-themes` | `♿ E2E Accessibility Tests`, `semantic-title / 📝 Validate PR Title`, `🎭 E2E Tests`, `🏗️ Build & Quality Checks (20)`, `🏗️ Build & Quality Checks (22)`, `sbom / 📋 SBOM & Supply Chain`, `📦 Validate Examples`, `codeql / 🔬 CodeQL Analysis`, `security-audit / 🔐 Security Audit`, `🔥 E2E Smoke Tests` |
 | `checks-winnow` | `17448561` | `winnow` | `codeql / 🔬 CodeQL Analysis`, `security-audit / 🔐 Security Audit`, `semantic-title / 📝 Validate PR Title`, `test / Aggregate Python Results`, `test / 🧪 Python Compatibility`, `validate / 🧾 Validate Lintro Version` |
 


### PR DESCRIPTION
Registry follow-up: org rulesets `16132643` (checks-rustume) and `16132645` (checks-holy-grail) flipped to `validate / 📌 Validate Action Pinning` (PUT, lockstep with lgtm-hq/Rustume#391 and lgtm-hq/holy-grail#150). Completes the emoji canon rollout (#514) for the pinning check.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the org ruleset registry for the pinning check naming rollout.

- `checks-holy-grail` now lists `validate / 📌 Validate Action Pinning`.
- `checks-rustume` now lists `validate / 📌 Validate Action Pinning`.
- The table now matches the nearby emoji-prefixed pinning check convention.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed documentation.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/org-rulesets.md | Updates two ruleset rows to use the canonical emoji-prefixed action pinning check name. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(org): registry reflects 📌 pinning ..."](https://github.com/lgtm-hq/lgtm-ci/commit/d356d24d263f58ecb54873789491ddbfc97d526f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43648287)</sub>

<!-- /greptile_comment -->