### PR TITLE
chore(api): remove deprecated compat inputs

### DIFF
--- a/.github/actions/validate-action-pinning/action.yml
+++ b/.github/actions/validate-action-pinning/action.yml
@@ -16,11 +16,6 @@ inputs:
       available (e.g., some-org/action-without-shas)
     required: false
     default: ""
-  allow-org-versions:
-    description: >-
-      Deprecated alias for allow-tag-exceptions. Prefer allow-tag-exceptions.
-    required: false
-    default: ""
   scan-paths:
     description: >-
       Paths to scan for workflow files
@@ -75,7 +70,6 @@ runs:
         GH_TOKEN: ${{ inputs['gh-token'] || env.GH_TOKEN || github.token }}
         INPUT_ENFORCE: ${{ inputs.enforce }}
         INPUT_ALLOW_TAG_EXCEPTIONS: ${{ inputs['allow-tag-exceptions'] }}
-        INPUT_ALLOW_ORG_VERSIONS: ${{ inputs['allow-org-versions'] }}
         INPUT_SCAN_PATHS: ${{ inputs['scan-paths'] }}
         INPUT_VERIFY_TAGS: ${{ inputs['verify-tags'] }}
         INPUT_AUDIT_TRANSITIVE: ${{ inputs['audit-transitive'] }}

--- a/.github/workflows/reusable-docker.yml
+++ b/.github/workflows/reusable-docker.yml
@@ -1,16 +1,15 @@
 ---
 name: Reusable Docker Build and Push
 
-# Thin orchestrator kept for backwards compatibility (#381). The classify job
-# resolves the build strategy, then delegates to the focused reusables:
+# Supported Docker entry-point orchestrator (#381). The classify job resolves
+# the build strategy, then delegates to the focused reusables:
 #   - reusable-docker-build.yml          (use-split=false: single-platform or
 #                                         QEMU multi-platform build+scan)
 #   - reusable-docker-multiplatform.yml  (use-split=true: runner-map matrix,
 #                                         manifest merge, signing)
-# Consumers may keep calling this workflow unchanged, or migrate to the
-# focused reusables directly — see docs/workflow-contract.md (runner-map
-# section) for the migration path. reusable-docker-smoke-test.yml is a
-# standalone image-validation reusable and is not called from here.
+# Callers may use this workflow, or call the focused reusables directly —
+# see docs/workflow-contract.md (runner-map section). reusable-docker-smoke-test.yml
+# is a standalone image-validation reusable and is not called from here.
 #
 # Caller repos only need to pin this workflow; all shared shell scripts are
 # resolved from lgtm-ci via a cross-repo checkout (same pattern as

--- a/.github/workflows/reusable-quality-lint.yml
+++ b/.github/workflows/reusable-quality-lint.yml
@@ -14,11 +14,6 @@ on:
         required: false
         type: string
         default: ""
-      lintro-tools:
-        description: "Deprecated alias for tools"
-        required: false
-        type: string
-        default: ""
       fail-on-error:
         description: "Fail workflow if linting errors found"
         required: false
@@ -190,7 +185,7 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
         env:
           STEP: check
-          TOOLS: ${{ inputs.tools != '' && inputs.tools || inputs.lintro-tools }}
+          TOOLS: ${{ inputs.tools }}
           TOOL_OPTIONS: ${{ inputs.lintro-tool-options }}
           FAIL_ON_ERROR: ${{ inputs.fail-on-error }}
           MAP_HOST_USER: "true"

--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -15,11 +15,6 @@ on:
         required: false
         type: string
         default: ""
-      toolchain:
-        description: "Deprecated alias for rust-toolchain"
-        required: false
-        type: string
-        default: "stable"
       features:
         description: "Feature flags for cargo (e.g., --all-features)"
         required: false
@@ -279,7 +274,7 @@ jobs:
           MATRIX_LABEL: Rust toolchain
           DEFAULT_VERSION: >-
             ${{ inputs.rust-toolchain != '' && inputs.rust-toolchain ||
-            inputs.toolchain || 'stable' }}
+            'stable' }}
           VERSIONS_INPUT: ${{ inputs.rust-toolchains }}
         run: bash .lgtm-ci-tooling/scripts/ci/actions/generate-version-matrix.sh
   test:

