### PR TITLE
feat(docker): surface blocked-egress signatures on build failure

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -344,6 +344,13 @@ jobs:
           # yamllint enable rule:line-length
           provenance: ${{ inputs.provenance && inputs.push && inputs.health-check-cmd == '' }}
           sbom: ${{ inputs.sbom && inputs.push && inputs.health-check-cmd == '' }}
+      - name: Summarize blocked egress
+        if: ${{ failure() }}
+        shell: bash
+        env:
+          STEP: summarize-blocked-egress
+          BUILD_LOG: ${{ runner.temp }}/docker-build.log
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
       - name: Resolve local image for health check
         if: inputs.health-check-cmd != ''
         id: local-health-check-image

--- a/.github/workflows/reusable-docker-multiplatform.yml
+++ b/.github/workflows/reusable-docker-multiplatform.yml
@@ -365,6 +365,13 @@ jobs:
           # yamllint enable rule:line-length
           provenance: false
           sbom: ${{ inputs.sbom && inputs.push }}
+      - name: Summarize blocked egress
+        if: ${{ failure() }}
+        shell: bash
+        env:
+          STEP: summarize-blocked-egress
+          BUILD_LOG: ${{ runner.temp }}/docker-build.log
+        run: .lgtm-ci-tooling/scripts/ci/actions/build-docker.sh
       - name: Record staging digest
         shell: bash
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **docker**: surface blocked-egress signatures on build failure — the reusable
+  Docker build workflows now scan the failed build's log for blocked-egress
+  signatures (DNS failures, apk I/O errors, i/o timeouts, buildkit rpc errors),
+  emit `::error::` annotations naming the likely-blocked host, and write a
+  "Possible blocked egress" step-summary section (upstream half of
+  lgtm-hq/Rustume#459)
+
 ### Changed
 
 ### Deprecated

--- a/scripts/ci/actions/build-docker.sh
+++ b/scripts/ci/actions/build-docker.sh
@@ -7,7 +7,7 @@
 #          set-output-digest, classify, record-digest, smoke-test, smoke-test-local,
 #          health-check, health-check-local, resolve-local-health-check-image,
 #          resolve-local-scan-image, sign-image,
-#          merge-manifests, verify-published
+#          merge-manifests, verify-published, summarize-blocked-egress
 #
 # Each step's environment variable contract is documented in the corresponding
 # scripts/ci/actions/docker/<step>.sh script. The smoke-test and
@@ -26,7 +26,7 @@ case "$STEP" in
 setup | build | push | metadata | parse-tags | set-output-digest | classify | \
 	record-digest | resolve-local-health-check-image | resolve-local-scan-image | \
 	health-check | health-check-local | merge-manifests | verify-published | \
-	sign-image | summary)
+	sign-image | summary | summarize-blocked-egress)
 	# shellcheck disable=SC1090
 	source "$SCRIPT_DIR/docker/${STEP}.sh"
 	;;

--- a/scripts/ci/actions/docker/build.sh
+++ b/scripts/ci/actions/docker/build.sh
@@ -168,11 +168,14 @@ done
 log_info "Running: ${safe_cmd[*]}"
 
 # Execute build, teeing output to BUILD_LOG so a failure step can scan it
-# for blocked-egress signatures. pipefail (set above) preserves the build's
-# exit code through the pipe.
-mkdir -p "$(dirname "$BUILD_LOG")"
-exit_code=0
-"${BUILD_CMD[@]}" 2>&1 | tee "$BUILD_LOG" || exit_code=$?
+# for blocked-egress signatures. The log is best-effort diagnostics: take the
+# build's own exit code from PIPESTATUS[0] (not the pipeline status) so a tee
+# failure (e.g. unwritable BUILD_LOG) can never misreport the build result.
+mkdir -p "$(dirname "$BUILD_LOG")" 2>/dev/null || true
+set +e
+"${BUILD_CMD[@]}" 2>&1 | tee "$BUILD_LOG"
+exit_code=${PIPESTATUS[0]}
+set -e
 
 # Set outputs
 set_github_output "exit-code" "$exit_code"

