### PR TITLE
fix(sbom): scope contents:write to release-asset upload job

### DIFF
--- a/.github/actions/generate-sbom/action.yml
+++ b/.github/actions/generate-sbom/action.yml
@@ -30,6 +30,12 @@ inputs:
     description: "Name for the uploaded artifact"
     required: false
     default: "sbom"
+  upload-release-assets:
+    description: >-
+      Upload SBOM to the GitHub Release via anchore/sbom-action. Prefer false and
+      a dedicated contents:write job (reusable-sbom upload-release-assets).
+    required: false
+    default: "false"
 
 outputs:
   sbom-file:
@@ -63,6 +69,7 @@ runs:
         output-file: ${{ inputs.output-file }}
         upload-artifact: ${{ inputs.upload-artifact }}
         artifact-name: ${{ inputs.artifact-name }}
+        upload-release-assets: ${{ inputs.upload-release-assets }}
 
     - name: Generate summary
       if: inputs.output-file != ''

--- a/.github/workflows/reusable-sbom.yml
+++ b/.github/workflows/reusable-sbom.yml
@@ -46,6 +46,20 @@ on:
         required: false
         type: string
         default: "sbom"
+      upload-release-assets:
+        description: >-
+          When true, run a dedicated contents:write job that attaches the SBOM
+          artifact to the GitHub Release. Generation itself stays contents:read.
+        required: false
+        type: boolean
+        default: false
+      release-tag:
+        description: >-
+          Release tag for asset upload when upload-release-assets is true.
+          Defaults to github.ref_name when empty.
+        required: false
+        type: string
+        default: ""
 
       tooling-ref:
         description: "Git ref to use when checking out lgtm-ci tooling scripts"
@@ -131,9 +145,9 @@ jobs:
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
-      # write: attach CycloneDX SBOM to the GitHub Release asset list
-      # (anchore/sbom-action defaults upload-release-assets on release events)
-      contents: write
+      # Generation/scan/attest only need read for contents. Release asset upload
+      # is isolated in upload-release-assets (contents: write) — see #532.
+      contents: read
       security-events: write
       id-token: write
       attestations: write
@@ -188,6 +202,9 @@ jobs:
           format: ${{ inputs.sbom-format }}
           upload-artifact: "true"
           artifact-name: ${{ inputs.artifact-name }}
+          # Never let anchore attach release assets here — that needs
+          # contents:write and belongs in upload-release-assets (#532).
+          upload-release-assets: "false"
       - name: Scan vulnerabilities
         id: scan
         if: inputs.scan-vulnerabilities
@@ -203,3 +220,41 @@ jobs:
         uses: ./.lgtm-ci-tooling/.github/actions/attest-build
         with:
           subject-path: ${{ steps.generate.outputs.sbom-file }}
+
+  upload-release-assets:
+    name: Upload SBOM release assets
+    needs: [sbom]
+    if: inputs.upload-release-assets
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: write
+
+    steps:
+      - name: Harden runner
+        if: runner.os == 'Linux' || runner.environment == 'self-hosted'
+        # Pinned to SHA for supply chain security
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+      - name: Download SBOM artifact
+        # Pinned to SHA for supply chain security
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: sbom-artifact
+      - name: Upload SBOM to GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release-tag != '' && inputs.release-tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(find sbom-artifact -type f ! -name '.*' | sort)
+          if [[ ${#files[@]} -eq 0 ]]; then
+            echo "::error::No SBOM files found in downloaded artifact '${{ inputs.artifact-name }}'"
+            exit 1
+          fi
+          gh release upload "$RELEASE_TAG" "${files[@]}" --clobber
+          echo "Uploaded ${#files[@]} SBOM file(s) to release ${RELEASE_TAG}"

--- a/tests/bats/integration/test_reusable_sbom.bats
+++ b/tests/bats/integration/test_reusable_sbom.bats
@@ -50,3 +50,49 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-sbom.yml"
 	' "$WORKFLOW"
 	assert_success
 }
+
+@test "reusable-sbom: generation job uses contents: read" {
+	run awk '
+		/^  sbom:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  sbom:/ { in_job = 0 }
+		in_job && /^    permissions:/ { perms = 1 }
+		in_job && perms && /^      contents: read$/ { found = 1; exit }
+		in_job && perms && /^    [a-z]/ && !/^    permissions:/ { perms = 0 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-sbom: upload-release-assets job uses contents: write" {
+	run awk '
+		/^  upload-release-assets:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  upload-release-assets:/ { in_job = 0 }
+		in_job && /^    permissions:/ { perms = 1 }
+		in_job && perms && /^      contents: write$/ { found = 1; exit }
+		in_job && perms && /^    [a-z]/ && !/^    permissions:/ { perms = 0 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-sbom: upload-release-assets job gated on upload-release-assets input" {
+	run awk '
+		/^  upload-release-assets:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  upload-release-assets:/ { in_job = 0 }
+		in_job && /if: inputs\.upload-release-assets/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-sbom: generate step disables anchore release asset upload" {
+	run awk '
+		/^  sbom:/ { in_job = 1; gen = 0 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  sbom:/ { in_job = 0; gen = 0 }
+		in_job && /- name: Generate SBOM/ { gen = 1 }
+		in_job && gen && /^[[:space:]]+- name:/ && $0 !~ /Generate SBOM/ { gen = 0 }
+		in_job && gen && /upload-release-assets: "false"/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}


### PR DESCRIPTION
## Summary
- Keep SBOM generation at `contents: read` and disable anchore release-asset upload in that job.
- Add a dedicated `upload-release-assets` job (`contents: write`) gated on the `upload-release-assets` input, downloading the SBOM artifact and attaching it via `gh release upload`.

Closes #532

## Test plan
- [x] BATS contract tests for permissions / gate / anchore disable
- [ ] CI shell-tests + action pinning green

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR splits SBOM generation from release-asset upload. The main changes are:

- Keeps the SBOM generation job at `contents: read`.
- Disables Anchore release-asset upload during generation.
- Adds an opt-in release upload job with `contents: write`.
- Adds workflow contract tests for the new permission split.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/generate-sbom/action.yml | Adds an `upload-release-assets` input and passes it to the SBOM action. |
| .github/workflows/reusable-sbom.yml | Moves release-asset upload into a dedicated opt-in job. |
| tests/bats/integration/test_reusable_sbom.bats | Adds contract tests for permissions, gating, and upload suppression. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/532-sbom-pe..."](https://github.com/lgtm-hq/lgtm-ci/commit/32a1f0ffff9643ec5647124c72cebddfad18749c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43688617)</sub>

<!-- /greptile_comment -->