### PR TITLE
refactor(test): extract shared _install_health_mocks helper for docker health bats suites

### DIFF
--- a/tests/bats/unit/actions/docker/test_health_check_local.bats
+++ b/tests/bats/unit/actions/docker/test_health_check_local.bats
@@ -5,6 +5,7 @@
 load "../../../../helpers/common"
 load "../../../../helpers/mocks"
 load "../../../../helpers/github_env"
+load "../../../../helpers/health_mocks"
 
 SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/docker/health-check-local.sh"
 
@@ -24,39 +25,6 @@ teardown() {
 	restore_path
 	teardown_github_env
 	teardown_temp_dir
-}
-
-_install_health_mocks() {
-	local mock_bin="${BATS_TEST_TMPDIR}/bin"
-	local docker_calls="${BATS_TEST_TMPDIR}/mock_calls_docker"
-	mkdir -p "$mock_bin"
-	: >"$docker_calls"
-
-	cat >"${mock_bin}/docker" <<EOF
-#!/usr/bin/env bash
-echo "\$*" >> '${docker_calls}'
-case "\$1" in
-run) echo "cid-local"; exit 0 ;;
-logs|rm) exit 0 ;;
-*) exit 0 ;;
-esac
-EOF
-	chmod +x "${mock_bin}/docker"
-
-	cat >"${mock_bin}/timeout" <<'EOF'
-#!/usr/bin/env bash
-shift
-exec "$@"
-EOF
-	chmod +x "${mock_bin}/timeout"
-
-	cat >"${mock_bin}/nc" <<'EOF'
-#!/usr/bin/env bash
-exit 0
-EOF
-	chmod +x "${mock_bin}/nc"
-
-	export PATH="${mock_bin}:$PATH"
 }
 
 @test "health-check-local.sh: runs health check against local image" {

--- a/tests/bats/unit/actions/docker/test_health_lib.bats
+++ b/tests/bats/unit/actions/docker/test_health_lib.bats
@@ -4,6 +4,7 @@
 
 load "../../../../helpers/common"
 load "../../../../helpers/mocks"
+load "../../../../helpers/health_mocks"
 
 LIB="${PROJECT_ROOT}/scripts/ci/actions/docker/health-lib.sh"
 ACTIONS_LIB="${PROJECT_ROOT}/scripts/ci/lib/actions.sh"
@@ -16,49 +17,6 @@ setup() {
 teardown() {
 	restore_path
 	teardown_temp_dir
-}
-
-_install_health_mocks() {
-	local mock_bin="${BATS_TEST_TMPDIR}/bin"
-	local docker_calls="${BATS_TEST_TMPDIR}/mock_calls_docker"
-	mkdir -p "$mock_bin"
-	: >"$docker_calls"
-
-	# docker: run prints a container id; logs/rm succeed
-	cat >"${mock_bin}/docker" <<EOF
-#!/usr/bin/env bash
-echo "\$*" >> '${docker_calls}'
-case "\$1" in
-run)
-	echo "cid123"
-	exit 0
-	;;
-logs|rm)
-	exit 0
-	;;
-*)
-	exit 0
-	;;
-esac
-EOF
-	chmod +x "${mock_bin}/docker"
-
-	# macOS/CI-safe timeout: ignore duration, run remaining args
-	cat >"${mock_bin}/timeout" <<'EOF'
-#!/usr/bin/env bash
-shift
-exec "$@"
-EOF
-	chmod +x "${mock_bin}/timeout"
-
-	# Make port_listening succeed immediately via nc
-	cat >"${mock_bin}/nc" <<'EOF'
-#!/usr/bin/env bash
-exit 0
-EOF
-	chmod +x "${mock_bin}/nc"
-
-	export PATH="${mock_bin}:$PATH"
 }
 
 @test "health-lib.sh: parse_duration_seconds accepts Ns form" {

--- a/tests/helpers/health_mocks.bash
+++ b/tests/helpers/health_mocks.bash
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Docker health-check command mocks for BATS tests
+#
+# Usage: In your .bats file:
+#   load "../../../../helpers/health_mocks"
+
+# Install docker, timeout, and nc mocks used by docker health-check tests.
+# Optional first argument sets the container id echoed by docker run.
+_install_health_mocks() {
+	local container_id="${1:-cid-health-mock}"
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	local docker_calls="${BATS_TEST_TMPDIR}/mock_calls_docker"
+	mkdir -p "$mock_bin"
+	: >"$docker_calls"
+
+	# docker: run prints a container id; logs/rm succeed
+	cat >"${mock_bin}/docker" <<EOF
+#!/usr/bin/env bash
+echo "\$*" >> '${docker_calls}'
+case "\$1" in
+run)
+	echo "${container_id}"
+	exit 0
+	;;
+logs|rm)
+	exit 0
+	;;
+*)
+	exit 0
+	;;
+esac
+EOF
+	chmod +x "${mock_bin}/docker"
+
+	# macOS/CI-safe timeout: ignore duration, run remaining args
+	cat >"${mock_bin}/timeout" <<'EOF'
+#!/usr/bin/env bash
+shift
+exec "$@"
+EOF
+	chmod +x "${mock_bin}/timeout"
+
+	# Make port_listening succeed immediately via nc
+	cat >"${mock_bin}/nc" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+	chmod +x "${mock_bin}/nc"
+
+	export PATH="${mock_bin}:$PATH"
+}