--- a/scripts/ci/actions/docker/build.sh
+++ b/scripts/ci/actions/docker/build.sh
@@ -18,6 +18,9 @@
 #            Note: Values containing commas are not supported
 #   CACHE_FROM - Cache sources
 #   CACHE_TO - Cache destinations
+#   BUILD_LOG - File to tee the buildx output to, so a later failure step can
+#               scan it for blocked-egress signatures
+#               (default: $RUNNER_TEMP/docker-build.log)
 
 set -euo pipefail
 
@@ -41,6 +44,7 @@ source "$SCRIPT_DIR/../../lib/docker.sh"
 : "${LABELS:=}"
 : "${CACHE_FROM:=}"
 : "${CACHE_TO:=}"
+: "${BUILD_LOG:=${RUNNER_TEMP:-/tmp}/docker-build.log}"
 
 # Validate required inputs
 if [[ -z "$IMAGE_NAME" ]]; then
@@ -163,9 +167,12 @@ for arg in "${BUILD_CMD[@]}"; do
 done
 log_info "Running: ${safe_cmd[*]}"
 
-# Execute build
+# Execute build, teeing output to BUILD_LOG so a failure step can scan it
+# for blocked-egress signatures. pipefail (set above) preserves the build's
+# exit code through the pipe.
+mkdir -p "$(dirname "$BUILD_LOG")"
 exit_code=0
-"${BUILD_CMD[@]}" || exit_code=$?
+"${BUILD_CMD[@]}" 2>&1 | tee "$BUILD_LOG" || exit_code=$?
 
 # Set outputs
 set_github_output "exit-code" "$exit_code"

--- a/scripts/ci/actions/docker/summarize-blocked-egress.sh
+++ b/scripts/ci/actions/docker/summarize-blocked-egress.sh
@@ -33,7 +33,7 @@ source "$SCRIPT_DIR/../../lib/actions.sh"
 
 # Fallback: recover the latest build's log from buildx history (buildx >= 0.20)
 if [[ ! -s "$BUILD_LOG" ]] && command -v docker >/dev/null 2>&1; then
-	mkdir -p "$(dirname "$BUILD_LOG")"
+	mkdir -p "$(dirname "$BUILD_LOG")" || true
 	docker buildx history logs >"$BUILD_LOG" 2>/dev/null || true
 fi
 

