### PR TITLE
test(docker): ratchet BATS coverage for step scripts

### DIFF
--- a/scripts/ci/quality/script-test-coverage-allowlist.txt
+++ b/scripts/ci/quality/script-test-coverage-allowlist.txt
@@ -4,14 +4,6 @@
 actions/check-coverage-threshold.sh
 actions/collect-coverage.sh
 actions/deploy-pages.sh
-actions/docker/health-check-local.sh
-actions/docker/merge-manifests.sh
-actions/docker/metadata.sh
-actions/docker/push.sh
-actions/docker/resolve-local-health-check-image.sh
-actions/docker/resolve-local-scan-image.sh
-actions/docker/setup.sh
-actions/docker/sign-image.sh
 actions/generate-coverage-badge.sh
 actions/generate-lintro-comment.sh
 actions/generate-matrix.sh

--- a/tests/bats/unit/actions/docker/test_build.bats
+++ b/tests/bats/unit/actions/docker/test_build.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/actions/docker/build.sh (per-step edge cases)
+
+load "../../../../helpers/common"
+load "../../../../helpers/mocks"
+load "../../../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/docker/build.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+	setup_github_env
+	export SCRIPT
+	export IMAGE_NAME="org/repo"
+	export REGISTRY="ghcr.io"
+	export CONTEXT="."
+	export FILE="Dockerfile"
+	export PLATFORMS="linux/amd64,linux/arm64"
+	export PUSH="false"
+	export LOAD="false"
+	unset TAGS VERSION BUILD_ARGS LABELS CACHE_FROM CACHE_TO || true
+}
+
+teardown() {
+	restore_path
+	teardown_github_env
+	teardown_temp_dir
+}
+
+_mock_docker_buildx() {
+	local exit_code="${1:-0}"
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	local calls_file="${BATS_TEST_TMPDIR}/mock_calls_docker"
+	mkdir -p "$mock_bin"
+	: >"$calls_file"
+
+	cat >"${mock_bin}/docker" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> '${calls_file}'
+exit ${exit_code}
+EOF
+	chmod +x "${mock_bin}/docker"
+	export PATH="${mock_bin}:$PATH"
+}
+
+@test "build.sh: fails when IMAGE_NAME is unset" {
+	unset IMAGE_NAME GITHUB_REPOSITORY || true
+	_mock_docker_buildx
+
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "IMAGE_NAME is required"
+}
+
+@test "build.sh: succeeds and sets exit-code/tags outputs" {
+	_mock_docker_buildx
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_github_output "exit-code" "0"
+	assert_output --partial "Build completed successfully"
+
+	# SHA + branch tags from github_env defaults
+	run grep -F -- "buildx build" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+	run grep -F -- "--platform linux/amd64,linux/arm64" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+	run grep -F -- "--tag ghcr.io/org/repo:sha-abc1234" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+	run grep -F -- "--tag ghcr.io/org/repo:main" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+}
+
+@test "build.sh: omits --platform when LOAD=true" {
+	export LOAD="true"
+	_mock_docker_buildx
+
+	run bash "$SCRIPT"
+	assert_success
+	run grep -F -- "--load" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+	run grep -F -- "--platform" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_failure
+}
+
+@test "build.sh: adds --push when PUSH=true" {
+	export PUSH="true"
+	_mock_docker_buildx
+
+	run bash "$SCRIPT"
+	assert_success
+	run grep -F -- "--push" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+	run grep -F -- "--load" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_failure
+}
+
+@test "build.sh: adds semver and custom tags" {
+	export VERSION="1.2.3"
+	export TAGS="canary,ghcr.io/org/repo:extra"
+	_mock_docker_buildx
+
+	run bash "$SCRIPT"
+	assert_success
+	run grep -F -- "--tag ghcr.io/org/repo:1.2.3" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+	run grep -F -- "--tag ghcr.io/org/repo:latest" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+	run grep -F -- "--tag ghcr.io/org/repo:canary" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+	run grep -F -- "--tag ghcr.io/org/repo:extra" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+}
+
+@test "build.sh: redacts build-arg and label values in log" {
+	export BUILD_ARGS="SECRET=s3cr3t"
+	export LABELS="private=value"
+	_mock_docker_buildx
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "--build-arg [REDACTED]"
+	assert_output --partial "--label [REDACTED]"
+	refute_output --partial "s3cr3t"
+	refute_output --partial "private=value"
+
+	# Actual docker invocation still receives real values
+	run grep -F -- "--build-arg SECRET=s3cr3t" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+	run grep -F -- "--label private=value" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+}
+
+@test "build.sh: propagates docker failure exit code" {
+	_mock_docker_buildx 7
+
+	run bash "$SCRIPT"
+	assert_failure
+	assert_equal "$status" "7"
+	assert_github_output "exit-code" "7"
+	assert_output --partial "Build failed with exit code: 7"
+}
+
+@test "build.sh: applies cache-from and cache-to" {
+	export CACHE_FROM="type=gha"
+	export CACHE_TO="type=gha,mode=max"
+	_mock_docker_buildx
+
+	run bash "$SCRIPT"
+	assert_success
+	run grep -F -- "--cache-from type=gha" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+	run grep -F -- "--cache-to type=gha,mode=max" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+}

