### PR TITLE
docs(scripts): add Google-style docstrings to fix-sparse-checkout-scripts.py functions

### DIFF
--- a/scripts/ci/actions/fix-sparse-checkout-scripts.py
+++ b/scripts/ci/actions/fix-sparse-checkout-scripts.py
@@ -34,7 +34,7 @@ def fix_sparse_block(block: str) -> str:
 
     Returns:
         The block unchanged when ``scripts/ci/`` is already present, or
-        with ``scripts/ci/`` inserted after the first matching action path.
+        with ``scripts/ci/`` inserted after a supported action path.
     """
     if "scripts/ci/" in block or "scripts/ci/actions/" in block:
         return block
@@ -133,7 +133,8 @@ def main() -> int:
     ``scripts/ci/``.
 
     Returns:
-        Process exit code (always 0 on success).
+        0 always; raises on I/O errors propagated from ``Path.read_text``
+        or ``Path.write_text``.
     """
     updated = 0
     for path in sorted(WORKFLOWS.glob("reusable-*.yml")):

--- a/scripts/ci/actions/fix-sparse-checkout-scripts.py
+++ b/scripts/ci/actions/fix-sparse-checkout-scripts.py
@@ -15,10 +15,27 @@ EGRESS_STEP = re.compile(r"^\s+- name: Checkout lgtm-ci egress tooling\s*$")
 
 
 def job_needs_scripts(job_body: str) -> bool:
+    """Return True when a job runs CI scripts from lgtm-ci tooling.
+
+    Args:
+        job_body: YAML text for a single workflow job.
+
+    Returns:
+        True if the job references ``.lgtm-ci-tooling/scripts``.
+    """
     return ".lgtm-ci-tooling/scripts" in job_body
 
 
 def fix_sparse_block(block: str) -> str:
+    """Insert ``scripts/ci/`` into a sparse-checkout block when missing.
+
+    Args:
+        block: Indented sparse-checkout path lines from a checkout step.
+
+    Returns:
+        The block unchanged when ``scripts/ci/`` is already present, or
+        with ``scripts/ci/`` inserted after the first matching action path.
+    """
     if "scripts/ci/" in block or "scripts/ci/actions/" in block:
         return block
     if "resolve-egress-allowlist" in block:
@@ -37,6 +54,18 @@ def fix_sparse_block(block: str) -> str:
 
 
 def fix_job(job_body: str) -> str:
+    """Ensure sparse-checkout includes ``scripts/ci/`` for tooling jobs.
+
+    Skips egress tooling checkout steps, which use a separate sparse
+    checkout that must not be modified.
+
+    Args:
+        job_body: YAML text for a single workflow job.
+
+    Returns:
+        Updated job text with ``scripts/ci/`` added to applicable
+        sparse-checkout blocks.
+    """
     if not job_needs_scripts(job_body):
         return job_body
 
@@ -70,6 +99,14 @@ def fix_job(job_body: str) -> str:
 
 
 def fix_workflow(text: str) -> str:
+    """Apply sparse-checkout fixes to every job in a workflow file.
+
+    Args:
+        text: Full contents of a reusable workflow YAML file.
+
+    Returns:
+        Updated workflow text with job-level sparse-checkout fixes applied.
+    """
     parts: list[str] = []
     last = 0
     for match in re.finditer(r"^  (\w[\w-]*):\n", text, re.MULTILINE):
@@ -89,6 +126,15 @@ def fix_workflow(text: str) -> str:
 
 
 def main() -> int:
