### PR TITLE
feat(api)!: cut release for deprecated-input hard-cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **release**: cut a version for the #551 deprecated-input hard-cut (conventional
+  `chore` alone does not bump)
+
 ### Deprecated
 
 ### Removed


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

`#551` landed as `chore(api)` so release automation detected bump type `none`. This follow-up uses a conventional breaking commit so the Unreleased `#540` hard-cut ships as a versioned release (clamped to minor → 0.53.0).

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

Documents / triggers release for the #551 hard-cut of deprecated aliases. No additional API removals beyond #551.

## Closes

- Relates to #540

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a changelog note for the deprecated-input release cut. The main change is:

- Adds an Unreleased entry documenting the release trigger for the hard-cut.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CHANGELOG.md | Adds a documentation-only Unreleased changelog entry for the deprecated-input release cut. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(api)!: cut release for deprecated-i..."](https://github.com/lgtm-hq/lgtm-ci/commit/2a74ea86fa98e1bd7229019c25c5fcb0ef6620d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43713382)</sub>

<!-- /greptile_comment -->