### PR TITLE
docs(pages): replace stale publish-test-results v0.23.0 pin

### DIFF
--- a/docs/pages-publishing.md
+++ b/docs/pages-publishing.md
@@ -221,7 +221,7 @@ When a repository must keep **separate** Model A publish jobs (for example pytho
 then node on the same ref), enable merge on each job after the first:
 
 ```yaml
-- uses: lgtm-hq/lgtm-ci/.github/actions/publish-test-results@v0.23.0
+- uses: lgtm-hq/lgtm-ci/.github/actions/publish-test-results@v1.2.3  # or @<sha>
   with:
     target-dir: vitest
     coverage-path: coverage/

--- a/docs/pages-publishing.md
+++ b/docs/pages-publishing.md
@@ -221,7 +221,7 @@ When a repository must keep **separate** Model A publish jobs (for example pytho
 then node on the same ref), enable merge on each job after the first:
 
 ```yaml
-- uses: lgtm-hq/lgtm-ci/.github/actions/publish-test-results@v1.2.3  # or @<sha>
+- uses: lgtm-hq/lgtm-ci/.github/actions/publish-test-results@<sha>
   with:
     target-dir: vitest
     coverage-path: coverage/


### PR DESCRIPTION
## Summary

Replace the stale `publish-test-results@v0.23.0` hard pin in pages-publishing docs with the repo's `@v1.2.3` / `@<sha>` placeholder convention.

## Type

- [x] 📚 Documentation

## Changes Made

- Update Model A merge example pin in `docs/pages-publishing.md`
- Verified `docs/org-rulesets.md` registry rows against live org rulesets: holy-grail/rustume/py-lintro already match; podex still requires `test / Aggregate Python Results` without emoji in its live ruleset (consumer follow-up, not a stale doc row)

## Closes

- Closes #530

## Testing

- [x] Existing tests pass (docs-only)
- [ ] New tests added

## Quality Checks

- [x] Signed commit
- [ ] Full local `lintro chk` (host load); CI gates

## Checklist

- [x] PR title follows conventional commits
- [x] Changes are focused and atomic

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the Pages publishing docs to use the repo’s action-ref placeholder convention.

- Replaces the stale `publish-test-results` version-style ref in the Model A merge example.
- Uses `@<sha>` for the action ref in `docs/pages-publishing.md`.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/pages-publishing.md | Updates the Model A merge example to use the documented `@<sha>` placeholder style. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(pages): use @&lt;sha&gt; placeholder for ..."](https://github.com/lgtm-hq/lgtm-ci/commit/e26f262ccee5d9a32e3e9e8d33f0ade286563789) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43677392)</sub>

<!-- /greptile_comment -->