--- a/scripts/ci/actions/docker/summarize-blocked-egress.sh
+++ b/scripts/ci/actions/docker/summarize-blocked-egress.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Surface likely blocked egress after a failed Docker build
+#          (build-docker STEP: summarize-blocked-egress)
+#
+# When harden-runner runs with egress-policy: block, disallowed traffic is
+# silently dropped. Clients with long timeouts (e.g. bun install) hang until
+# buildkit is killed with an illegible "runner received shutdown signal";
+# clients with short timeouts (e.g. apk) fail fast with a bare I/O error.
+# This step makes those failures legible: it scans the build log for
+# blocked-egress signatures, emits ::error:: annotations naming the
+# likely-blocked host, and writes a step-summary section.
+#
+# Intended to run in an `if: failure()` step after the build. Exits 0 in all
+# cases (including no log / no matches) — it is diagnostic only and must not
+# mask the original build failure.
+#
+# Optional environment variables:
+#   BUILD_LOG - Build log to scan (default: $RUNNER_TEMP/docker-build.log).
+#               When the file is missing or empty (e.g. the build ran via
+#               docker/build-push-action, which does not write a log file),
+#               the script falls back to `docker buildx history logs` to
+#               recover the most recent build's output.
+
+set -euo pipefail
+
+# Source common action libraries
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../../lib/actions.sh
+source "$SCRIPT_DIR/../../lib/actions.sh"
+
+: "${BUILD_LOG:=${RUNNER_TEMP:-/tmp}/docker-build.log}"
+
+# Fallback: recover the latest build's log from buildx history (buildx >= 0.20)
+if [[ ! -s "$BUILD_LOG" ]] && command -v docker >/dev/null 2>&1; then
+	mkdir -p "$(dirname "$BUILD_LOG")"
+	docker buildx history logs >"$BUILD_LOG" 2>/dev/null || true
+fi
+
+if [[ ! -s "$BUILD_LOG" ]]; then
+	log_info "No build log found at $BUILD_LOG — skipping blocked-egress scan"
+	exit 0
+fi
+
+# Blocked-egress signatures observed when harden-runner drops packets:
+# DNS failures (curl/apk), fast I/O errors (apk APKINDEX), stalled TCP
+# (bun/go), and buildkit dying mid-build after a long silent hang.
+signature_regex='could not resolve host'
+signature_regex+='|temporary error \(try again later\)'
+signature_regex+='|temporary failure in name resolution'
+signature_regex+='|i/o error'
+signature_regex+='|io error'
+signature_regex+='|network error \(check Internet connection'
+signature_regex+='|connection timed out'
+signature_regex+='|i/o timeout'
+signature_regex+='|connection reset by peer'
+signature_regex+='|connect: connection refused'
+signature_regex+='|context canceled'
+signature_regex+='|failed to receive status: rpc error'
+
+matched_lines=$(grep -iE "$signature_regex" "$BUILD_LOG" || true)
+
+if [[ -z "$matched_lines" ]]; then
+	log_info "No blocked-egress signatures found in $BUILD_LOG"
+	exit 0
+fi
+
+# Extract candidate hosts near the matches: URLs, resolver errors, and Go
+# dial/lookup errors all name the endpoint the build was trying to reach.
+hosts=$(
+	{
+		grep -oiE 'https?://[a-z0-9.-]+' <<<"$matched_lines" | sed -E 's#https?://##I'
+		sed -nE 's/.*[Cc]ould not resolve host:? ([A-Za-z0-9.-]+).*/\1/p' <<<"$matched_lines"
+		sed -nE 's/.*lookup ([A-Za-z0-9.-]+)( on [0-9.:]+)?:.*/\1/p' <<<"$matched_lines"
+		sed -nE 's/.*dial tcp:? (lookup )?([A-Za-z0-9.-]+)(:[0-9]+)?:.*/\2/p' <<<"$matched_lines"
+		sed -nE 's/.*[Ff]ailed to connect to ([A-Za-z0-9.-]+)( port [0-9]+)?.*/\1/p' <<<"$matched_lines"
+	} | sed '/^$/d' | sort -u
+)
+
+if [[ -n "$hosts" ]]; then
+	while IFS= read -r host; do
+		echo "::error::Likely blocked egress: ${host} — if legitimate, add ${host}:443 to allowed-endpoints"
+	done <<<"$hosts"
+else
+	echo "::error::Build log contains blocked-egress signatures but no host could be extracted — check the matched lines in the step summary and the harden-runner allowed-endpoints list"
+fi
+
+# Step summary section
+add_github_summary "## 🚫 Possible blocked egress"
+add_github_summary ""
+add_github_summary "The failed build's log matches blocked-egress signatures. With harden-runner \`egress-policy: block\`, disallowed traffic is silently dropped: short-timeout clients (apk) fail fast with I/O errors, long-timeout clients (bun) hang until buildkit is killed."
+add_github_summary ""
+if [[ -n "$hosts" ]]; then
+	add_github_summary "**Likely blocked host(s):**"
+	add_github_summary ""
+	while IFS= read -r host; do
+		add_github_summary "- \`${host}\` — if legitimate, add \`${host}:443\` to \`allowed-endpoints\`"
+	done <<<"$hosts"
+	add_github_summary ""
+fi
+# shellcheck disable=SC2016 # literal markdown code-fence backticks, not expansion
+add_github_summary_details "Matched log lines" "$(printf '```\n%s\n```' "$matched_lines")"
+
+exit 0

