### PR TITLE
fix(ci): pass COVERAGE env to node test summary staging step

### DIFF
--- a/.github/workflows/reusable-test-node.yml
+++ b/.github/workflows/reusable-test-node.yml
@@ -487,6 +487,7 @@ jobs:
         env:
           WORKING_DIRECTORY: ${{ inputs.working-directory }}
           COVERAGE_SUMMARY_FILE: ${{ inputs.coverage-summary-file }}
+          COVERAGE: ${{ inputs.coverage }}
         run: >-
           bash .lgtm-ci-tooling/scripts/ci/actions/stage-node-coverage-test-summary.sh
       - name: Upload coverage for test summary

--- a/tests/bats/integration/test_reusable_test_node.bats
+++ b/tests/bats/integration/test_reusable_test_node.bats
@@ -54,11 +54,13 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node.yml"
 			script = 0
 			env_wd = 0
 			env_cov = 0
+			env_coverage = 0
 		}
 		in_job && in_step && /stage-node-coverage-test-summary\.sh/ { script = 1 }
 		in_job && in_step && /WORKING_DIRECTORY:/ { env_wd = 1 }
 		in_job && in_step && /COVERAGE_SUMMARY_FILE:/ { env_cov = 1 }
-		END { exit !(script && env_wd && env_cov) }
+		in_job && in_step && /COVERAGE: \$\{\{ inputs\.coverage \}\}/ { env_coverage = 1 }
+		END { exit !(script && env_wd && env_cov && env_coverage) }
 	' "$WORKFLOW"
 	assert_success
 }
@@ -86,10 +88,12 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node.yml"
 			script = 0
 			env_wd = 0
 			env_cov = 0
+			env_coverage = 0
 		}
 		in_job && in_stage && /stage-node-coverage-test-summary\.sh/ { script = 1 }
 		in_job && in_stage && /WORKING_DIRECTORY:/ { env_wd = 1 }
 		in_job && in_stage && /COVERAGE_SUMMARY_FILE:/ { env_cov = 1 }
+		in_job && in_stage && /COVERAGE: \$\{\{ inputs\.coverage \}\}/ { env_coverage = 1 }
 		/^  publish-test-summary:/ { in_publish = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ {
 			in_publish = 0
@@ -99,7 +103,7 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node.yml"
 		in_publish && in_cov && /inputs\.working-directory/ && /inputs\.coverage-summary-file/ {
 			publish = 1
 		}
-		END { exit !(script && env_wd && env_cov && publish) }
+		END { exit !(script && env_wd && env_cov && env_coverage && publish) }
 	' "$WORKFLOW"
 	assert_success
 }

--- a/tests/bats/integration/test_reusable_test_node_custom.bats
+++ b/tests/bats/integration/test_reusable_test_node_custom.bats
@@ -57,11 +57,13 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node-custom.yml"
 			script = 0
 			env_wd = 0
 			env_cov = 0
+			env_coverage = 0
 		}
 		in_job && in_step && /stage-node-coverage-test-summary\.sh/ { script = 1 }
 		in_job && in_step && /WORKING_DIRECTORY:/ { env_wd = 1 }
 		in_job && in_step && /COVERAGE_SUMMARY_FILE:/ { env_cov = 1 }
-		END { exit !(script && env_wd && env_cov) }
+		in_job && in_step && /COVERAGE: \$\{\{ inputs\.coverage \}\}/ { env_coverage = 1 }
+		END { exit !(script && env_wd && env_cov && env_coverage) }
 	' "$WORKFLOW"
 	assert_success
 }
@@ -89,10 +91,12 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node-custom.yml"
 			script = 0
 			env_wd = 0
 			env_cov = 0
+			env_coverage = 0
 		}
 		in_job && in_stage && /stage-node-coverage-test-summary\.sh/ { script = 1 }
 		in_job && in_stage && /WORKING_DIRECTORY:/ { env_wd = 1 }
 		in_job && in_stage && /COVERAGE_SUMMARY_FILE:/ { env_cov = 1 }