--- a/tests/bats/unit/actions/docker/test_health_check_local.bats
+++ b/tests/bats/unit/actions/docker/test_health_check_local.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/actions/docker/health-check-local.sh
+
+load "../../../../helpers/common"
+load "../../../../helpers/mocks"
+load "../../../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/docker/health-check-local.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+	setup_github_env
+	export SCRIPT
+	export IMAGE="ghcr.io/org/repo:local"
+	export HEALTH_CHECK_CMD="true"
+	export HEALTH_CHECK_PORT="8080"
+	export HEALTH_CHECK_TIMEOUT="5s"
+	unset PLATFORM || true
+}
+
+teardown() {
+	restore_path
+	teardown_github_env
+	teardown_temp_dir
+}
+
+_install_health_mocks() {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	local docker_calls="${BATS_TEST_TMPDIR}/mock_calls_docker"
+	mkdir -p "$mock_bin"
+	: >"$docker_calls"
+
+	cat >"${mock_bin}/docker" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> '${docker_calls}'
+case "\$1" in
+run) echo "cid-local"; exit 0 ;;
+logs|rm) exit 0 ;;
+*) exit 0 ;;
+esac
+EOF
+	chmod +x "${mock_bin}/docker"
+
+	cat >"${mock_bin}/timeout" <<'EOF'
+#!/usr/bin/env bash
+shift
+exec "$@"
+EOF
+	chmod +x "${mock_bin}/timeout"
+
+	cat >"${mock_bin}/nc" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+	chmod +x "${mock_bin}/nc"
+
+	export PATH="${mock_bin}:$PATH"
+}
+
+@test "health-check-local.sh: runs health check against local image" {
+	_install_health_mocks
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Health check passed"
+	run grep -F "run -d -p 127.0.0.1:8080:8080 ghcr.io/org/repo:local" \
+		"${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+}
+
+@test "health-check-local.sh: requires IMAGE" {
+	unset IMAGE || true
+	_install_health_mocks
+
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "IMAGE is required"
+}
+
+@test "health-check-local.sh: requires HEALTH_CHECK_PORT" {
+	unset HEALTH_CHECK_PORT || true
+	_install_health_mocks
+
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "HEALTH_CHECK_PORT is required"
+}
+
+@test "health-check-local.sh: requires HEALTH_CHECK_CMD" {
+	unset HEALTH_CHECK_CMD || true
+	_install_health_mocks
+
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "HEALTH_CHECK_CMD is required"
+}

--- a/tests/bats/unit/actions/docker/test_health_lib.bats
+++ b/tests/bats/unit/actions/docker/test_health_lib.bats
@@ -3,16 +3,62 @@
 # Purpose: Unit tests for scripts/ci/actions/docker/health-lib.sh
 
 load "../../../../helpers/common"
+load "../../../../helpers/mocks"
 
 LIB="${PROJECT_ROOT}/scripts/ci/actions/docker/health-lib.sh"
 ACTIONS_LIB="${PROJECT_ROOT}/scripts/ci/lib/actions.sh"
 
 setup() {
 	setup_temp_dir
+	save_path
 }
 
 teardown() {
+	restore_path
 	teardown_temp_dir
+}
+
+_install_health_mocks() {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	local docker_calls="${BATS_TEST_TMPDIR}/mock_calls_docker"
+	mkdir -p "$mock_bin"
+	: >"$docker_calls"
+
+	# docker: run prints a container id; logs/rm succeed
+	cat >"${mock_bin}/docker" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> '${docker_calls}'
+case "\$1" in
+run)
+	echo "cid123"
+	exit 0
+	;;
+logs|rm)
+	exit 0
+	;;
+*)
+	exit 0
+	;;
+esac
+EOF
+	chmod +x "${mock_bin}/docker"
+
+	# macOS/CI-safe timeout: ignore duration, run remaining args
+	cat >"${mock_bin}/timeout" <<'EOF'
+#!/usr/bin/env bash
+shift
+exec "$@"
+EOF
+	chmod +x "${mock_bin}/timeout"
+
+	# Make port_listening succeed immediately via nc
+	cat >"${mock_bin}/nc" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+	chmod +x "${mock_bin}/nc"
+
+	export PATH="${mock_bin}:$PATH"
 }
 
 @test "health-lib.sh: parse_duration_seconds accepts Ns form" {
@@ -64,4 +110,69 @@ teardown() {
 	'
 	assert_success
 	assert_output "5"
+}
+
+@test "health-lib.sh: run_health_check passes without port" {
+	_install_health_mocks
+
+	run bash -c '
+		source "'"$ACTIONS_LIB"'"
+		source "'"$LIB"'"
+		export IMAGE="ghcr.io/org/repo:local"
+		export HEALTH_CHECK_CMD="true"
+		unset HEALTH_CHECK_PORT PLATFORM || true
+		export HEALTH_CHECK_TIMEOUT="5s"
+		run_health_check
+	'
+	assert_success
+	assert_output --partial "Health check passed"
+	run grep -F "run -d ghcr.io/org/repo:local" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+}
+
+@test "health-lib.sh: run_health_check publishes port and uses platform" {
+	_install_health_mocks
+
+	run bash -c '
+		source "'"$ACTIONS_LIB"'"
+		source "'"$LIB"'"
+		export IMAGE="ghcr.io/org/repo:local"
+		export HEALTH_CHECK_CMD="true"
+		export HEALTH_CHECK_PORT="8080"
+		export PLATFORM="linux/arm64"
+		export HEALTH_CHECK_TIMEOUT="5s"
+		run_health_check
+	'
+	assert_success
+	run grep -F "run -d -p 127.0.0.1:8080:8080 --platform linux/arm64 ghcr.io/org/repo:local" \
+		"${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+}
+
+@test "health-lib.sh: run_health_check fails when health command fails" {
+	_install_health_mocks
+
+	run bash -c '
+		source "'"$ACTIONS_LIB"'"
+		source "'"$LIB"'"
+		export IMAGE="ghcr.io/org/repo:local"
+		export HEALTH_CHECK_CMD="false"
+		unset HEALTH_CHECK_PORT || true
+		export HEALTH_CHECK_TIMEOUT="5s"
+		run_health_check
+	'
+	assert_failure
+	assert_output --partial "Health check command failed"
+}
+
+@test "health-lib.sh: run_health_check requires IMAGE" {
+	run bash -c '
+		source "'"$ACTIONS_LIB"'"
+		source "'"$LIB"'"
+		unset IMAGE || true
+		export HEALTH_CHECK_CMD="true"
+		run_health_check
+	'
+	assert_failure
+	assert_output --partial "IMAGE is required"
 }

--- a/tests/bats/unit/actions/docker/test_merge_manifests.bats
+++ b/tests/bats/unit/actions/docker/test_merge_manifests.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/actions/docker/merge-manifests.sh
+
+load "../../../../helpers/common"
+load "../../../../helpers/mocks"
+load "../../../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/docker/merge-manifests.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+	setup_github_env
+	export SCRIPT
+	export REGISTRY="ghcr.io"
+	export IMAGE_NAME="org/repo"
+	export RUN_ID="99"
+	export MATRIX='[{"platform":"linux/amd64","slug":"linux-amd64"},{"platform":"linux/arm64","slug":"linux-arm64"}]'
+	export TARGET_TAGS=$'ghcr.io/org/repo:main\nghcr.io/org/repo:sha-abc'
+}
+
+teardown() {
+	restore_path
+	teardown_github_env
+	teardown_temp_dir
+}
+
+setup_file() {
+	if ! command -v jq >/dev/null 2>&1; then
+		skip "jq not available — required by merge-manifests.sh"
+	fi
+}
+
+@test "merge-manifests.sh: creates multi-arch manifest from staging tags" {
+	mock_command_record "docker"
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Multi-arch manifest created"
+
+	local calls="${BATS_TEST_TMPDIR}/mock_calls_docker"
+	run grep -F -- "buildx imagetools create" "$calls"
+	assert_success
+	run grep -F -- "--tag ghcr.io/org/repo:main" "$calls"
+	assert_success
+	run grep -F -- "--tag ghcr.io/org/repo:sha-abc" "$calls"
+	assert_success
+	run grep -F -- "ghcr.io/org/repo:build-99-linux-amd64" "$calls"
+	assert_success
+	run grep -F -- "ghcr.io/org/repo:build-99-linux-arm64" "$calls"
+	assert_success
+}
+
+@test "merge-manifests.sh: fails when TARGET_TAGS is whitespace only" {
+	export TARGET_TAGS=$'  \n\t'
+	mock_command_record "docker"
+
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "No valid tags found in TARGET_TAGS"
+}
+
+@test "merge-manifests.sh: fails when MATRIX is unset" {
+	unset MATRIX || true
+	mock_command_record "docker"
+
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "MATRIX is required"
+}

--- a/tests/bats/unit/actions/docker/test_metadata.bats
+++ b/tests/bats/unit/actions/docker/test_metadata.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/actions/docker/metadata.sh
+
+load "../../../../helpers/common"
+load "../../../../helpers/mocks"
+load "../../../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/docker/metadata.sh"
+VALID_DIGEST="sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+
+setup() {
+	setup_temp_dir
+	save_path
+	setup_github_env
+	export SCRIPT
+	export REGISTRY="ghcr.io"
+	export IMAGE_NAME="org/repo"
+	unset BUILT_TAGS || true
+}
+
+teardown() {
+	restore_path
+	teardown_github_env
+	teardown_temp_dir
+}
+
+_mock_imagetools_inspect() {
+	local digest="${1:-}"
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	local calls_file="${BATS_TEST_TMPDIR}/mock_calls_docker"
+	mkdir -p "$mock_bin"
+	: >"$calls_file"
+	cat >"${mock_bin}/docker" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> '${calls_file}'
+if [[ "\$1" == "buildx" && "\$2" == "imagetools" && "\$3" == "inspect" ]]; then
+	if [[ -n '${digest}' ]]; then
+		echo '${digest}'
+		exit 0
+	fi
+	exit 1
+fi
+exit 1
+EOF
+	chmod +x "${mock_bin}/docker"
+	export PATH="${mock_bin}:$PATH"
+}
+
+@test "metadata.sh: extracts digest from first built tag" {
+	export BUILT_TAGS=$'ghcr.io/org/repo:sha-abc\nghcr.io/org/repo:main'
+	_mock_imagetools_inspect "$VALID_DIGEST"
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_github_output "digest" "$VALID_DIGEST"
+	assert_output --partial "Extracted digest"
+	run grep -F "imagetools inspect ghcr.io/org/repo:sha-abc" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+}
+
+@test "metadata.sh: falls back to image:latest when BUILT_TAGS empty" {
+	export BUILT_TAGS=""
+	_mock_imagetools_inspect "$VALID_DIGEST"
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_github_output "digest" "$VALID_DIGEST"
+	run grep -F "imagetools inspect ghcr.io/org/repo:latest" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+}
+
+@test "metadata.sh: outputs empty digest and warns when inspect fails" {
+	export BUILT_TAGS="ghcr.io/org/repo:missing"
+	_mock_imagetools_inspect ""
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Could not extract digest"
+	# Empty values are written as "digest="; get_github_output skips blanks.
+	run grep -Fx "digest=" "$GITHUB_OUTPUT"
+	assert_success
+}

--- a/tests/bats/unit/actions/docker/test_push.bats
+++ b/tests/bats/unit/actions/docker/test_push.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/actions/docker/push.sh
+
+load "../../../../helpers/common"
+load "../../../../helpers/mocks"
+load "../../../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/docker/push.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+	setup_github_env
+	export SCRIPT
+	export REGISTRY="ghcr.io"
+	export IMAGE_NAME="org/repo"
+	unset TAGS || true
+}
+
+teardown() {
+	restore_path
+	teardown_github_env
+	teardown_temp_dir
+}
+
+@test "push.sh: pushes newline-separated tags" {
+	export TAGS=$'ghcr.io/org/repo:main\nghcr.io/org/repo:sha-abc'
+	mock_command_record "docker"
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Push completed"
+	run grep -Fx "push ghcr.io/org/repo:main" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+	run grep -Fx "push ghcr.io/org/repo:sha-abc" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+}
+
+@test "push.sh: pushes comma-separated tags and skips blanks" {
+	export TAGS="ghcr.io/org/repo:a, ,ghcr.io/org/repo:b"
+	mock_command_record "docker"
+
+	run bash "$SCRIPT"
+	assert_success
+	run grep -Fx "push ghcr.io/org/repo:a" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+	run grep -Fx "push ghcr.io/org/repo:b" "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_success
+	# Only two push lines
+	run bash -c "grep -c '^push ' '${BATS_TEST_TMPDIR}/mock_calls_docker'"
+	assert_output "2"
+}
+
+@test "push.sh: succeeds with empty TAGS (no pushes)" {
+	export TAGS=""
+	mock_command_record "docker"
+
+	run bash "$SCRIPT"
+	assert_success
+	run grep -F "push " "${BATS_TEST_TMPDIR}/mock_calls_docker"
+	assert_failure
+}

