### PR TITLE
docs(changelog): move verify-tags default flip to v0.48.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,7 +183,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps**: update ghcr.io/lgtm-hq/py-lintro digest (#463) (0f17d22)
 - **workflows**: split reusable-docker.yml into focused workflows (#461) (8104b09)
 - **deps**: update lycheeverse/lychee-action to v2.9.0 (minor) (#462) (3312cb7)
-- **security**: verify-tags default flip (#369) — moved to v0.48.2 (misattributed)
+_Note: The `verify-tags` default flip entry was moved to v0.48.2 because it was previously misattributed here._
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps**: update ghcr.io/lgtm-hq/py-lintro digest (#463) (0f17d22)
 - **workflows**: split reusable-docker.yml into focused workflows (#461) (8104b09)
 - **deps**: update lycheeverse/lychee-action to v2.9.0 (minor) (#462) (3312cb7)
+
 ### Fixed
 
 - **deps**: update ghcr.io/lgtm-hq/py-lintro digest (#458) (34dd9ee)
@@ -191,8 +192,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (6193843)
 - **pages**: delete stale same-run Pages artifacts before upload (#451) (af2b2bb)
 - **release**: wrap generated changelog lines to 88 columns (#452) (e9e4246)
-
-_Note: The `verify-tags` default flip entry was moved to v0.48.2 because it was previously misattributed here._
 
 ## [0.48.2] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,8 +183,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps**: update ghcr.io/lgtm-hq/py-lintro digest (#463) (0f17d22)
 - **workflows**: split reusable-docker.yml into focused workflows (#461) (8104b09)
 - **deps**: update lycheeverse/lychee-action to v2.9.0 (minor) (#462) (3312cb7)
-_Note: The `verify-tags` default flip entry was moved to v0.48.2 because it was previously misattributed here._
-
 ### Fixed
 
 - **deps**: update ghcr.io/lgtm-hq/py-lintro digest (#458) (34dd9ee)
@@ -193,6 +191,8 @@ _Note: The `verify-tags` default flip entry was moved to v0.48.2 because it was 
   (6193843)
 - **pages**: delete stale same-run Pages artifacts before upload (#451) (af2b2bb)
 - **release**: wrap generated changelog lines to 88 columns (#452) (e9e4246)
+
+_Note: The `verify-tags` default flip entry was moved to v0.48.2 because it was previously misattributed here._
 
 ## [0.48.2] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **deps**: update ghcr.io/lgtm-hq/py-lintro digest (#463) (0f17d22)
 - **workflows**: split reusable-docker.yml into focused workflows (#461) (8104b09)
 - **deps**: update lycheeverse/lychee-action to v2.9.0 (minor) (#462) (3312cb7)
+- **security**: verify-tags default flip (#369) — moved to v0.48.2 (misattributed)
+
+### Fixed
+
+- **deps**: update ghcr.io/lgtm-hq/py-lintro digest (#458) (34dd9ee)
+- **workflows**: fail or skip on missing node-custom coverage summary (#444) (4f3852e)
+- **actions**: byte-cap file-breakdown comment against GitHub size limit (#450)
+  (6193843)
+- **pages**: delete stale same-run Pages artifacts before upload (#451) (af2b2bb)
+- **release**: wrap generated changelog lines to 88 columns (#452) (e9e4246)
+
+## [0.48.2] - 2026-07-09
+
+### Changed
 
 - **security**: default `verify-tags` to `true` in the
   `validate-action-pinning` action and `reusable-validate-action-pinning.yml`
@@ -195,16 +209,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Callers that already relied on the API being reachable need no change; tag
   resolution failures are reported as warnings, not hard failures.
 
-### Fixed
-
-- **deps**: update ghcr.io/lgtm-hq/py-lintro digest (#458) (34dd9ee)
-- **workflows**: fail or skip on missing node-custom coverage summary (#444) (4f3852e)
-- **actions**: byte-cap file-breakdown comment against GitHub size limit (#450)
-  (6193843)
-- **pages**: delete stale same-run Pages artifacts before upload (#451) (af2b2bb)
-- **release**: wrap generated changelog lines to 88 columns (#452) (e9e4246)
-
-## [0.48.2] - 2026-07-09
+  Note: this breaking default flip shipped in tag v0.48.2 (compare
+  [v0.48.1...v0.48.2](https://github.com/lgtm-hq/lgtm-ci/compare/v0.48.1...v0.48.2))
+  despite originally being listed under Unreleased / later misattributed to v0.49.0.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

Relocate the verify-tags default-flip changelog entry (#369) from v0.49.0 to v0.48.2, where it actually shipped, and leave a misattribution pointer under v0.49.0.

## Type

- [x] 📚 Documentation

## Changes Made

- Move #369 verify-tags default flip entry into the v0.48.2 Changed section
- Annotate that the change shipped in v0.48.2 with compare link v0.48.1...v0.48.2
- Leave a one-line pointer under v0.49.0 noting the misattribution

## Closes

- Closes #533

## Testing

- [x] Existing tests pass (docs-only)
- [ ] New tests added
- [ ] Manual testing performed

## Quality Checks

- [x] Code formatted (`uv run lintro fmt`)
- [ ] All checks pass (`uv run lintro chk`) — full suite blocked by host load; CI will gate
- [x] Signed commit

## Checklist

- [x] PR title follows conventional commits
- [x] Changes are focused and atomic
- [x] No secrets or credentials committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the v0.49.0 changelog with previously missing fix details.
  * Clarified the release version and history for the “verify-tags” default change.
  * Added a comparison link and explanatory note to the v0.48.2 changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects where the `verify-tags` default change appears in the changelog.

- Moves the `verify-tags` default flip entry into the `v0.48.2` section.
- Keeps the `v0.49.0` fixed entries scoped above the `v0.48.2` heading.
- Adds a note and compare link explaining the earlier misattribution.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Updates the changelog section layout so the `verify-tags` entry is listed under `v0.48.2`. |

</details>

<sub>Reviews (4): Last reviewed commit: ["docs(changelog): drop v0.49.0 misattribu..."](https://github.com/lgtm-hq/lgtm-ci/commit/34ebac5f74d0ec52b3731133b17b1f9259ff6cf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43676086)</sub>

<!-- /greptile_comment -->