+		in_job && in_stage && /COVERAGE: \$\{\{ inputs\.coverage \}\}/ { env_coverage = 1 }
 		/^  publish-test-summary:/ { in_publish = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  publish-test-summary:/ {
 			in_publish = 0
@@ -102,7 +106,7 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-test-node-custom.yml"
 		in_publish && in_cov && /inputs\.working-directory/ && /inputs\.coverage-summary-file/ {
 			publish = 1
 		}
-		END { exit !(script && env_wd && env_cov && publish) }
+		END { exit !(script && env_wd && env_cov && env_coverage && publish) }
 	' "$WORKFLOW"
 	assert_success
 }


### PR DESCRIPTION
## Summary

Fixes a hard failure in `reusable-test-node.yml` where the **Stage coverage for test summary** step calls `stage-node-coverage-test-summary.sh` without setting the required `COVERAGE` env var. Single-version Node callers with `coverage: true` and `publish-test-summary: true` on pull requests fail every required test job.

Audited sibling workflows: `reusable-test-node-custom.yml` already sets `COVERAGE`; no other workflows use this staging script.

After this release ships, Rustume can revert its `publish-test-summary: false` workaround (lgtm-hq/Rustume#385).

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #511
- Relates to #510

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a one-line omission in `reusable-test-node.yml` where the "Stage coverage for test summary" step was invoking `stage-node-coverage-test-summary.sh` without exposing `COVERAGE` as an environment variable, causing hard failures for any caller using `coverage: true` with `publish-test-summary: true` on pull requests.

- **Workflow fix**: adds `COVERAGE: ${{ inputs.coverage }}` to the env block of the staging step, matching the pattern already present in the sibling `reusable-test-node-custom.yml`.
- **Test updates**: both bats contract-test files are extended with an `env_coverage` assertion so the new env var is verified structurally, and the `reusable-test-node-custom.yml` tests gain the same assertion as a hardening step.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single env-var addition that unblocks a hard CI failure and is fully verified by updated contract tests.

The diff is minimal and surgical: one line added to the workflow env block, two bats files updated consistently to assert that line exists. The fix matches the established pattern in the custom-workflow sibling, and a grep across all workflows confirms no other caller of stage-node-coverage-test-summary.sh is affected. No logic is altered; only the missing env var is supplied.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-test-node.yml | Adds the missing `COVERAGE: ${{ inputs.coverage }}` env var to the "Stage coverage for test summary" step, fixing failures for callers using `coverage: true` with `publish-test-summary: true` on PRs. |
| tests/bats/integration/test_reusable_test_node.bats | Two awk-based contract tests updated to assert `COVERAGE: ${{ inputs.coverage }}` is present in the staging step; correctly tracks the bug fix. |
| tests/bats/integration/test_reusable_test_node_custom.bats | Parallel test hardening — adds env_coverage assertions for the custom workflow (which already carried COVERAGE), bringing its test contract in line with the fixed main workflow. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as Caller Workflow
    participant RTN as reusable-test-node.yml
    participant Script as stage-node-coverage-test-summary.sh
    participant UA as actions/upload-artifact
    Caller->>RTN: workflow_call (PR event, coverage: true)
    Note over RTN: Stage coverage for test summary step
    RTN->>Script: bash (WORKING_DIRECTORY, COVERAGE_SUMMARY_FILE, COVERAGE)
    Script-->>RTN: stages files into node-coverage-staged/
    RTN->>UA: Upload artifact node-coverage
    UA-->>Caller: artifact available for publish-test-summary
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as Caller Workflow
    participant RTN as reusable-test-node.yml
    participant Script as stage-node-coverage-test-summary.sh
    participant UA as actions/upload-artifact
    Caller->>RTN: workflow_call (PR event, coverage: true)
    Note over RTN: Stage coverage for test summary step
    RTN->>Script: bash (WORKING_DIRECTORY, COVERAGE_SUMMARY_FILE, COVERAGE)
    Script-->>RTN: stages files into node-coverage-staged/
    RTN->>UA: Upload artifact node-coverage
    UA-->>Caller: artifact available for publish-test-summary
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): pass COVERAGE env to node test ..."](https://github.com/lgtm-hq/lgtm-ci/commit/70b842585f1d53bcee5d6fe224a1c944ec9e183d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44899524)</sub>

<!-- /greptile_comment -->