### PR TITLE
docs(contract): document v0.50.0 harden-runner egress semantics and merge-queue-safe required-check guidance

### DIFF
--- a/docs/org-rulesets.md
+++ b/docs/org-rulesets.md
@@ -60,10 +60,15 @@ reported check path and breaks the ruleset gate (checks stay **Expected**
 while Actions shows green under the new name).
 
 Never require an **app-generated code-scanning summary check** (for example
-the bare `CodeQL` context from the github-advanced-security app) in a repo
-that uses a merge queue: the app only produces it on `pull_request` commits,
-never merge-group commits, so every queue entry times out and is silently
-ejected (holy-grail, 2026-07-11). Require the workflow-job contexts instead.
+the bare `CodeQL` context from the github-advanced-security app, without a
+`{caller_job_id} /` prefix) in a repo that uses a merge queue: the app produces
+that check only on `pull_request` commits, never on `merge_group` commits, so
+every queue entry times out and is silently ejected
+([holy-grail#143](https://github.com/lgtm-hq/holy-grail/pull/143)). Require
+the workflow-job contexts from `reusable-codeql.yml` instead — for example
+`codeql / 🔬 CodeQL Analysis` — matching the exact `{caller_job_id} / {job-name}`
+path in this registry. Never combine a merge queue with required app-level
+code-scanning summary checks.
 
 When migrating additional rulesets, update this table in the same PR that
 updates the live ruleset.

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -699,13 +699,46 @@ Reusable workflows default to `egress-policy: block` and
 `allowed-endpoints-mode: replace`. `resolve-egress-allowlist` expands presets via
 bundled `lib/egress/presets.sh` (synced from `scripts/ci/lib/egress/presets.sh`).
 
+### Pre-enforcement allowlist (harden-runner, since v0.50.0)
+
+Since [#467](https://github.com/lgtm-hq/lgtm-ci/issues/467) (v0.50.0), reusables feed
+the caller's `allowed-endpoints` **verbatim** to the job-start
+`step-security/harden-runner` step, before `resolve-egress-allowlist` runs. That
+pre-enforcement value **replaces** the reusable's default GitHub/Ubuntu baseline
+whenever it is non-empty — even when `allowed-endpoints-mode: append` (append only
+affects the later, non-enforcing resolution step for tooling/checkout helpers).
+
+`step-security/harden-runner` splits `allowed-endpoints` on **spaces**. A
+newline-separated `|` literal block (the common multiline YAML style) is passed as a
+single bogus endpoint (string ending in `:0`), which blocks **all** egress — including
+`github.com:443` checkout. Prefer a folded scalar (`>-`) with space-separated
+`host:port` tokens, or use `egress-preset` / `allowed-endpoints-mode: append` with
+empty caller endpoints so the baked-in preset reaches pre-enforcement.
+
+Upgrade incidents during org-wide v0.52.3 adoption
+([#510](https://github.com/lgtm-hq/lgtm-ci/issues/510)):
+[homebrew-tap#126](https://github.com/lgtm-hq/homebrew-tap/pull/126),
+[podex#152](https://github.com/lgtm-hq/podex/pull/152),
+[Rustume#385](https://github.com/lgtm-hq/Rustume/pull/385),
+[turbo-themes#526](https://github.com/lgtm-hq/turbo-themes/pull/526),
+[py-lintro#1281](https://github.com/lgtm-hq/py-lintro/pull/1281).
+
+A future release may restore pre-enforcement normalization in
+[#467](https://github.com/lgtm-hq/lgtm-ci/issues/467) so presets merge again before
+the harden-runner `pre` hook runs; until then, treat non-empty `allowed-endpoints`
+as the complete enforced allowlist.
+
+The table below describes `resolve-egress-allowlist` / `allowed-endpoints-mode` only
+(not the pre-enforcement harden-runner step):
+
 | Mode      | Behavior                                                                        |
 | --------- | ------------------------------------------------------------------------------- |
 | `replace` | Non-empty `allowed-endpoints` overrides `egress-preset`; empty uses preset only |
 | `append`  | Merges preset + `allowed-endpoints` (deduped, first-seen wins)                  |
 
 Use `append` to keep lgtm-ci defaults and add project-specific hosts. Empty
-`allowed-endpoints` under `append` still means preset-only (same as omitting extras).
+`allowed-endpoints` under `append` still means preset-only (same as omitting extras)
+and is the safe way to inherit the reusable preset at pre-enforcement.
 `audit` mode is unchanged (no enforced allowlist).
 
 | Preset           | Use case                                                             |
@@ -733,6 +766,41 @@ egress-preset: quality
 `timeout-minutes: 45`.
 
 ## Egress block examples
+
+### Allowlist formatting
+
+**Wrong** — `|` block becomes one token; harden-runner blocks all egress:
+
+```yaml
+allowed-endpoints: |
+  github.com:443
+  api.github.com:443
+```
+
+**Right** — folded scalar (`>-`) yields space-separated hosts:
+
+```yaml
+allowed-endpoints: >-
+  github.com:443
+  api.github.com:443
+```
+
+**Right** — rely on preset (recommended when the reusable ships one):
+
+```yaml
+egress-preset: quality
+allowed-endpoints-mode: append
+allowed-endpoints: ''
+```
+
+Or add project-specific hosts without replacing the preset baseline:
+
+```yaml
+egress-preset: quality
+allowed-endpoints-mode: append
+allowed-endpoints: >-
+  ghcr.io:443
+```
 
 ### Node / Bun (web)
 
@@ -1201,6 +1269,18 @@ Callers using GitHub merge queue must add `merge_group:` triggers to every
 caller workflow that produces a required check, alongside `pull_request:` —
 otherwise queued PRs time out waiting for checks that never report. The
 starter examples (`examples/ci-*.yml`) include `merge_group:` by default.
+
+### App-level code-scanning checks
+
+Never require the github-advanced-security app's code-scanning **summary** context
+(`CodeQL` alone, without a caller-job prefix) in a ruleset when the repo uses a
+merge queue. The app produces that check only on `pull_request` commits, never on
+`merge_group` commits, so every queue entry times out and is silently ejected
+([holy-grail#143](https://github.com/lgtm-hq/holy-grail/pull/143), twice during
+v0.52.3 adoption). Require the workflow-job contexts instead — for example
+`codeql / 🔬 CodeQL Analysis` (the `{caller_job_id} / {job-name}` path your caller
+passes to `reusable-codeql.yml`). See [org-rulesets.md](org-rulesets.md)
+(Check-name contract).
 
 | Workflow                               | `merge_group` behavior                         |
 | -------------------------------------- | ---------------------------------------------- |

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -709,11 +709,12 @@ whenever it is non-empty — even when `allowed-endpoints-mode: append` (append 
 affects the later, non-enforcing resolution step for tooling/checkout helpers).
 
 `step-security/harden-runner` splits `allowed-endpoints` on **spaces**. A
-newline-separated `|` literal block (the common multiline YAML style) is passed as a
-single bogus endpoint (string ending in `:0`), which blocks **all** egress — including
-`github.com:443` checkout. Prefer a folded scalar (`>-`) with space-separated
-`host:port` tokens, or use `egress-preset` / `allowed-endpoints-mode: append` with
-empty caller endpoints so the baked-in preset reaches pre-enforcement.
+newline-separated `|` literal block (the common multiline YAML style) is treated as
+a single unrecognised host:port token (the whole multiline string), which blocks
+**all** egress — including `github.com:443` checkout. Prefer a folded scalar (`>-`)
+with space-separated `host:port` tokens, or use `egress-preset` /
+`allowed-endpoints-mode: append` with empty caller endpoints so the baked-in preset
+reaches pre-enforcement.
 
 Upgrade incidents during org-wide v0.52.3 adoption
 ([#510](https://github.com/lgtm-hq/lgtm-ci/issues/510)):
@@ -723,10 +724,10 @@ Upgrade incidents during org-wide v0.52.3 adoption
 [turbo-themes#526](https://github.com/lgtm-hq/turbo-themes/pull/526),
 [py-lintro#1281](https://github.com/lgtm-hq/py-lintro/pull/1281).
 
-A future release may restore pre-enforcement normalization in
-[#467](https://github.com/lgtm-hq/lgtm-ci/issues/467) so presets merge again before
-the harden-runner `pre` hook runs; until then, treat non-empty `allowed-endpoints`
-as the complete enforced allowlist.
+A future release may restore pre-enforcement normalization (tracked in the same
+[#467](https://github.com/lgtm-hq/lgtm-ci/issues/467) thread) so presets merge again
+before the harden-runner `pre` hook runs; until then, treat non-empty
+`allowed-endpoints` as the complete enforced allowlist.
 
 The table below describes `resolve-egress-allowlist` / `allowed-endpoints-mode` only
 (not the pre-enforcement harden-runner step):


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Document two consumer-facing gotchas surfaced during org-wide v0.52.3 adoption (#510): v0.50.0 harden-runner pre-enforcement egress replace semantics, and merge-queue incompatibility with app-level CodeQL summary checks.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #512

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This documentation-only PR records two consumer-facing gotchas uncovered during the org-wide v0.52.3 adoption: the v0.50.0 harden-runner pre-enforcement egress replace semantics (including the `|` vs `>-` YAML formatting trap), and the incompatibility between app-level CodeQL summary checks and GitHub merge queues.

- **`docs/workflow-contract.md`**: Adds a \"Pre-enforcement allowlist\" section explaining that since v0.50.0 a non-empty `allowed-endpoints` is passed verbatim to harden-runner before `resolve-egress-allowlist` runs, overriding the baseline even under `append` mode; includes a new \"Allowlist formatting\" subsection with wrong/right YAML examples and links to the five upgrade-incident PRs.
- **`docs/org-rulesets.md`**: Expands the merge-queue warning to name the concrete check context (`codeql / 🔬 CodeQL Analysis`), reference the incident PR (`holy-grail#143`), and reinforce that only workflow-job contexts are safe to require in merge-queue rulesets.
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no functional code modified; safe to merge.

Both files contain only prose and YAML example additions. The new egress semantics section and merge-queue check guidance accurately reflect the described v0.50.0 behaviour and registry table. The one inconsistency — existing stack examples using `>` while new guidance promotes `>-` — is a minor documentation clarity gap that does not affect runtime behaviour of any shipped workflow.

docs/workflow-contract.md — the pre-existing Node/Bun, Rust, and PyPI stack examples use `>` while the newly added guidance examples use `>-`; a reader copying those older examples may be confused about which form is canonical.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/workflow-contract.md | Adds pre-enforcement egress semantics section (v0.50.0) and merge-queue code-scanning check guidance; new `>-` formatting examples are inconsistent with existing `>` stack examples in the same document. |
| docs/org-rulesets.md | Clarifies app-level CodeQL check merge-queue incompatibility with a concrete PR reference and adds workflow-job context example; changes are accurate and consistent with the registry table. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller passes allowed-endpoints] --> B{Non-empty?}
    B -- Yes --> C[harden-runner pre hook\nreceives value verbatim\nv0.50.0+]
    B -- No --> D[harden-runner uses\nreusable baseline]
    C --> E{YAML scalar type?}
    E -- literal block pipe --> F["❌ Entire multiline string\nbecomes one token\nAll egress blocked"]
    E -- folded >- or empty --> G["✅ Space-separated tokens\nParsed correctly"]
    G --> H[resolve-egress-allowlist runs\nappend / replace mode applies]
    D --> H
    F --> X[Checkout fails]
    H --> I{allowed-endpoints-mode?}
    I -- replace --> J[Non-empty overrides preset\nEmpty uses preset only]
    I -- append --> K[Merges preset + endpoints\ndeduped first-seen wins]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Caller passes allowed-endpoints] --> B{Non-empty?}
    B -- Yes --> C[harden-runner pre hook\nreceives value verbatim\nv0.50.0+]
    B -- No --> D[harden-runner uses\nreusable baseline]
    C --> E{YAML scalar type?}
    E -- literal block pipe --> F["❌ Entire multiline string\nbecomes one token\nAll egress blocked"]
    E -- folded >- or empty --> G["✅ Space-separated tokens\nParsed correctly"]
    G --> H[resolve-egress-allowlist runs\nappend / replace mode applies]
    D --> H
    F --> X[Checkout fails]
    H --> I{allowed-endpoints-mode?}
    I -- replace --> J[Non-empty overrides preset\nEmpty uses preset only]
    I -- append --> K[Merges preset + endpoints\ndeduped first-seen wins]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: address Greptile review on egress ..."](https://github.com/lgtm-hq/lgtm-ci/commit/590a826e1f8810c7ad6f347befae5dbbecf8679f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44895273)</sub>

<!-- /greptile_comment -->