### PR TITLE
fix(test): harden port flake and registry empty-name assertions

### DIFF
--- a/tests/bats/unit/lib/network/test_port.bats
+++ b/tests/bats/unit/lib/network/test_port.bats
@@ -110,14 +110,25 @@ teardown() {
 }
 
 @test "wait_for_port_listen: fails when no listener is bound" {
-	run bash -c 'source "$LIB_DIR/network/port.sh" && wait_for_port_listen 49994 1 0.1'
+	# Bind then close so the chosen port is known-free (avoids collision flake).
+	run bash -c '
+		python3 -c "import socket; s=socket.socket(); s.bind((\"127.0.0.1\", 0)); print(s.getsockname()[1]); s.close()"
+	'
+	assert_success
+	free_port="$output"
+	run bash -c "source \"$LIB_DIR/network/port.sh\" && wait_for_port_listen ${free_port} 1 0.1"
 	assert_failure
 }
 
 @test "wait_for_port_listen: logs waiting message" {
-	run bash -c 'source "$LIB_DIR/network/port.sh" && wait_for_port_listen 49993 1 0.1 2>&1'
+	run bash -c '
+		python3 -c "import socket; s=socket.socket(); s.bind((\"127.0.0.1\", 0)); print(s.getsockname()[1]); s.close()"
+	'
+	assert_success
+	free_port="$output"
+	run bash -c "source \"$LIB_DIR/network/port.sh\" && wait_for_port_listen ${free_port} 1 0.1 2>&1"
 	assert_failure
-	assert_output --partial "Waiting for port 49993 to accept connections"
+	assert_output --partial "Waiting for port ${free_port} to accept connections"
 }
 
 # =============================================================================

--- a/tests/bats/unit/lib/network/test_port.bats
+++ b/tests/bats/unit/lib/network/test_port.bats
@@ -110,18 +110,38 @@ teardown() {
 }
 
 @test "wait_for_port_listen: fails when no listener is bound" {
-	# Probe-and-retry: bind/close to pick a free port, then assert listen wait fails.
-	# Retry a few times if another process steals the port in the tiny gap.
+	# Hold an exclusive bind WITHOUT listen() so nothing else can steal the port,
+	# while nc/tcp probes still fail (no accepting listener).
 	run bash -c '
 		source "$LIB_DIR/network/port.sh"
-		for _ in 1 2 3 4 5; do
-			port="$(python3 -c "import socket; s=socket.socket(); s.bind((\"127.0.0.1\", 0)); print(s.getsockname()[1]); s.close()")"
-			if ! wait_for_port_listen "${port}" 1 0.1; then
-				exit 0
-			fi
+		declare -F wait_for_port_listen >/dev/null || { echo "wait_for_port_listen missing" >&2; exit 1; }
+		holder="$(mktemp)"
+		python3 - "$holder" <<'"'"'PY'"'"'
+import socket, sys, time
+path = sys.argv[1]
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+port = s.getsockname()[1]
+open(path, "w", encoding="utf-8").write(str(port))
+time.sleep(60)
+PY
+		py_pid=$!
+		trap "kill ${py_pid} 2>/dev/null || true; rm -f ${holder}" EXIT
+		for _ in $(seq 1 50); do
+			[[ -s "$holder" ]] && break
+			sleep 0.05
 		done
-		echo "failed to find an unbound port after retries" >&2
-		exit 1
+		port="$(cat "$holder")"
+		out="$(wait_for_port_listen "${port}" 1 0.1 2>&1)" && {
+			echo "unexpected listen success on bound-but-not-listening port ${port}" >&2
+			echo "$out" >&2
+			exit 1
+		}
+		printf "%s\n" "$out"
+		case "$out" in
+			*"Port ${port} not ready after"*) ;;
+			*) echo "missing timeout diagnostic: $out" >&2; exit 1 ;;
+		esac
 	'
 	assert_success
 }
@@ -129,19 +149,36 @@ teardown() {
 @test "wait_for_port_listen: logs waiting message" {
 	run bash -c '
 		source "$LIB_DIR/network/port.sh"
-		for _ in 1 2 3 4 5; do
-			port="$(python3 -c "import socket; s=socket.socket(); s.bind((\"127.0.0.1\", 0)); print(s.getsockname()[1]); s.close()")"
-			out="$(wait_for_port_listen "${port}" 1 0.1 2>&1)" || {
-				printf "%s\n" "$out"
-				exit 0
-			}
+		declare -F wait_for_port_listen >/dev/null || { echo "wait_for_port_listen missing" >&2; exit 1; }
+		holder="$(mktemp)"
+		python3 - "$holder" <<'"'"'PY'"'"'
+import socket, sys, time
+path = sys.argv[1]
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+port = s.getsockname()[1]
+open(path, "w", encoding="utf-8").write(str(port))
+time.sleep(60)
+PY
+		py_pid=$!
+		trap "kill ${py_pid} 2>/dev/null || true; rm -f ${holder}" EXIT
+		for _ in $(seq 1 50); do
+			[[ -s "$holder" ]] && break
+			sleep 0.05
 		done
-		echo "failed to find an unbound port after retries" >&2
-		exit 1
+		port="$(cat "$holder")"
+		out="$(wait_for_port_listen "${port}" 1 0.1 2>&1)" || true
+		printf "%s\n" "$out"
+		case "$out" in
+			*"Waiting for port ${port} to accept connections"*) ;;
+			*) echo "missing waiting log: $out" >&2; exit 1 ;;
+		esac
+		case "$out" in
+			*"Port ${port} not ready after"*) ;;
+			*) echo "missing timeout diagnostic: $out" >&2; exit 1 ;;
+		esac
 	'
 	assert_success
