### PR TITLE
fix(release): skip version-PR updates when merge-queued

### DIFF
--- a/.github/workflows/reusable-release-version-pr.yml
+++ b/.github/workflows/reusable-release-version-pr.yml
@@ -345,6 +345,36 @@ jobs:
         # yamllint disable-line rule:line-length
         run: >-
           .lgtm-ci-tooling/scripts/ci/release/check-version-files-changed.sh
+      - name: Check version PR merge queue
+        # Skip branch updates when the target version PR is already queued.
+        # Queued branches cannot be updated by create-pull-request (#528).
+        # Runs before tooling removal so the detection script is still present.
+        # yamllint disable-line rule:line-length
+        if: >-
+          steps.guard.outputs.is-release-commit == 'false'
+          && steps.check-pr.outputs.pr-exists == 'false'
+          && steps.version.outputs.release-needed == 'true'
+          && steps.changes.outputs.has-pr-changes == 'true'
+        id: mq-check
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.check-pr.outputs.pr-number }}
+          # yamllint disable-line rule:line-length
+          BRANCH: ${{ inputs.release-branch-prefix }}${{ inputs.tag-prefix }}${{ steps.version.outputs.next-version }}
+          REPO: ${{ github.repository }}
+        run: >-
+          .lgtm-ci-tooling/scripts/ci/release/check-version-pr-merge-queue.sh
+      - name: Notice skipped queued version PR update
+        # yamllint disable-line rule:line-length
+        if: >-
+          steps.mq-check.outputs.skip-branch-update == 'true'
+        shell: bash
+        env:
+          PR_NUMBER: ${{ steps.mq-check.outputs.pr-number }}
+          REASON: ${{ steps.mq-check.outputs.reason }}
+        run: |
+          echo "::notice::Skipping version PR branch update (reason=${REASON}, pr=${PR_NUMBER:-none})"
       - name: Remove tooling checkout before PR creation
         # yamllint disable-line rule:line-length
         if: >-
@@ -352,6 +382,7 @@ jobs:
           && steps.check-pr.outputs.pr-exists == 'false'
           && steps.version.outputs.release-needed == 'true'
           && steps.changes.outputs.has-pr-changes == 'true'
+          && steps.mq-check.outputs.skip-branch-update != 'true'
         shell: bash
         run: .lgtm-ci-tooling/scripts/ci/release/remove-tooling-checkout.sh
       - name: Create or update version PR
@@ -361,6 +392,7 @@ jobs:
           && steps.check-pr.outputs.pr-exists == 'false'
           && steps.version.outputs.release-needed == 'true'
           && steps.changes.outputs.has-pr-changes == 'true'
+          && steps.mq-check.outputs.skip-branch-update != 'true'
         id: create-pr
         # yamllint disable-line rule:line-length
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8