--- a/tests/bats/unit/actions/docker/test_resolve_local_images.bats
+++ b/tests/bats/unit/actions/docker/test_resolve_local_images.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for resolve-local-scan-image.sh and resolve-local-health-check-image.sh
+
+load "../../../../helpers/common"
+load "../../../../helpers/github_env"
+
+SCAN_SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/docker/resolve-local-scan-image.sh"
+HEALTH_SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/docker/resolve-local-health-check-image.sh"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+	unset TAGS || true
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+@test "resolve-local-scan-image.sh: outputs first tag as ref" {
+	export TAGS=$'ghcr.io/org/repo:local\nghcr.io/org/repo:other'
+
+	run bash "$SCAN_SCRIPT"
+	assert_success
+	assert_github_output "ref" "ghcr.io/org/repo:local"
+	assert_output --partial "Local scan image"
+}
+
+@test "resolve-local-scan-image.sh: fails when TAGS is empty" {
+	export TAGS="   "
+
+	run bash "$SCAN_SCRIPT"
+	assert_failure
+	assert_output --partial "No image tag available for local Trivy scan"
+}
+
+@test "resolve-local-scan-image.sh: requires TAGS" {
+	unset TAGS || true
+
+	run bash "$SCAN_SCRIPT"
+	assert_failure
+	assert_output --partial "TAGS is required"
+}
+
+@test "resolve-local-health-check-image.sh: outputs first tag as image" {
+	export TAGS=$'ghcr.io/org/repo:health\nghcr.io/org/repo:other'
+
+	run bash "$HEALTH_SCRIPT"
+	assert_success
+	assert_github_output "image" "ghcr.io/org/repo:health"
+	assert_output --partial "Local health-check image"
+}
+
+@test "resolve-local-health-check-image.sh: fails when TAGS is empty" {
+	export TAGS=$'\n\t'
+
+	run bash "$HEALTH_SCRIPT"
+	assert_failure
+	assert_output --partial "No image tag available for local health check"
+}