-	assert_output --partial "Waiting for port"
-	assert_output --partial "to accept connections"
 }
 
 # =============================================================================

--- a/tests/bats/unit/lib/network/test_port.bats
+++ b/tests/bats/unit/lib/network/test_port.bats
@@ -110,25 +110,38 @@ teardown() {
 }
 
 @test "wait_for_port_listen: fails when no listener is bound" {
-	# Bind then close so the chosen port is known-free (avoids collision flake).
+	# Probe-and-retry: bind/close to pick a free port, then assert listen wait fails.
+	# Retry a few times if another process steals the port in the tiny gap.
 	run bash -c '
-		python3 -c "import socket; s=socket.socket(); s.bind((\"127.0.0.1\", 0)); print(s.getsockname()[1]); s.close()"
+		source "$LIB_DIR/network/port.sh"
+		for _ in 1 2 3 4 5; do
+			port="$(python3 -c "import socket; s=socket.socket(); s.bind((\"127.0.0.1\", 0)); print(s.getsockname()[1]); s.close()")"
+			if ! wait_for_port_listen "${port}" 1 0.1; then
+				exit 0
+			fi
+		done
+		echo "failed to find an unbound port after retries" >&2
+		exit 1
 	'
 	assert_success
-	free_port="$output"
-	run bash -c "source \"$LIB_DIR/network/port.sh\" && wait_for_port_listen ${free_port} 1 0.1"
-	assert_failure
 }
 
 @test "wait_for_port_listen: logs waiting message" {
 	run bash -c '
-		python3 -c "import socket; s=socket.socket(); s.bind((\"127.0.0.1\", 0)); print(s.getsockname()[1]); s.close()"
+		source "$LIB_DIR/network/port.sh"
+		for _ in 1 2 3 4 5; do
+			port="$(python3 -c "import socket; s=socket.socket(); s.bind((\"127.0.0.1\", 0)); print(s.getsockname()[1]); s.close()")"
+			out="$(wait_for_port_listen "${port}" 1 0.1 2>&1)" || {
+				printf "%s\n" "$out"
+				exit 0
+			}
+		done
+		echo "failed to find an unbound port after retries" >&2
+		exit 1
 	'
 	assert_success
-	free_port="$output"
-	run bash -c "source \"$LIB_DIR/network/port.sh\" && wait_for_port_listen ${free_port} 1 0.1 2>&1"
-	assert_failure
-	assert_output --partial "Waiting for port ${free_port} to accept connections"
+	assert_output --partial "Waiting for port"
+	assert_output --partial "to accept connections"
 }
 
 # =============================================================================

--- a/tests/bats/unit/lib/network/test_port.bats
+++ b/tests/bats/unit/lib/network/test_port.bats
@@ -116,7 +116,7 @@ teardown() {
 		source "$LIB_DIR/network/port.sh"
 		declare -F wait_for_port_listen >/dev/null || { echo "wait_for_port_listen missing" >&2; exit 1; }
 		holder="$(mktemp)"
-		python3 - "$holder" <<'"'"'PY'"'"'
+		python3 - "$holder" <<'"'"'PY'"'"' &
 import socket, sys, time
 path = sys.argv[1]
 s = socket.socket()
@@ -151,7 +151,7 @@ PY
 		source "$LIB_DIR/network/port.sh"
 		declare -F wait_for_port_listen >/dev/null || { echo "wait_for_port_listen missing" >&2; exit 1; }
 		holder="$(mktemp)"
-		python3 - "$holder" <<'"'"'PY'"'"'
+		python3 - "$holder" <<'"'"'PY'"'"' &
 import socket, sys, time
 path = sys.argv[1]
 s = socket.socket()

--- a/tests/bats/unit/lib/publish/test_registry.bats
+++ b/tests/bats/unit/lib/publish/test_registry.bats
@@ -49,6 +49,9 @@ teardown() {
 @test "check_pypi_availability: requires package name" {
 	run bash -c 'source "$LIB_DIR/publish/registry.sh" && check_pypi_availability "" "1.0.0" 2>&1'
 	assert_failure
+	assert_output --partial "Package name required"
+	# Guard against vacuous exit-127 (function missing in subshell)
+	refute_output --partial "command not found"
 }
 
 # =============================================================================
@@ -72,6 +75,8 @@ teardown() {
 @test "check_npm_availability: requires package name" {
 	run bash -c 'source "$LIB_DIR/publish/registry.sh" && check_npm_availability "" "1.0.0" 2>&1'
 	assert_failure
+	assert_output --partial "Package name required"
+	refute_output --partial "command not found"
 }
 
 # =============================================================================
@@ -109,6 +114,8 @@ teardown() {
 @test "check_rubygems_availability: requires gem name" {
 	run bash -c 'source "$LIB_DIR/publish/registry.sh" && check_rubygems_availability "" "1.0.0" 2>&1'
 	assert_failure
+	assert_output --partial "Gem name required"
+	refute_output --partial "command not found"
 }
 
 # =============================================================================

--- a/tests/bats/unit/lib/publish/test_registry.bats
+++ b/tests/bats/unit/lib/publish/test_registry.bats
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: MIT
 # Purpose: Tests for scripts/ci/lib/publish/registry.sh
 
+bats_require_minimum_version 1.5.0
+
 load "../../../../helpers/common"
 load "../../../../helpers/mocks"
 
@@ -47,11 +49,9 @@ teardown() {
 }
 
 @test "check_pypi_availability: requires package name" {
-	run bash -c 'source "$LIB_DIR/publish/registry.sh" && check_pypi_availability "" "1.0.0" 2>&1'
-	assert_failure
+	# bash ${1:?} exits 127 for null/empty params — expect that explicitly (BW01)
+	run -127 bash -c 'source "$LIB_DIR/publish/registry.sh" && check_pypi_availability "" "1.0.0" 2>&1'
 	assert_output --partial "Package name required"
-	# Guard against vacuous exit-127 (function missing in subshell)
-	refute_output --partial "command not found"
 }
 
 # =============================================================================
@@ -73,10 +73,8 @@ teardown() {
 }
 
 @test "check_npm_availability: requires package name" {
-	run bash -c 'source "$LIB_DIR/publish/registry.sh" && check_npm_availability "" "1.0.0" 2>&1'
-	assert_failure
+	run -127 bash -c 'source "$LIB_DIR/publish/registry.sh" && check_npm_availability "" "1.0.0" 2>&1'
 	assert_output --partial "Package name required"
-	refute_output --partial "command not found"
 }
 
 # =============================================================================
@@ -112,10 +110,8 @@ teardown() {
 }
 
 @test "check_rubygems_availability: requires gem name" {
-	run bash -c 'source "$LIB_DIR/publish/registry.sh" && check_rubygems_availability "" "1.0.0" 2>&1'
-	assert_failure
+	run -127 bash -c 'source "$LIB_DIR/publish/registry.sh" && check_rubygems_availability "" "1.0.0" 2>&1'
 	assert_output --partial "Gem name required"
-	refute_output --partial "command not found"
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fix the flaky free-port assumption in `wait_for_port_listen` negative tests and strengthen registry empty-name assertions so missing-function exit-127 cannot pass vacuously.

## Type

- [x] 🐛 Bug fix
- [x] ✅ Tests

## Changes Made

- Pick a known-free port by binding then closing before negative `wait_for_port_listen` cases
- Assert `Package/Gem name required` output and refute `command not found` on empty-name registry tests

## Closes

- Closes #529

## Testing

- [x] Targeted BATS attempted locally (see CI for full suite)
- [ ] New tests added (existing tests strengthened)

## Quality Checks

- [x] Signed commit
- [ ] Full local `lintro chk` (host load); CI gates

## Checklist

- [x] PR title follows conventional commits
- [x] Changes are focused and atomic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved network tests to reliably validate behavior when no service is listening, including waiting messages.
  * Strengthened package registry validation tests to confirm expected exit codes and error messages.
  * Added a minimum supported version requirement for the test framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens flaky BATS tests for port checks and registry empty-name validation. The main changes are:

- Holds an ephemeral loopback port with a background bind-only process during negative port-listen tests.
- Checks the expected waiting and timeout diagnostics for non-listening ports.
- Adds explicit registry empty-name output checks.
- Declares the minimum BATS version needed by the updated tests.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/bats/unit/lib/network/test_port.bats | Updates negative port-listen tests to keep the selected port bound while asserting timeout behavior. |
| tests/bats/unit/lib/publish/test_registry.bats | Updates registry empty-name tests with explicit exit expectations, required-name output checks, and a BATS version requirement. |

</details>

<sub>Reviews (6): Last reviewed commit: ["fix(test): background port-holder proces..."](https://github.com/lgtm-hq/lgtm-ci/commit/fd790304c5b7954048aeceddd330ed26e93f395b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43677853)</sub>

<!-- /greptile_comment -->