+    """Update reusable workflows that run lgtm-ci tooling scripts.
+
+    Scans ``.github/workflows/reusable-*.yml`` and rewrites files that
+    reference ``.lgtm-ci-tooling/scripts`` so sparse-checkout includes
+    ``scripts/ci/``.
+
+    Returns:
+        Process exit code (always 0 on success).
+    """
     updated = 0
     for path in sorted(WORKFLOWS.glob("reusable-*.yml")):
         text = path.read_text()


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Add Google-style docstrings with Args and Returns sections to all five functions in `scripts/ci/actions/fix-sparse-checkout-scripts.py`, bringing the sole non-compliant Python script in line with stand-py and the rest of the repo.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the sparse-checkout repair tooling, clarifying its inputs, outputs, processing conditions, and exclusions.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds Google-style docstrings (with `Args:` and `Returns:` sections) to all five functions in `scripts/ci/actions/fix-sparse-checkout-scripts.py`, bringing it in line with the rest of the repo's documentation standard. No logic was changed.

- `job_needs_scripts`, `fix_job`, `fix_workflow`, and `main` docstrings are accurate and complete.
- `fix_sparse_block`'s `Returns:` section describes two outcomes but omits the silent fall-through case where neither anchor pattern is found and the block is returned unchanged — flagged in a previous review thread.
</details>


<h3>Confidence Score: 5/5</h3>

Documentation-only change with no modifications to logic or behavior; safe to merge.

The change is limited to adding docstrings. All function signatures, implementations, and module-level constants are untouched. The docstrings are accurate for their respective functions, and the one existing inaccuracy in fix_sparse_block was already caught in a prior review thread.