--- a/scripts/ci/release/check-version-pr-merge-queue.sh
+++ b/scripts/ci/release/check-version-pr-merge-queue.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Detect whether a version PR is already in the merge queue
+#
+# peter-evans/create-pull-request cannot update a branch whose PR sits in a
+# merge queue ("Branches queued for merging cannot be updated"). Detect that
+# state before the update and emit a skip signal so the workflow stays green.
+#
+# Why skip (not dequeue/requeue or per-run branch names):
+# - Dequeue/requeue races auto-merge and can drop a ready release mid-queue.
+# - Per-run branch names orphan prior version PRs and break 1 PR = 1 release.
+# - Skipping is idempotent: the queued PR already carries the release bump.
+#
+# Env (optional unless noted):
+#   GH_TOKEN     - required for gh/api auth
+#   PR_NUMBER    - known version PR number (preferred when set)
+#   BRANCH       - head branch name to resolve a PR (e.g. release/v1.2.3)
+#   REPO         - owner/name (defaults to github.repository / gh repo resolve)
+#
+# Outputs (GITHUB_OUTPUT + stdout):
+#   queued              - true | false | unknown
+#   skip-branch-update  - true when update must be skipped
+#   pr-number           - resolved PR number (may be empty)
+#   reason              - short machine-readable reason
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+# shellcheck source=../lib/log.sh
+source "$LIB_DIR/log.sh"
+# shellcheck source=../lib/github.sh
+source "$LIB_DIR/github.sh"
+
+PR_TITLE_PREFIX="${PR_TITLE_PREFIX:-chore(release): version}"
+REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
+PR_NUMBER="${PR_NUMBER:-}"
+BRANCH="${BRANCH:-}"
+
+emit() {
+	local queued="$1"
+	local skip="$2"
+	local number="$3"
+	local reason="$4"
+
+	set_github_output "queued" "$queued"
+	set_github_output "skip-branch-update" "$skip"
+	set_github_output "pr-number" "$number"
+	set_github_output "reason" "$reason"
+	echo "queued=${queued}"
+	echo "skip-branch-update=${skip}"
+	echo "pr-number=${number}"
+	echo "reason=${reason}"
+}
+
+if [[ -z "${GH_TOKEN:-${GITHUB_TOKEN:-}}" ]]; then
+	log_warn "GH_TOKEN unset; cannot query merge queue (skipping branch update)"
+	emit "unknown" "true" "" "missing-token"
+	exit 0
+fi
+
+if [[ -z "$REPO" ]]; then
+	REPO="$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || true)"
+fi
+
+if [[ -z "$REPO" || "$REPO" != */* ]]; then
+	log_warn "Unable to resolve repository owner/name; skipping branch update"
+	emit "unknown" "true" "" "missing-repo"
+	exit 0
+fi
+
+OWNER="${REPO%%/*}"
+NAME="${REPO#*/}"
+
+resolve_pr_number() {
+	if [[ -n "$PR_NUMBER" ]]; then
+		echo "$PR_NUMBER"
+		return 0
+	fi
+
+	local found=""
+	if [[ -n "$BRANCH" ]]; then
+		found="$(
+			gh pr list --repo "$REPO" --state open --head "$BRANCH" \
+				--json number --jq '.[0].number // empty' 2>/dev/null || true
+		)"
+		if [[ -n "$found" ]]; then
+			echo "$found"
+			return 0
+		fi
+	fi
+
+	found="$(
+		gh pr list --repo "$REPO" --state open \
+			--search "in:title ${PR_TITLE_PREFIX}" \
+			--json number --jq '.[0].number // empty' 2>/dev/null || true
+	)"
+	echo "$found"
+}
+
+PR_NUMBER="$(resolve_pr_number || true)"
+
+if [[ -z "$PR_NUMBER" ]]; then
+	log_info "No open version PR found for merge-queue check"
+	emit "false" "false" "" "no-pr"
+	exit 0
+fi
+
+# GraphQL variable names ($owner/$name/$number) are not shell expansions.
+# shellcheck disable=SC2016
+QUERY='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){number mergeQueueEntry{position state}}}}'
+
+RESPONSE="$(
+	gh api graphql \
+		-F owner="$OWNER" \
+		-F name="$NAME" \
+		-F number="$PR_NUMBER" \
+		-f query="$QUERY" 2>/dev/null || true
+)"
+
+if [[ -z "$RESPONSE" ]]; then
+	log_warn "Merge-queue GraphQL query failed for PR #${PR_NUMBER}; skipping branch update"
+	emit "unknown" "true" "$PR_NUMBER" "api-error"
+	exit 0
+fi
+
+if echo "$RESPONSE" | jq -e '.errors? | select(length > 0)' >/dev/null 2>&1; then
+	log_warn "Merge-queue GraphQL returned errors for PR #${PR_NUMBER}; skipping branch update"
+	emit "unknown" "true" "$PR_NUMBER" "api-error"
+	exit 0
+fi
+
+ENTRY="$(echo "$RESPONSE" | jq -c '.data.repository.pullRequest.mergeQueueEntry // null' 2>/dev/null || echo "null")"
+
+if [[ "$ENTRY" != "null" && -n "$ENTRY" ]]; then
+	log_info "Version PR #${PR_NUMBER} is in the merge queue; skipping branch update"
+	emit "true" "true" "$PR_NUMBER" "queued"
+	exit 0
+fi
+
+log_info "Version PR #${PR_NUMBER} is not in the merge queue"
+emit "false" "false" "$PR_NUMBER" "not-queued"

