### PR TITLE
feat(ci): reusable auto-rerun for transient infra failures

### DIFF
--- a/.github/workflows/reusable-auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/reusable-auto-rerun-on-infra-failure.yml
@@ -1,0 +1,145 @@
+---
+name: Reusable - Auto Re-run on Infra Failure
+
+# Re-runs the failed jobs of a completed workflow run when — and only when —
+# the failed-job logs match a known transient-infrastructure signature
+# (GitHub-side outages such as "Failed to resolve action download info").
+# RUN_ATTEMPT gating caps automation at max-reruns re-run(s) per run so a
+# persistent outage can never loop. Call from a workflow_run consumer gated
+# on a failed conclusion (see examples/auto-rerun-on-infra-failure.yml):
+#
+#   rerun:
+#     if: github.event.workflow_run.conclusion == 'failure'
+#     uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@<sha>
+#     permissions:
+#       actions: write
+#       contents: read
+#     with:
+#       run-id: ${{ github.event.workflow_run.id }}
+#       run-attempt: ${{ github.event.workflow_run.run_attempt }}
+#       tooling-ref: <sha>
+
+"on":
+  workflow_call:
+    inputs:
+      run-id:
+        description: "Workflow run id to inspect and potentially re-run"
+        required: true
+        type: string
+      run-attempt:
+        description: "Attempt number of the failed run"
+        required: true
+        type: string
+      max-reruns:
+        description: "Maximum automatic re-runs per run"
+        required: false
+        type: string
+        default: "1"
+      signatures:
+        description: >-
+          Extra newline-separated failure-log signatures appended to the
+          built-in transient-infra defaults
+        required: false
+        type: string
+        default: ""
+      tooling-ref:
+        description: "Git ref to use when checking out lgtm-ci tooling scripts"
+        required: false
+        type: string
+        default: ""
+
+      egress-policy:
+        description: "harden-runner egress policy (audit or block)"
+        required: false
+        type: string
+        default: "block"
+      allowed-endpoints:
+        description: "Allowed endpoints when egress-policy is block"
+        required: false
+        type: string
+        default: >
+          github.com:443
+          api.github.com:443
+          codeload.github.com:443
+          objects.githubusercontent.com:443
+          pipelines.actions.githubusercontent.com:443
+      allowed-endpoints-mode:
+        description: >-
+          replace: non-empty allowed-endpoints overrides egress-preset; append:
+          merges preset with allowed-endpoints (deduped, first-seen wins)
+        required: false
+        type: string
+        default: "replace"
+      egress-preset:
+        description: >-
+          Named allowlist when allowed-endpoints is empty and egress-policy is
+          block (github-minimal, github-pages, github-tooling, docker,
+          playwright, pypi, rubygems, npm-publish, quality, sbom, scorecard)
+        required: false
+        type: string
+        default: "github-minimal"
+
+      runner-image:
+        description: "GitHub-hosted runner image label"
+        required: false
+        type: string
+        default: "ubuntu-24.04"
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 10
+
+permissions:
+  contents: read
+
+jobs:
+  rerun:
+    name: Re-run failed jobs on infra failure
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      # Re-run failed jobs and read failed-job logs
+      actions: write
+      # Read repository context for the tooling checkout
+      contents: read
+
+    steps:
+      - name: Harden runner
+        if: runner.os == 'Linux' || runner.environment == 'self-hosted'
+        # Pinned to SHA for supply chain security
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/checkout-and-harden
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+      - name: Checkout and harden
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+        with:
+          tooling-ref: ${{ inputs.tooling-ref }}
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+          sparse-checkout-extra: |
+            scripts/ci/
+      - name: Re-run failed jobs on matched infra signature
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ inputs.run-id }}
+          RUN_ATTEMPT: ${{ inputs.run-attempt }}
+          MAX_RERUNS: ${{ inputs.max-reruns }}
+          SIGNATURES: ${{ inputs.signatures }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/rerun-on-infra-failure.sh

--- a/.github/workflows/reusable-auto-rerun-on-infra-failure.yml
+++ b/.github/workflows/reusable-auto-rerun-on-infra-failure.yml
@@ -111,7 +111,16 @@ jobs:
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: ${{ inputs.egress-policy }}
-          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          # Literal GitHub bootstrap allowlist (same pattern as the main
+          # failure notifier): the tooling checkout and preset resolution run
+          # after this step, so an empty caller allowed-endpoints must not
+          # leave block-policy egress with an empty allowlist.
+          allowed-endpoints: >
+            github.com:443
+            api.github.com:443
+            codeload.github.com:443
+            objects.githubusercontent.com:443
+            pipelines.actions.githubusercontent.com:443
       - name: Checkout lgtm-ci tooling
         # yamllint disable-line rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ci**: reusable auto-rerun of failed jobs on transient infra failure
+  signatures (lgtm-hq/Rustume#463)
+
 ### Changed
 
 ### Deprecated

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -396,6 +396,52 @@ workflow declares. Grant at least `actions: read` and `issues: write` on the
 caller job, or pass `report-failures: false` when upgrading from a release that
 did not include failure reporting.
 
+### Auto re-run on infra failure
+
+`reusable-auto-rerun-on-infra-failure.yml` re-runs the failed jobs of a
+completed workflow run when — and only when — the failed-job logs match a
+known transient-infrastructure signature. Built-in signatures:
+
+- `Failed to resolve action download info`
+- `The runner has received a shutdown signal`
+- `Error resolving allowed domain`
+- `lost communication with the server`
+
+Extend the list via the multiline `signatures` input (newline-separated,
+appended to the defaults). When no signature matches, the job writes a step
+summary and exits successfully without re-running — a real failure stays
+failed. `max-reruns` (default `1`) caps automation per run: attempts beyond
+the cap exit without re-running, so a persistent outage can never loop.
+
+Call it from a thin `workflow_run` consumer gated on a failed conclusion
+(see [examples/auto-rerun-on-infra-failure.yml](../examples/auto-rerun-on-infra-failure.yml)):
+
+```yaml
+"on":
+  workflow_run:
+    workflows: ["CI", "Deploy Pages", "Coverage"]
+    types: [completed]
+
+jobs:
+  rerun:
+    if: github.event.workflow_run.conclusion == 'failure'
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@<sha> # vX.Y.Z
+    permissions:
+      actions: write
+      contents: read
+    with:
+      tooling-ref: "<sha>" # vX.Y.Z
+      run-id: ${{ format('{0}', github.event.workflow_run.id) }}
+      run-attempt: ${{ format('{0}', github.event.workflow_run.run_attempt) }}
+```
+
+Caveats: `workflow_run` triggers only execute from the workflow definition on
+the **default branch**, so the caller file must land on main before it fires.
+`workflow_run.workflows` matches workflow `name:` values, not file names. The
+run id and attempt are numbers in the event payload; wrap them in `format()`
+so they arrive as the strings the inputs expect.
+
 Recommended caller `run-name` (reusable workflows cannot set this for you):
 
 ```yaml

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -61,6 +61,7 @@ standard summary comment when callers grant `pull-requests: write`.
 | `reusable-release-version-pr.yml` | Release version PR with changelog |
 | `reusable-release-auto-tag.yml` | Tag + GitHub release on merge |
 | `reusable-main-failure-notifier.yml` | Dedup'd issue on any main-branch workflow failure |
+| `reusable-auto-rerun-on-infra-failure.yml` | Re-run failed jobs once on transient infra outage signatures |
 | `reusable-publish-artifact-preview.yml` | Sticky PR comment linking a build artifact |
 | `reusable-publish-artifact-report.yml` | Publish markdown report from an artifact |
 | `reusable-publish-file-breakdown.yml` | PR changed-files breakdown comment |

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,7 @@ Sample caller layouts for lgtm-hq repositories. Copy and adapt into your
 | [release-auto-tag.yml](release-auto-tag.yml)                                   | Tag + GitHub Release when the version PR merges                                |
 | [release-version-pr-changelog-only.yml](release-version-pr-changelog-only.yml) | Version PRs for repos with no package version files                            |
 | [publish-python-release.yml](publish-python-release.yml)                       | Publish to PyPI on tag (trusted publishing + attestation)                      |
+| [auto-rerun-on-infra-failure.yml](auto-rerun-on-infra-failure.yml)             | Re-run failed jobs once when logs match a transient infra outage               |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/examples/auto-rerun-on-infra-failure.yml
+++ b/examples/auto-rerun-on-infra-failure.yml
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: MIT
+# Auto re-run on transient infra failures: when a listed workflow fails and
+# its failed-job logs match a known GitHub-side outage signature ("Failed to
+# resolve action download info", runner shutdowns, …), re-run only the failed
+# jobs — once. Copy into your repository as
+# .github/workflows/auto-rerun-on-infra-failure.yml and list the workflows
+# to watch by their `name:`.
+#
+# Caveat: workflow_run triggers only run from the workflow definition on the
+# default branch, so this file must land on main before it fires — and edits
+# only take effect once merged.
+---
+name: Auto Rerun on Infra Failure
+
+"on":
+  workflow_run:
+    workflows: ["CI", "Deploy Pages", "Coverage"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  rerun:
+    if: github.event.workflow_run.conclusion == 'failure'
+    # yamllint disable-line rule:line-length
+    uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-auto-rerun-on-infra-failure.yml@ee5bebbb1f0346ed0520abf75bd9ac9c418166ab # v0.53.1
+    permissions:
+      actions: write
+      contents: read
+    with:
+      tooling-ref: "ee5bebbb1f0346ed0520abf75bd9ac9c418166ab" # v0.53.1
+      # run id/attempt are numbers in the event payload; format() passes them
+      # as the strings the reusable workflow inputs expect.
+      run-id: ${{ format('{0}', github.event.workflow_run.id) }}
+      run-attempt: ${{ format('{0}', github.event.workflow_run.run_attempt) }}
+      # max-reruns: "1"
+      # signatures: |
+      #   Some extra transient failure signature
+      egress-policy: block
+      egress-preset: github-minimal

--- a/scripts/ci/actions/rerun-on-infra-failure.sh
+++ b/scripts/ci/actions/rerun-on-infra-failure.sh
@@ -27,6 +27,18 @@ set -euo pipefail
 : "${MAX_RERUNS:=1}"
 : "${SIGNATURES:=}"
 
+# RUN_ATTEMPT and MAX_RERUNS feed an arithmetic comparison; reject anything
+# that is not a non-negative integer up front so workflow-input typos fail
+# loudly instead of raising an arithmetic error under set -e.
+if [[ ! "$RUN_ATTEMPT" =~ ^[0-9]+$ ]]; then
+	echo "::error::RUN_ATTEMPT must be a non-negative integer (got '${RUN_ATTEMPT}')"
+	exit 1
+fi
+if [[ ! "$MAX_RERUNS" =~ ^[0-9]+$ ]]; then
+	echo "::error::MAX_RERUNS must be a non-negative integer (got '${MAX_RERUNS}')"
+	exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
 # shellcheck source=../lib/actions.sh
 source "$SCRIPT_DIR/../lib/actions.sh"

--- a/scripts/ci/actions/rerun-on-infra-failure.sh
+++ b/scripts/ci/actions/rerun-on-infra-failure.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Re-run failed jobs of a workflow run when — and only when — the
+#          failure logs match a known transient-infrastructure signature.
+#
+# Transient GitHub-side outages ("Failed to resolve action download info",
+# runner shutdowns, …) fail workflows outright and previously needed a human
+# to press re-run. This script inspects the failed-job logs of a completed
+# run and, when a known infra signature matches, re-runs only the failed
+# jobs. RUN_ATTEMPT gating caps automation at MAX_RERUNS re-runs per run so
+# a persistent outage can never loop.
+#
+# Environment variables:
+#   RUN_ID            - Workflow run id to inspect and potentially re-run (required)
+#   RUN_ATTEMPT       - Attempt number of the failed run (required)
+#   MAX_RERUNS        - Maximum automatic re-runs per run (default: 1)
+#   SIGNATURES        - Extra newline-separated log signatures appended to the
+#                       built-in defaults (optional)
+#   GITHUB_REPOSITORY - owner/repo (provided by GitHub Actions)
+#   GH_TOKEN          - Token with actions:write scope
+
+set -euo pipefail
+
+: "${RUN_ID:?RUN_ID is required}"
+: "${RUN_ATTEMPT:?RUN_ATTEMPT is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${MAX_RERUNS:=1}"
+: "${SIGNATURES:=}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/actions.sh
+source "$SCRIPT_DIR/../lib/actions.sh"
+# shellcheck source=../lib/github/summary.sh
+source "$SCRIPT_DIR/../lib/github/summary.sh"
+
+# Known transient infra failure signatures (fixed strings, one per line).
+DEFAULT_SIGNATURES="Failed to resolve action download info
+The runner has received a shutdown signal
+Error resolving allowed domain
+lost communication with the server"
+
+# Build the effective signature list: defaults plus optional SIGNATURES
+# extensions, blank lines dropped.
+build_signatures() {
+	printf '%s\n' "$DEFAULT_SIGNATURES"
+	if [[ -n "$SIGNATURES" ]]; then
+		printf '%s\n' "$SIGNATURES"
+	fi
+}
+
+fetch_failed_logs() {
+	gh run view "$RUN_ID" --repo "$GITHUB_REPOSITORY" --log-failed
+}
+
+# Print the first signature found in the logs on stdin; return 1 when none
+# match.
+match_signature() {
+	local logs="$1" signature
+	while IFS= read -r signature; do
+		[[ -z "$signature" ]] && continue
+		if grep -qF -- "$signature" <<<"$logs"; then
+			printf '%s\n' "$signature"
+			return 0
+		fi
+	done < <(build_signatures)
+	return 1
+}
+
+main() {
+	if [[ "$RUN_ATTEMPT" -gt "$MAX_RERUNS" ]]; then
+		log_info "Run ${RUN_ID} attempt ${RUN_ATTEMPT} exceeds MAX_RERUNS=${MAX_RERUNS}; not re-running"
+		add_github_summary "## Auto re-run on infra failure"
+		add_github_summary ""
+		add_github_summary "Attempt ${RUN_ATTEMPT} exceeds the max of ${MAX_RERUNS} automatic re-run(s); leaving run ${RUN_ID} failed for a human."
+		return 0
+	fi
+
+	local logs
+	if ! logs="$(fetch_failed_logs)"; then
+		die "Failed to fetch failed-job logs for run ${RUN_ID}"
+	fi
+
+	local matched
+	if ! matched="$(match_signature "$logs")"; then
+		log_info "No infra signature matched in failed-job logs of run ${RUN_ID}; not re-running"
+		add_github_summary "## Auto re-run on infra failure"
+		add_github_summary ""
+		add_github_summary "No infra signature matched in the failed-job logs of run ${RUN_ID}; not re-running. The failure looks real — investigate it."
+		return 0
+	fi
+
+	log_info "Infra signature matched for run ${RUN_ID}: ${matched}"
+	gh run rerun "$RUN_ID" --repo "$GITHUB_REPOSITORY" --failed
+	echo "::notice::Re-ran failed jobs of run ${RUN_ID} (attempt ${RUN_ATTEMPT}): matched infra signature '${matched}'"
+	add_github_summary "## Auto re-run on infra failure"
+	add_github_summary ""
+	add_github_summary "Matched transient infra signature \`${matched}\` in the failed-job logs of run ${RUN_ID} (attempt ${RUN_ATTEMPT}); re-ran the failed jobs."
+	log_success "Re-ran failed jobs of run ${RUN_ID}"
+}
+
+main "$@"

--- a/tests/bats/integration/test_reusable_auto_rerun_on_infra_failure.bats
+++ b/tests/bats/integration/test_reusable_auto_rerun_on_infra_failure.bats
@@ -33,6 +33,19 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-auto-rerun-on-infra-failure
 	assert_success
 }
 
+@test "auto-rerun: bootstrap harden step pins literal github hosts" {
+	# The first harden-runner step must not depend on caller input: an empty
+	# allowed-endpoints would otherwise block the tooling checkout that
+	# resolves the egress preset.
+	run awk '
+		/step-security\/harden-runner@/ { in_harden = 1 }
+		in_harden && /allowed-endpoints: \$\{\{/ { bad = 1; exit }
+		in_harden && /api\.github\.com:443/ { found = 1; exit }
+		END { exit !(found && !bad) }
+	' "$WORKFLOW"
+	assert_success
+}
+
 @test "auto-rerun: delegates to the rerun script with no inline shell" {
 	run grep -F "rerun-on-infra-failure.sh" "$WORKFLOW"
 	assert_success

--- a/tests/bats/integration/test_reusable_auto_rerun_on_infra_failure.bats
+++ b/tests/bats/integration/test_reusable_auto_rerun_on_infra_failure.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Contract tests for reusable-auto-rerun-on-infra-failure.yml
+
+load "../../helpers/common"
+
+WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-auto-rerun-on-infra-failure.yml"
+
+@test "auto-rerun: requires run-id and run-attempt inputs" {
+	local input
+	for input in run-id run-attempt; do
+		run awk -v name="${input}:" '
+			$1 == name { in_input = 1; next }
+			in_input && /required: true/ { found = 1; exit }
+			in_input && /^      [a-z-]+:/ { in_input = 0 }
+			END { exit !found }
+		' "$WORKFLOW"
+		assert_success
+	done
+}
+
+@test "auto-rerun: rerun job grants actions write" {
+	run grep -F "actions: write" "$WORKFLOW"
+	assert_success
+	run grep -F "contents: read" "$WORKFLOW"
+	assert_success
+}
+
+@test "auto-rerun: hardens egress before re-running" {
+	run grep -F "harden-runner" "$WORKFLOW"
+	assert_success
+	run grep -F "checkout-and-harden" "$WORKFLOW"
+	assert_success
+}
+
+@test "auto-rerun: delegates to the rerun script with no inline shell" {
+	run grep -F "rerun-on-infra-failure.sh" "$WORKFLOW"
+	assert_success
+	run grep -F "RUN_ID: \${{ inputs.run-id }}" "$WORKFLOW"
+	assert_success
+	run grep -F "RUN_ATTEMPT: \${{ inputs.run-attempt }}" "$WORKFLOW"
+	assert_success
+	run grep -F "MAX_RERUNS: \${{ inputs.max-reruns }}" "$WORKFLOW"
+	assert_success
+	run grep -F "SIGNATURES: \${{ inputs.signatures }}" "$WORKFLOW"
+	assert_success
+}
+
+@test "auto-rerun: tooling checkout includes the rerun script" {
+	run grep -F "sparse-checkout" "$WORKFLOW"
+	assert_success
+	run grep -F "scripts/ci/" "$WORKFLOW"
+	assert_success
+}
+
+@test "auto-rerun: caps automatic re-runs at one by default" {
+	run awk '
+		/^      max-reruns:/ { in_input = 1; next }
+		in_input && /default: "1"/ { found = 1; exit }
+		in_input && /^      [a-z-]+:/ { in_input = 0 }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}

--- a/tests/bats/unit/actions/test_rerun_on_infra_failure.bats
+++ b/tests/bats/unit/actions/test_rerun_on_infra_failure.bats
@@ -1,0 +1,206 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Tests for scripts/ci/actions/rerun-on-infra-failure.sh (#463)
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+
+setup() {
+	setup_temp_dir
+	save_path
+	export SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/rerun-on-infra-failure.sh"
+	export GITHUB_REPOSITORY="lgtm-hq/Rustume"
+	export GH_TOKEN="test-token"
+	export RUN_ID="29252857248"
+	export RUN_ATTEMPT="1"
+	export GITHUB_STEP_SUMMARY="${BATS_TEST_TMPDIR}/summary.md"
+	export RERUN_CALLS="${BATS_TEST_TMPDIR}/rerun_calls"
+	unset MAX_RERUNS SIGNATURES
+}
+
+teardown() {
+	restore_path
+	teardown_temp_dir
+}
+
+# Mock gh: serve the given failed-job logs for `run view --log-failed` and
+# record `run rerun` invocations.
+_mock_gh() {
+	local logs="$1"
+
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+
+	local logs_file="${mock_bin}/.failed_logs"
+	printf '%s\n' "$logs" >"$logs_file"
+	: >"$RERUN_CALLS"
+
+	cat >"${mock_bin}/gh" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+	run\ view\ *--log-failed*)
+		cat '${logs_file}'
+		;;
+	run\ rerun\ *)
+		echo "\$*" >> '${RERUN_CALLS}'
+		;;
+	*)
+		echo "unexpected gh call: \$*" >&2
+		exit 1
+		;;
+esac
+EOF
+	chmod +x "${mock_bin}/gh"
+	export PATH="${mock_bin}:$PATH"
+}
+
+# =============================================================================
+# Required env var validation
+# =============================================================================
+
+@test "rerun-on-infra-failure: fails when RUN_ID is unset" {
+	_mock_gh "irrelevant"
+	run bash -c 'unset RUN_ID; bash "$SCRIPT" 2>&1'
+	assert_failure
+	assert_output --partial "RUN_ID is required"
+}
+
+@test "rerun-on-infra-failure: fails when RUN_ATTEMPT is unset" {
+	_mock_gh "irrelevant"
+	run bash -c 'unset RUN_ATTEMPT; bash "$SCRIPT" 2>&1'
+	assert_failure
+	assert_output --partial "RUN_ATTEMPT is required"
+}
+
+# =============================================================================
+# Default signatures trigger a rerun of failed jobs
+# =============================================================================
+
+@test "rerun-on-infra-failure: 'Failed to resolve action download info' triggers rerun" {
+	_mock_gh "job: Failed to resolve action download info. Error: Service Unavailable"
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "::notice::"
+	assert_output --partial "Failed to resolve action download info"
+	run grep -c -- "--failed" "$RERUN_CALLS"
+	assert_output "1"
+}
+
+@test "rerun-on-infra-failure: 'The runner has received a shutdown signal' triggers rerun" {
+	_mock_gh "The runner has received a shutdown signal."
+	run bash "$SCRIPT"
+	assert_success
+	run grep -c -- "--failed" "$RERUN_CALLS"
+	assert_output "1"
+}
+
+@test "rerun-on-infra-failure: 'Error resolving allowed domain' triggers rerun" {
+	_mock_gh "Error resolving allowed domain github.com"
+	run bash "$SCRIPT"
+	assert_success
+	run grep -c -- "--failed" "$RERUN_CALLS"
+	assert_output "1"
+}
+
+@test "rerun-on-infra-failure: 'lost communication with the server' triggers rerun" {
+	_mock_gh "The runner lost communication with the server."
+	run bash "$SCRIPT"
+	assert_success
+	run grep -c -- "--failed" "$RERUN_CALLS"
+	assert_output "1"
+}
+
+# =============================================================================
+# Rerun command shape
+# =============================================================================
+
+@test "rerun-on-infra-failure: rerun targets only failed jobs of the run" {
+	_mock_gh "Failed to resolve action download info"
+	run bash "$SCRIPT"
+	assert_success
+	run cat "$RERUN_CALLS"
+	assert_output --partial "run rerun ${RUN_ID}"
+	assert_output --partial "--failed"
+}
+
+# =============================================================================
+# No signature match
+# =============================================================================
+
+@test "rerun-on-infra-failure: no matching signature exits 0 without rerun" {
+	_mock_gh "assertion failed: expected 200 got 500 in tests/api_test.rs"
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "not re-running"
+	[ ! -s "$RERUN_CALLS" ]
+	run grep -c "No infra signature matched" "$GITHUB_STEP_SUMMARY"
+	assert_output "1"
+}
+
+# =============================================================================
+# Attempt gating
+# =============================================================================
+
+@test "rerun-on-infra-failure: RUN_ATTEMPT above MAX_RERUNS skips without fetching logs" {
+	export RUN_ATTEMPT="2"
+	_mock_gh "Failed to resolve action download info"
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "exceeds MAX_RERUNS=1"
+	[ ! -s "$RERUN_CALLS" ]
+}
+
+@test "rerun-on-infra-failure: raised MAX_RERUNS allows a second attempt" {
+	export RUN_ATTEMPT="2"
+	export MAX_RERUNS="2"
+	_mock_gh "Failed to resolve action download info"
+	run bash "$SCRIPT"
+	assert_success
+	run grep -c -- "--failed" "$RERUN_CALLS"
+	assert_output "1"
+}
+
+# =============================================================================
+# Custom SIGNATURES extend the defaults
+# =============================================================================
+
+@test "rerun-on-infra-failure: custom SIGNATURES entry triggers rerun" {
+	export SIGNATURES="No space left on device"
+	_mock_gh "write /tmp/foo: No space left on device"
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "No space left on device"
+	run grep -c -- "--failed" "$RERUN_CALLS"
+	assert_output "1"
+}
+
+@test "rerun-on-infra-failure: defaults still match when SIGNATURES is set" {
+	export SIGNATURES="No space left on device"
+	_mock_gh "Failed to resolve action download info"
+	run bash "$SCRIPT"
+	assert_success
+	run grep -c -- "--failed" "$RERUN_CALLS"
+	assert_output "1"
+}
+
+@test "rerun-on-infra-failure: custom SIGNATURES does not loosen matching" {
+	export SIGNATURES="No space left on device"
+	_mock_gh "a perfectly ordinary test failure"
+	run bash "$SCRIPT"
+	assert_success
+	[ ! -s "$RERUN_CALLS" ]
+}
+
+# =============================================================================
+# Step summary on rerun
+# =============================================================================
+
+@test "rerun-on-infra-failure: writes a step summary naming the signature" {
+	_mock_gh "Failed to resolve action download info"
+	run bash "$SCRIPT"
+	assert_success
+	run grep -c "Auto re-run on infra failure" "$GITHUB_STEP_SUMMARY"
+	assert_output "1"
+	run grep -c "Failed to resolve action download info" "$GITHUB_STEP_SUMMARY"
+	assert_output "1"
+}

--- a/tests/bats/unit/actions/test_rerun_on_infra_failure.bats
+++ b/tests/bats/unit/actions/test_rerun_on_infra_failure.bats
@@ -72,6 +72,33 @@ EOF
 	assert_output --partial "RUN_ATTEMPT is required"
 }
 
+@test "rerun-on-infra-failure: non-numeric RUN_ATTEMPT fails with a clear error" {
+	export RUN_ATTEMPT="not-a-number"
+	_mock_gh "Failed to resolve action download info"
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "::error::RUN_ATTEMPT must be a non-negative integer (got 'not-a-number')"
+	[ ! -s "$RERUN_CALLS" ]
+}
+
+@test "rerun-on-infra-failure: non-numeric MAX_RERUNS fails with a clear error" {
+	export MAX_RERUNS="one"
+	_mock_gh "Failed to resolve action download info"
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "::error::MAX_RERUNS must be a non-negative integer (got 'one')"
+	[ ! -s "$RERUN_CALLS" ]
+}
+
+@test "rerun-on-infra-failure: negative RUN_ATTEMPT fails validation" {
+	export RUN_ATTEMPT="-1"
+	_mock_gh "Failed to resolve action download info"
+	run bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "RUN_ATTEMPT must be a non-negative integer"
+	[ ! -s "$RERUN_CALLS" ]
+}
+
 # =============================================================================
 # Default signatures trigger a rerun of failed jobs
 # =============================================================================


### PR DESCRIPTION
## Summary

Resolves lgtm-hq/Rustume#463.

Transient GitHub-side outages fail workflows outright and need manual reruns. Real incident (2026-07-13 ~13:13–13:31 UTC, lgtm-hq/Rustume): `Failed to resolve action download info. Error: Service Unavailable` failed Deploy-Pages (run 29252857248) and Coverage (run 29252725585 — twice; the manual rerun hit the same outage). All passed on a later rerun.

This adds a reusable mechanism that re-runs failed jobs when — and only when — the failed-job log matches a known infra signature, capped at one auto-rerun per run.

## Changes

- **`scripts/ci/actions/rerun-on-infra-failure.sh`** — fetches `gh run view --log-failed`, matches against default signatures (`Failed to resolve action download info`, `The runner has received a shutdown signal`, `Error resolving allowed domain`, `lost communication with the server`; extendable via newline-separated `SIGNATURES`), and on match runs `gh run rerun --failed` with a `::notice::` naming the signature plus a step summary. `RUN_ATTEMPT > MAX_RERUNS` (default 1) exits 0 without fetching logs, so a persistent outage can never loop. No match → step summary + exit 0.
- **`.github/workflows/reusable-auto-rerun-on-infra-failure.yml`** — `workflow_call` reusable: required `run-id`/`run-attempt`, optional `max-reruns`/`signatures`/`tooling-ref`, standard egress inputs; `actions: write` + `contents: read` at the job level; static job name; harden-runner + checkout-and-harden with `github-minimal` preset; no inline shell.
- **`examples/auto-rerun-on-infra-failure.yml`** — thin `workflow_run` consumer gated on `conclusion == 'failure'`; documents the default-branch-only caveat of `workflow_run` and wraps the numeric run id/attempt in `format()`.
- **Docs** — new section in `docs/reusable-workflows.md`, catalog row in `docs/workflows/README.md`, index row in `examples/README.md`.
- **Tests** — `tests/bats/unit/actions/test_rerun_on_infra_failure.bats` (14 cases: each default signature, no-match no-rerun, attempt gating, custom SIGNATURES extension, `--failed` command shape, step summaries) and contract test `tests/bats/integration/test_reusable_auto_rerun_on_infra_failure.bats` mirroring the notifier's.
- **`CHANGELOG.md`** — `[Unreleased] > Added` entry.

## Testing

- Full BATS suite: 2937 tests, 0 failures (`bats --recursive tests/bats`).
- `validate-script-test-coverage.sh`, `validate-runner-contract.sh`, `validate-static-job-names.sh`, `validate-tooling-sparse-checkout.sh` all pass; coverage allowlist untouched.
- shellcheck, shfmt, yamllint, markdownlint, actionlint clean on changed files.

## Notes

- The example pins v0.53.1 (`ee5bebb`) as a placeholder; the reusable ships in the next release and the pin bumps with the usual release flow.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds reusable CI automation for rerunning failed jobs after transient infrastructure failures. The main changes are:

- New reusable workflow for failed-log inspection and auto-rerun.
- New shell script for signature matching, attempt gating, and `gh run rerun --failed`.
- Example `workflow_run` consumer for downstream repositories.
- Docs, changelog entries, and BATS coverage for the new workflow and script.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-auto-rerun-on-infra-failure.yml | Adds the reusable auto-rerun workflow with bootstrap egress hardening, tooling checkout, and script execution. |
| scripts/ci/actions/rerun-on-infra-failure.sh | Adds failed-log fetching, signature matching, input validation, attempt gating, and failed-job rerun logic. |
| examples/auto-rerun-on-infra-failure.yml | Adds a sample `workflow_run` caller that forwards the failed run id and attempt to the reusable workflow. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): harden bootstrap egress and val..."](https://github.com/lgtm-hq/lgtm-ci/commit/33d85175aa70707139f71c38b9c3393c3886edcb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43850268)</sub>

<!-- /greptile_comment -->