--- a/tests/bats/unit/actions/docker/test_resolve_local_images.bats
+++ b/tests/bats/unit/actions/docker/test_resolve_local_images.bats
@@ -60,3 +60,11 @@ teardown() {
 	assert_failure
 	assert_output --partial "No image tag available for local health check"
 }
+
+@test "resolve-local-health-check-image.sh: requires TAGS" {
+	unset TAGS || true
+
+	run bash "$HEALTH_SCRIPT"
+	assert_failure
+	assert_output --partial "TAGS is required"
+}

--- a/tests/bats/unit/actions/docker/test_setup.bats
+++ b/tests/bats/unit/actions/docker/test_setup.bats
@@ -58,10 +58,14 @@ EOF
 
 @test "setup.sh: fails when docker is missing" {
 	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	local bash_path cmd
 	mkdir -p "$mock_bin"
-	export PATH="${mock_bin}:/usr/bin:/bin"
-
-	run bash "$SCRIPT"
+	bash_path="$(command -v bash)"
+	# Minimal PATH with coreutils but no docker (GHA ships docker in /usr/bin).
+	for cmd in dirname uname tr; do
+		ln -sf "$(command -v "$cmd")" "${mock_bin}/${cmd}"
+	done
+	run env PATH="${mock_bin}" "$bash_path" "$SCRIPT"
 	assert_failure
 	assert_output --partial "Docker is not available"
 }