--- a/.github/workflows/reusable-scorecards.yml
+++ b/.github/workflows/reusable-scorecards.yml
@@ -30,14 +30,6 @@ on:
         type: string
         default: "results.sarif"
 
-      tooling-ref:
-        description: >-
-          Deprecated no-op — the scorecard job cannot run lgtm-ci composites
-          (scorecard-action publish allowlist, #518). Kept for caller compat.
-        required: false
-        type: string
-        default: ""
-
       egress-policy:
         description: "harden-runner egress policy (audit or block)"
         required: false
@@ -58,23 +50,6 @@ on:
           api.osv.dev:443
           api.scorecard.dev:443
           api.securityscorecards.dev:443
-      allowed-endpoints-mode:
-        description: >-
-          Deprecated no-op — the scorecard job cannot run the allowlist
-          resolver composite (scorecard-action publish allowlist, #518).
-          allowed-endpoints is fed to harden-runner verbatim.
-        required: false
-        type: string
-        default: "replace"
-
-      egress-preset:
-        description: >-
-          Deprecated no-op — preset resolution needs lgtm-ci composites, which
-          the scorecard-action publish allowlist forbids in this job (#518).
-          Override allowed-endpoints instead.
-        required: false
-        type: string
-        default: "scorecard"
       job-name:
         description: "GitHub check name for OpenSSF Scorecard"
         required: false

--- a/.github/workflows/reusable-test-e2e.yml
+++ b/.github/workflows/reusable-test-e2e.yml
@@ -34,13 +34,6 @@ on:
         required: false
         type: boolean
         default: true
-      publish-results:
-        description: >-
-          Deprecated: use a separate publish caller workflow instead. Ignored
-          by this workflow.
-        required: false
-        type: boolean
-        default: false
       extra-args:
         description: "Additional arguments to pass to Playwright"
         required: false

--- a/.github/workflows/reusable-validate.yml
+++ b/.github/workflows/reusable-validate.yml
@@ -95,7 +95,7 @@ on:
 
 jobs:
   validate:
-    name: ${{ inputs.job-name }}
+    name: ${{ inputs.job-name != '' && inputs.job-name || 'Validation' }}
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
@@ -151,7 +151,7 @@ jobs:
         env:
           SCRIPT_PATH: ${{ inputs.script }}
           # yamllint disable-line rule:line-length
-          VALIDATION_NAME: ${{ inputs.job-name }}
+          VALIDATION_NAME: ${{ inputs.job-name != '' && inputs.job-name || 'Validation' }}
           WORKING_DIRECTORY: ${{ inputs.working-directory }}
           COMMENT_OUTPUT: validation-report.md
           OUTPUT_FILE: validation-output.txt

--- a/.github/workflows/reusable-validate.yml
+++ b/.github/workflows/reusable-validate.yml
@@ -8,11 +8,6 @@ on:
         description: "Repo-relative validation script to execute"
         required: true
         type: string
-      name:
-        description: "Deprecated alias for job-name"
-        required: false
-        type: string
-        default: ""
       job-name:
         description: "Display name for the validation check"
         required: false
@@ -100,9 +95,7 @@ on:
 
 jobs:
   validate:
-    name: >-
-      ${{ inputs.job-name != '' && inputs.job-name ||
-      (inputs.name != '' && inputs.name || 'Validation') }}
+    name: ${{ inputs.job-name }}
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
@@ -158,7 +151,7 @@ jobs:
         env:
           SCRIPT_PATH: ${{ inputs.script }}
           # yamllint disable-line rule:line-length
-          VALIDATION_NAME: ${{ inputs.job-name != '' && inputs.job-name || (inputs.name != '' && inputs.name || 'Validation') }}
+          VALIDATION_NAME: ${{ inputs.job-name }}
           WORKING_DIRECTORY: ${{ inputs.working-directory }}
           COMMENT_OUTPUT: validation-report.md
           OUTPUT_FILE: validation-output.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **workflows**: hard-cut deprecated / kept-for-compat inputs (#540):
+  - `reusable-rust-test.yml` `toolchain` (use `rust-toolchain`)
+  - `reusable-quality-lint.yml` `lintro-tools` (use `tools`)
+  - `reusable-validate.yml` `name` (use `job-name`)
+  - `validate-action-pinning` `allow-org-versions` (use `allow-tag-exceptions`)
+  - `reusable-scorecards.yml` no-op `tooling-ref`, `allowed-endpoints-mode`,
+    `egress-preset`
+  - `reusable-test-e2e.yml` ignored `publish-results`
+- **workflows**: `reusable-docker.yml` is the supported Docker entry point
+  (compat-only framing dropped; focused reusables remain available)
+
 ### Fixed
+
+- **test**: isolate cargo-llvm-cov absence check from Homebrew PATH pollution
 
 ### Security
 

--- a/docs/rust-testing.md
+++ b/docs/rust-testing.md
@@ -41,8 +41,7 @@ never runs both uninstrumented nextest and llvm-cov in the same pipeline.
 
 Use `rust-toolchains` (comma-separated) for multi-toolchain compat checks
 (MSRV, stable, beta). Compat matrix runs require `coverage: false` and
-`publish-test-summary: false`. Use `rust-toolchain` (or deprecated `toolchain`)
-for single-toolchain coverage and PR comments.
+`publish-test-summary: false`. Use `rust-toolchain` for single-toolchain coverage and PR comments.
 
 ```yaml
 rust-compat:

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -52,10 +52,15 @@ For these workflows:
 
 - Pin the reusable `uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-*.yml@<sha>`
   ref in production.
-- `tooling-ref` is **optional** and pins egress composites only — not CI
-  scripts. When omitted, reusables default to `github.workflow_sha` (the pinned
-  workflow SHA). Pass a matching `tooling-ref` only when testing unreleased
-  egress composite changes on a branch.
+- `tooling-ref` is **optional** on the action-only wrappers that still expose it
+  (labeler, dependency-review, semantic-pr-title, codeql) and pins egress
+  composites only — not CI scripts. When omitted, those reusables default to
+  `github.workflow_sha` (the pinned workflow SHA). Pass a matching `tooling-ref`
+  only when testing unreleased egress composite changes on a branch.
+- `reusable-scorecards.yml` does **not** accept `tooling-ref` (or
+  `egress-preset` / `allowed-endpoints-mode`): the scorecard publish allowlist
+  forbids lgtm-ci composites, so egress uses a static `allowed-endpoints`
+  default (#540).
 - Do **not** assume `tooling-ref` pins the third-party action inside the
   reusable; those actions are pinned by SHA inside the workflow YAML.
 

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -92,7 +92,7 @@ working unchanged.
 
 | Workflow                            | Responsibility                                                         | `runner-map`?                      |
 | ----------------------------------- | ---------------------------------------------------------------------- | ---------------------------------- |
-| `reusable-docker.yml`               | Orchestrator: classify + delegate (backwards-compatible entry point)   | Yes (resolved by `classify`)       |
+| `reusable-docker.yml`               | Orchestrator: classify + delegate (supported entry point)              | Yes (resolved by `classify`)       |
 | `reusable-docker-build.yml`         | Single-platform or QEMU multi-platform build + scan (non-split path)   | No (fixed `ubuntu-24.04` + QEMU)   |
 | `reusable-docker-multiplatform.yml` | Per-platform matrix build + smoke/health gates + manifest merge + sign | No (takes classify `matrix` input) |
 | `reusable-docker-smoke-test.yml`    | Standalone validation of a published image by immutable digest         | No (`runner-image` input)          |

--- a/docs/workflows/testing.md
+++ b/docs/workflows/testing.md
@@ -83,8 +83,7 @@ jobs:
 **Inputs:** `node-version` (default '20'), `project` (Playwright project),
 `browsers` (chromium/firefox/webkit/all, default 'chromium'), `shard` (for
 example "1/3"), `reporter` (json/html/junit, default 'html'),
-`upload-report` (default true), `publish-results` (deprecated no-op,
-default false).
+`upload-report` (default true).
 
 **Outputs:** `tests-passed`, `tests-failed`, `passed`.
 

--- a/scripts/ci/actions/validate-action-pinning.sh
+++ b/scripts/ci/actions/validate-action-pinning.sh
@@ -5,7 +5,6 @@
 # Environment variables:
 #   INPUT_ENFORCE              - Fail if violations are found (true/false)
 #   INPUT_ALLOW_TAG_EXCEPTIONS - Comma-separated action names allowed to use tag refs
-#   INPUT_ALLOW_ORG_VERSIONS   - Deprecated alias for INPUT_ALLOW_TAG_EXCEPTIONS
 #   INPUT_SCAN_PATHS           - Space-separated paths to scan for workflow files
 #   INPUT_VERIFY_TAGS          - Verify Renovate version comments match pinned SHAs
 #   INPUT_AUDIT_TRANSITIVE     - Warn on mutable tag refs in nested composite actions
@@ -17,7 +16,6 @@ set -euo pipefail
 
 : "${INPUT_ENFORCE:=true}"
 : "${INPUT_ALLOW_TAG_EXCEPTIONS:=}"
-: "${INPUT_ALLOW_ORG_VERSIONS:=}"
 : "${INPUT_SCAN_PATHS:=.github/workflows .github/actions}"
 : "${INPUT_VERIFY_TAGS:=false}"
 : "${INPUT_AUDIT_TRANSITIVE:=false}"
@@ -37,9 +35,6 @@ readonly LGTM_CI_RELEASE_COMMIT_SHA='d3736367191ddaf56c41804d2dd5174732ed2d2b'
 TAG_EXCEPTIONS=()
 if [[ -n "$INPUT_ALLOW_TAG_EXCEPTIONS" ]]; then
 	IFS=',' read -ra TAG_EXCEPTIONS <<<"$INPUT_ALLOW_TAG_EXCEPTIONS"
-elif [[ -n "$INPUT_ALLOW_ORG_VERSIONS" ]]; then
-	log_warn "INPUT_ALLOW_ORG_VERSIONS is deprecated; use INPUT_ALLOW_TAG_EXCEPTIONS instead"
-	IFS=',' read -ra TAG_EXCEPTIONS <<<"$INPUT_ALLOW_ORG_VERSIONS"
 fi
 
 for i in "${!TAG_EXCEPTIONS[@]}"; do

--- a/tests/bats/integration/test_reusable_quality_lint_workflow.bats
+++ b/tests/bats/integration/test_reusable_quality_lint_workflow.bats
@@ -58,4 +58,8 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-quality-lint.yml"
 	assert_success
 	run grep -qE '^      lintro-tools:' "$WORKFLOW"
 	assert_failure
+	run grep -qF 'inputs.lintro-tools' "$WORKFLOW"
+	assert_failure
+	run grep -qF 'inputs.tools' "$WORKFLOW"
+	assert_success
 }

--- a/tests/bats/integration/test_reusable_quality_lint_workflow.bats
+++ b/tests/bats/integration/test_reusable_quality_lint_workflow.bats
@@ -52,3 +52,10 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-quality-lint.yml"
 	' "$WORKFLOW"
 	assert_success
 }
+
+@test "reusable-quality-lint: tools is canonical; lintro-tools alias removed" {
+	run grep -qE '^      tools:' "$WORKFLOW"
+	assert_success
+	run grep -qE '^      lintro-tools:' "$WORKFLOW"
+	assert_failure
+}

--- a/tests/bats/integration/test_reusable_rust_test.bats
+++ b/tests/bats/integration/test_reusable_rust_test.bats
@@ -9,8 +9,10 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-rust-test.yml"
 @test "reusable-rust-test: exposes coverage flag and nextest inputs" {
 	run grep -qE '^      coverage:' "$WORKFLOW"
 	assert_success
-	run grep -qE '^      toolchain:' "$WORKFLOW"
+	run grep -qE '^      rust-toolchain:' "$WORKFLOW"
 	assert_success
+	run grep -qE '^      toolchain:' "$WORKFLOW"
+	assert_failure
 	run grep -q 'run-rust-nextest.sh' "$WORKFLOW"
 	assert_success
 	run grep -q 'run-rust-nextest-coverage.sh' "$WORKFLOW"

--- a/tests/bats/integration/test_reusable_rust_test.bats
+++ b/tests/bats/integration/test_reusable_rust_test.bats
@@ -13,6 +13,10 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-rust-test.yml"
 	assert_success
 	run grep -qE '^      toolchain:' "$WORKFLOW"
 	assert_failure
+	run grep -qF 'inputs.toolchain' "$WORKFLOW"
+	assert_failure
+	run grep -qF 'inputs.rust-toolchain' "$WORKFLOW"
+	assert_success
 	run grep -q 'run-rust-nextest.sh' "$WORKFLOW"
 	assert_success
 	run grep -q 'run-rust-nextest-coverage.sh' "$WORKFLOW"

--- a/tests/bats/integration/test_reusable_scorecards.bats
+++ b/tests/bats/integration/test_reusable_scorecards.bats
@@ -84,4 +84,10 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-scorecards.yml"
 	assert_failure
 	run grep -qE '^      egress-preset:' "$WORKFLOW"
 	assert_failure
+	run grep -qF 'inputs.tooling-ref' "$WORKFLOW"
+	assert_failure
+	run grep -qF 'inputs.allowed-endpoints-mode' "$WORKFLOW"
+	assert_failure
+	run grep -qF 'inputs.egress-preset' "$WORKFLOW"
+	assert_failure
 }

--- a/tests/bats/integration/test_reusable_scorecards.bats
+++ b/tests/bats/integration/test_reusable_scorecards.bats
@@ -76,3 +76,12 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-scorecards.yml"
 	' "$WORKFLOW"
 	assert_success
 }
+
+@test "reusable-scorecards: drops deprecated no-op tooling/egress inputs" {
+	run grep -qE '^      tooling-ref:' "$WORKFLOW"
+	assert_failure
+	run grep -qE '^      allowed-endpoints-mode:' "$WORKFLOW"
+	assert_failure
+	run grep -qE '^      egress-preset:' "$WORKFLOW"
+	assert_failure
+}

--- a/tests/bats/unit/testing/rust/test_run_rust_coverage_html.bats
+++ b/tests/bats/unit/testing/rust/test_run_rust_coverage_html.bats
@@ -64,10 +64,12 @@ EOF
 }
 
 @test "run-rust-coverage-html: fails when cargo-llvm-cov is missing" {
-	local bash_dir
-	bash_dir="$(dirname "$(command -v bash)")"
+	# Absolute bash + coreutils PATH so Homebrew tools beside bash (including
+	# a real cargo-llvm-cov) cannot satisfy the check, while rm stays available.
+	local bash_path
+	bash_path="$(command -v bash)"
 
-	run env PATH="${bash_dir}" bash "$SCRIPT"
+	run env PATH="/bin:/usr/bin" "$bash_path" "$SCRIPT"
 	assert_failure
 	assert_output --partial "cargo-llvm-cov is required"
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Hard-cut deprecated / kept-for-compat workflow and action inputs so callers must use canonical names. `reusable-docker.yml` remains the supported Docker entry point (compat-only framing dropped). Also hardens a local BATS PATH flake for the cargo-llvm-cov absence check.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

Callers must stop using these removed inputs:

- `reusable-rust-test.yml`: `toolchain` → use `rust-toolchain`
- `reusable-quality-lint.yml`: `lintro-tools` → use `tools`
- `reusable-validate.yml`: `name` → use `job-name`
- `validate-action-pinning`: `allow-org-versions` → use `allow-tag-exceptions`
- `reusable-scorecards.yml`: remove unused `tooling-ref`, `allowed-endpoints-mode`, `egress-preset`
- `reusable-test-e2e.yml`: remove ignored `publish-results`

## Closes

- Closes #540

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes deprecated compatibility inputs from the shared CI API. The main changes are:

- Removed old workflow input aliases in Rust test, quality lint, validate, scorecards, and e2e workflows.
- Removed the old validate-action-pinning tag-exception alias.
- Updated docs, changelog entries, and BATS checks for the canonical input names.
- Hardened the cargo-llvm-cov absence test against local PATH pollution.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-quality-lint.yml | Removes the old lint input alias and uses the canonical tools input. |
| .github/workflows/reusable-rust-test.yml | Removes the old toolchain alias while keeping the stable fallback for the canonical Rust toolchain input. |
| .github/workflows/reusable-validate.yml | Removes the old validation name alias and keeps the canonical job-name fallback. |
| .github/workflows/reusable-scorecards.yml | Removes unused scorecards inputs that are no longer part of the workflow contract. |
| .github/actions/validate-action-pinning/action.yml | Removes the old action input alias and keeps the canonical tag-exception input. |
| scripts/ci/actions/validate-action-pinning.sh | Drops parsing for the old tag-exception environment variable and uses the canonical variable. |
| tests/bats/unit/testing/rust/test_run_rust_coverage_html.bats | Runs the missing cargo-llvm-cov check with a restricted PATH and an absolute bash path. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api): address review feedback on dep..."](https://github.com/lgtm-hq/lgtm-ci/commit/f4b26c06091beef35dc1f9ea846ccf1c4a93b933) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43705856)</sub>

<!-- /greptile_comment -->