No files require special attention; fix_sparse_block's docstring gap was already discussed in a prior thread.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/ci/actions/fix-sparse-checkout-scripts.py | Added Google-style docstrings to all five functions; no logic changes. Docstrings are largely accurate, with a minor omission in fix_sparse_block regarding the silent no-op fall-through path (already flagged in a prior review thread). |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[main] --> B{glob reusable-*.yml}
    B --> C{contains .lgtm-ci-tooling/scripts?}
    C -- No --> B
    C -- Yes --> D[fix_workflow]
    D --> E{for each regex job match}
    E --> F{job_name in on/permissions/concurrency?}
    F -- Yes, skip --> E
    F -- No --> G[fix_job]
    G --> H{job_needs_scripts?}
    H -- No --> I[return unchanged]
    H -- Yes --> J{for each sparse-checkout block}
    J --> K{egress step?}
    K -- Yes --> L[skip block]
    K -- No --> M[fix_sparse_block]
    M --> N{scripts/ci/ already present?}
    N -- Yes --> O[return block unchanged]
    N -- No --> P{resolve-egress-allowlist in block?}
    P -- Yes --> Q[insert after that line]
    P -- No --> R{.github/actions/ in block?}
    R -- Yes --> S[insert after .github/actions/]
    R -- No --> T[return block unchanged - silent no-op]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[main] --> B{glob reusable-*.yml}
    B --> C{contains .lgtm-ci-tooling/scripts?}
    C -- No --> B
    C -- Yes --> D[fix_workflow]
    D --> E{for each regex job match}
    E --> F{job_name in on/permissions/concurrency?}
    F -- Yes, skip --> E
    F -- No --> G[fix_job]
    G --> H{job_needs_scripts?}
    H -- No --> I[return unchanged]
    H -- Yes --> J{for each sparse-checkout block}
    J --> K{egress step?}
    K -- Yes --> L[skip block]
    K -- No --> M[fix_sparse_block]
    M --> N{scripts/ci/ already present?}
    N -- Yes --> O[return block unchanged]
    N -- No --> P{resolve-egress-allowlist in block?}
    P -- Yes --> Q[insert after that line]
    P -- No --> R{.github/actions/ in block?}
    R -- Yes --> S[insert after .github/actions/]
    R -- No --> T[return block unchanged - silent no-op]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/ci/actions/fix-sparse-checkout-scripts.py`, line 39-53 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/f3a06008516dcc743a36847b8497625fee5f0070/scripts/ci/actions/fix-sparse-checkout-scripts.py#L39-L53)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Docstring omits the silent no-op return path**

   The Returns section says the block comes back either "unchanged when `scripts/ci/` is already present, or with `scripts/ci/` inserted after the first matching action path." There is a third outcome the docstring does not cover: when neither `resolve-egress-allowlist` nor `.github/actions/` appears in the block, the function falls through all three branches and returns `block` unchanged without inserting anything. A caller reading only the docstring would not know that the insertion can silently be skipped.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Factions%2Ffix-sparse-checkout-scripts.py%0ALine%3A%2039-53%0A%0AComment%3A%0A**Docstring%20omits%20the%20silent%20no-op%20return%20path**%0A%0AThe%20Returns%20section%20says%20the%20block%20comes%20back%20either%20%22unchanged%20when%20%60scripts%2Fci%2F%60%20is%20already%20present%2C%20or%20with%20%60scripts%2Fci%2F%60%20inserted%20after%20the%20first%20matching%20action%20path.%22%20There%20is%20a%20third%20outcome%20the%20docstring%20does%20not%20cover%3A%20when%20neither%20%60resolve-egress-allowlist%60%20nor%20%60.github%2Factions%2F%60%20appears%20in%20the%20block%2C%20the%20function%20falls%20through%20all%20three%20branches%20and%20returns%20%60block%60%20unchanged%20without%20inserting%20anything.%20A%20caller%20reading%20only%20the%20docstring%20would%20not%20know%20that%20the%20insertion%20can%20silently%20be%20skipped.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=581&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Factions%2Ffix-sparse-checkout-scripts.py%0ALine%3A%2039-53%0A%0AComment%3A%0A**Docstring%20omits%20the%20silent%20no-op%20return%20path**%0A%0AThe%20Returns%20section%20says%20the%20block%20comes%20back%20either%20%22unchanged%20when%20%60scripts%2Fci%2F%60%20is%20already%20present%2C%20or%20with%20%60scripts%2Fci%2F%60%20inserted%20after%20the%20first%20matching%20action%20path.%22%20There%20is%20a%20third%20outcome%20the%20docstring%20does%20not%20cover%3A%20when%20neither%20%60resolve-egress-allowlist%60%20nor%20%60.github%2Factions%2F%60%20appears%20in%20the%20block%2C%20the%20function%20falls%20through%20all%20three%20branches%20and%20returns%20%60block%60%20unchanged%20without%20inserting%20anything.%20A%20caller%20reading%20only%20the%20docstring%20would%20not%20know%20that%20the%20insertion%20can%20silently%20be%20skipped.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=581&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22lgtm-hq%2Flgtm-ci%22%20on%20the%20existing%20branch%20%22docs%2F566-fix-sparse-checkout-docstrings%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22docs%2F566-fix-sparse-checkout-docstrings%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fci%2Factions%2Ffix-sparse-checkout-scripts.py%0ALine%3A%2039-53%0A%0AComment%3A%0A**Docstring%20omits%20the%20silent%20no-op%20return%20path**%0A%0AThe%20Returns%20section%20says%20the%20block%20comes%20back%20either%20%22unchanged%20when%20%60scripts%2Fci%2F%60%20is%20already%20present%2C%20or%20with%20%60scripts%2Fci%2F%60%20inserted%20after%20the%20first%20matching%20action%20path.%22%20There%20is%20a%20third%20outcome%20the%20docstring%20does%20not%20cover%3A%20when%20neither%20%60resolve-egress-allowlist%60%20nor%20%60.github%2Factions%2F%60%20appears%20in%20the%20block%2C%20the%20function%20falls%20through%20all%20three%20branches%20and%20returns%20%60block%60%20unchanged%20without%20inserting%20anything.%20A%20caller%20reading%20only%20the%20docstring%20would%20not%20know%20that%20the%20insertion%20can%20silently%20be%20skipped.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=lgtm-hq%2Flgtm-ci&pr=581&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["docs(scripts): tighten docstrings per re..."](https://github.com/lgtm-hq/lgtm-ci/commit/b2831eb5a4acf052934f6a355055ba0dd9735df1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44890248)</sub>

<!-- /greptile_comment -->