--- a/scripts/ci/actions/docker/summarize-blocked-egress.sh
+++ b/scripts/ci/actions/docker/summarize-blocked-egress.sh
@@ -65,22 +65,31 @@ if [[ -z "$matched_lines" ]]; then
 	exit 0
 fi
 
-# Extract candidate hosts near the matches: URLs, resolver errors, and Go
-# dial/lookup errors all name the endpoint the build was trying to reach.
-hosts=$(
+# Extract candidate endpoints (host:port) near the matches: URLs, resolver
+# errors, and Go dial/lookup errors all name the endpoint the build was
+# trying to reach. Preserve an explicit port when the log names one; default
+# to 443 (or 80 for plain-http URLs) only when it does not.
+endpoints=$(
 	{
-		grep -oiE 'https?://[a-z0-9.-]+' <<<"$matched_lines" | sed -E 's#https?://##I'
-		sed -nE 's/.*[Cc]ould not resolve host:? ([A-Za-z0-9.-]+).*/\1/p' <<<"$matched_lines"
-		sed -nE 's/.*lookup ([A-Za-z0-9.-]+)( on [0-9.:]+)?:.*/\1/p' <<<"$matched_lines"
-		sed -nE 's/.*dial tcp:? (lookup )?([A-Za-z0-9.-]+)(:[0-9]+)?:.*/\2/p' <<<"$matched_lines"
-		sed -nE 's/.*[Ff]ailed to connect to ([A-Za-z0-9.-]+)( port [0-9]+)?.*/\1/p' <<<"$matched_lines"
+		# URLs: keep an explicit port; default 443 for https, 80 for http
+		grep -oiE 'https?://[a-z0-9.-]+(:[0-9]+)?' <<<"$matched_lines" |
+			sed -E \
+				-e 's#^[Hh][Tt][Tt][Pp][Ss]://([A-Za-z0-9.-]+)$#\1:443#' \
+				-e 's#^[Hh][Tt][Tt][Pp]://([A-Za-z0-9.-]+)$#\1:80#' \
+				-e 's#^[Hh][Tt][Tt][Pp][Ss]?://##'
+		# Resolver/lookup errors carry no port — assume 443
+		sed -nE 's/.*[Cc]ould not resolve host:? ([A-Za-z0-9.-]+).*/\1:443/p' <<<"$matched_lines"
+		sed -nE 's/.*dial tcp: lookup ([A-Za-z0-9.-]+)( on [0-9.:]+)?:.*/\1:443/p' <<<"$matched_lines"
+		# Go dial errors and curl connect errors name the port — keep it
+		sed -nE 's/.*dial tcp ([A-Za-z0-9.-]+):([0-9]+):.*/\1:\2/p' <<<"$matched_lines"
+		sed -nE 's/.*[Ff]ailed to connect to ([A-Za-z0-9.-]+) port ([0-9]+).*/\1:\2/p' <<<"$matched_lines"
 	} | sed '/^$/d' | sort -u
 )
 
-if [[ -n "$hosts" ]]; then
-	while IFS= read -r host; do
-		echo "::error::Likely blocked egress: ${host} — if legitimate, add ${host}:443 to allowed-endpoints"
-	done <<<"$hosts"
+if [[ -n "$endpoints" ]]; then
+	while IFS= read -r endpoint; do
+		echo "::error::Likely blocked egress: ${endpoint} — if legitimate, add ${endpoint} to allowed-endpoints"
+	done <<<"$endpoints"
 else
 	echo "::error::Build log contains blocked-egress signatures but no host could be extracted — check the matched lines in the step summary and the harden-runner allowed-endpoints list"
 fi
@@ -90,12 +99,12 @@ add_github_summary "## 🚫 Possible blocked egress"
 add_github_summary ""
 add_github_summary "The failed build's log matches blocked-egress signatures. With harden-runner \`egress-policy: block\`, disallowed traffic is silently dropped: short-timeout clients (apk) fail fast with I/O errors, long-timeout clients (bun) hang until buildkit is killed."
 add_github_summary ""
-if [[ -n "$hosts" ]]; then
-	add_github_summary "**Likely blocked host(s):**"
+if [[ -n "$endpoints" ]]; then
+	add_github_summary "**Likely blocked endpoint(s):**"
 	add_github_summary ""
-	while IFS= read -r host; do
-		add_github_summary "- \`${host}\` — if legitimate, add \`${host}:443\` to \`allowed-endpoints\`"
-	done <<<"$hosts"
+	while IFS= read -r endpoint; do
+		add_github_summary "- \`${endpoint}\` — if legitimate, add \`${endpoint}\` to \`allowed-endpoints\`"
+	done <<<"$endpoints"
 	add_github_summary ""
 fi
 # shellcheck disable=SC2016 # literal markdown code-fence backticks, not expansion

--- a/tests/bats/unit/actions/docker/test_build.bats
+++ b/tests/bats/unit/actions/docker/test_build.bats
@@ -20,7 +20,8 @@ setup() {
 	export PLATFORMS="linux/amd64,linux/arm64"
 	export PUSH="false"
 	export LOAD="false"
-	unset TAGS VERSION BUILD_ARGS LABELS CACHE_FROM CACHE_TO || true
+	export RUNNER_TEMP="$BATS_TEST_TMPDIR"
+	unset TAGS VERSION BUILD_ARGS LABELS CACHE_FROM CACHE_TO BUILD_LOG || true
 }
 
 teardown() {
@@ -39,6 +40,7 @@ _mock_docker_buildx() {
 	cat >"${mock_bin}/docker" <<EOF
 #!/usr/bin/env bash
 echo "\$*" >> '${calls_file}'
+echo "mock-docker-build-output"
 exit ${exit_code}
 EOF
 	chmod +x "${mock_bin}/docker"
@@ -141,6 +143,42 @@ EOF
 	assert_equal "$status" "7"
 	assert_github_output "exit-code" "7"
 	assert_output --partial "Build failed with exit code: 7"
+}
+
+@test "build.sh: tees build output to BUILD_LOG" {
+	_mock_docker_buildx
+	export BUILD_LOG="${BATS_TEST_TMPDIR}/docker-build.log"
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_github_output "exit-code" "0"
+	run grep -F -- "mock-docker-build-output" "$BUILD_LOG"
+	assert_success
+}
+
+@test "build.sh: tee failure does not mask build success" {
+	_mock_docker_buildx
+	# Point BUILD_LOG at an existing directory so tee itself fails while
+	# the (mocked) build succeeds — the build result must still win.
+	export BUILD_LOG="${BATS_TEST_TMPDIR}/logdir"
+	mkdir -p "$BUILD_LOG"
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_github_output "exit-code" "0"
+	assert_output --partial "Build completed successfully"
+}
+
+@test "build.sh: build failure exit code survives the tee" {
+	_mock_docker_buildx 5
+	export BUILD_LOG="${BATS_TEST_TMPDIR}/docker-build.log"
+
+	run bash "$SCRIPT"
+	assert_failure
+	assert_equal "$status" "5"
+	assert_github_output "exit-code" "5"
+	run grep -F -- "mock-docker-build-output" "$BUILD_LOG"
+	assert_success
 }
 
 @test "build.sh: applies cache-from and cache-to" {

--- a/tests/bats/unit/actions/docker/test_summarize_blocked_egress.bats
+++ b/tests/bats/unit/actions/docker/test_summarize_blocked_egress.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/actions/docker/summarize-blocked-egress.sh
+
+load "../../../../helpers/common"
+load "../../../../helpers/mocks"
+load "../../../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/docker/summarize-blocked-egress.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+	setup_github_env
+	export SCRIPT
+	export RUNNER_TEMP="$BATS_TEST_TMPDIR"
+	export BUILD_LOG="$BATS_TEST_TMPDIR/docker-build.log"
+}
+
+teardown() {
+	restore_path
+	teardown_github_env
+	teardown_temp_dir
+}
+
+# Write a bun-style hang log: registry.npmjs.org blocked, buildkit dies with
+# an rpc error after harden-runner silently drops the packets.
+_write_bun_hang_log() {
+	cat >"$BUILD_LOG" <<'EOF'
+#12 [full 5/9] RUN bun install --frozen-lockfile
+#12 3.214 bun install v1.2.19 (aad3abea)
+#12 1499.7 error: ConnectionRefused downloading package manifest react
+#12 1499.7 GET https://registry.npmjs.org/react - dial tcp: lookup registry.npmjs.org: i/o timeout
+ERROR: failed to receive status: rpc error: code = Unavailable desc = error reading from server: EOF
+EOF
+}
+
+# Write an apk-style fast failure: APKINDEX fetch I/O error.
+_write_apk_log() {
+	cat >"$BUILD_LOG" <<'EOF'
+#6 [base 2/4] RUN apk add --no-cache curl
+#6 0.412 fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/main/x86_64/APKINDEX.tar.gz
+#6 5.021 ERROR: https://dl-cdn.alpinelinux.org/alpine/v3.20/main: temporary error (try again later)
+#6 5.021 WARNING: fetching https://dl-cdn.alpinelinux.org/alpine/v3.20/main: I/O error
+EOF
+}
+
+# Write a curl-style connection-refused log.
+_write_curl_refused_log() {
+	cat >"$BUILD_LOG" <<'EOF'
+#8 [tools 3/6] RUN curl -fsSL https://static.rust-lang.org/rustup/rustup-init.sh -o rustup-init.sh
+#8 2.001 curl: (7) Failed to connect to static.rust-lang.org port 443 after 2000 ms: connect: connection refused
+EOF
+}
+
+@test "summarize-blocked-egress: bun hang log annotates registry.npmjs.org" {
+	_write_bun_hang_log
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "::error::Likely blocked egress: registry.npmjs.org"
+	assert_output --partial "add registry.npmjs.org:443 to allowed-endpoints"
+}
+
+@test "summarize-blocked-egress: bun hang log writes step summary section" {
+	_write_bun_hang_log
+
+	run bash "$SCRIPT"
+	assert_success
+
+	local summary
+	summary=$(get_github_step_summary)
+	[[ "$summary" == *"Possible blocked egress"* ]]
+	[[ "$summary" == *"registry.npmjs.org"* ]]
+	[[ "$summary" == *"Matched log lines"* ]]
+	[[ "$summary" == *"failed to receive status: rpc error"* ]]
+}
+
+@test "summarize-blocked-egress: apk I/O error log names the APKINDEX host" {
+	_write_apk_log
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "::error::Likely blocked egress: dl-cdn.alpinelinux.org"
+
+	local summary
+	summary=$(get_github_step_summary)
+	[[ "$summary" == *"dl-cdn.alpinelinux.org"* ]]
+	[[ "$summary" == *"temporary error (try again later)"* ]]
+}
+
+@test "summarize-blocked-egress: curl connection refused names the host" {
+	_write_curl_refused_log
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "::error::Likely blocked egress: static.rust-lang.org"
+}
+
+@test "summarize-blocked-egress: clean log emits nothing and exits 0" {
+	cat >"$BUILD_LOG" <<'EOF'
+#10 [full 4/9] COPY . .
+#10 DONE 0.3s
+#11 exporting to image
+#11 DONE 1.2s
+EOF
+
+	run bash "$SCRIPT"
+	assert_success
+	[[ "$output" != *"::error::"* ]]
+
+	local summary
+	summary=$(get_github_step_summary)
+	[[ "$summary" != *"Possible blocked egress"* ]]
+}
+
+@test "summarize-blocked-egress: missing log exits 0 without annotations" {
+	rm -f "$BUILD_LOG"
+	# Mock docker so the buildx-history fallback stays inert
+	mock_command "docker" "" 1
+
+	run bash "$SCRIPT"
+	assert_success
+	[[ "$output" != *"::error::"* ]]
+}
+
+@test "summarize-blocked-egress: signature without extractable host emits generic error" {
+	cat >"$BUILD_LOG" <<'EOF'
+#9 [deps 2/5] RUN cargo fetch
+#9 30.101 Connection timed out
+EOF
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "::error::Build log contains blocked-egress signatures but no host could be extracted"
+}
+
+@test "summarize-blocked-egress: dispatcher routes STEP=summarize-blocked-egress" {
+	_write_apk_log
+	export STEP="summarize-blocked-egress"
+
+	run bash "${PROJECT_ROOT}/scripts/ci/actions/build-docker.sh"
+	assert_success
+	assert_output --partial "::error::Likely blocked egress: dl-cdn.alpinelinux.org"
+}

--- a/tests/bats/unit/actions/docker/test_summarize_blocked_egress.bats
+++ b/tests/bats/unit/actions/docker/test_summarize_blocked_egress.bats
@@ -97,6 +97,32 @@ EOF
 	assert_output --partial "::error::Likely blocked egress: static.rust-lang.org"
 }
 
+@test "summarize-blocked-egress: explicit non-443 port is preserved" {
+	cat >"$BUILD_LOG" <<'EOF'
+#4 [base 2/3] RUN apk add --no-cache --repository http://mirror.internal:8080/alpine/v3.20/main curl
+#4 5.104 ERROR: http://mirror.internal:8080/alpine/v3.20/main: temporary error (try again later)
+EOF
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "::error::Likely blocked egress: mirror.internal:8080"
+	assert_output --partial "add mirror.internal:8080 to allowed-endpoints"
+	[[ "$output" != *"mirror.internal:443"* ]]
+}
+
+@test "summarize-blocked-egress: plain-http URL without port defaults to 80" {
+	cat >"$BUILD_LOG" <<'EOF'
+#4 [base 2/3] RUN wget http://legacy-mirror.example/pkg.tar.gz
+#4 30.001 wget: can't connect to remote host: Connection timed out
+#4 30.001 wget: http://legacy-mirror.example/pkg.tar.gz: Connection timed out
+EOF
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "::error::Likely blocked egress: legacy-mirror.example:80"
+	assert_output --partial "add legacy-mirror.example:80 to allowed-endpoints"
+}
+
 @test "summarize-blocked-egress: clean log emits nothing and exits 0" {
 	cat >"$BUILD_LOG" <<'EOF'
 #10 [full 4/9] COPY . .


### PR DESCRIPTION
## Summary

With harden-runner `egress-policy: block`, disallowed traffic is silently dropped in the reusable Docker builds. Short-timeout clients (apk) fail fast with a bare I/O error; long-timeout clients (bun install) hang ~25 minutes until buildkit dies with an illegible "runner received shutdown signal". Real incidents: Rustume run 29245203256 (bun, `registry.npmjs.org` missing from the allowlist, 25-minute silent hang) and run 29235168888 (apk, fast I/O error).

This PR makes blocked egress legible: on build failure, the failed build's log is scanned for blocked-egress signatures, `::error::` annotations name the likely-blocked host with the exact `allowed-endpoints` fix, and a "🚫 Possible blocked egress" step-summary section is written.

Resolves the upstream (lgtm-ci) half of lgtm-hq/Rustume#459.

## Changes

- `scripts/ci/actions/docker/build.sh`: tee the buildx output to `BUILD_LOG` (default `$RUNNER_TEMP/docker-build.log`), preserving the exit code via pipefail. No behavior change otherwise.
- `scripts/ci/actions/docker/summarize-blocked-egress.sh` (new, `STEP: summarize-blocked-egress` in the `build-docker.sh` dispatcher): scans `BUILD_LOG` for blocked-egress signatures (`Could not resolve host`, apk `temporary error (try again later)` / `I/O error`, `Connection timed out`, `i/o timeout`, `connection reset by peer`, `connect: connection refused`, `context canceled`, `failed to receive status: rpc error`, …), extracts the likely-blocked host, emits `::error::` annotations and a step-summary section. Exits 0 in all cases (diagnostic only — never masks the original failure). When no log file exists — the workflows build via `docker/build-push-action`, which writes no log file — it falls back to `docker buildx history logs` to recover the most recent build's output.
- `.github/workflows/reusable-docker-build.yml` + `.github/workflows/reusable-docker-multiplatform.yml`: add a static-named `if: failure()` "Summarize blocked egress" step right after the build step (env + script call only, no inline shell).
- `tests/bats/unit/actions/docker/test_summarize_blocked_egress.bats`: 8 tests — bun-style hang log (buildkit rpc EOF), apk APKINDEX I/O error, curl connection refused, clean log (silent exit 0), missing log, unextractable-host generic error, dispatcher routing.
- `CHANGELOG.md`: `[Unreleased]` → Added entry.

## Testing

- `bats tests/bats/unit/actions/docker/test_summarize_blocked_egress.bats` — 8/8 pass
- `bats --recursive tests/bats/unit/actions/docker` — 107/107 pass
- Related integration suites (`test_reusable_docker_build_workflow`, `test_reusable_docker_workflow`, `test_reusable_static_job_names`) — 41/41 pass
- Script test-coverage ratchet satisfied without touching the allowlist
- shellcheck, shfmt, yamllint, markdownlint, and `uv run lintro chk` clean on all changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker build failures now provide clearer diagnostics for likely blocked network endpoints.
  * Failed builds include matching log details and suggested host information in CI error annotations and summaries.
  * Build logging now preserves the original build result even if log capture encounters an issue.

* **Documentation**
  * Added changelog notes describing blocked-egress diagnostics.

* **Tests**
  * Added coverage for log capture, failure handling, endpoint detection, and summary output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes Docker build egress failures easier to diagnose. The main changes are:

- Captures Docker build output in a log file for later scanning.
- Adds a blocked-egress summary script with endpoint extraction and step-summary output.
- Wires the summary step into the reusable Docker workflows after failed builds.
- Adds tests for log capture, endpoint extraction, missing logs, and dispatcher routing.
- Updates the changelog entry for the new diagnostics.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The build log capture now keeps the Docker build result separate from log-write failures.
- The endpoint output now preserves explicit ports in the covered Docker failure logs.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/ci/actions/docker/build.sh | Captures build output while preserving the Docker build exit code. |
| scripts/ci/actions/docker/summarize-blocked-egress.sh | Adds blocked-egress log scanning, endpoint annotations, and summary output. |
| .github/workflows/reusable-docker-build.yml | Runs the blocked-egress summary step after a failed Docker build. |
| .github/workflows/reusable-docker-multiplatform.yml | Runs the blocked-egress summary step after a failed multiplatform Docker build. |
| tests/bats/unit/actions/docker/test_build.bats | Adds tests for build log capture and exit-code preservation. |
| tests/bats/unit/actions/docker/test_summarize_blocked_egress.bats | Adds tests for blocked-egress detection, endpoint extraction, and dispatcher routing. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(docker): make summarize-blocked-egre..."](https://github.com/lgtm-hq/lgtm-ci/commit/4dec66c23ad697812cb1fadc36e2f1ec57b99ef3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43844106)</sub>

<!-- /greptile_comment -->