--- a/tests/helpers/health_mocks.bash
+++ b/tests/helpers/health_mocks.bash
@@ -48,5 +48,7 @@ exit 0
 EOF
 	chmod +x "${mock_bin}/nc"
 
-	export PATH="${mock_bin}:$PATH"
+	if [[ ":$PATH:" != *":${mock_bin}:"* ]]; then
+		export PATH="${mock_bin}:$PATH"
+	fi
 }


### PR DESCRIPTION
## Summary

Extract the duplicated `_install_health_mocks` function from the docker health BATS suites into a shared helper at `tests/helpers/health_mocks.bash`, and source it from both `test_health_check_local.bats` and `test_health_lib.bats`.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #562

## Test plan

- [x] `uv run lintro fmt` and `uv run lintro chk` (zero issues)
- [x] `bats --jobs 1 --recursive tests/bats` (full suite)
- [x] `bats tests/bats/unit/actions/docker/test_health_check_local.bats tests/bats/unit/actions/docker/test_health_lib.bats` (13/13 passing)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extracts the duplicated `_install_health_mocks` function from `test_health_check_local.bats` and `test_health_lib.bats` into a single shared helper at `tests/helpers/health_mocks.bash`, which is then `load`-ed from both files.

- The shared helper parameterizes the container ID via `${1:-cid-health-mock}`, replacing the previously hardcoded `cid-local` and `cid123` defaults; no test asserts on the container ID value itself, so behavior is unchanged.
- A defensive `if [[ ":$PATH:" != *":${mock_bin}:"* ]]; then` guard was added around the `export PATH` line, making the helper consistent with the rest of the mocking framework.
- Both `.bats` files drop their local copy of the function and add a `load "../../../../helpers/health_mocks"` line.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a pure extraction refactor with no changes to test logic or assertions.

No test asserts on the container ID value, so changing the default from cid-local/cid123 to cid-health-mock is harmless. The PATH-dedup guard is an improvement over the originals. The load paths resolve correctly for both callers at the same directory depth. No functional code was touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/helpers/health_mocks.bash | New shared helper; docker/timeout/nc mocks are correct, container ID is parameterized, and the PATH-dedup guard is properly applied. |
| tests/bats/unit/actions/docker/test_health_check_local.bats | Local _install_health_mocks definition removed; load added; all test logic preserved. |
| tests/bats/unit/actions/docker/test_health_lib.bats | Local _install_health_mocks definition removed; load added; all test logic preserved. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant B1 as test_health_check_local.bats
    participant B2 as test_health_lib.bats
    participant H as helpers/health_mocks.bash

    Note over B1,B2: BATS load phase
    B1->>H: load health_mocks
    B2->>H: load health_mocks
    H-->>B1: _install_health_mocks() available
    H-->>B2: _install_health_mocks() available

    Note over B1: Per-test setup
    B1->>H: _install_health_mocks()
    H-->>B1: writes mock docker/timeout/nc to BATS_TEST_TMPDIR/bin
    H-->>B1: exports PATH (guarded)

    Note over B2: Per-test setup
    B2->>H: _install_health_mocks()
    H-->>B2: writes mock docker/timeout/nc to BATS_TEST_TMPDIR/bin
    H-->>B2: exports PATH (guarded)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant B1 as test_health_check_local.bats
    participant B2 as test_health_lib.bats
    participant H as helpers/health_mocks.bash

    Note over B1,B2: BATS load phase
    B1->>H: load health_mocks
    B2->>H: load health_mocks
    H-->>B1: _install_health_mocks() available
    H-->>B2: _install_health_mocks() available

    Note over B1: Per-test setup
    B1->>H: _install_health_mocks()
    H-->>B1: writes mock docker/timeout/nc to BATS_TEST_TMPDIR/bin
    H-->>B1: exports PATH (guarded)

    Note over B2: Per-test setup
    B2->>H: _install_health_mocks()
    H-->>B2: writes mock docker/timeout/nc to BATS_TEST_TMPDIR/bin
    H-->>B2: exports PATH (guarded)
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(test): guard PATH prepend in health ..."](https://github.com/lgtm-hq/lgtm-ci/commit/24c22141b6ce9c9141052e5ac1598a3d46d8ac34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44896814)</sub>

<!-- /greptile_comment -->