--- a/tests/bats/integration/test_check_version_pr_merge_queue.bats
+++ b/tests/bats/integration/test_check_version_pr_merge_queue.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/release/check-version-pr-merge-queue.sh (#528)
+
+load "../../helpers/common"
+load "../../helpers/mocks"
+load "../../helpers/github_env"
+
+setup() {
+	setup_temp_dir
+	save_path
+	setup_github_env
+	export LIB_DIR
+	export BATS_TEST_TMPDIR
+	export PROJECT_ROOT
+	export GH_TOKEN="fake-token"
+	export REPO="lgtm-hq/lgtm-ci"
+	export GITHUB_REPOSITORY="lgtm-hq/lgtm-ci"
+}
+
+teardown() {
+	restore_path
+	teardown_github_env
+	teardown_temp_dir
+}
+
+run_mq_check() {
+	run bash -c "
+		export GITHUB_OUTPUT='$GITHUB_OUTPUT'
+		export GH_TOKEN='${GH_TOKEN}'
+		export REPO='${REPO}'
+		export PR_NUMBER='${PR_NUMBER:-}'
+		export BRANCH='${BRANCH:-}'
+		export PATH='$PATH'
+		'$PROJECT_ROOT/scripts/ci/release/check-version-pr-merge-queue.sh' 2>&1
+	"
+}
+
+@test "check-version-pr-merge-queue: queued PR emits skip signal" {
+	export PR_NUMBER="42"
+	mock_command_multi "gh" '
+		*graphql*) printf "%s\n" "{\"data\":{\"repository\":{\"pullRequest\":{\"number\":42,\"mergeQueueEntry\":{\"position\":1,\"state\":\"QUEUED\"}}}}}";;
+		*) exit 1;;
+	'
+
+	run_mq_check
+	assert_success
+	assert_line --partial "queued=true"
+	assert_line --partial "skip-branch-update=true"
+	assert_line --partial "reason=queued"
+	assert_line --partial "pr-number=42"
+}
+
+@test "check-version-pr-merge-queue: not-queued PR proceeds" {
+	export PR_NUMBER="42"
+	mock_command_multi "gh" '
+		*graphql*) printf "%s\n" "{\"data\":{\"repository\":{\"pullRequest\":{\"number\":42,\"mergeQueueEntry\":null}}}}";;
+		*) exit 1;;
+	'
+
+	run_mq_check
+	assert_success
+	assert_line --partial "queued=false"
+	assert_line --partial "skip-branch-update=false"
+	assert_line --partial "reason=not-queued"
+}
+
+@test "check-version-pr-merge-queue: API error skips update" {
+	export PR_NUMBER="42"
+	mock_command_multi "gh" '
+		*graphql*) exit 1;;
+		*) exit 1;;
+	'
+
+	run_mq_check
+	assert_success
+	assert_line --partial "queued=unknown"
+	assert_line --partial "skip-branch-update=true"
+	assert_line --partial "reason=api-error"
+}
+
+@test "check-version-pr-merge-queue: no PR found proceeds" {
+	unset PR_NUMBER || true
+	export BRANCH="release/v1.2.3"
+	mock_command_multi "gh" '
+		*pr*list*) printf "%s\n" "";;
+		*) exit 1;;
+	'
+
+	run_mq_check
+	assert_success
+	assert_line --partial "queued=false"
+	assert_line --partial "skip-branch-update=false"
+	assert_line --partial "reason=no-pr"
+}

--- a/tests/bats/integration/test_reusable_release_version_pr.bats
+++ b/tests/bats/integration/test_reusable_release_version_pr.bats
@@ -102,6 +102,20 @@ load "../../helpers/common"
 	assert_success
 }
 
+@test "reusable-release-version-pr: gates create-pull-request on merge-queue skip" {
+	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
+
+	run grep -F "check-version-pr-merge-queue.sh" "$workflow"
+	assert_success
+	run awk '
+		/- name: Create or update version PR/ { in_step = 1 }
+		in_step && /skip-branch-update != '\''true'\''/ { found = 1; exit }
+		in_step && /^      - name:/ && $0 !~ /Create or update version PR/ { in_step = 0 }
+		END { exit !found }
+	' "$workflow"
+	assert_success
+}
+
 @test "reusable-release-version-pr: wires CHANGELOG-only expect flag when ecosystems empty" {
 	local workflow="${PROJECT_ROOT}/.github/workflows/reusable-release-version-pr.yml"
 


### PR DESCRIPTION
## Summary
- Add `check-version-pr-merge-queue.sh` (GraphQL `mergeQueueEntry`) so version-PR branch updates are skipped with a neutral notice when the PR is already queued.
- Prefer skip over dequeue/requeue or per-run branch names to preserve 1 PR = 1 release.

Closes #528

## Test plan
- [x] BATS: queued → skip, not-queued → proceed, API error → skip, no PR → proceed
- [x] Workflow contract test gates create-pull-request on skip signal
- [ ] CI green

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR skips release version PR updates when the target PR is already in the merge queue. The main changes are:

- Adds a merge-queue check script using GitHub GraphQL.
- Emits workflow outputs to skip queued branch updates cleanly.
- Gates tooling cleanup and create-pull-request on the skip signal.
- Adds BATS and workflow contract coverage for the new behavior.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-release-version-pr.yml | Adds the merge-queue check and gates the release PR update steps on its skip output. |
| scripts/ci/release/check-version-pr-merge-queue.sh | Adds a helper that resolves a version PR, checks its merge-queue state, and writes workflow outputs. |
| tests/bats/integration/test_check_version_pr_merge_queue.bats | Adds integration tests for queued, not-queued, API-error, and no-PR cases. |
| tests/bats/integration/test_reusable_release_version_pr.bats | Adds a workflow contract test for the create-pull-request gate. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into fix/528-version..."](https://github.com/lgtm-hq/lgtm-ci/commit/58232c7b9b4f865f67cd9eda2444a813741b70ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43688618)</sub>

<!-- /greptile_comment -->