--- a/tests/bats/unit/actions/docker/test_setup.bats
+++ b/tests/bats/unit/actions/docker/test_setup.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/actions/docker/setup.sh
+
+load "../../../../helpers/common"
+load "../../../../helpers/mocks"
+load "../../../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/docker/setup.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+	setup_github_env
+	export SCRIPT
+}
+
+teardown() {
+	restore_path
+	teardown_github_env
+	teardown_temp_dir
+}
+
+_mock_docker_ready() {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+	cat >"${mock_bin}/docker" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+info)
+	exit 0
+	;;
+"buildx version")
+	echo "github.com/docker/buildx mock"
+	exit 0
+	;;
+"--version")
+	echo "Docker version mock"
+	exit 0
+	;;
+*)
+	echo "unexpected docker args: $*" >&2
+	exit 1
+	;;
+esac
+EOF
+	chmod +x "${mock_bin}/docker"
+	export PATH="${mock_bin}:$PATH"
+}
+
+@test "setup.sh: succeeds when docker and buildx are available" {
+	_mock_docker_ready
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Docker environment ready"
+}
+
+@test "setup.sh: fails when docker is missing" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+	export PATH="${mock_bin}:/usr/bin:/bin"
+
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "Docker is not available"
+}
+
+@test "setup.sh: fails when buildx is unavailable" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+	cat >"${mock_bin}/docker" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+info) exit 0 ;;
+"buildx version") exit 1 ;;
+*) exit 1 ;;
+esac
+EOF
+	chmod +x "${mock_bin}/docker"
+	export PATH="${mock_bin}:$PATH"
+
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "Docker Buildx is not available"
+}

