### PR TITLE
test(docker): add unset-TAGS coverage for health-check-local script

### DIFF
--- a/tests/bats/unit/actions/docker/test_health_check_local.bats
+++ b/tests/bats/unit/actions/docker/test_health_check_local.bats
@@ -1,6 +1,9 @@
 #!/usr/bin/env bats
 # SPDX-License-Identifier: MIT
 # Purpose: Unit tests for scripts/ci/actions/docker/health-check-local.sh
+#
+# TAGS is resolved upstream by resolve-local-health-check-image.sh; unset-TAGS
+# failure coverage lives in test_resolve_local_images.bats.
 
 load "../../../../helpers/common"
 load "../../../../helpers/mocks"
@@ -68,6 +71,15 @@ EOF
 	run grep -F "run -d -p 127.0.0.1:8080:8080 ghcr.io/org/repo:local" \
 		"${BATS_TEST_TMPDIR}/mock_calls_docker"
 	assert_success
+}
+
+@test "health-check-local.sh: does not require TAGS" {
+	unset TAGS || true
+	_install_health_mocks
+
+	run bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Health check passed"
 }
 
 @test "health-check-local.sh: requires IMAGE" {


### PR DESCRIPTION
## Summary

Closes the CodeRabbit review gap from PR #555: `health-check-local.sh` does not read `TAGS` (it consumes `IMAGE` from the upstream `resolve-local-health-check-image` step). This PR adds an explicit unset-`TAGS` success test and documents where the failure-path coverage lives.

**Stacked on #583 / `refactor/562-shared-health-mocks`** — merge after #583 lands.

## Type of Change

- [ ] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None

## Closes

- Closes #563

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds one explicit bats test to `tests/bats/unit/actions/docker/test_health_check_local.bats`, documenting that `health-check-local.sh` does not consume `TAGS` (which is resolved upstream by `resolve-local-health-check-image.sh`). It also adds a file-level comment cross-referencing where unset-`TAGS` failure coverage lives.

- Adds `@test "health-check-local.sh: does not require TAGS"` that unsets `TAGS`, runs the script through the shared health mocks, and asserts both success and the expected `"Health check passed"` output.
- The header comment accurately describes the architecture: `TAGS` is consumed by `resolve-local-health-check-image.sh`, and its required-but-missing failure path is already covered in `test_resolve_local_images.bats`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single additive bats test with no production code touched.

The new test accurately reflects the script's behaviour: health-check-local.sh never references TAGS, so asserting success with TAGS unset is correct. The unset TAGS || true guard is the standard defensive pattern used throughout this test suite, the mocks are re-used consistently, and the cross-reference comment to test_resolve_local_images.bats is accurate. No existing tests are modified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tests/bats/unit/actions/docker/test_health_check_local.bats | Adds one explicit unset-TAGS success test and a header comment; test logic is correct and consistent with the existing pattern in this file. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CI as CI Workflow
    participant RLH as resolve-local-health-check-image.sh
    participant HCL as health-check-local.sh
    participant Test as test_health_check_local.bats

    CI->>RLH: TAGS (multi-line image refs)
    RLH-->>CI: outputs IMAGE (first tag)
    CI->>HCL: IMAGE, HEALTH_CHECK_CMD, HEALTH_CHECK_PORT
    Note over HCL: TAGS is NOT read here

    Note over Test: New test: unset TAGS, assert success
    Test->>HCL: IMAGE set, TAGS unset
    HCL-->>Test: "Health check passed" ✓
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CI as CI Workflow
    participant RLH as resolve-local-health-check-image.sh
    participant HCL as health-check-local.sh
    participant Test as test_health_check_local.bats

    CI->>RLH: TAGS (multi-line image refs)
    RLH-->>CI: outputs IMAGE (first tag)
    CI->>HCL: IMAGE, HEALTH_CHECK_CMD, HEALTH_CHECK_PORT
    Note over HCL: TAGS is NOT read here

    Note over Test: New test: unset TAGS, assert success
    Test->>HCL: IMAGE set, TAGS unset
    HCL-->>Test: "Health check passed" ✓
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(docker): document health-check-loca..."](https://github.com/lgtm-hq/lgtm-ci/commit/618ca8baf068af2ba6fa781e953be810a59f9ac2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44923931)</sub>

<!-- /greptile_comment -->