### PR TITLE
feat(sbom): add release-assets mode to reusable-sbom

### DIFF
--- a/.github/actions/harden-runner/lib/egress/presets.sh
+++ b/.github/actions/harden-runner/lib/egress/presets.sh
@@ -169,7 +169,9 @@ egress_preset_endpoints() {
 			api.deps.dev:443
 		;;
 	sbom)
-		# SBOM + Grype scan + Sigstore attestation (py-lintro sbom-on-main.yml).
+		# SBOM + Grype scan + Sigstore attestation/cosign + release asset upload.
+		# oauth2.sigstore.dev is required for keyless cosign OIDC in release-assets
+		# mode (#524); uploads.github.com for gh release upload.
 		printf '%s\n' \
 			github.com:443 \
 			api.github.com:443 \
@@ -177,6 +179,7 @@ egress_preset_endpoints() {
 			release-assets.githubusercontent.com:443 \
 			objects.githubusercontent.com:443 \
 			raw.githubusercontent.com:443 \
+			uploads.github.com:443 \
 			anchore.io:443 \
 			get.anchore.io:443 \
 			toolbox-data.anchore.io:443 \
@@ -186,7 +189,8 @@ egress_preset_endpoints() {
 			rekor.sigstore.dev:443 \
 			timestamp.sigstore.dev:443 \
 			tuf-repo-cdn.sigstore.dev:443 \
-			sigstore-tuf-root.storage.googleapis.com:443
+			sigstore-tuf-root.storage.googleapis.com:443 \
+			oauth2.sigstore.dev:443
 		;;
 	scorecard)
 		# OpenSSF Scorecard (reusable-scorecards.yml).

--- a/.github/workflows/reusable-sbom.yml
+++ b/.github/workflows/reusable-sbom.yml
@@ -153,15 +153,15 @@ on:
     outputs:
       sbom-file:
         description: "Path to the generated SBOM file, or 'none' if not generated"
-        value: ${{ jobs.sbom.outputs.sbom-file }}
+        value: ${{ jobs.sbom.outputs.sbom-file || 'none' }}
       vulnerabilities-found:
         description:
           "Whether vulnerabilities were found (true/false), or 'not-run' if scan was
           skipped"
-        value: ${{ jobs.sbom.outputs.vulnerabilities-found }}
+        value: ${{ jobs.sbom.outputs.vulnerabilities-found || 'not-run' }}
       attestation-url:
         description: "URL of the attestation, or 'not-run' if attestation was skipped"
-        value: ${{ jobs.sbom.outputs.attestation-url }}
+        value: ${{ jobs.sbom.outputs.attestation-url || 'not-run' }}
 
 jobs:
   validate:

--- a/.github/workflows/reusable-sbom.yml
+++ b/.github/workflows/reusable-sbom.yml
@@ -4,6 +4,13 @@ name: Reusable SBOM Workflow
 on:
   workflow_call:
     inputs:
+      mode:
+        description: >-
+          report: generate/scan/attest (default). release-assets: multi-format
+          SBOM + optional cosign sign + upload to the GitHub Release.
+        required: false
+        type: string
+        default: "report"
       target:
         description: "Target to generate SBOM for"
         required: false
@@ -15,12 +22,25 @@ on:
         type: string
         default: "dir"
       sbom-format:
-        description: "SBOM output format: cyclonedx-json, spdx-json"
+        description: "SBOM output format for report mode: cyclonedx-json, spdx-json"
         required: false
         type: string
         default: "cyclonedx-json"
+      formats:
+        description: >-
+          Comma-separated Syft formats for release-assets mode
+          (default: spdx-json,cyclonedx-json)
+        required: false
+        type: string
+        default: "spdx-json,cyclonedx-json"
+      sign:
+        description: >-
+          Cosign keyless (OIDC) sign SBOM files in release-assets mode
+        required: false
+        type: boolean
+        default: true
       scan-vulnerabilities:
-        description: "Scan SBOM for vulnerabilities"
+        description: "Scan SBOM for vulnerabilities (report mode)"
         required: false
         type: boolean
         default: true
@@ -48,15 +68,17 @@ on:
         default: "sbom"
       upload-release-assets:
         description: >-
-          When true, run a dedicated contents:write job that attaches the SBOM
-          artifact to the GitHub Release. Generation itself stays contents:read.
+          Report mode only: when true, run a dedicated contents:write job that
+          attaches the SBOM artifact to the GitHub Release. Generation itself
+          stays contents:read.
         required: false
         type: boolean
         default: false
       release-tag:
         description: >-
-          Release tag for asset upload when upload-release-assets is true.
-          Defaults to github.ref_name when empty.
+          Release tag for asset upload. Required when mode is release-assets.
+          In report mode with upload-release-assets, defaults to github.ref_name
+          when empty.
         required: false
         type: string
         default: ""
@@ -82,6 +104,7 @@ on:
           release-assets.githubusercontent.com:443
           objects.githubusercontent.com:443
           raw.githubusercontent.com:443
+          uploads.github.com:443
           anchore.io:443
           get.anchore.io:443
           toolbox-data.anchore.io:443
@@ -92,6 +115,7 @@ on:
           timestamp.sigstore.dev:443
           tuf-repo-cdn.sigstore.dev:443
           sigstore-tuf-root.storage.googleapis.com:443
+          oauth2.sigstore.dev:443
       allowed-endpoints-mode:
         description: >-
           replace: non-empty allowed-endpoints overrides egress-preset; append:
@@ -140,8 +164,42 @@ on:
         value: ${{ jobs.sbom.outputs.attestation-url }}
 
 jobs:
+  validate:
+    name: Validate SBOM inputs
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        if: runner.os == 'Linux' || runner.environment == 'self-hosted'
+        # Pinned to SHA for supply chain security
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            scripts/ci/
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+      - name: Validate mode inputs
+        shell: bash
+        env:
+          MODE: ${{ inputs.mode }}
+          RELEASE_TAG: ${{ inputs.release-tag }}
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/validate-sbom-mode.sh
+
   sbom:
     name: ${{ inputs.job-name }}
+    needs: [validate]
+    if: inputs.mode != 'release-assets'
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
@@ -223,8 +281,8 @@ jobs:
 
   upload-release-assets:
     name: Upload SBOM release assets
-    needs: [sbom]
-    if: inputs.upload-release-assets
+    needs: [validate, sbom]
+    if: inputs.mode != 'release-assets' && inputs.upload-release-assets
     runs-on: ${{ inputs.runner-image }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     permissions:
@@ -262,4 +320,85 @@ jobs:
           RELEASE_TAG: ${{ inputs.release-tag != '' && inputs.release-tag || github.ref_name }}
           ARTIFACT_NAME: ${{ inputs.artifact-name }}
           SBOM_ARTIFACT_DIR: sbom-artifact
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/upload-sbom-release-assets.sh
+
+  release-assets:
+    name: ${{ inputs.job-name }}
+    needs: [validate]
+    if: inputs.mode == 'release-assets'
+    runs-on: ${{ inputs.runner-image }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Harden runner
+        if: runner.os == 'Linux' || runner.environment == 'self-hosted'
+        # Pinned to SHA for supply chain security
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: ${{ inputs.egress-policy }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+      - name: Checkout repository at release tag
+        # Pinned to SHA for supply chain security
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.release-tag }}
+          persist-credentials: false
+      - name: Checkout lgtm-ci tooling
+        # yamllint disable-line rule:line-length
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: lgtm-hq/lgtm-ci
+          path: .lgtm-ci-tooling
+          ref: ${{ inputs.tooling-ref != '' && inputs.tooling-ref || github.workflow_sha }}
+          sparse-checkout: |
+            .github/actions/checkout-and-harden
+          sparse-checkout-cone-mode: true
+          persist-credentials: false
+      - name: Checkout and harden
+        id: egress
+        uses: ./.lgtm-ci-tooling/.github/actions/checkout-and-harden
+        with:
+          tooling-ref: ${{ inputs.tooling-ref }}
+          egress-policy: ${{ inputs.egress-policy }}
+          egress-preset: ${{ inputs.egress-preset }}
+          allowed-endpoints: ${{ inputs.allowed-endpoints }}
+          allowed-endpoints-mode: ${{ inputs.allowed-endpoints-mode }}
+          sparse-checkout-extra: |
+            scripts/ci/
+      - name: Install Syft
+        shell: bash
+        env:
+          STEP: install
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/generate-sbom-release-assets.sh
+      - name: Generate multi-format SBOMs
+        id: generate
+        shell: bash
+        env:
+          STEP: generate
+          TARGET: ${{ inputs.target }}
+          TARGET_TYPE: ${{ inputs.target-type }}
+          FORMATS: ${{ inputs.formats }}
+          OUTPUT_DIR: sbom
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/generate-sbom-release-assets.sh
+      - name: Install Cosign
+        if: inputs.sign
+        # Pinned to SHA for supply chain security
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      - name: Sign SBOM files
+        if: inputs.sign
+        shell: bash
+        env:
+          SIGN: ${{ inputs.sign }}
+          SBOM_DIR: sbom
+        run: bash .lgtm-ci-tooling/scripts/ci/actions/sign-sbom-release-assets.sh
+      - name: Upload SBOM assets to GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.release-tag }}
+          ARTIFACT_NAME: ${{ inputs.artifact-name }}
+          SBOM_ARTIFACT_DIR: sbom
         run: bash .lgtm-ci-tooling/scripts/ci/actions/upload-sbom-release-assets.sh

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -863,16 +863,27 @@ All inputs are opt-in; existing callers keep current behavior without changes.
 ### SBOM (`reusable-sbom.yml`)
 
 Generates an SBOM with Syft, optionally scans it with Grype, and can create a