--- a/tests/bats/unit/actions/docker/test_sign_image.bats
+++ b/tests/bats/unit/actions/docker/test_sign_image.bats
@@ -46,10 +46,14 @@ teardown() {
 
 @test "sign-image.sh: fails when cosign is missing" {
 	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	local bash_path cmd
 	mkdir -p "$mock_bin"
-	export PATH="${mock_bin}:/usr/bin:/bin"
-
-	run bash "$SCRIPT"
+	bash_path="$(command -v bash)"
+	# Minimal PATH with coreutils but no cosign (may live under /usr/bin on some runners).
+	for cmd in dirname uname tr; do
+		ln -sf "$(command -v "$cmd")" "${mock_bin}/${cmd}"
+	done
+	run env PATH="${mock_bin}" "$bash_path" "$SCRIPT"
 	assert_failure
 	assert_output --partial "cosign not found"
 }

--- a/tests/bats/unit/actions/docker/test_sign_image.bats
+++ b/tests/bats/unit/actions/docker/test_sign_image.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/actions/docker/sign-image.sh
+
+load "../../../../helpers/common"
+load "../../../../helpers/mocks"
+load "../../../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/docker/sign-image.sh"
+VALID_DIGEST="sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+
+setup() {
+	setup_temp_dir
+	save_path
+	setup_github_env
+	export SCRIPT
+	export REGISTRY="ghcr.io"
+	export IMAGE_NAME="org/repo"
+	export DIGEST="$VALID_DIGEST"
+}
+
+teardown() {
+	restore_path
+	teardown_github_env
+	teardown_temp_dir
+}
+
+@test "sign-image.sh: signs image digest with cosign" {
+	mock_command_record "cosign"
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Signed image: ghcr.io/org/repo@${VALID_DIGEST}"
+	run grep -Fx "sign --yes ghcr.io/org/repo@${VALID_DIGEST}" "${BATS_TEST_TMPDIR}/mock_calls_cosign"
+	assert_success
+}
+
+@test "sign-image.sh: rejects invalid digest" {
+	export DIGEST="not-a-digest"
+	mock_command_record "cosign"
+
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "DIGEST is not a valid sha256 digest"
+}
+
+@test "sign-image.sh: fails when cosign is missing" {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+	export PATH="${mock_bin}:/usr/bin:/bin"
+
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "cosign not found"
+}
+
+@test "sign-image.sh: requires DIGEST" {
+	unset DIGEST || true
+	mock_command_record "cosign"
+
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "DIGEST is required"
+}

--- a/tests/bats/unit/actions/docker/test_summary.bats
+++ b/tests/bats/unit/actions/docker/test_summary.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/actions/docker/summary.sh (per-step edge cases)
+
+load "../../../../helpers/common"
+load "../../../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/docker/summary.sh"
+
+setup() {
+	setup_temp_dir
+	setup_github_env
+	export SCRIPT
+	export REGISTRY="ghcr.io"
+	export IMAGE_NAME="org/repo"
+	export PLATFORMS="linux/amd64"
+	export PUSH="false"
+	unset TAGS DIGEST COSIGN_SIGNED SCAN_ENABLED VALIDATE_ON_PR MATRIX HEALTH_CHECK_ENABLED || true
+}
+
+teardown() {
+	teardown_github_env
+	teardown_temp_dir
+}
+
+@test "summary.sh: writes base docker build results table" {
+	run bash "$SCRIPT"
+	assert_success
+	assert_file_contains_literal "$GITHUB_STEP_SUMMARY" "## Docker Build Results"
+	assert_file_contains_literal "$GITHUB_STEP_SUMMARY" "| Image | \`ghcr.io/org/repo\` |"
+	assert_file_contains_literal "$GITHUB_STEP_SUMMARY" "| Platforms | \`linux/amd64\` |"
+	assert_file_contains_literal "$GITHUB_STEP_SUMMARY" "| Pushed | false |"
+	run grep -F -- "PR validation" "$GITHUB_STEP_SUMMARY"
+	assert_failure
+}
+
+@test "summary.sh: includes PR validation row when enabled" {
+	export VALIDATE_ON_PR="true"
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_file_contains_literal "$GITHUB_STEP_SUMMARY" "| PR validation | enabled |"
+}
+
+@test "summary.sh: includes digest section when DIGEST set" {
+	export DIGEST="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_file_contains "$GITHUB_STEP_SUMMARY" "### Digest"
+	assert_file_contains "$GITHUB_STEP_SUMMARY" "\`sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\`"
+}
+
+@test "summary.sh: lists matrix platforms when MATRIX is non-empty" {
+	export MATRIX='[{"platform":"linux/amd64"},{"platform":"linux/arm64"}]'
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_file_contains "$GITHUB_STEP_SUMMARY" "### Per-platform build matrix"
+	assert_file_contains "$GITHUB_STEP_SUMMARY" "\`linux/amd64\`"
+	assert_file_contains "$GITHUB_STEP_SUMMARY" "\`linux/arm64\`"
+}
+
+@test "summary.sh: skips matrix section for empty array" {
+	export MATRIX='[]'
+
+	run bash "$SCRIPT"
+	assert_success
+	run grep -F "Per-platform build matrix" "$GITHUB_STEP_SUMMARY"
+	assert_failure
+}
+
+@test "summary.sh: lists tags and ignores blank lines" {
+	export TAGS=$'ghcr.io/org/repo:main\n\nghcr.io/org/repo:sha-abc\n'
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_file_contains "$GITHUB_STEP_SUMMARY" "### Tags"
+	assert_file_contains "$GITHUB_STEP_SUMMARY" "\`ghcr.io/org/repo:main\`"
+	assert_file_contains "$GITHUB_STEP_SUMMARY" "\`ghcr.io/org/repo:sha-abc\`"
+}
+
+@test "summary.sh: includes cosign verify snippet when signed with digest" {
+	export DIGEST="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	export COSIGN_SIGNED="true"
+	export GITHUB_REPOSITORY="acme/widgets"
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_file_contains "$GITHUB_STEP_SUMMARY" "### Image signature"
+	assert_file_contains "$GITHUB_STEP_SUMMARY" "cosign verify ghcr.io/org/repo@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	assert_file_contains "$GITHUB_STEP_SUMMARY" "https://github.com/acme/widgets/.*"
+}
+
+@test "summary.sh: omits cosign section without digest even when signed" {
+	export COSIGN_SIGNED="true"
+	unset DIGEST || true
+
+	run bash "$SCRIPT"
+	assert_success
+	run grep -F "Image signature" "$GITHUB_STEP_SUMMARY"
+	assert_failure
+}
+
+@test "summary.sh: includes scan and health-check sections when enabled" {
+	export SCAN_ENABLED="true"
+	export HEALTH_CHECK_ENABLED="true"
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_file_contains "$GITHUB_STEP_SUMMARY" "### Vulnerability scan"
+	assert_file_contains "$GITHUB_STEP_SUMMARY" "### Health check"
+	assert_file_contains "$GITHUB_STEP_SUMMARY" "Trivy scanned CRITICAL/HIGH"
+	assert_file_contains "$GITHUB_STEP_SUMMARY" "Detached-container health check passed"
+}


### PR DESCRIPTION
## Summary

Continue the #477 script-to-BATS coverage ratchet with the docker tranche: per-step unit tests for `build.sh`, `summary.sh`, and `health-lib.sh` (`run_health_check`), plus unit coverage for the remaining allowlisted docker step scripts so the ratchet can drop those entries.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Changes Made

- Add BATS unit tests for `actions/docker/build.sh` (IMAGE_NAME, LOAD/PUSH, tags, redact, cache, exit codes)
- Add BATS unit tests for `actions/docker/summary.sh` (table, digest, matrix, tags, cosign, scan/health sections)
- Expand `health-lib.sh` tests for `run_health_check` edge cases
- Add unit tests for setup, metadata, push, merge-manifests, sign-image, resolve-local-*, health-check-local
- Remove 8 docker entries from `script-test-coverage-allowlist.txt` (33 → 24 allowlisted)

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #477

## Testing

- `uv run lintro fmt` / `uv run lintro chk` — clean
- `make test` — 2915 tests passed
- `validate-script-test-coverage.sh` — OK (136/160 entrypoints tested, 24 allowlisted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for Docker build, health checks, manifest merging, metadata, image pushing, local image resolution, environment setup, signing, and build summaries.
  * Added validation for successful workflows, configuration options, error handling, sensitive-value redaction, output generation, and failure propagation.
  * Removed covered Docker scripts from the test-coverage exception list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds BATS coverage for the Docker CI step scripts. The main changes are:

- New unit tests for Docker build, summary, metadata, push, setup, signing, manifest merge, health check, and local image resolution scripts.
- Expanded health library coverage for `run_health_check` behavior.
- Removed the covered Docker scripts from the script-test coverage allowlist.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The missing-tool tests now run with a restricted PATH, so real system Docker or Cosign binaries are not reachable in those checks.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/bats/unit/actions/docker/test_setup.bats | Adds setup script tests, including an isolated missing-Docker check. |
| tests/bats/unit/actions/docker/test_sign_image.bats | Adds signing script tests, including an isolated missing-Cosign check. |
| tests/bats/unit/actions/docker/test_resolve_local_images.bats | Adds local image resolver tests for scan and health-check tag handling. |
| scripts/ci/quality/script-test-coverage-allowlist.txt | Removes Docker scripts now covered by BATS tests. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(docker): cover missing TAGS for hea..."](https://github.com/lgtm-hq/lgtm-ci/commit/8f8fad03bb73029469b9f0c259a159d6b94a562d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43723986)</sub>

<!-- /greptile_comment -->