### PR TITLE
fix(release): pin repo checkout to triggering commit in release reusables

### DIFF
--- a/.github/workflows/reusable-release-auto-tag.yml
+++ b/.github/workflows/reusable-release-auto-tag.yml
@@ -180,6 +180,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Pin to the commit that triggered this run: an unpinned checkout
+          # floats to the branch tip, so a commit landing in the trigger→
+          # checkout window makes guard-release-commit read the wrong commit
+          # and permanently skip the tag (observed: lgtm-hq/Rustume v0.29.1,
+          # three release PRs merged with no tag cut).
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/reusable-release-version-pr.yml
+++ b/.github/workflows/reusable-release-version-pr.yml
@@ -212,6 +212,9 @@ jobs:
         # yamllint disable-line rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # Pin to the triggering commit — same guard race as
+          # reusable-release-auto-tag.yml (see comment there).
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **release**: pin repository checkout in auto-tag and version-PR reusables to
-  the triggering commit — an unpinned checkout raced commits landing after the
-  trigger, making guard-release-commit skip legitimate release tags
-  (observed: lgtm-hq/Rustume v0.29.1 wedge)
-
 ### Added
 
 - **ci**: reusable auto-rerun of failed jobs on transient infra failure
@@ -32,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+- **release**: pin repository checkout in auto-tag and version-PR reusables to
+  the triggering commit — an unpinned checkout raced commits landing after the
+  trigger, making guard-release-commit skip legitimate release tags
+  (observed: lgtm-hq/Rustume v0.29.1 wedge)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **release**: pin repository checkout in auto-tag and version-PR reusables to
+  the triggering commit — an unpinned checkout raced commits landing after the
+  trigger, making guard-release-commit skip legitimate release tags
+  (observed: lgtm-hq/Rustume v0.29.1 wedge)
+
 ### Added
 
 - **ci**: reusable auto-rerun of failed jobs on transient infra failure


### PR DESCRIPTION
## Summary

Root-cause fix for the Rustume v0.29.1 release wedge (three merged `chore(release): version 0.29.1` PRs, no tag ever cut).

**Race:** `guard-release-commit.sh` reads `git log -1 HEAD`, but the repository checkout in `reusable-release-auto-tag.yml` (and `reusable-release-version-pr.yml`) floats to the branch tip at checkout time. Rustume run 29257573078: release merge triggered the run at 14:21:07, Renovate's #461 merged seconds later, guard saw `chore(deps): pin dependencies` → `is-release-commit=false` → tag skipped. From then on main already carried the bumped version, later bump merges had no Cargo.toml diff, and the path-filtered workflow never fired again — permanent wedge.

## Changes

- Pin `ref: ${{ github.sha }}` on the repository checkout in both release reusables (comments document the race). Guard, version resolution, and tag creation now all operate on the commit that actually triggered the run.

## Testing

- yamllint clean; no script/BATS changes needed (script contract unchanged — it was fed the wrong tree).
- Live validation: Rustume unwedged manually (signed v0.29.1 tag pushed); this prevents recurrence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the release process to consistently use the triggering commit when creating tags and version updates.
  - Prevented release tags from being skipped due to timing issues during automated releases.

- **Documentation**
  - Added a changelog entry describing the release reliability improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a release workflow race by pinning release checkouts to the triggering commit.

- Adds `ref: ${{ github.sha }}` to the auto-tag reusable checkout.
- Adds the same checkout pin to the version-PR reusable workflow.
- Documents the release wedge fix in the changelog.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-release-auto-tag.yml | Pins the release auto-tag checkout to the commit that triggered the workflow. |
| .github/workflows/reusable-release-version-pr.yml | Pins the release version-PR checkout to the commit that triggered the workflow. |
| CHANGELOG.md | Records the release checkout race fix. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(docs): fill template Fixed heading i..."](https://github.com/lgtm-hq/lgtm-ci/commit/479a6948b8f668553e9fb3d60606e9d2f3725542) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43922052)</sub>

<!-- /greptile_comment -->