### PR TITLE
fix(actions): support Windows Git Bash in setup-rust binstall

### DIFF
--- a/scripts/ci/actions/setup-rust.sh
+++ b/scripts/ci/actions/setup-rust.sh
@@ -40,6 +40,7 @@ binstall)
 
 		os=$(uname -s)
 		arch=$(uname -m)
+		binary="cargo-binstall"
 		case "$os" in
 		Linux)
 			case "$arch" in
@@ -55,6 +56,21 @@ binstall)
 		Darwin)
 			target="universal-apple-darwin"
 			ext="zip"
+			;;
+		MINGW* | MSYS* | CYGWIN*)
+			# windows-latest runners execute bash steps under Git Bash,
+			# where uname -s reports MINGW64_NT-<version> (or MSYS/CYGWIN
+			# variants).
+			case "$arch" in
+			x86_64) target="x86_64-pc-windows-msvc" ;;
+			aarch64 | arm64) target="aarch64-pc-windows-msvc" ;;
+			*)
+				echo "Unsupported architecture: $arch"
+				exit 1
+				;;
+			esac
+			ext="zip"
+			binary="cargo-binstall.exe"
 			;;
 		*)
 			echo "Unsupported OS: $os"
@@ -77,7 +93,7 @@ binstall)
 
 		install_dir="${CARGO_HOME:-$HOME/.cargo}/bin"
 		mkdir -p "$install_dir"
-		install -m 0755 "$tmpdir/cargo-binstall" "$install_dir/cargo-binstall"
+		install -m 0755 "$tmpdir/$binary" "$install_dir/$binary"
 		echo "cargo-binstall v${CARGO_BINSTALL_VERSION} installed to $install_dir"
 	else
 		echo "cargo-binstall already installed"

--- a/tests/bats/unit/actions/test_setup_rust.bats
+++ b/tests/bats/unit/actions/test_setup_rust.bats
@@ -136,6 +136,66 @@ EOF
 	assert_output --partial "Unsupported OS"
 }
 
+@test "setup-rust: binstall step installs windows-msvc zip under Git Bash" {
+	local mock_bin="${BATS_TEST_TMPDIR}/mock_bin"
+	mkdir -p "$mock_bin"
+
+	local calls_file="${BATS_TEST_TMPDIR}/mock_calls_curl"
+	: >"$calls_file"
+
+	# Build a real zip with a cargo-binstall.exe binary
+	local archive_dir="${BATS_TEST_TMPDIR}/archive_content"
+	mkdir -p "$archive_dir"
+	printf '#!/usr/bin/env bash\necho "cargo-binstall mock"\n' >"$archive_dir/cargo-binstall.exe"
+	chmod +x "$archive_dir/cargo-binstall.exe"
+	local archive_file="${BATS_TEST_TMPDIR}/cargo-binstall.zip"
+	(cd "$archive_dir" && zip -q "$archive_file" cargo-binstall.exe)
+
+	cat >"${mock_bin}/curl" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >>'${calls_file}'
+output_file=""
+while [[ \$# -gt 0 ]]; do
+    case "\$1" in
+        -o) output_file="\$2"; shift 2;;
+        *) shift;;
+    esac
+done
+if [[ -n "\$output_file" ]]; then
+    cp '${archive_file}' "\$output_file"
+fi
+exit 0
+EOF
+	chmod +x "${mock_bin}/curl"
+
+	# uname as reported by Git Bash on windows-latest runners
+	cat >"${mock_bin}/uname" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+    -m) echo "x86_64";;
+    *) echo "MINGW64_NT-10.0-26100";;
+esac
+EOF
+	chmod +x "${mock_bin}/uname"
+
+	run bash -c "
+		export PATH='${mock_bin}:/usr/bin:/bin'
+		export STEP=binstall
+		export CARGO_HOME='$CARGO_HOME'
+		bash '$SCRIPT' 2>&1
+	"
+	assert_success
+	assert_output --partial "Installing cargo-binstall"
+	assert_output --partial "installed to"
+	refute_output --partial "Unsupported OS"
+
+	# .exe binary installed to CARGO_HOME/bin
+	[[ -x "$CARGO_HOME/bin/cargo-binstall.exe" ]]
+
+	run cat "$calls_file"
+	assert_output --partial "cargo-binstall-x86_64-pc-windows-msvc.zip"
+}
+
 @test "setup-rust: pinned version carries a renovate comment" {
 	run bash -c "grep -B1 'CARGO_BINSTALL_VERSION=' '$SCRIPT' | head -2"
 	assert_success


### PR DESCRIPTION
## Summary

cargo-binstall installation in the `setup-rust` composite fails on `windows-latest` runners with `Unsupported OS: MINGW64_NT-10.0-26100` — the `uname -s` case only handles Linux and Darwin. This breaks every Rustume `Publish - GitHub Release` run since v0.26.0 (Windows binary job fails, Create Release skipped).

- Map `MINGW*` / `MSYS*` / `CYGWIN*` to the `{x86_64,aarch64}-pc-windows-msvc` zip release
- Extract and install `cargo-binstall.exe` (Windows binary name)
- New BATS test covering the Git Bash path (zip download, `.exe` install)

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have tested these changes locally (`bats tests/bats/unit/actions/test_setup_rust.bats` — 7/7 pass)
- [ ] I have updated documentation if needed (no doc surface)
- [x] Shell scripts pass `shellcheck` (and `shfmt -d` clean)
- [ ] YAML files pass `yamllint` (no YAML changed)
- [ ] Python code passes `ruff` and `black` (no Python changed)

## Breaking Changes

None

## Related Issues

Relates to lgtm-hq/Rustume#439

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds Windows Git Bash support to the `setup-rust` cargo-binstall step. The main changes are:

- Maps `MINGW`, `MSYS`, and `CYGWIN` `uname` values to Windows MSVC release targets.
- Installs `cargo-binstall.exe` for the Windows zip archive.
- Adds a BATS test for the Windows Git Bash install path.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/actions/setup-rust.sh | Adds Windows OS and architecture handling for cargo-binstall and selects the `.exe` binary only on that path. |
| tests/bats/unit/actions/test_setup_rust.bats | Adds regression coverage for the Git Bash Windows path using mocked `uname`, mocked `curl`, and a real zip archive. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(actions): support Windows Git Bash i..."](https://github.com/lgtm-hq/lgtm-ci/commit/6ac8d001c0ae9395c8030f8a86ffbb0d84d579a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43744261)</sub>

<!-- /greptile_comment -->