-Sigstore attestation. Used by release layouts such as
+Sigstore attestation. `mode: release-assets` generates multi-format SBOMs,
+optionally cosign-signs them (keyless OIDC), and uploads them to a GitHub
+Release. Used by release layouts such as
 [python-release-publish.md](python-release-publish.md).
 
-| Input                  | Default      | Description                                      |
-| ---------------------- | ------------ | ------------------------------------------------ |
-| `scan-vulnerabilities` | `true`       | Run Grype against the generated SBOM             |
-| `fail-on-severity`     | `"critical"` | Fail when findings meet this severity or higher  |
-| `upload-sarif`         | `false`      | Upload Grype SARIF to GitHub Security            |
-| `create-attestation`   | `false`      | Create a Sigstore attestation for the SBOM       |
-| `egress-preset`        | `sbom`       | Harden-runner allowlist preset (workflow-contract) |
+<!-- markdownlint-disable MD013 -- SBOM input table; columns exceed default line length -->
+
+| Input                  | Default                      | Description                                      |
+| ---------------------- | ---------------------------- | ------------------------------------------------ |
+| `mode`                 | `report`                     | `report` or `release-assets`                     |
+| `formats`              | `spdx-json,cyclonedx-json`   | Syft formats for `release-assets` mode           |
+| `sign`                 | `true`                       | Cosign keyless sign in `release-assets` mode     |
+| `release-tag`          | `""`                         | Required when `mode: release-assets`             |
+| `scan-vulnerabilities` | `true`                       | Run Grype against the generated SBOM (report)    |
+| `fail-on-severity`     | `"critical"`                 | Fail when findings meet this severity or higher  |
+| `upload-sarif`         | `false`                      | Upload Grype SARIF to GitHub Security            |
+| `create-attestation`   | `false`                      | Create a Sigstore attestation for the SBOM       |
+| `upload-release-assets`| `false`                      | Report mode: attach artifact to release (#532)   |
+| `egress-preset`        | `sbom`                       | Harden-runner allowlist preset (workflow-contract) |
+
+<!-- markdownlint-enable MD013 -->
 
 **Breaking (#480):** `fail-on-severity` previously defaulted to `""` (advisory
 only). Callers that must keep advisory-only behavior should pass
@@ -889,6 +900,19 @@ sbom:
   with:
     # default fail-on-severity is critical; opt out for advisory-only:
     # fail-on-severity: ""
+```
+
+```yaml
+sbom-release:
+  uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@<sha>
+  permissions:
+    contents: write
+    id-token: write
+  with:
+    mode: release-assets
+    release-tag: ${{ github.ref_name }}
+    formats: spdx-json,cyclonedx-json
+    sign: true
 ```
 
 ## PR Automation And Security

--- a/docs/workflow-contract.md
+++ b/docs/workflow-contract.md
@@ -316,6 +316,12 @@ sibling when `coverage: true`). Node no longer uses inline matrix publish jobs
 | PyPI upload (OIDC)    | `contents: read`; `id-token` + `attestations: write` | `prepare-pypi-upload` + pypa step            |
 | PyPI build            | `contents: read`                                     | `reusable-build-python-dist.yml`             |
 | GitHub Release assets | `contents: write`                                    | `reusable-github-release.yml`                |
+| SBOM report           | `contents: read`, `security-events: write`,          | `reusable-sbom.yml` (`mode: report`)         |
+|                       | `id-token: write`, `attestations: write`             |                                              |
+| SBOM report + upload  | Report perms + `contents: write`                     | `reusable-sbom.yml`                          |
+|                       |                                                      | (`upload-release-assets: true`)              |
+| SBOM release assets   | `contents: write`, `id-token: write`                 | `reusable-sbom.yml`                          |
+|                       |                                                      | (`mode: release-assets`)                     |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -720,7 +726,7 @@ Use `append` to keep lgtm-ci defaults and add project-specific hosts. Empty
 | `npm-publish`    | npm OIDC trusted publish + Sigstore (`oauth2.sigstore.dev`)          |
 | `quality`        | Docker `lintro chk` (default on quality lint)                        |
 | `rust-release`   | Rust cross-compile releases (`reusable-build-rust-binaries.yml`)     |
-| `sbom`           | SBOM, Grype scan, Sigstore attestation                               |
+| `sbom`           | SBOM, Grype scan, Sigstore attestation/cosign, release upload        |
 | `scorecard`      | OpenSSF Scorecard (`reusable-scorecards.yml`)                        |
 | `osv-scanner`    | GitHub tooling + release assets + OSV APIs                           |
 
@@ -887,8 +893,24 @@ egress-policy: block
 egress-preset: sbom
 ```
 
-Covers GitHub, Anchore (Syft/Grype), Sigstore attestation hosts. Canonical list:
-`scripts/ci/lib/egress/presets.sh` (preset name `sbom`).
+Covers GitHub, Anchore (Syft/Grype), Sigstore attestation/cosign hosts
+(`fulcio.sigstore.dev`, `rekor.sigstore.dev`, `oauth2.sigstore.dev`), and
+`uploads.github.com` for release-asset upload. Canonical list:
+`scripts/ci/lib/egress/presets.sh` (preset name `sbom`). With
+`allowed-endpoints-mode: replace`, a non-empty `allowed-endpoints` input
+overrides the preset — callers that pass a custom allowlist must include the
+full baseline (see #512).
+
+#### Permissions by mode (`reusable-sbom.yml`)
+
+<!-- markdownlint-disable MD013 -- SBOM mode permissions; columns exceed default line length -->
+
+| Mode | Job permissions | Notes |
+| ---- | --------------- | ----- |
+| `report` (default) | `contents: read`, `security-events: write`, `id-token: write`, `attestations: write` | Scan/attest path; optional `upload-release-assets` job adds `contents: write` |
+| `release-assets` | `contents: write`, `id-token: write` | Multi-format generate + cosign sign + `gh release upload`; requires `release-tag` |
+
+<!-- markdownlint-enable MD013 -->
 
 `reusable-sbom.yml` defaults `fail-on-severity` to `critical` (breaking as of
 issue #480). The Grype gate fails the job when findings meet or exceed that
@@ -900,6 +922,21 @@ sbom:
   uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@<sha>
   with:
     fail-on-severity: "" # advisory-only; default is critical
+```
+
+Release-asset mode (multi-format + optional cosign, no Grype gate):
+
+```yaml
+sbom-release:
+  uses: lgtm-hq/lgtm-ci/.github/workflows/reusable-sbom.yml@<sha>
+  permissions:
+    contents: write
+    id-token: write
+  with:
+    mode: release-assets
+    release-tag: ${{ github.ref_name }}
+    formats: spdx-json,cyclonedx-json
+    sign: true
 ```
 
 ## Action pinning policy

--- a/scripts/ci/actions/generate-sbom-release-assets.sh
+++ b/scripts/ci/actions/generate-sbom-release-assets.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Generate multi-format SBOMs for release-asset mode.
+#
+# Required environment variables:
+#   none (defaults applied)
+#
+# Optional environment variables:
+#   TARGET       - Scan target (default: .)
+#   TARGET_TYPE  - dir | image | file (default: dir)
+#   FORMATS      - Comma/space/newline-separated Syft formats
+#                  (default: spdx-json,cyclonedx-json)
+#   OUTPUT_DIR   - Directory for generated SBOM files (default: sbom)
+#   SYFT_VERSION - Syft version for install step (default: latest)
+#   STEP         - install | generate | parse-formats (default: generate)
+#
+# parse-formats prints one canonical format per line (for tests / callers).
+
+set -euo pipefail
+
+: "${STEP:=generate}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/actions.sh
+source "$SCRIPT_DIR/../lib/actions.sh"
+
+# Parse FORMATS into canonical Syft format names (one per line).
+# Usage: parse_sbom_format_list "spdx-json, cyclonedx-json"
+parse_sbom_format_list() {
+	local raw="${1:-}"
+	local token
+	local -a formats=()
+	local normalized
+
+	raw="${raw//,/ }"
+	raw="${raw//$'\n'/ }"
+
+	for token in ${raw}; do
+		[[ -z "${token}" ]] && continue
+		normalized="$(normalize_sbom_format "${token}")"
+		if ! validate_sbom_format "${normalized}"; then
+			echo "::error::Unsupported SBOM format: ${token}" >&2
+			return 1
+		fi
+		formats+=("${normalized}")
+	done
+
+	if [[ ${#formats[@]} -eq 0 ]]; then
+		echo "::error::formats must list at least one SBOM format" >&2
+		return 1
+	fi
+
+	printf '%s\n' "${formats[@]}"
+}
+
+# Map a format to a stable release-asset filename under OUTPUT_DIR.
+sbom_release_filename() {
+	local format="$1"
+	local output_dir="$2"
+
+	case "${format}" in
+	spdx-json)
+		echo "${output_dir}/sbom.spdx.json"
+		;;
+	cyclonedx-json)
+		echo "${output_dir}/sbom.cyclonedx.json"
+		;;
+	cyclonedx-xml)
+		echo "${output_dir}/sbom.cyclonedx.xml"
+		;;
+	spdx-tag-value)
+		echo "${output_dir}/sbom.spdx"
+		;;
+	syft-json)
+		echo "${output_dir}/sbom.syft.json"
+		;;
+	*)
+		echo "${output_dir}/sbom$(get_sbom_extension "${format}")"
+		;;
+	esac
+}
+
+case "${STEP}" in
+parse-formats)
+	: "${FORMATS:=spdx-json,cyclonedx-json}"
+	parse_sbom_format_list "${FORMATS}"
+	;;
+
+install)
+	install_anchore_tool "syft" "${SYFT_VERSION:-latest}"
+	;;
+
+generate)
+	: "${TARGET:=.}"
+	: "${TARGET_TYPE:=dir}"
+	: "${FORMATS:=spdx-json,cyclonedx-json}"
+	: "${OUTPUT_DIR:=sbom}"
+
+	mkdir -p "${OUTPUT_DIR}"
+
+	mapfile -t format_list < <(parse_sbom_format_list "${FORMATS}")
+
+	if ! validate_scan_target "${TARGET}" "${TARGET_TYPE}"; then
+		log_error "Invalid target for type ${TARGET_TYPE}: ${TARGET}"
+		exit 1
+	fi
+
+	if ! SYFT_TARGET="$(resolve_scan_target "${TARGET}" "${TARGET_TYPE}")"; then
+		log_error "Unsupported target type: ${TARGET_TYPE}"
+		exit 1
+	fi
+
+	generated=()
+	for format in "${format_list[@]}"; do
+		outfile="$(sbom_release_filename "${format}" "${OUTPUT_DIR}")"
+		log_info "Generating ${format} -> ${outfile}"
+		syft "${SYFT_TARGET}" -o "${format}=${outfile}"
+		if [[ ! -f "${outfile}" ]]; then
+			log_error "Failed to generate SBOM: ${outfile}"
+			exit 1
+		fi
+		generated+=("${outfile}")
+	done
+
+	log_success "Generated ${#generated[@]} SBOM file(s) in ${OUTPUT_DIR}"
+	set_github_output "sbom-dir" "${OUTPUT_DIR}"
+	set_github_output "sbom-count" "${#generated[@]}"
+	if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+		{
+			echo "sbom-files<<EOF"
+			printf '%s\n' "${generated[@]}"
+			echo "EOF"
+		} >>"${GITHUB_OUTPUT}"
+	fi
+	;;
+
+*)
+	die_unknown_step "${STEP}"
+	;;
+esac

--- a/scripts/ci/actions/generate-sbom-release-assets.sh
+++ b/scripts/ci/actions/generate-sbom-release-assets.sh
@@ -98,7 +98,14 @@ generate)
 
 	mkdir -p "${OUTPUT_DIR}"
 
-	mapfile -t format_list < <(parse_sbom_format_list "${FORMATS}")
+	# Process substitution does not propagate non-zero exit under mapfile;
+	# capture first so invalid FORMATS fail the step.
+	_fmt_out="$(parse_sbom_format_list "${FORMATS}")" || exit 1
+	mapfile -t format_list <<<"${_fmt_out}"
+	if [[ ${#format_list[@]} -eq 0 ]]; then
+		echo "::error::No valid SBOM formats parsed from FORMATS" >&2
+		exit 1
+	fi
 
 	if ! validate_scan_target "${TARGET}" "${TARGET_TYPE}"; then
 		log_error "Invalid target for type ${TARGET_TYPE}: ${TARGET}"

--- a/scripts/ci/actions/sign-sbom-release-assets.sh
+++ b/scripts/ci/actions/sign-sbom-release-assets.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Cosign-sign SBOM release assets (keyless OIDC) with optional gating.
+#
+# Required environment variables:
+#   SBOM_DIR - Directory containing SBOM files to sign
+#
+# Optional environment variables:
+#   SIGN - When false/0/no/off, skip signing and exit 0 (default: true)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)"
+# shellcheck source=../lib/actions.sh
+source "$SCRIPT_DIR/../lib/actions.sh"
+
+: "${SBOM_DIR:?SBOM_DIR is required}"
+SIGN="${SIGN:-true}"
+
+case "$(printf '%s' "${SIGN}" | tr '[:upper:]' '[:lower:]')" in
+false | 0 | no | off)
+	log_info "Skipping SBOM signing (sign=${SIGN})"
+	set_github_output "signed-count" "0"
+	set_github_output "skipped" "true"
+	exit 0
+	;;
+esac
+
+if [[ ! -d "${SBOM_DIR}" ]]; then
+	echo "::error::SBOM directory not found: ${SBOM_DIR}" >&2
+	exit 1
+fi
+
+if ! command -v cosign >/dev/null 2>&1; then
+	die "cosign not found. Install via sigstore/cosign-installer action."
+fi
+
+mapfile -t sbom_files < <(
+	find "${SBOM_DIR}" -type f \
+		\( -name '*.json' -o -name '*.xml' -o -name '*.spdx' \) \
+		! -name '*.bundle' ! -name '*.sig' ! -name '*.pem' ! -name '.*' |
+		sort
+)
+
+if [[ ${#sbom_files[@]} -eq 0 ]]; then
+	echo "::error::No SBOM files found to sign in ${SBOM_DIR}" >&2
+	exit 1
+fi
+
+log_info "Signing ${#sbom_files[@]} SBOM file(s) with Cosign keyless signing"
+
+signed_count=0
+for sbom_file in "${sbom_files[@]}"; do
+	bundle_file="${sbom_file}.bundle"
+	log_info "Signing: ${sbom_file}"
+	cosign sign-blob --yes --bundle="${bundle_file}" "${sbom_file}"
+	if [[ ! -f "${bundle_file}" ]]; then
+		log_error "Failed to create signature bundle: ${bundle_file}"
+		exit 1
+	fi
+	signed_count=$((signed_count + 1))
+	log_success "Signed: $(basename "${sbom_file}")"
+done
+
+log_success "Successfully signed ${signed_count} SBOM file(s)"
+set_github_output "signed-count" "${signed_count}"
+set_github_output "skipped" "false"

--- a/scripts/ci/actions/validate-sbom-mode.sh
+++ b/scripts/ci/actions/validate-sbom-mode.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# Purpose: Validate reusable-sbom mode inputs before generate/sign/upload.
+#
+# Required environment variables:
+#   MODE - Workflow mode: report | release-assets (default: report)
+#
+# Optional environment variables:
+#   RELEASE_TAG - Required when MODE=release-assets
+
+set -euo pipefail
+
+MODE="${MODE:-report}"
+
+case "${MODE}" in
+report) ;;
+release-assets)
+	if [[ -z "${RELEASE_TAG:-}" ]]; then
+		echo "::error::release-tag is required when mode is release-assets" >&2
+		exit 1
+	fi
+	;;
+*)
+	echo "::error::Invalid mode '${MODE}' (expected report or release-assets)" >&2
+	exit 1
+	;;
+esac
+
+echo "SBOM mode validated: ${MODE}"

--- a/scripts/ci/lib/egress/presets.sh
+++ b/scripts/ci/lib/egress/presets.sh
@@ -169,7 +169,9 @@ egress_preset_endpoints() {
 			api.deps.dev:443
 		;;
 	sbom)
-		# SBOM + Grype scan + Sigstore attestation (py-lintro sbom-on-main.yml).
+		# SBOM + Grype scan + Sigstore attestation/cosign + release asset upload.
+		# oauth2.sigstore.dev is required for keyless cosign OIDC in release-assets
+		# mode (#524); uploads.github.com for gh release upload.
 		printf '%s\n' \
 			github.com:443 \
 			api.github.com:443 \
@@ -177,6 +179,7 @@ egress_preset_endpoints() {
 			release-assets.githubusercontent.com:443 \
 			objects.githubusercontent.com:443 \
 			raw.githubusercontent.com:443 \
+			uploads.github.com:443 \
 			anchore.io:443 \
 			get.anchore.io:443 \
 			toolbox-data.anchore.io:443 \
@@ -186,7 +189,8 @@ egress_preset_endpoints() {
 			rekor.sigstore.dev:443 \
 			timestamp.sigstore.dev:443 \
 			tuf-repo-cdn.sigstore.dev:443 \
-			sigstore-tuf-root.storage.googleapis.com:443
+			sigstore-tuf-root.storage.googleapis.com:443 \
+			oauth2.sigstore.dev:443
 		;;
 	scorecard)
 		# OpenSSF Scorecard (reusable-scorecards.yml).

--- a/scripts/ci/quality/validate-static-job-names.sh
+++ b/scripts/ci/quality/validate-static-job-names.sh
@@ -34,9 +34,14 @@ fi
 # Event-gated (check is not required so skip does not block merge):
 #   reusable-dependency-review.yml:dependency-review
 #
+# Mode-gated SBOM (#524): report vs release-assets share job-name for ruleset
+# contexts; exactly one of the two jobs runs per call.
+#   reusable-sbom.yml:sbom
+#   reusable-sbom.yml:release-assets
+#
 # Uses always() — never actually skips; conditional-success gate:
 #   reusable-required-check.yml:gate
-STATIC_JOB_NAME_EXCEPTIONS="${STATIC_JOB_NAME_EXCEPTIONS-reusable-dependency-review.yml:dependency-review reusable-required-check.yml:gate reusable-test-e2e.yml:test reusable-test-rust-build.yml:build reusable-test-node.yml:test-vitest reusable-site-quality.yml:site-build-link reusable-site-quality.yml:site-test reusable-test-python.yml:test reusable-test-node-custom.yml:test reusable-test-shell.yml:test reusable-rust-test.yml:test}"
+STATIC_JOB_NAME_EXCEPTIONS="${STATIC_JOB_NAME_EXCEPTIONS-reusable-dependency-review.yml:dependency-review reusable-required-check.yml:gate reusable-test-e2e.yml:test reusable-test-rust-build.yml:build reusable-test-node.yml:test-vitest reusable-site-quality.yml:site-build-link reusable-site-quality.yml:site-test reusable-test-python.yml:test reusable-test-node-custom.yml:test reusable-test-shell.yml:test reusable-rust-test.yml:test reusable-sbom.yml:sbom reusable-sbom.yml:release-assets}"
 
 violations=0
 

--- a/tests/bats/integration/test_reusable_sbom.bats
+++ b/tests/bats/integration/test_reusable_sbom.bats
@@ -79,7 +79,10 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-sbom.yml"
 	run awk '
 		/^  upload-release-assets:/ { in_job = 1 }
 		/^  [a-zA-Z0-9_-]+:/ && !/^  upload-release-assets:/ { in_job = 0 }
-		in_job && /if: inputs\.upload-release-assets/ { found = 1; exit }
+		in_job && /if: inputs\.mode != '\''release-assets'\'' && inputs\.upload-release-assets/ {
+			found = 1
+			exit
+		}
 		END { exit !found }
 	' "$WORKFLOW"
 	assert_success
@@ -95,4 +98,69 @@ WORKFLOW="${PROJECT_ROOT}/.github/workflows/reusable-sbom.yml"
 		END { exit !found }
 	' "$WORKFLOW"
 	assert_success
+}
+
+@test "reusable-sbom: mode defaults to report" {
+	run awk '/^      mode:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: "report"'
+}
+
+@test "reusable-sbom: formats default to spdx and cyclonedx json" {
+	run awk '/^      formats:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: "spdx-json,cyclonedx-json"'
+}
+
+@test "reusable-sbom: sign defaults to true" {
+	run awk '/^      sign:$/{show=1;next} show&&/^      [a-z]/ {exit} show{print}' \
+		"$WORKFLOW"
+	assert_success
+	assert_output --partial 'default: true'
+}
+
+@test "reusable-sbom: report job skipped in release-assets mode" {
+	run awk '
+		/^  sbom:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  sbom:/ { in_job = 0 }
+		in_job && /if: inputs\.mode != '\''release-assets'\''/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-sbom: release-assets job uses contents write and id-token write" {
+	run awk '
+		/^  release-assets:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  release-assets:/ { in_job = 0 }
+		in_job && /^    permissions:/ { perms = 1 }
+		in_job && perms && /^      contents: write$/ { contents = 1 }
+		in_job && perms && /^      id-token: write$/ { idtoken = 1 }
+		in_job && perms && /^    [a-z]/ && !/^    permissions:/ { perms = 0 }
+		END { exit !(contents && idtoken) }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-sbom: release-assets job gated on mode" {
+	run awk '
+		/^  release-assets:/ { in_job = 1 }
+		/^  [a-zA-Z0-9_-]+:/ && !/^  release-assets:/ { in_job = 0 }
+		in_job && /if: inputs\.mode == '\''release-assets'\''/ { found = 1; exit }
+		END { exit !found }
+	' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-sbom: validate job invokes validate-sbom-mode.sh" {
+	run grep -F 'scripts/ci/actions/validate-sbom-mode.sh' "$WORKFLOW"
+	assert_success
+}
+
+@test "reusable-sbom: release-assets reuses upload-sbom-release-assets.sh" {
+	run grep -cF 'scripts/ci/actions/upload-sbom-release-assets.sh' "$WORKFLOW"
+	assert_success
+	[[ "$output" -ge 2 ]]
 }

--- a/tests/bats/unit/actions/test_generate_sbom_release_assets.bats
+++ b/tests/bats/unit/actions/test_generate_sbom_release_assets.bats
@@ -50,6 +50,22 @@ teardown() {
 	assert_output --partial "::error::formats must list at least one SBOM format"
 }
 
+@test "generate-sbom-release-assets: generate fails when FORMATS is invalid" {
+	local target_dir="${BATS_TEST_TMPDIR}/src"
+	mkdir -p "$target_dir"
+	printf 'ok\n' >"${target_dir}/file.txt"
+
+	run env \
+		STEP=generate \
+		TARGET="$target_dir" \
+		TARGET_TYPE=dir \
+		FORMATS="not-a-format" \
+		OUTPUT_DIR="${BATS_TEST_TMPDIR}/sbom" \
+		bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "::error::Unsupported SBOM format: not-a-format"
+}
+
 @test "generate-sbom-release-assets: generate writes files and assembles upload paths" {
 	local target_dir="${BATS_TEST_TMPDIR}/src"
 	mkdir -p "$target_dir"

--- a/tests/bats/unit/actions/test_generate_sbom_release_assets.bats
+++ b/tests/bats/unit/actions/test_generate_sbom_release_assets.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/actions/generate-sbom-release-assets.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+load "../../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/generate-sbom-release-assets.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+	setup_github_env
+	export LIB_DIR
+	export PROJECT_ROOT
+	export SCRIPT
+}
+
+teardown() {
+	restore_path
+	teardown_github_env
+	teardown_temp_dir
+}
+
+@test "generate-sbom-release-assets: parse-formats defaults to spdx+cyclonedx json" {
+	run env STEP=parse-formats bash "$SCRIPT"
+	assert_success
+	assert_output --partial "spdx-json"
+	assert_output --partial "cyclonedx-json"
+}
+
+@test "generate-sbom-release-assets: parse-formats splits comma and space lists" {
+	run env STEP=parse-formats FORMATS="spdx-json, cyclonedx-xml" bash "$SCRIPT"
+	assert_success
+	assert_equal "$(printf '%s\n' "$output" | wc -l | tr -d ' ')" "2"
+	assert_output --partial "spdx-json"
+	assert_output --partial "cyclonedx-xml"
+}
+
+@test "generate-sbom-release-assets: parse-formats rejects unknown format with ::error::" {
+	run env STEP=parse-formats FORMATS="not-a-format" bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "::error::Unsupported SBOM format: not-a-format"
+}
+
+@test "generate-sbom-release-assets: parse-formats rejects empty list with ::error::" {
+	run env STEP=parse-formats FORMATS=" , " bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "::error::formats must list at least one SBOM format"
+}
+
+@test "generate-sbom-release-assets: generate writes files and assembles upload paths" {
+	local target_dir="${BATS_TEST_TMPDIR}/src"
+	mkdir -p "$target_dir"
+	printf 'ok\n' >"${target_dir}/file.txt"
+
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+	cat >"${mock_bin}/syft" <<'EOF'
+#!/usr/bin/env bash
+# syft <target> -o format=outfile
+outfile=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	-o)
+		outfile="${2#*=}"
+		shift 2
+		;;
+	*)
+		shift
+		;;
+	esac
+done
+printf '{"bomFormat":"CycloneDX"}\n' >"$outfile"
+EOF
+	chmod +x "${mock_bin}/syft"
+	export PATH="${mock_bin}:$PATH"
+
+	run env \
+		STEP=generate \
+		TARGET="$target_dir" \
+		TARGET_TYPE=dir \
+		FORMATS="spdx-json,cyclonedx-json" \
+		OUTPUT_DIR="${BATS_TEST_TMPDIR}/sbom" \
+		bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Generated 2 SBOM file(s)"
+
+	[[ -f "${BATS_TEST_TMPDIR}/sbom/sbom.spdx.json" ]]
+	[[ -f "${BATS_TEST_TMPDIR}/sbom/sbom.cyclonedx.json" ]]
+
+	run grep -E 'sbom-files|sbom\.spdx\.json|sbom\.cyclonedx\.json' "${GITHUB_OUTPUT}"
+	assert_success
+	assert_output --partial "sbom.spdx.json"
+	assert_output --partial "sbom.cyclonedx.json"
+}

--- a/tests/bats/unit/actions/test_sign_sbom_release_assets.bats
+++ b/tests/bats/unit/actions/test_sign_sbom_release_assets.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/actions/sign-sbom-release-assets.sh
+
+load "../../../helpers/common"
+load "../../../helpers/mocks"
+load "../../../helpers/github_env"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/sign-sbom-release-assets.sh"
+
+setup() {
+	setup_temp_dir
+	save_path
+	setup_github_env
+	export LIB_DIR
+	export PROJECT_ROOT
+	export SCRIPT
+	export SBOM_DIR="${BATS_TEST_TMPDIR}/sbom"
+	mkdir -p "$SBOM_DIR"
+	printf '{"bomFormat":"CycloneDX"}\n' >"${SBOM_DIR}/sbom.cyclonedx.json"
+	printf '{"spdxVersion":"SPDX-2.3"}\n' >"${SBOM_DIR}/sbom.spdx.json"
+}
+
+teardown() {
+	restore_path
+	teardown_github_env
+	teardown_temp_dir
+}
+
+_mock_cosign_bundle() {
+	local mock_bin="${BATS_TEST_TMPDIR}/bin"
+	mkdir -p "$mock_bin"
+	cat >"${mock_bin}/cosign" <<'MOCK'
+#!/usr/bin/env bash
+bundle=""
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--bundle=*)
+		bundle="${1#--bundle=}"
+		shift
+		;;
+	--bundle)
+		bundle="$2"
+		shift 2
+		;;
+	*)
+		shift
+		;;
+	esac
+done
+if [[ -n "$bundle" ]]; then
+	echo '{"payload":"fake"}' >"$bundle"
+fi
+exit 0
+MOCK
+	chmod +x "${mock_bin}/cosign"
+	export PATH="${mock_bin}:$PATH"
+}
+
+@test "sign-sbom-release-assets: skips when sign is false" {
+	run env SIGN=false bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Skipping SBOM signing"
+	[[ ! -f "${SBOM_DIR}/sbom.cyclonedx.json.bundle" ]]
+}
+
+@test "sign-sbom-release-assets: skips when sign is off" {
+	run env SIGN=off bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Skipping SBOM signing"
+}
+
+@test "sign-sbom-release-assets: signs sbom files when sign is true" {
+	_mock_cosign_bundle
+	run env SIGN=true bash "$SCRIPT"
+	assert_success
+	assert_output --partial "Successfully signed 2 SBOM file(s)"
+	[[ -f "${SBOM_DIR}/sbom.cyclonedx.json.bundle" ]]
+	[[ -f "${SBOM_DIR}/sbom.spdx.json.bundle" ]]
+}
+
+@test "sign-sbom-release-assets: fails when SBOM_DIR missing" {
+	run env SBOM_DIR="${BATS_TEST_TMPDIR}/missing" SIGN=true bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "::error::SBOM directory not found"
+}
+
+@test "sign-sbom-release-assets: fails when no sbom files present" {
+	rm -f "${SBOM_DIR}"/*
+	_mock_cosign_bundle
+	run env SIGN=true bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "::error::No SBOM files found to sign"
+}

--- a/tests/bats/unit/actions/test_validate_sbom_mode.bats
+++ b/tests/bats/unit/actions/test_validate_sbom_mode.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# Purpose: Unit tests for scripts/ci/actions/validate-sbom-mode.sh
+
+load "../../../helpers/common"
+
+SCRIPT="${PROJECT_ROOT}/scripts/ci/actions/validate-sbom-mode.sh"
+
+@test "validate-sbom-mode: defaults to report and succeeds" {
+	run env -u MODE -u RELEASE_TAG bash "$SCRIPT"
+	assert_success
+	assert_output --partial "SBOM mode validated: report"
+}
+
+@test "validate-sbom-mode: report mode allows empty release-tag" {
+	run env MODE=report RELEASE_TAG= bash "$SCRIPT"
+	assert_success
+}
+
+@test "validate-sbom-mode: release-assets without release-tag fails with ::error::" {
+	run env MODE=release-assets RELEASE_TAG= bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "::error::release-tag is required when mode is release-assets"
+}
+
+@test "validate-sbom-mode: release-assets with release-tag succeeds" {
+	run env MODE=release-assets RELEASE_TAG=v1.2.3 bash "$SCRIPT"
+	assert_success
+	assert_output --partial "SBOM mode validated: release-assets"
+}
+
+@test "validate-sbom-mode: invalid mode fails with ::error::" {
+	run env MODE=scan bash "$SCRIPT"
+	assert_failure
+	assert_output --partial "::error::Invalid mode 'scan'"
+}

--- a/tests/bats/unit/lib/egress/test_presets.bats
+++ b/tests/bats/unit/lib/egress/test_presets.bats
@@ -50,6 +50,9 @@ PRESETS="${PROJECT_ROOT}/scripts/ci/lib/egress/presets.sh"
 	assert_success
 	assert_output --partial 'anchore.io:443'
 	assert_output --partial 'fulcio.sigstore.dev:443'
+	assert_output --partial 'rekor.sigstore.dev:443'
+	assert_output --partial 'oauth2.sigstore.dev:443'
+	assert_output --partial 'uploads.github.com:443'
 	assert_output --partial 'sigstore-tuf-root.storage.googleapis.com:443'
 }
 


### PR DESCRIPTION
## Summary

Adds `mode: report|release-assets` to `reusable-sbom.yml` so consumers can generate multi-format SBOMs, optionally cosign-sign them (keyless OIDC), and upload them as GitHub Release assets — absorbing turbo-themes' local reusable without breaking existing report-mode callers.

Stacked on #589 (`refactor/564-extract-inline-shell`) because both touch `reusable-sbom.yml`; must merge after #589.

## Type of Change

- [x] New feature (composite action, reusable workflow, or utility script)
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD improvement

## Checklist

- [x] I have tested these changes locally
- [x] I have updated documentation if needed
- [x] Shell scripts pass `shellcheck`
- [x] YAML files pass `yamllint`
- [x] Python code passes `ruff` and `black`

## Breaking Changes

None. `mode` defaults to `report`; existing callers keep current scan/report behavior. Report-mode `upload-release-assets` (#532) is unchanged.

## Closes

- Closes #524
- Relates to #520
- Relates to #589

## Changes Made

- Add `mode`, `formats`, and `sign` inputs to `reusable-sbom.yml`
- `release-assets` job: checkout tagged ref → multi-format Syft generate → optional cosign → `upload-sbom-release-assets.sh` (reused from #564)
- Scripts: `validate-sbom-mode.sh`, `generate-sbom-release-assets.sh`, `sign-sbom-release-assets.sh`
- Extend `sbom` egress preset with `oauth2.sigstore.dev` + `uploads.github.com` (synced harden-runner bundle)
- Document permissions-by-mode and egress in `workflow-contract.md` / `reusable-workflows.md`
- BATS for mode validation, format parsing, sign gating, workflow contracts

## Testing

- [x] BATS unit/integration for new scripts and reusable-sbom contracts
- [x] Full `uv run lintro fmt` / `chk`
- [x] Full `bats --recursive tests/bats/` (local)

## Quality Checks

- [x] `uv run lintro fmt`
- [x] `uv run lintro chk`
- [x] Signed commit

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds `mode: release-assets` to `reusable-sbom.yml`, enabling multi-format SBOM generation, optional keyless cosign signing, and direct GitHub Release upload without touching the existing `report`-mode path. A new `validate` job gates both modes on `validate-sbom-mode.sh` before any generation work starts.

- **New `release-assets` job**: checks out the repo at `release-tag`, generates multi-format SBOMs with Syft via `generate-sbom-release-assets.sh`, optionally cosign-signs them, and uploads via the existing `upload-sbom-release-assets.sh`. The `|| 'none'` / `|| 'not-run'` fallbacks on the three workflow outputs correctly surface sentinel values to callers when the `sbom` job is skipped.
- **No workflow-level outputs from `release-assets` job**: the `generate` step's `sbom-count`, `sbom-dir`, and `sbom-files` outputs are accessible within the job but are not wired into the reusable workflow's `outputs` block, so callers in `release-assets` mode cannot introspect how many SBOMs were generated or uploaded.
- **Egress preset updated**: both copies of `presets.sh` gain `uploads.github.com:443` and `oauth2.sigstore.dev:443` to cover `gh release upload` and cosign OIDC respectively.
</details>


<h3>Confidence Score: 4/5</h3>

Safe to merge for the report-mode path; release-assets mode is functional but callers cannot introspect generated SBOM counts or file paths from the workflow's output contract.

The three workflow outputs now carry || 'none' / || 'not-run' fallbacks that correctly resolve to sentinel values when the sbom job is skipped in release-assets mode — that specific breakage is fixed. What remains open is that the release-assets job itself declares no outputs block, so the sbom-count, sbom-dir, and sbom-files values produced by the generate step are only visible within the job and never surfaced at the reusable-workflow level. Any caller that wants to act on the uploaded SBOM list has no structured data to work with in this mode.

.github/workflows/reusable-sbom.yml — the release-assets job needs an outputs block mapping steps.generate.outputs.* to job-level outputs, and those job outputs then need to be wired into the workflow-level outputs section alongside the existing sbom.* references.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/reusable-sbom.yml | Core change: adds mode/formats/sign inputs, a new validate job, and a new release-assets job. Workflow outputs gain || 'none' fallbacks. The release-assets job exposes no workflow-level outputs, so callers in that mode cannot introspect generated SBOM paths or counts. |
| scripts/ci/actions/generate-sbom-release-assets.sh | New script handling install/generate/parse-formats for multi-format SBOM generation. Correctly uses mapfile with captured output to propagate parse errors. Does not deduplicate format tokens (previously flagged P2). |
| scripts/ci/actions/sign-sbom-release-assets.sh | New script for keyless cosign signing. Correctly excludes already-signed artifacts (*.bundle, *.sig, *.pem) from the sign loop, validates cosign is installed, and gates on the SIGN env var. |
| scripts/ci/actions/validate-sbom-mode.sh | New script that validates MODE and enforces RELEASE_TAG when mode is release-assets. Clean and minimal; well tested. |
| .github/actions/harden-runner/lib/egress/presets.sh | Adds uploads.github.com:443 and oauth2.sigstore.dev:443 to the sbom preset, matching the release-asset upload and cosign OIDC requirements. Synced with scripts/ci/lib/egress/presets.sh. |
| scripts/ci/lib/egress/presets.sh | Same sbom preset update as the action copy — adds uploads.github.com and oauth2.sigstore.dev. Changes are identical to the harden-runner copy. |
| scripts/ci/quality/validate-static-job-names.sh | Adds reusable-sbom.yml:sbom and reusable-sbom.yml:release-assets to the static job name exceptions list, correctly accounting for the mode-gated pattern where exactly one of the two jobs runs per call. |
| tests/bats/integration/test_reusable_sbom.bats | Extends existing integration test suite with mode/sign/formats default checks and job-gating assertions. Coverage is thorough for the new workflow structural contracts. |
| tests/bats/unit/actions/test_generate_sbom_release_assets.bats | Good unit coverage for parse-formats, generate, and error paths. No test for duplicate-format deduplication (pre-existing P2). |
| tests/bats/unit/actions/test_sign_sbom_release_assets.bats | Covers skip-on-false, skip-on-off, happy path, missing SBOM_DIR, and empty directory cases. Mock cosign correctly creates bundle files. |
| tests/bats/unit/actions/test_validate_sbom_mode.bats | Comprehensive coverage of all mode/tag combinations. All five test cases pass logically. |
| tests/bats/unit/lib/egress/test_presets.bats | Extends sbom preset assertions to include the two new endpoints (oauth2.sigstore.dev, uploads.github.com) and rekor.sigstore.dev. |
| docs/reusable-workflows.md | Adds mode/formats/sign/release-tag to the SBOM input table and provides a release-assets mode usage example. |
| docs/workflow-contract.md | Documents permissions-by-mode table and updated sbom egress preset. Adds release-assets mode usage example. Accurate and complete. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller as Caller Workflow
    participant V as validate job
    participant S as sbom job
    participant U as upload-release-assets job
    participant R as release-assets job

    Caller->>V: trigger (any mode)
    V->>V: harden-runner (minimal)
    V->>V: checkout lgtm-ci scripts
    V->>V: validate-sbom-mode.sh (MODE + RELEASE_TAG)
    V-->>Caller: success / fail

    alt "mode == report (default)"
        V->>S: needs:[validate]
        S->>S: harden-runner + checkout-and-harden (preset)
        S->>S: generate SBOM (Syft, single format)
        S->>S: scan (Grype) [optional]
        S->>S: attest (Sigstore) [optional]
        S-->>Caller: sbom-file, vulnerabilities-found, attestation-url
        opt "upload-release-assets == true"
            S->>U: needs:[validate, sbom]
            U->>U: download artifact + upload-sbom-release-assets.sh
        end
    else "mode == release-assets"
        V->>R: needs:[validate]
        R->>R: harden-runner (minimal)
        R->>R: "checkout repo @ release-tag"
        R->>R: checkout-and-harden (preset)
        R->>R: install Syft
        R->>R: generate-sbom-release-assets.sh (multi-format)
        opt "sign == true"
            R->>R: install Cosign
            R->>R: sign-sbom-release-assets.sh (keyless OIDC bundle)
        end
        R->>R: upload-sbom-release-assets.sh (gh release upload)
        R-->>Caller: "sbom-file=none, vulnerabilities-found=not-run, attestation-url=not-run"
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller as Caller Workflow
    participant V as validate job
    participant S as sbom job
    participant U as upload-release-assets job
    participant R as release-assets job

    Caller->>V: trigger (any mode)
    V->>V: harden-runner (minimal)
    V->>V: checkout lgtm-ci scripts
    V->>V: validate-sbom-mode.sh (MODE + RELEASE_TAG)
    V-->>Caller: success / fail

    alt "mode == report (default)"
        V->>S: needs:[validate]
        S->>S: harden-runner + checkout-and-harden (preset)
        S->>S: generate SBOM (Syft, single format)
        S->>S: scan (Grype) [optional]
        S->>S: attest (Sigstore) [optional]
        S-->>Caller: sbom-file, vulnerabilities-found, attestation-url
        opt "upload-release-assets == true"
            S->>U: needs:[validate, sbom]
            U->>U: download artifact + upload-sbom-release-assets.sh
        end
    else "mode == release-assets"
        V->>R: needs:[validate]
        R->>R: harden-runner (minimal)
        R->>R: "checkout repo @ release-tag"
        R->>R: checkout-and-harden (preset)
        R->>R: install Syft
        R->>R: generate-sbom-release-assets.sh (multi-format)
        opt "sign == true"
            R->>R: install Cosign
            R->>R: sign-sbom-release-assets.sh (keyless OIDC bundle)
        end
        R->>R: upload-sbom-release-assets.sh (gh release upload)
        R-->>Caller: "sbom-file=none, vulnerabilities-found=not-run, attestation-url=not-run"
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `.github/workflows/reusable-sbom.yml`, line 153-164 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/ea403e61387f83d46c6bfeaac6b7285023149a3b/.github/workflows/reusable-sbom.yml#L153-L164)) 

   **Workflow outputs always empty in `release-assets` mode**

   All three workflow outputs are wired to `jobs.sbom.outputs.*`. When `mode: release-assets` the `sbom` job is **skipped entirely**, and GitHub Actions returns `''` for skipped-job outputs — not the `'none'` / `'not-run'` fallbacks documented in the descriptions (those fallbacks only fire when the job runs but an individual step is skipped). Any downstream caller that gates on `needs.<ref>.outputs.sbom-file != 'none'` or `!= ''` will silently see the wrong value when the mode is switched.

   The `release-assets` job currently produces no workflow-level outputs either, so there is no way for a caller to introspect the generated SBOM paths or counts. Consider either wiring `jobs.release-assets.outputs.*` into the workflow outputs with appropriate fallback expressions, or adding a note to the output descriptions clarifying that values are `''` in `release-assets` mode.

2. `.github/workflows/reusable-sbom.yml`, line 167-197 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/ea403e61387f83d46c6bfeaac6b7285023149a3b/.github/workflows/reusable-sbom.yml#L167-L197)) 

   **`validate` job's `harden-runner` does not apply `egress-preset`**

   The new `validate` job configures harden-runner with only `egress-policy` and `allowed-endpoints`, omitting `egress-preset`. Because the job never calls `checkout-and-harden` (which is the normal vehicle for applying the preset), a caller who passes a custom `egress-preset` without also overriding `allowed-endpoints` will have the validate job's harden-runner fall back to the comprehensive `allowed-endpoints` default — a broader list than their preset intended. The same pattern exists in the pre-existing `upload-release-assets` job and is low-severity in practice (the default list already covers everything needed), but it is an inconsistency worth flagging as the validate job is newly introduced here.

3. `scripts/ci/actions/generate-sbom-release-assets.sh`, line 113-134 ([link](https://github.com/lgtm-hq/lgtm-ci/blob/ea403e61387f83d46c6bfeaac6b7285023149a3b/scripts/ci/actions/generate-sbom-release-assets.sh#L113-L134)) 

   **Duplicate formats inflate `sbom-count` and `sbom-files` outputs**

   `parse_sbom_format_list` does not deduplicate format tokens, so `FORMATS=spdx-json,spdx-json` causes the loop to run twice for the same format: the first generation writes `sbom/sbom.spdx.json`, the second silently overwrites it, `generated` ends up with two identical entries, and `sbom-count` reports `2` while only one unique file exists on disk. The `sbom-files` heredoc will also contain the path twice. While `upload-sbom-release-assets.sh` scans the directory rather than reading this output, any consumer that trusts `sbom-count` will receive a misleading value. A small deduplication check (e.g. tracking seen formats in an associative array before appending) would prevent this.

   There is currently no BATS test covering the duplicate-format case.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["chore: nudge CI after semantic-title uni..."](https://github.com/lgtm-hq/lgtm-ci/commit/c415a5b852938bc2a154fcfb9ccaf28615cea553) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44943658)</sub>

<!-- /greptile_comment -->